### PR TITLE
feat(router): exhaust all keys before falling back + tests (supersedes #33, credits @deadc)

### DIFF
--- a/server/src/__tests__/services/routing-exhaustion.test.ts
+++ b/server/src/__tests__/services/routing-exhaustion.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { routeRequest } from '../../services/router.js';
+import * as ratelimit from '../../services/ratelimit.js';
+import { getDb, initDb } from '../../db/index.js';
+import * as crypto from '../../lib/crypto.js';
+
+// Mock ratelimit to control quota availability
+vi.mock('../../services/ratelimit.js', async () => {
+  const actual = await vi.importActual('../../services/ratelimit.js');
+  return {
+    ...actual,
+    canMakeRequest: vi.fn(),
+    canUseTokens: vi.fn(),
+    isOnCooldown: vi.fn(() => false),
+  };
+});
+
+// Mock crypto to avoid IV errors
+vi.mock('../../lib/crypto.js', async () => {
+  const actual = await vi.importActual('../../lib/crypto.js');
+  return {
+    ...actual,
+    decrypt: vi.fn(() => 'mocked-api-key'),
+  };
+});
+
+describe('Routing Key Exhaustion', () => {
+  beforeEach(() => {
+    initDb(':memory:');
+    const db = getDb();
+    
+    // Setup: 2 models (Pro and Flash)
+    // Pro is higher priority (priority 1), Flash is lower (priority 2)
+    db.prepare("INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, enabled) VALUES ('google', 'gemini-1.5-pro', 'Pro', 1, 1, 1)").run();
+    db.prepare("INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, enabled) VALUES ('google', 'gemini-1.5-flash', 'Flash', 2, 2, 1)").run();
+    
+    const proId = db.prepare("SELECT id FROM models WHERE model_id = 'gemini-1.5-pro'").get().id;
+    const flashId = db.prepare("SELECT id FROM models WHERE model_id = 'gemini-1.5-flash'").get().id;
+    
+    db.prepare("INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, 1, 1)").run(proId);
+    db.prepare("INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, 2, 1)").run(flashId);
+    
+    // Setup: 2 keys for Google
+    db.prepare("INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled) VALUES ('google', 'Key A', 'enc', 'iv', 'tag', 'healthy', 1)").run();
+    db.prepare("INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled) VALUES ('google', 'Key B', 'enc', 'iv', 'tag', 'healthy', 1)").run();
+
+    vi.clearAllMocks();
+  });
+
+  it('should skip exhausted Key B and use functional Key A for the same high-priority model', () => {
+    const db = getDb();
+    const keys = db.prepare("SELECT id, label FROM api_keys").all();
+    const keyA = keys.find(k => k.label === 'Key A');
+    const keyB = keys.find(k => k.label === 'Key B');
+
+    // Mock behavior:
+    // Key B is exhausted (returns false for canMakeRequest)
+    // Key A is functional (returns true)
+    (ratelimit.canMakeRequest as any).mockImplementation((platform, modelId, keyId) => {
+      if (keyId === keyB.id) return false;
+      if (keyId === keyA.id) return true;
+      return true;
+    });
+    (ratelimit.canUseTokens as any).mockReturnValue(true);
+
+    // Act: Route request
+    const result = routeRequest(100);
+
+    // Assert: It should have picked the Pro model despite Key B being exhausted
+    expect(result.modelId).toBe('gemini-1.5-pro');
+    expect(result.keyId).toBe(keyA.id);
+    expect(ratelimit.canMakeRequest).toHaveBeenCalled();
+  });
+
+  it('should fallback to Flash model only if BOTH Key A and Key B are exhausted for Pro', () => {
+    const db = getDb();
+    const proId = db.prepare("SELECT id FROM models WHERE model_id = 'gemini-1.5-pro'").get().id;
+    const keys = db.prepare("SELECT id FROM api_keys").all();
+
+    // Mock behavior: Both keys for Google are exhausted
+    (ratelimit.canMakeRequest as any).mockReturnValue(false);
+
+    // Act: Route request
+    const result = routeRequest(100);
+
+    // Assert: Pro is exhausted, so it must fall back to Flash
+    // (Note: Flash will also fail in this mock because canMakeRequest returns false for everything, 
+    // but the router will try it. In reality, it would throw 429 if ALL are exhausted)
+    
+    // Let's adjust mock to allow Flash but not Pro
+    (ratelimit.canMakeRequest as any).mockImplementation((platform, modelId, keyId) => {
+      if (modelId === 'gemini-1.5-pro') return false;
+      if (modelId === 'gemini-1.5-flash') return true;
+      return true;
+    });
+
+    const result2 = routeRequest(100);
+    expect(result2.modelId).toBe('gemini-1.5-flash');
+  });
+});

--- a/server/src/__tests__/services/routing-exhaustion.test.ts
+++ b/server/src/__tests__/services/routing-exhaustion.test.ts
@@ -72,29 +72,20 @@ describe('Routing Key Exhaustion', () => {
     expect(ratelimit.canMakeRequest).toHaveBeenCalled();
   });
 
-  it('should fallback to Flash model only if BOTH Key A and Key B are exhausted for Pro', () => {
-    const db = getDb();
-    const proId = db.prepare("SELECT id FROM models WHERE model_id = 'gemini-1.5-pro'").get().id;
-    const keys = db.prepare("SELECT id FROM api_keys").all();
-
-    // Mock behavior: Both keys for Google are exhausted
+  it('should throw 429 when every key on every model is exhausted', () => {
     (ratelimit.canMakeRequest as any).mockReturnValue(false);
+    expect(() => routeRequest(100)).toThrow(/All models exhausted/);
+  });
 
-    // Act: Route request
-    const result = routeRequest(100);
-
-    // Assert: Pro is exhausted, so it must fall back to Flash
-    // (Note: Flash will also fail in this mock because canMakeRequest returns false for everything, 
-    // but the router will try it. In reality, it would throw 429 if ALL are exhausted)
-    
-    // Let's adjust mock to allow Flash but not Pro
-    (ratelimit.canMakeRequest as any).mockImplementation((platform, modelId, keyId) => {
+  it('should fall back to Flash when Pro is exhausted but Flash has quota', () => {
+    (ratelimit.canMakeRequest as any).mockImplementation((_platform: string, modelId: string) => {
       if (modelId === 'gemini-1.5-pro') return false;
       if (modelId === 'gemini-1.5-flash') return true;
       return true;
     });
+    (ratelimit.canUseTokens as any).mockReturnValue(true);
 
-    const result2 = routeRequest(100);
-    expect(result2.modelId).toBe('gemini-1.5-flash');
+    const result = routeRequest(100);
+    expect(result.modelId).toBe('gemini-1.5-flash');
   });
 });

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -174,7 +174,15 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
 
     if (keys.length === 0) continue;
 
-    // Round-robin across keys
+    // Get limits once for this model
+    const limits = {
+      rpm: model.rpm_limit,
+      rpd: model.rpd_limit,
+      tpm: model.tpm_limit,
+      tpd: model.tpd_limit,
+    };
+
+    // Try all keys for this model before giving up on it
     const rrKey = `${model.platform}:${model.model_id}`;
     let idx = roundRobinIndex.get(rrKey) ?? 0;
 
@@ -188,18 +196,11 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
       // Check cooldown (from previous 429s)
       if (isOnCooldown(model.platform, model.model_id, key.id)) continue;
 
-      const limits = {
-        rpm: model.rpm_limit,
-        rpd: model.rpd_limit,
-        tpm: model.tpm_limit,
-        tpd: model.tpd_limit,
-      };
-
       if (!canMakeRequest(model.platform, model.model_id, key.id, limits)) continue;
       if (!canUseTokens(model.platform, model.model_id, key.id, estimatedTokens, limits)) continue;
 
+      // We found a working key for this model!
       roundRobinIndex.set(rrKey, idx);
-
       const decryptedKey = decrypt(key.encrypted_key, key.iv, key.auth_tag);
 
       return {
@@ -213,7 +214,13 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
       };
     }
 
+    // If we reach here, this specific model has NO available keys.
+    // Update round-robin index even if we failed so we don't get stuck.
     roundRobinIndex.set(rrKey, idx);
+    
+    // We don't explicitly penalize the model here because the fact that we 
+    // couldn't find a key means we will naturally move to the next model 
+    // in the `sortedChain` for THIS specific request.
   }
 
   const err = new Error('All models exhausted. Add more API keys or wait for rate limits to reset.') as any;


### PR DESCRIPTION
Supersedes #33 (couldn't merge directly — that branch had unrelated commits from @deadc's already-merged #32 plus a revert, so it doesn't apply cleanly onto current main). This PR is a clean cherry-pick of the two routing commits onto today's main, plus one fix-up commit for a bug in the new test.

## What this changes

The intent of #33 was: "for a high-priority model, try every healthy key before giving up and moving to the next model in the fallback chain." On review, **that behavior already existed on main** — the inner `for (let attempt = 0; attempt < keys.length; attempt++)` loop in `routeRequest` already iterates all keys per model before falling through. So the actual code change is small:

- Hoist the `limits` object out of the inner loop (computed once per model instead of per key attempt — tiny optimization, identical behavior)
- Add clarifying comments explaining the model-first / key-exhaust-then-fall-back contract
- **+100 lines of new tests** in `server/src/__tests__/services/routing-exhaustion.test.ts` that document the behavior with explicit mocked scenarios (key A exhausted but key B works → still uses Pro; Pro exhausted on all keys → falls back to Flash; all exhausted → throws 429)

The third commit in this PR (`b80bd55`) fixes a bug in the new test file — the original second test made an unguarded `routeRequest(100)` call *before* adjusting its mock, which threw "All models exhausted" and crashed the test. Split into two clean tests: one asserts the throw, one asserts the fallback.

## Test plan
- [x] `npm test --prefix server -- --run` — **95/95 passing** (was 92 baseline + 3 new routing tests)
- [x] `npm run build --prefix server` — tsc clean
- [x] E2E smoke test against a running dev server: `/api/ping` 200, `/api/models` 72 rows (10 Ollama from V10 present), `/api/fallback` 72 rows, `/v1/chat/completions` returns 400 on bad body and 503 on no-keys path
- [x] Existing 5-test `router.test.ts` suite still passes (no regressions)

## Credit
Two commits authored by @deadc (preserved via cherry-pick). #33 will be closed referencing this PR.