### PR TITLE
feat(catalog): migrateModelsV7 — probe-verified OR :free delta + Z.ai

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -41,6 +41,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV4(db);
   migrateModelsV5(db);
   migrateModelsV6(db);
+  migrateModelsV7(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -644,6 +645,67 @@ function migrateModelsV6(db: Database.Database) {
     // OpenRouter :free pool — 20 RPM / 50 RPD (1000 once $10 credits bought).
     ['openrouter', 'google/gemma-4-31b-it:free',                   'Gemma 4 31B (free)',             19, 9,  'Medium',   20, 200, null, null, '~6M', 262144],
     ['openrouter', 'liquid/lfm-2.5-1.2b-instruct:free',            'Liquid LFM 2.5 1.2B (free)',     30, 10, 'Small',    20, 200, null, null, '~6M', 32768],
+  ];
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    const missing = db.prepare(`
+      SELECT m.id FROM models m
+      LEFT JOIN fallback_config f ON m.id = f.model_db_id
+      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+    `).all() as { id: number }[];
+    if (missing.length > 0) {
+      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+    }
+  });
+  apply();
+}
+
+/**
+ * V7 (April 2026): live-probed delta against OpenRouter's free pool + Z.ai.
+ * - Removes inclusionai/ling-2.6-flash:free (transitioned to paid, 404 on chat).
+ * - Adds 8 new :free routes confirmed via /v1/models + chat-completion probe.
+ * - Adds zhipu/glm-4.7-flash (probe: 429 "overloaded" — free-pool throttle, not
+ *   "insufficient balance" which paid models return). Same baseUrl works for both
+ *   api.z.ai and open.bigmodel.cn keys.
+ * HF and NVIDIA left as-is: HF still serves chat with current key; NVIDIA already disabled.
+ */
+function migrateModelsV7(db: Database.Database) {
+  const deleteModel = db.prepare(`DELETE FROM models WHERE platform = ? AND model_id = ?`);
+  const deleteFallback = db.prepare(`
+    DELETE FROM fallback_config WHERE model_db_id IN (
+      SELECT id FROM models WHERE platform = ? AND model_id = ?
+    )
+  `);
+  const removals: Array<[string, string]> = [
+    ['openrouter', 'inclusionai/ling-2.6-flash:free'],
+  ];
+  const applyRemovals = db.transaction(() => {
+    for (const [p, m] of removals) {
+      deleteFallback.run(p, m);
+      deleteModel.run(p, m);
+    }
+  });
+  applyRemovals();
+
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  // OpenRouter :free quotas: 20 RPM / 50 RPD without credits, 1000 RPD with $10 lifetime topup.
+  // Catalog convention is rpd=200 (matches existing rows).
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['openrouter', 'inclusionai/ling-2.6-1t:free',                           'Ling 2.6 1T (free)',                       4,  9,  'Frontier', 20, 200, null, null, '~6M', 262144],
+    ['openrouter', 'tencent/hy3-preview:free',                               'Tencent HY3 Preview (free)',               7,  9,  'Frontier', 20, 200, null, null, '~6M', 262144],
+    ['openrouter', 'poolside/laguna-m.1:free',                               'Poolside Laguna M.1 (free)',               13, 9,  'Large',    20, 200, null, null, '~6M', 131072],
+    ['openrouter', 'google/gemma-4-26b-a4b-it:free',                         'Gemma 4 26B-A4B (free)',                   22, 9,  'Medium',   20, 200, null, null, '~6M', 262144],
+    ['openrouter', 'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free',     'Nemotron 3 Nano 30B Reasoning (free)',     23, 9,  'Medium',   20, 200, null, null, '~6M', 262144],
+    ['openrouter', 'poolside/laguna-xs.2:free',                              'Poolside Laguna XS.2 (free)',              26, 10, 'Medium',   20, 200, null, null, '~6M', 131072],
+    ['openrouter', 'nvidia/nemotron-nano-9b-v2:free',                        'Nemotron Nano 9B v2 (free)',               28, 10, 'Medium',   20, 200, null, null, '~6M', 128000],
+    ['openrouter', 'liquid/lfm-2.5-1.2b-thinking:free',                      'Liquid LFM 2.5 1.2B Thinking (free)',      30, 10, 'Small',    20, 200, null, null, '~6M', 32768],
+    // Zhipu (Z.ai) — free pool. glm-4.7-flash quotas unpublished; mirror glm-4.5-flash row shape.
+    ['zhipu',      'glm-4.7-flash',                                          'GLM-4.7 Flash',                            18, 4,  'Large',    null, null, null, 1000000, '~30M', 131072],
   ];
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);


### PR DESCRIPTION
## Summary

Live-probed delta against OpenRouter's free pool (29 models live as of 2026-04-29) plus a Z.ai free-pool addition.

## Changes

**Removals**
- \`openrouter/inclusionai/ling-2.6-flash:free\` — transitioned to paid (OR returns 404 with explicit message).

**Additions — OpenRouter \`:free\` (chat-probe verified, HTTP 200)**
- \`inclusionai/ling-2.6-1t:free\` (Frontier, 262K)
- \`tencent/hy3-preview:free\` (Frontier, 262K)
- \`poolside/laguna-m.1:free\` (Large, 131K)
- \`google/gemma-4-26b-a4b-it:free\` (Medium, 262K)
- \`nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free\` (Medium reasoning, 262K)
- \`poolside/laguna-xs.2:free\` (Medium, 131K)
- \`nvidia/nemotron-nano-9b-v2:free\` (Medium, 128K)
- \`liquid/lfm-2.5-1.2b-thinking:free\` (Small, 32K)

**Additions — Zhipu (Z.ai)**
- \`zhipu/glm-4.7-flash\` — 429 \"service overloaded\" under load, distinct from the paid-tier \"insufficient balance\" response. Same key works on both \`api.z.ai\` and the existing provider's \`open.bigmodel.cn\` endpoint.

## Skipped

- \`cognitivecomputations/dolphin-mistral-24b-venice-edition:free\` — flaky 429s, not worth adding.
- New \`zai\` platform — existing \`zhipu\` provider already covers both endpoints with the same key, no separate platform needed.

## Verification

- Pre/post-V7 in-memory DB dump: 50 → 57 models.
- All 75 server tests pass.
- Build clean (\`tsc\`).

## Test plan

- [ ] Run server, confirm V7 migration applies idempotently to existing DB.
- [ ] Spot-check at least one new OR \`:free\` model end-to-end via the proxy with a configured OR key.
- [ ] Confirm fallback ordering still includes new high-rank entries (ling-2.6-1t at rank 4, tencent/hy3-preview at rank 7).