### PR TITLE
test(google): camelCase thoughtSignature fixture + credit @deadc for #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Thanks to everyone who's helped improve FreeLLMAPI:
 - [@moaaz12-web](https://github.com/moaaz12-web) — tool-calling support across providers (#3)
 - [@lukasulc](https://github.com/lukasulc) — better-sqlite3 bump to fix npm install on Node 24+ (#12)
 - [@VinhPhamAI](https://github.com/VinhPhamAI) — root `.env` PORT now propagates to server + Vite dev proxy + UI base URL (#27)
+- [@deadc](https://github.com/deadc) — preserve Gemini `thoughtSignature` so multi-turn function calling stops 400-ing (#32)
 
 ## Terms of Service review
 

--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -182,7 +182,7 @@ describe('GoogleProvider', () => {
           candidates: [{
             content: {
               parts: [{
-                thought_signature: 'sig_123',
+                thoughtSignature: 'sig_123',
                 functionCall: {
                   id: 'call_123',
                   name: 'get_weather',
@@ -227,7 +227,7 @@ describe('GoogleProvider', () => {
     );
 
     const assistantEntry = capturedBody.contents.find((c: any) => c.role === 'model');
-    expect(assistantEntry.parts[0].thought_signature).toBe('sig_123');
+    expect(assistantEntry.parts[0].thoughtSignature).toBe('sig_123');
     expect(assistantEntry.parts[0].functionCall.name).toBe('get_weather');
   });
 });


### PR DESCRIPTION
## Summary
- The new `thought_signature` test added in #32 set `thought_signature` (snake_case) in the mocked Gemini response, but the implementation reads `part.thoughtSignature` (camelCase, matching Gemini's REST wire format) — so the extraction assertion saw `undefined` and the test failed locally on `main`.
- Updates the fixture and the corresponding outgoing-body assertion to use camelCase. Implementation is unchanged; the underlying fix from #32 is correct.
- Adds @deadc to the README contributors list.

## Test plan
- [x] `npm test --prefix server -- --run` — 90/90 passing (was 89/90 before this change; the new `should preserve and pass through thought_signature` test now passes)
- [x] `npm run build --prefix server` — tsc clean