### PR TITLE
docs: credit @lukasulc for #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 Thanks to everyone who's helped improve FreeLLMAPI:
 
 - [@moaaz12-web](https://github.com/moaaz12-web) — tool-calling support across providers (#3)
+- [@lukasulc](https://github.com/lukasulc) — better-sqlite3 bump to fix npm install on Node 24+ (#12)
 
 ## Terms of Service review
 


### PR DESCRIPTION
Adds @lukasulc to the Contributors section for the better-sqlite3 bump that unblocked npm install on Node 24+ (#12, closed #11).