### PR TITLE
feat(catalog): integrate Ollama Cloud as a new platform (V10) — closes #14

### DIFF
--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -66,6 +66,7 @@ const platformColors: Record<string, string> = {
   cohere:      '#d946ef',
   cloudflare:  '#f38020',
   zhipu:       '#06b6d4',
+  ollama:      '#000000',
 }
 
 function TokenUsageBar({ data }: { data: TokenUsageData }) {

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -20,6 +20,7 @@ const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'cohere', label: 'Cohere' },
   { value: 'cloudflare', label: 'Cloudflare Workers AI' },
   { value: 'zhipu', label: 'Zhipu AI (Z.ai)' },
+  { value: 'ollama', label: 'Ollama Cloud' },
 ]
 
 const statusDot: Record<string, string> = {

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -156,6 +156,42 @@ describe('OpenAICompatProvider', () => {
     expect(result.choices[0].message.content).toBe('part one part two');
   });
 
+  it('folds reasoning into content when content is empty (Ollama style — bare `reasoning` field)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        id: 'id', object: 'chat.completion', created: 1, model: 'm',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: '', reasoning: 'ollama answer' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    } as any);
+
+    const result = await provider.chatCompletion('k', [{ role: 'user', content: 'hi' }], 'm');
+    expect(result.choices[0].message.content).toBe('ollama answer');
+  });
+
+  it('prefers reasoning_content over reasoning when both are present', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        id: 'id', object: 'chat.completion', created: 1, model: 'm',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: '', reasoning_content: 'preferred', reasoning: 'fallback' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    } as any);
+
+    const result = await provider.chatCompletion('k', [{ role: 'user', content: 'hi' }], 'm');
+    expect(result.choices[0].message.content).toBe('preferred');
+  });
+
   it('does NOT fold reasoning_content when tool_calls are present', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: true,

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -796,16 +796,20 @@ function migrateModelsV10(db: Database.Database) {
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
-    ['ollama', 'qwen3-coder:480b',     'Qwen3-Coder 480B (Ollama)',    2,  9, 'Frontier', null, null, null, null, 'session-based', 262144],
-    ['ollama', 'mistral-large-3:675b', 'Mistral Large 3 675B (Ollama)', 3,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
-    ['ollama', 'deepseek-v3.2',        'DeepSeek V3.2 (Ollama)',        4,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
-    ['ollama', 'cogito-2.1:671b',      'Cogito 2.1 671B (Ollama)',      4,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
-    ['ollama', 'kimi-k2-thinking',     'Kimi K2 Thinking (Ollama)',     5,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
-    ['ollama', 'glm-4.7',              'GLM-4.7 (Ollama)',              6,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
-    ['ollama', 'gpt-oss:120b',         'GPT-OSS 120B (Ollama)',         6,  9, 'Large',    null, null, null, null, 'session-based', 131072],
-    ['ollama', 'devstral-2:123b',      'Devstral 2 123B (Ollama)',      8, 10, 'Large',    null, null, null, null, 'session-based', 131072],
-    ['ollama', 'gpt-oss:20b',          'GPT-OSS 20B (Ollama)',         18, 10, 'Medium',   null, null, null, null, 'session-based', 131072],
-    ['ollama', 'gemma4:31b',           'Gemma 4 31B (Ollama)',         22, 10, 'Medium',   null, null, null, null, 'session-based', 131072],
+    // Budget strings are estimates: Ollama publishes no token cap (quota is GPU-time +
+    // 7-day rolling). Frontier ~5-10M, Large ~10-20M, Medium ~20-30M reflect that
+    // heavier models burn quota faster. Numeric limits stay null — real provider
+    // throttling is the source of truth, not these display strings.
+    ['ollama', 'qwen3-coder:480b',     'Qwen3-Coder 480B (Ollama)',    2,  9, 'Frontier', null, null, null, null, '~5-10M',  262144],
+    ['ollama', 'mistral-large-3:675b', 'Mistral Large 3 675B (Ollama)', 3,  9, 'Frontier', null, null, null, null, '~5-10M',  131072],
+    ['ollama', 'deepseek-v3.2',        'DeepSeek V3.2 (Ollama)',        4,  9, 'Frontier', null, null, null, null, '~5-10M',  131072],
+    ['ollama', 'cogito-2.1:671b',      'Cogito 2.1 671B (Ollama)',      4,  9, 'Frontier', null, null, null, null, '~5-10M',  131072],
+    ['ollama', 'kimi-k2-thinking',     'Kimi K2 Thinking (Ollama)',     5,  9, 'Frontier', null, null, null, null, '~5-10M',  131072],
+    ['ollama', 'glm-4.7',              'GLM-4.7 (Ollama)',              6,  9, 'Frontier', null, null, null, null, '~5-10M',  131072],
+    ['ollama', 'gpt-oss:120b',         'GPT-OSS 120B (Ollama)',         6,  9, 'Large',    null, null, null, null, '~10-20M', 131072],
+    ['ollama', 'devstral-2:123b',      'Devstral 2 123B (Ollama)',      8, 10, 'Large',    null, null, null, null, '~10-20M', 131072],
+    ['ollama', 'gpt-oss:20b',          'GPT-OSS 20B (Ollama)',         18, 10, 'Medium',   null, null, null, null, '~20-30M', 131072],
+    ['ollama', 'gemma4:31b',           'Gemma 4 31B (Ollama)',         22, 10, 'Medium',   null, null, null, null, '~20-30M', 131072],
   ];
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -44,6 +44,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV7(db);
   migrateModelsV8(db);
   migrateModelsV9(db);
+  migrateModelsV10(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -773,6 +774,53 @@ function migrateModelsV9(db: Database.Database) {
   db.prepare(
     "UPDATE models SET enabled = 0 WHERE platform = 'cerebras' AND model_id = 'zai-glm-4.7'"
   ).run();
+}
+
+/**
+ * V10 (May 2026): Ollama Cloud — first new platform since Z.ai/Zhipu in V7.
+ * Free plan: GPU-time-based quota (not per-token), 1 concurrent model,
+ * 5h session caps, no card required. /v1/models lists 39 SKUs but only 28
+ * respond on the Free tier — paid models return 403 with an explicit
+ * "this model requires a subscription" message.
+ *
+ * Curated to ~10 representative free models that either (a) aren't reachable
+ * elsewhere in the catalog or (b) provide a useful alternate route through
+ * Ollama's independent rate-limit pool. Probe-verified May 2 2026.
+ *
+ * Quota shape: GPU-time, not tokens. monthly_token_budget reflects rough
+ * Free-tier "session" capacity rather than a hard token cap.
+ */
+function migrateModelsV10(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['ollama', 'qwen3-coder:480b',     'Qwen3-Coder 480B (Ollama)',    2,  9, 'Frontier', null, null, null, null, 'session-based', 262144],
+    ['ollama', 'mistral-large-3:675b', 'Mistral Large 3 675B (Ollama)', 3,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
+    ['ollama', 'deepseek-v3.2',        'DeepSeek V3.2 (Ollama)',        4,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
+    ['ollama', 'cogito-2.1:671b',      'Cogito 2.1 671B (Ollama)',      4,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
+    ['ollama', 'kimi-k2-thinking',     'Kimi K2 Thinking (Ollama)',     5,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
+    ['ollama', 'glm-4.7',              'GLM-4.7 (Ollama)',              6,  9, 'Frontier', null, null, null, null, 'session-based', 131072],
+    ['ollama', 'gpt-oss:120b',         'GPT-OSS 120B (Ollama)',         6,  9, 'Large',    null, null, null, null, 'session-based', 131072],
+    ['ollama', 'devstral-2:123b',      'Devstral 2 123B (Ollama)',      8, 10, 'Large',    null, null, null, null, 'session-based', 131072],
+    ['ollama', 'gpt-oss:20b',          'GPT-OSS 20B (Ollama)',         18, 10, 'Medium',   null, null, null, null, 'session-based', 131072],
+    ['ollama', 'gemma4:31b',           'Gemma 4 31B (Ollama)',         22, 10, 'Medium',   null, null, null, null, 'session-based', 131072],
+  ];
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    const missing = db.prepare(`
+      SELECT m.id FROM models m
+      LEFT JOIN fallback_config f ON m.id = f.model_db_id
+      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+    `).all() as { id: number }[];
+    if (missing.length > 0) {
+      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+    }
+  });
+  apply();
 }
 
 function ensureUnifiedKey(db: Database.Database) {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -86,6 +86,23 @@ register(new OpenAICompatProvider({
 // HF tool-call format issues; Moonshot moved to paid; MiniMax superseded by
 // the OpenRouter route (openrouter/minimax/minimax-m2.5:free).
 
+// Ollama Cloud — OpenAI-compatible. Free plan: 1 concurrent model, 5h session
+// caps, GPU-time-based quota (not per-token). Many catalog models on the
+// /v1/models list are subscription-only — Free returns 403 with an explicit
+// "this model requires a subscription" message. Catalog rows are filtered to
+// confirmed-Free entries.
+//
+// Frontier reasoning models (glm-4.7, kimi-k2-thinking, cogito-2.1:671b)
+// regularly take 30-90s on Ollama Cloud Free, so the timeout is bumped from
+// the default 15s. Ollama returns reasoning in `message.reasoning` (not
+// `reasoning_content`) — handled by normalizeChoices.
+register(new OpenAICompatProvider({
+  platform: 'ollama',
+  name: 'Ollama Cloud',
+  baseUrl: 'https://ollama.com/v1',
+  timeoutMs: 120000,
+}));
+
 export function getProvider(platform: Platform): BaseProvider | undefined {
   return providers.get(platform);
 }

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -160,22 +160,28 @@ export class OpenAICompatProvider extends BaseProvider {
  */
 function normalizeChoices(data: ChatCompletionResponse): void {
   for (const choice of data.choices ?? []) {
-    const msg = choice.message as ChatMessage & { reasoning_content?: string; content: unknown };
+    const msg = choice.message as ChatMessage & {
+      reasoning_content?: string;
+      reasoning?: string;
+      content: unknown;
+    };
     // Flatten array content (Mistral magistral) → join text segments.
     if (Array.isArray(msg.content)) {
       msg.content = (msg.content as Array<{ text?: string; type?: string }>)
         .map(seg => (typeof seg === 'string' ? seg : (seg.text ?? '')))
         .join('');
     }
-    // Fold reasoning_content into content if content is empty AND there are no
+    // Fold reasoning into content if content is empty AND there are no
     // tool_calls. With tool_calls present, content=null is the correct OpenAI
     // shape; folding reasoning would confuse clients that branch on content.
+    // Field naming varies by provider: Z.ai uses `reasoning_content`, Ollama
+    // uses `reasoning`. Prefer `reasoning_content` when both are set.
     const hasToolCalls = Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0;
-    if (!hasToolCalls
-        && (msg.content === '' || msg.content == null)
-        && typeof msg.reasoning_content === 'string'
-        && msg.reasoning_content.length > 0) {
-      msg.content = msg.reasoning_content;
+    if (!hasToolCalls && (msg.content === '' || msg.content == null)) {
+      const fold = (typeof msg.reasoning_content === 'string' && msg.reasoning_content.length > 0)
+        ? msg.reasoning_content
+        : (typeof msg.reasoning === 'string' && msg.reasoning.length > 0 ? msg.reasoning : null);
+      if (fold !== null) msg.content = fold;
     }
   }
 }

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -11,7 +11,7 @@ export const keysRouter = Router();
 // (see migrateModelsV4 comment block).
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
-  'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu',
+  'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
 ] as const;
 
 const addKeySchema = z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -15,7 +15,8 @@ export type Platform =
   | 'github'
   | 'cohere'
   | 'cloudflare'
-  | 'zhipu';
+  | 'zhipu'
+  | 'ollama';
 
 export interface Model {
   id: number;


### PR DESCRIPTION
## Summary
Adds **Ollama Cloud** as the 11th active platform — first new provider integration since Z.ai/Zhipu in V7.

Closes #14 (community request from @zhangyu1324).

## Why this fits the catalog
- **Genuinely free, no card** — Ollama Cloud's Free plan needs only an account; no payment method, no credit-card-on-file requirement.
- **Quota shape is different but real** — GPU-time-based, not per-token. 1 concurrent model, 5h session caps, 7-day rolling quota window. Translated to rough `monthly_token_budget` strings ("~5-10M" for Frontier, "~10-20M" for Large, "~20-30M" for Medium) so the existing UI sort/display still works.
- **Reaches models we don't have elsewhere** — Cogito 2.1 671B, Mistral Large 3 675B, Devstral 2 123B, Qwen3-Coder 480B, Kimi K2 Thinking aren't routable through any other platform in the catalog today.

## Changes
- `shared/types.ts` — adds `'ollama'` to the `Platform` union
- `server/src/providers/index.ts` — registers `OpenAICompatProvider` against `https://ollama.com/v1` with `timeoutMs: 120000` (frontier reasoning models take 30-90s on Free)
- `server/src/providers/openai-compat.ts` — extends `normalizeChoices` to fold Ollama's `message.reasoning` field (Z.ai uses `reasoning_content`, Ollama uses `reasoning`) into `message.content` when content is empty and there are no tool_calls
- `server/src/db/index.ts` — V10 migration adds 10 probe-verified Free-tier rows; auto-appends them to the fallback chain
- `server/src/routes/keys.ts` — adds `'ollama'` to the PLATFORMS allowlist
- `client/src/pages/KeysPage.tsx`, `FallbackPage.tsx` — adds Ollama to UI dropdowns/labels
- `server/src/__tests__/providers/openai-compat.test.ts` — +2 tests covering the Ollama reasoning-fold (with and without tool_calls)

## Catalog rows (V10)
| Model ID | Display | Tier |
|---|---|---|
| `qwen3-coder:480b` | Qwen3-Coder 480B | Frontier |
| `mistral-large-3:675b` | Mistral Large 3 675B | Frontier |
| `deepseek-v3.2` | DeepSeek V3.2 | Frontier |
| `cogito-2.1:671b` | Cogito 2.1 671B | Frontier |
| `kimi-k2-thinking` | Kimi K2 Thinking | Frontier |
| `glm-4.7` | GLM-4.7 | Frontier |
| `gpt-oss:120b` | GPT-OSS 120B | Large |
| `devstral-2:123b` | Devstral 2 123B | Large |
| `gpt-oss:20b` | GPT-OSS 20B | Medium |
| `gemma4:31b` | Gemma 4 31B | Medium |

Probe-verified against the Free tier (May 2026). Paid-only SKUs from the `/v1/models` listing were intentionally excluded.

## Test plan
- [x] `npm test --prefix server -- --run` — **92/92 passing** (added 2 new reasoning-fold tests)
- [x] `npm run build --prefix server` — tsc clean
- [x] Migration runs cleanly on a fresh `:memory:` DB (every test file exercises this)
- [x] Rebased onto current main; no conflicts with the recent #32/#40 changes