### PR TITLE
fix(proxy): honor explicit model field in chat-completions

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -191,7 +191,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     return;
   }
 
-  const { temperature, max_tokens, top_p, stream, tools, tool_choice, parallel_tool_calls } = parsed.data;
+  const { model: requestedModel, temperature, max_tokens, top_p, stream, tools, tool_choice, parallel_tool_calls } = parsed.data;
   const messages: ChatMessage[] = parsed.data.messages.map((m): ChatMessage => {
     if (m.role === 'assistant') {
       return {
@@ -224,8 +224,17 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   }, 0);
   const estimatedTotal = estimatedInputTokens + (max_tokens ?? 1000);
 
-  // Sticky session: prefer the same model for multi-turn conversations
-  const preferredModel = getStickyModel(messages);
+  // Explicit `model` field pins routing; sticky-session is the fallback.
+  let preferredModel: number | undefined;
+  if (requestedModel) {
+    const row = getDb()
+      .prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1')
+      .get(requestedModel) as { id: number } | undefined;
+    if (row) preferredModel = row.id;
+  }
+  if (preferredModel === undefined) {
+    preferredModel = getStickyModel(messages);
+  }
 
   // Retry loop: on 429/rate limit, skip that model+key and try the next one
   const skipKeys = new Set<string>();


### PR DESCRIPTION
## Summary

Reported: \"selecting specific model in playground isn't working well\" — every request was landing on the top fallback regardless of the dropdown selection.

## Root cause

\`server/src/routes/proxy.ts\` parsed \`model\` via \`chatCompletionSchema\` but the destructure on line 194 omitted it, so \`routeRequest\` only ever received \`getStickyModel(messages)\`. The user-supplied \`model\` field was silently dropped.

## Fix

When \`model\` is present, look it up in the catalog (\`models WHERE model_id = ? AND enabled = 1\`) and pass its db id as \`preferredModelDbId\` to \`routeRequest\`. Sticky-session falls back when no explicit model is sent (preserves multi-turn coherence for SDK clients that don't re-send the model field).

Unknown / disabled models silently fall through to auto-route — keeps behavior compatible with clients hardcoding foreign model names like \`gpt-4o\`.

## Verification (local)

- \`POST /v1/chat/completions {model:\"glm-4.5-flash\"}\` → routes to \`zhipu\` (response \`model: glm-4.5-flash\`).
- \`POST /v1/chat/completions {model:\"@cf/moonshotai/kimi-k2.6\"}\` → routes to \`cloudflare\` (response \`model: @cf/moonshotai/kimi-k2.6\`).
- Pre-fix: both routed to \`minimax/minimax-m2.5:free\` (top of fallback chain).
- All 75 server tests pass.

## Test plan

- [ ] In the playground UI, select a non-default model and confirm the response \`model\` field matches.
- [ ] Multi-turn conversation without explicit \`model\` continues to use the same model (sticky session intact).
- [ ] Sending an unknown \`model\` value still gets a successful response (auto-route fallback).