### PR TITLE
fix(server): error handler crash + missing platforms + per-provider timeout

### DIFF
--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,7 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 
-export function errorHandler(err: Error, _req: Request, res: Response, _next: NextFunction) {
+export function errorHandler(err: Error, _req: Request, res: Response, next: NextFunction) {
   console.error('[Error]', err.message);
+
+  if (res.headersSent) return next(err);
 
   const status = (err as any).status ?? 500;
   res.status(status).json({

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -17,6 +17,9 @@ export class OpenAICompatProvider extends BaseProvider {
   private readonly baseUrl: string;
   private readonly extraHeaders: Record<string, string>;
   private readonly validateUrl?: string;
+  /** Per-provider HTTP timeout override. Cloud APIs finish in ~15s; locally-hosted
+   * inference (llama.cpp / vLLM on CPU) can take 30-120s for long prompts. Default 15000. */
+  private readonly timeoutMs: number;
 
   constructor(opts: {
     platform: Platform;
@@ -24,6 +27,7 @@ export class OpenAICompatProvider extends BaseProvider {
     baseUrl: string;
     extraHeaders?: Record<string, string>;
     validateUrl?: string;
+    timeoutMs?: number;
   }) {
     super();
     this.platform = opts.platform;
@@ -31,6 +35,7 @@ export class OpenAICompatProvider extends BaseProvider {
     this.baseUrl = opts.baseUrl;
     this.extraHeaders = opts.extraHeaders ?? {};
     this.validateUrl = opts.validateUrl;
+    this.timeoutMs = opts.timeoutMs ?? 15000;
   }
 
   async chatCompletion(
@@ -56,7 +61,7 @@ export class OpenAICompatProvider extends BaseProvider {
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
       }),
-    });
+    }, this.timeoutMs);
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
@@ -92,7 +97,7 @@ export class OpenAICompatProvider extends BaseProvider {
         parallel_tool_calls: options?.parallel_tool_calls,
         stream: true,
       }),
-    });
+    }, this.timeoutMs);
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -9,6 +9,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'huggingface', 'cohere', 'cloudflare',
+  'zhipu', 'moonshot', 'minimax',
 ] as const;
 
 const addKeySchema = z.object({


### PR DESCRIPTION
Three small, independent fixes/improvements bundled together.

## 1. Guard `errorHandler` against headers-already-sent (`79b5ca7`)
When an LLM completion errors mid-stream, the response is already flushing tokens. The handler unconditionally called `res.status().json()`, throwing `ERR_HTTP_HEADERS_SENT` and triggering a pm2 restart on every failed stream. One-line guard short-circuits to Express's default handler once headers have been sent so the socket closes cleanly.

## 2. Configurable per-provider HTTP timeout (`f1dec2c`)
`OpenAICompatProvider` now accepts an optional `timeoutMs` constructor option (default 15000ms — unchanged behaviour for existing providers). Cloud APIs respond well within the default, but anyone wiring up a locally-hosted OpenAI-compatible endpoint (llama.cpp, vLLM on CPU, Ollama on a slow box) was getting requests aborted mid-generation, which then marks the key invalid. With this option, each provider registration can pick its own timeout.

## 3. Add zhipu/moonshot/minimax to keys allowlist (`6232e59`)
These three platforms exist in the `Platform` type union and have provider registrations, but were missing from the `PLATFORMS` array in the `/keys` route. Without them, the addKey Zod schema rejects requests to add API keys for those providers — they were effectively dead-coded.

## Test plan
- [ ] Trigger an upstream LLM stream error (e.g. invalid key mid-stream) and confirm pm2 does not restart
- [ ] Verify non-streamed errors still return the JSON error body as before
- [ ] Add an API key for `zhipu`, `moonshot`, `minimax` via the `/keys` endpoint and confirm it succeeds
- [ ] Existing providers (no `timeoutMs` passed) still time out at 15s as before