### PR TITLE
Fix server and Vite dev proxy port config from .env

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -70,6 +70,9 @@ function UnifiedKeySection() {
 
   const apiKey = data?.apiKey ?? ''
   const masked = apiKey ? apiKey.slice(0, 13) + '•'.repeat(32) : '…'
+  const baseUrl = import.meta.env.DEV
+    ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
+    : `${window.location.origin}/v1`
 
   function copy() {
     navigator.clipboard.writeText(apiKey)
@@ -110,7 +113,7 @@ function UnifiedKeySection() {
 
       <div className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
         <span className="text-muted-foreground">Base URL</span>
-        <code className="font-mono">http://localhost:3001/v1</code>
+        <code className="font-mono">{baseUrl}</code>
         <span className="text-muted-foreground">Endpoint</span>
         <code className="font-mono">/v1/chat/completions</code>
       </div>

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __SERVER_PORT__: string

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig(({ mode }) => {
     plugins: [react(), tailwindcss()],
     base: process.env.VITE_BASE ?? '/',
     envDir: path.resolve(__dirname, '..'),
+    define: {
+      __SERVER_PORT__: JSON.stringify(String(serverPort)),
+    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,20 +1,26 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  base: process.env.VITE_BASE ?? '/',
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, path.resolve(__dirname, '..'), '')
+  const serverPort = env.PORT ?? process.env.PORT ?? 3001
+
+  return {
+    plugins: [react(), tailwindcss()],
+    base: process.env.VITE_BASE ?? '/',
+    envDir: path.resolve(__dirname, '..'),
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    proxy: {
-      '/api': 'http://localhost:3001',
-      '/v1': 'http://localhost:3001',
+    server: {
+      proxy: {
+        '/api': `http://localhost:${serverPort}`,
+        '/v1': `http://localhost:${serverPort}`,
+      },
     },
-  },
+  }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -4991,9 +4991,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -11987,6 +11987,7 @@
         "@freellmapi/shared": "*",
         "better-sqlite3": "^12.4.1",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "drizzle-orm": "^0.44.2",
         "express": "^5.1.0",
         "helmet": "^8.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "@freellmapi/shared": "*",
     "better-sqlite3": "^12.4.1",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.2",
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0",
     "helmet": "^8.1.0",

--- a/server/src/env.ts
+++ b/server/src/env.ts
@@ -1,0 +1,7 @@
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,4 @@
+import './env.js';
 import { createApp } from './app.js';
 import { initDb } from './db/index.js';
 import { startHealthChecker } from './services/health.js';


### PR DESCRIPTION
## Problem
The server always started on the default port `3001` even when `PORT=3005` was configured in the root `.env` file. This also meant the Vite dev proxy continued targeting `localhost:3001`, so local development could point the client and server at different ports.

## Root cause
 The server process read `process.env.PORT`, but the app never loaded the root `.env` file. Since Node/tsx does not load `.env` automatically, `process.env.PORT` was undefined and the server fell back to `3001`. The client Vite proxy was also hardcoded to `3001`.

## Fix
Added explicit dotenv loading for the server before any app code reads environment variables. The loader resolves the root `.env` file so workspace execution from `server/` still works correctly.

Updated the Vite config to load environment values from the repo root and use the configured `PORT` for `/api` and `/v1` proxy targets. This keeps the client proxy aligned with the server port configured in `.env`.