### PR TITLE
fix(google): preserve Gemini thought_signature in tool calls

### DIFF
--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -171,4 +171,63 @@ describe('GoogleProvider', () => {
     expect(result.choices[0].message.tool_calls?.[0].function.name).toBe('get_weather');
     expect(result.choices[0].message.tool_calls?.[0].function.arguments).toBe('{"city":"Lahore"}');
   });
+
+  it('should preserve and pass through thought_signature', async () => {
+    let capturedBody: any;
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      capturedBody = JSON.parse((init as any).body);
+      return {
+        ok: true,
+        json: () => Promise.resolve({
+          candidates: [{
+            content: {
+              parts: [{
+                thought_signature: 'sig_123',
+                functionCall: {
+                  id: 'call_123',
+                  name: 'get_weather',
+                  args: { city: 'London' },
+                },
+              }],
+            },
+            finishReason: 'STOP',
+          }],
+          usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+        }),
+      } as any;
+    });
+
+    // 1. Check extraction
+    const result = await provider.chatCompletion(
+      'test-key',
+      [{ role: 'user', content: 'Weather?' }],
+      'gemini-2.5-pro',
+    );
+
+    expect(result.choices[0].message.tool_calls?.[0].thought_signature).toBe('sig_123');
+
+    // 2. Check injection in next turn
+    await provider.chatCompletion(
+      'test-key',
+      [
+        { role: 'user', content: 'Weather?' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'call_123',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"London"}' },
+            thought_signature: 'sig_123',
+          }],
+        },
+        { role: 'tool', tool_call_id: 'call_123', content: '{"temp": 20}' },
+      ],
+      'gemini-2.5-pro',
+    );
+
+    const assistantEntry = capturedBody.contents.find((c: any) => c.role === 'model');
+    expect(assistantEntry.parts[0].thought_signature).toBe('sig_123');
+    expect(assistantEntry.parts[0].functionCall.name).toBe('get_weather');
+  });
 });

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -13,6 +13,7 @@ const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
 interface GeminiPart {
   text?: string;
+  thought_signature?: string;
   functionCall?: {
     id?: string;
     name?: string;
@@ -124,6 +125,7 @@ function toGeminiContents(messages: ChatMessage[]) {
 
         for (const call of m.tool_calls ?? []) {
           parts.push({
+            thought_signature: call.thought_signature,
             functionCall: {
               id: call.id,
               name: call.function.name,
@@ -189,6 +191,7 @@ function extractToolCalls(parts: GeminiPart[] | undefined): ChatToolCall[] {
         name: part.functionCall.name,
         arguments: normalizeGeminiArgs(part.functionCall.args),
       },
+      thought_signature: part.thought_signature,
     });
   }
 

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -13,7 +13,7 @@ const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
 interface GeminiPart {
   text?: string;
-  thought_signature?: string;
+  thoughtSignature?: string;
   functionCall?: {
     id?: string;
     name?: string;
@@ -125,7 +125,7 @@ function toGeminiContents(messages: ChatMessage[]) {
 
         for (const call of m.tool_calls ?? []) {
           parts.push({
-            thought_signature: call.thought_signature,
+            thoughtSignature: call.thought_signature,
             functionCall: {
               id: call.id,
               name: call.function.name,
@@ -191,7 +191,7 @@ function extractToolCalls(parts: GeminiPart[] | undefined): ChatToolCall[] {
         name: part.functionCall.name,
         arguments: normalizeGeminiArgs(part.functionCall.args),
       },
-      thought_signature: part.thought_signature,
+      thought_signature: part.thoughtSignature,
     });
   }
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -84,6 +84,7 @@ const toolCallSchema = z.object({
     name: z.string().min(1),
     arguments: z.string(),
   }),
+  thought_signature: z.string().optional(),
 });
 
 const systemMessageSchema = z.object({
@@ -202,7 +203,12 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         role: 'assistant',
         content: m.content ?? null,
         ...(m.name ? { name: m.name } : {}),
-        ...(m.tool_calls ? { tool_calls: m.tool_calls } : {}),
+        ...(m.tool_calls ? { tool_calls: m.tool_calls.map(tc => ({
+          id: tc.id,
+          type: tc.type,
+          function: tc.function,
+          thought_signature: tc.thought_signature,
+        })) } : {}),
       };
     }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -76,6 +76,7 @@ export interface ChatToolCall {
   id: string;
   type: 'function';
   function: ChatToolCallFunction;
+  thought_signature?: string;
 }
 
 export interface ChatToolFunctionDefinition {


### PR DESCRIPTION
This PR fixes compatibility issues with newer Gemini models (Gemini 1.5/2.0/3.0 family) when performing multi-turn function calling.

### Problem
Recent Gemini models generate an opaque 'thought_signature' alongside function calls. This signature encapsulates the model's reasoning state. Google's API strictly enforces that this signature must be sent back in the conversation history during subsequent turns. If the signature is missing or stripped, the API returns an 'HTTP 400 (INVALID_ARGUMENT)' error. This was causing failures in agents like Hermes Agent and other stateful orchestrators.

### Solution
- **Shared Types:** Added 'thought_signature' to the ChatToolCall interface.
- **Proxy Router:** Updated Zod schema and mapping logic to preserve the signature from clients.
- **Google Provider:** Implemented extraction from Gemini responses and injection back into model messages in the history.
- **Testing:** Added verification tests in 'google.test.ts' covering the full signature lifecycle.