### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.env
+.env.*
+node_modules
+client/node_modules
+server/node_modules
+shared/node_modules
+client/dist
+server/dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.npm
+.cache
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,14 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-COPY . .
+COPY package.json package-lock.json ./
+COPY server/package.json server/package.json
+COPY client/package.json client/package.json
+COPY shared/package.json shared/package.json
 
-RUN npm install
+RUN npm ci
+
+COPY . .
 RUN npm run build
 
 
@@ -14,10 +19,21 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3001
+ENV DATABASE_PATH=/app/data/freellmapi.sqlite
 
-COPY --from=builder /app .
+COPY package.json package-lock.json ./
+COPY server/package.json server/package.json
+COPY shared/package.json shared/package.json
+COPY shared/types.ts shared/types.ts
 
-RUN mkdir -p /app/data
+RUN npm ci --omit=dev --workspace server --include-workspace-root=false
+
+COPY --from=builder /app/server/dist ./server/dist
+COPY --from=builder /app/client/dist ./client/dist
+
+RUN mkdir -p /app/data && chown -R node:node /app
+
+USER node
 
 EXPOSE 3001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+COPY --from=builder /app .
+
+RUN mkdir -p /app/data
+
+EXPOSE 3001
+
+CMD ["node", "server/dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral
 - [Features](#features)
 - [Not yet supported](#not-yet-supported)
 - [Quick start](#quick-start)
+- [Docker](#docker)
 - [Using the API](#using-the-api)
 - [Screenshots](#screenshots)
 - [How it works](#how-it-works)
@@ -115,6 +116,32 @@ For a production build:
 npm run build
 node server/dist/index.js     # server + dashboard both served on :3001
 ```
+
+## Docker
+
+Run full app with Docker Compose:
+
+```bash
+cp .env.example .env
+echo "ENCRYPTION_KEY=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")" >> .env
+docker compose up --build
+```
+
+App listens on `http://localhost:3001`. SQLite data persists in Docker volume `freellmapi_data`.
+Container runs as non-root, uses `init: true` for cleaner shutdown, and exposes a Compose healthcheck on `/api/ping`.
+
+If you prefer plain Docker:
+
+```bash
+docker build -t freellmapi .
+docker run --rm \
+  -p 3001:3001 \
+  -e ENCRYPTION_KEY=your-64-char-hex-key \
+  -v freellmapi_data:/app/data \
+  freellmapi
+```
+
+`ENCRYPTION_KEY` required. Use 32-byte hex value, same as `.env` setup above. Build context excludes `.env`, `node_modules`, git metadata, and local build output via `.dockerignore`.
 
 ## Using the API
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: freellmapi
     restart: unless-stopped
     ports:
-      - "3001:3001"
+      - "3018:3001"
     environment:
       NODE_ENV: production
       PORT: 3001

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  freellmapi:
+    build: .
+    container_name: freellmapi
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      DATABASE_PATH: /app/data/freellmapi.sqlite
+    volumes:
+      - freellmapi_data:/app/data
+
+volumes:
+  freellmapi_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   freellmapi:
     build: .
-    container_name: freellmapi
     restart: unless-stopped
+    init: true
     ports:
-      - "3018:3001"
+      - "3001:3001"
     environment:
       NODE_ENV: production
       PORT: 3001
@@ -12,6 +12,12 @@ services:
       DATABASE_PATH: /app/data/freellmapi.sqlite
     volumes:
       - freellmapi_data:/app/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:3001/api/ping >/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
 volumes:
   freellmapi_data:


### PR DESCRIPTION
## Summary

This PR adds first-class Docker support.

## Changes

- add Docker Compose support for running the app on port `3001`
- add a production-ready `Dockerfile`
- optimize Docker build caching by copying package manifests before source files
- run container as a non-root user
- add `init: true` for cleaner shutdown behavior in Compose
- add a Compose healthcheck using `GET /api/ping`
- add `.dockerignore` to exclude local env files, git metadata, build output, caches, and `node_modules`
- update `README.md` with Docker and Docker Compose usage instructions

## Verification

- `docker build -t freellmapi:test .` completed successfully
