### PR TITLE
feat(catalog): migrateModelsV9 — disable cerebras/zai-glm-4.7

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -43,6 +43,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV6(db);
   migrateModelsV7(db);
   migrateModelsV8(db);
+  migrateModelsV9(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -758,6 +759,20 @@ function migrateModelsV8(db: Database.Database) {
     }
   });
   apply();
+}
+
+/**
+ * V9 (May 2026): disable cerebras/zai-glm-4.7. The model still appears in
+ * Cerebras's /v1/models listing but the chat-completions endpoint returns
+ * 404 "Model does not exist or you do not have access" for free-tier keys —
+ * matches their docs note about temporarily reducing free-tier access on
+ * zai-glm-4.7 due to high demand. Row kept (not deleted) so it can be
+ * re-enabled later without losing fallback_config history.
+ */
+function migrateModelsV9(db: Database.Database) {
+  db.prepare(
+    "UPDATE models SET enabled = 0 WHERE platform = 'cerebras' AND model_id = 'zai-glm-4.7'"
+  ).run();
 }
 
 function ensureUnifiedKey(db: Database.Database) {


### PR DESCRIPTION
## Summary

End-to-end sweep of all 60 catalog models found `cerebras/zai-glm-4.7` returns `404 Model does not exist or you do not have access` for the configured free-tier key. Cerebras's `/v1/models` still lists it, but chat-completions is gated — matching their docs note about temporarily reducing free-tier access due to high demand.

## Change

`UPDATE models SET enabled = 0 WHERE platform = 'cerebras' AND model_id = 'zai-glm-4.7'`

Row kept (not deleted) so fallback_config history is preserved for when Cerebras restores access.

## Verification

- Re-probed direct against Cerebras: `HTTP 404 model_not_found`.
- Catalog dump after V9: `cerebras | zai-glm-4.7 | enabled=0`. Total still 61 rows; 60 enabled.
- 75/75 server tests pass.

## Test plan

- [ ] Confirm fallback_config no longer offers `zai-glm-4.7` in routing.
- [ ] Confirm playground dropdown either hides the model or marks it disabled.