### PR TITLE
feat: add Astraflow provider support (global and China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ ENCRYPTION_KEY=your-64-char-hex-key-here
 
 # Server port (default: 3001)
 PORT=3001
+
+# Astraflow (UCloud) — OpenAI-compatible platform supporting 200+ models
+# Global endpoint: https://astraflow.ucloud-global.com
+ASTRAFLOW_API_KEY=your-astraflow-global-api-key-here
+
+# China endpoint: https://astraflow.ucloud.cn
+ASTRAFLOW_CN_API_KEY=your-astraflow-china-api-key-here

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -20,6 +20,8 @@ const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'cohere', label: 'Cohere' },
   { value: 'cloudflare', label: 'Cloudflare Workers AI' },
   { value: 'zhipu', label: 'Zhipu AI (Z.ai)' },
+  { value: 'astraflow', label: 'Astraflow (UCloud — Global)' },
+  { value: 'astraflow_cn', label: 'Astraflow (UCloud — China)' },
 ]
 
 const statusDot: Record<string, string> = {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -82,6 +82,20 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
 }));
 
+// Astraflow (UCloud) - OpenAI-compatible aggregation platform, 200+ models (global)
+register(new OpenAICompatProvider({
+  platform: 'astraflow',
+  name: 'Astraflow',
+  baseUrl: 'https://api-us-ca.umodelverse.ai/v1',
+}));
+
+// Astraflow (UCloud) - OpenAI-compatible aggregation platform, 200+ models (China)
+register(new OpenAICompatProvider({
+  platform: 'astraflow_cn',
+  name: 'Astraflow CN',
+  baseUrl: 'https://api.modelverse.cn/v1',
+}));
+
 // Hugging Face, Moonshot, MiniMax direct integrations were dropped in V4 —
 // HF tool-call format issues; Moonshot moved to paid; MiniMax superseded by
 // the OpenRouter route (openrouter/minimax/minimax-m2.5:free).

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -12,6 +12,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu',
+  'astraflow', 'astraflow_cn',
 ] as const;
 
 const addKeySchema = z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -15,7 +15,9 @@ export type Platform =
   | 'github'
   | 'cohere'
   | 'cloudflare'
-  | 'zhipu';
+  | 'zhipu'
+  | 'astraflow'
+  | 'astraflow_cn';
 
 export interface Model {
   id: number;


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported provider — an OpenAI-compatible AI model aggregation platform supporting 200+ models, available via a global and a China endpoint.

Because Astraflow is fully OpenAI-compatible, the integration follows the exact same pattern as all other `OpenAICompatProvider` registrations (Groq, Mistral, Zhipu, etc.) — no new SDK, no new subpackage.

## Changes

| File | Change |
|------|--------|
| `shared/types.ts` | Added `'astraflow'` and `'astraflow_cn'` to the `Platform` union type |
| `server/src/providers/index.ts` | Registered both endpoints as `OpenAICompatProvider` instances |
| `server/src/routes/keys.ts` | Added both platforms to the `PLATFORMS` allowlist |
| `client/src/pages/KeysPage.tsx` | Added both platforms to the UI dropdown |
| `.env.example` | Documented `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` |

## Provider Details

- **Global endpoint:** `https://api-us-ca.umodelverse.ai/v1`  
  Sign up at https://astraflow.ucloud-global.com
- **China endpoint:** `https://api.modelverse.cn/v1`  
  Sign up at https://astraflow.ucloud.cn
- **Supports:** 200+ models via a single OpenAI-compatible API
