### PR TITLE
Add Anthropic provider + performance improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # Server encryption key for API key storage (generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
 ENCRYPTION_KEY=your-64-char-hex-key-here
 
+# Optional: pin the OpenAI-compatible bearer token so serverless/ephemeral DB deploys do not regenerate it.
+# FREEAPI_UNIFIED_API_KEY=freellmapi-your-stable-key
+
 # Server port (default: 3001)
 PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ server/data/
 deploy-pi.sh
 update-hermes.sh
 .vercel
+.env*.local

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ server/data/
 # Personal deployment scripts (contain keys/credentials — kept local)
 deploy-pi.sh
 update-hermes.sh
+.vercel

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,17 @@
+import '../server/dist/env.js';
+import { createApp } from '../server/dist/app.js';
+import { initDb } from '../server/dist/db/index.js';
+
+let app;
+
+function getApp() {
+  if (!app) {
+    initDb();
+    app = createApp();
+  }
+  return app;
+}
+
+export default function handler(req, res) {
+  return getApp()(req, res);
+}

--- a/api/index.js
+++ b/api/index.js
@@ -1,17 +1,20 @@
 import '../server/dist/env.js';
 import { createApp } from '../server/dist/app.js';
-import { initDb } from '../server/dist/db/index.js';
+import { initDbFromPersistentSnapshot } from '../server/dist/db/index.js';
 
-let app;
+let appPromise;
 
-function getApp() {
-  if (!app) {
-    initDb();
-    app = createApp();
+async function getApp() {
+  if (!appPromise) {
+    appPromise = (async () => {
+      await initDbFromPersistentSnapshot();
+      return createApp();
+    })();
   }
-  return app;
+  return appPromise;
 }
 
-export default function handler(req, res) {
-  return getApp()(req, res);
+export default async function handler(req, res) {
+  const app = await getApp();
+  return app(req, res);
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, NavLink } from 'react-router-do
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { LogOut } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { ErrorBoundary } from '@/components/error-boundary'
 import KeysPage from '@/pages/KeysPage'
 import PlaygroundPage from '@/pages/PlaygroundPage'
 import FallbackPage from '@/pages/FallbackPage'
@@ -102,10 +103,10 @@ function DashboardShell() {
       <main className="max-w-6xl mx-auto px-6 py-8">
         <Routes>
           <Route path="/" element={<Navigate to="/playground" replace />} />
-          <Route path="/playground" element={<PlaygroundPage />} />
-          <Route path="/keys" element={<KeysPage />} />
-          <Route path="/fallback" element={<FallbackPage />} />
-          <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/playground" element={<ErrorBoundary><PlaygroundPage /></ErrorBoundary>} />
+          <Route path="/keys" element={<ErrorBoundary><KeysPage /></ErrorBoundary>} />
+          <Route path="/fallback" element={<ErrorBoundary><FallbackPage /></ErrorBoundary>} />
+          <Route path="/analytics" element={<ErrorBoundary><AnalyticsPage /></ErrorBoundary>} />
           <Route path="/test" element={<Navigate to="/playground" replace />} />
           <Route path="/health" element={<Navigate to="/keys" replace />} />
         </Routes>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, NavLink } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { LogOut } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import KeysPage from '@/pages/KeysPage'
 import PlaygroundPage from '@/pages/PlaygroundPage'
 import FallbackPage from '@/pages/FallbackPage'
 import AnalyticsPage from '@/pages/AnalyticsPage'
+import LoginPage from '@/pages/LoginPage'
 
 const queryClient = new QueryClient()
 
@@ -66,37 +68,60 @@ function Brand() {
   )
 }
 
+function LogoutButton() {
+  async function logout() {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'same-origin' })
+    window.location.assign('/login')
+  }
+
+  return (
+    <Button variant="ghost" size="icon-sm" onClick={logout} aria-label="Log out" title="Log out">
+      <LogOut />
+    </Button>
+  )
+}
+
+function DashboardShell() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b">
+        <div className="max-w-6xl mx-auto px-6 flex items-center">
+          <Brand />
+          <nav className="flex items-center gap-6 ml-10">
+            <NavItem to="/playground">Playground</NavItem>
+            <NavItem to="/keys">Keys</NavItem>
+            <NavItem to="/fallback">Fallback</NavItem>
+            <NavItem to="/analytics">Analytics</NavItem>
+          </nav>
+          <div className="ml-auto flex items-center gap-1 py-2">
+            <DarkModeToggle />
+            <LogoutButton />
+          </div>
+        </div>
+      </header>
+      <main className="max-w-6xl mx-auto px-6 py-8">
+        <Routes>
+          <Route path="/" element={<Navigate to="/playground" replace />} />
+          <Route path="/playground" element={<PlaygroundPage />} />
+          <Route path="/keys" element={<KeysPage />} />
+          <Route path="/fallback" element={<FallbackPage />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
+          <Route path="/test" element={<Navigate to="/playground" replace />} />
+          <Route path="/health" element={<Navigate to="/keys" replace />} />
+        </Routes>
+      </main>
+    </div>
+  )
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter basename={import.meta.env.BASE_URL}>
-        <div className="min-h-screen bg-background">
-          <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b">
-            <div className="max-w-6xl mx-auto px-6 flex items-center">
-              <Brand />
-              <nav className="flex items-center gap-6 ml-10">
-                <NavItem to="/playground">Playground</NavItem>
-                <NavItem to="/keys">Keys</NavItem>
-                <NavItem to="/fallback">Fallback</NavItem>
-                <NavItem to="/analytics">Analytics</NavItem>
-              </nav>
-              <div className="ml-auto py-2">
-                <DarkModeToggle />
-              </div>
-            </div>
-          </header>
-          <main className="max-w-6xl mx-auto px-6 py-8">
-            <Routes>
-              <Route path="/" element={<Navigate to="/playground" replace />} />
-              <Route path="/playground" element={<PlaygroundPage />} />
-              <Route path="/keys" element={<KeysPage />} />
-              <Route path="/fallback" element={<FallbackPage />} />
-              <Route path="/analytics" element={<AnalyticsPage />} />
-              <Route path="/test" element={<Navigate to="/playground" replace />} />
-              <Route path="/health" element={<Navigate to="/keys" replace />} />
-            </Routes>
-          </main>
-        </div>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/*" element={<DashboardShell />} />
+        </Routes>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,18 +1,108 @@
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 
-export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    credentials: 'same-origin',
-    ...options,
-  });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
-    if (res.status === 401 && typeof window !== 'undefined' && window.location.pathname !== '/login') {
-      const next = encodeURIComponent(`${window.location.pathname}${window.location.search}`);
-      window.location.assign(`${BASE}/login?next=${next}`);
+const DEFAULT_RETRY_OPTIONS = {
+  maxRetries: 3,
+  retryDelay: 1000,
+  retryStatuses: [408, 429, 500, 502, 503, 504],
+};
+
+/**
+ * Fetch wrapper with automatic retry for transient errors.
+ * Retries on 429, 5xx, and network errors.
+ */
+export async function apiFetch<T>(
+  path: string,
+  options?: RequestInit & { retry?: Partial<typeof DEFAULT_RETRY_OPTIONS> }
+): Promise<T> {
+  const { retry: retryOptions, ...fetchOptions } = options ?? {};
+  const retryConfig = { ...DEFAULT_RETRY_OPTIONS, ...retryOptions };
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= retryConfig.maxRetries; attempt++) {
+    try {
+      const res = await fetch(`${BASE}${path}`, {
+        headers: { 'Content-Type': 'application/json', ...fetchOptions?.headers },
+        credentials: 'same-origin',
+        ...fetchOptions,
+      });
+
+      // Handle auth redirect
+      if (res.status === 401 && typeof window !== 'undefined' && window.location.pathname !== '/login') {
+        const next = encodeURIComponent(`${window.location.pathname}${window.location.search}`);
+        window.location.assign(`${BASE}/login?next=${next}`);
+      }
+
+      // Don't retry client errors (except 429)
+      if (!retryConfig.retryStatuses.includes(res.status)) {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
+          throw new Error(body.error?.message ?? `HTTP ${res.status}`);
+        }
+        return res.json();
+      }
+
+      // Rate limited — wait and retry
+      lastError = new Error(`HTTP ${res.status}: ${res.statusText}`);
+      if (attempt < retryConfig.maxRetries) {
+        const retryAfter = res.headers.get('Retry-After');
+        const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : retryConfig.retryDelay * (attempt + 1);
+        await sleep(delay);
+        continue;
+      }
+    } catch (err) {
+      // Network error — retry
+      if (attempt < retryConfig.maxRetries) {
+        lastError = err as Error;
+        await sleep(retryConfig.retryDelay * (attempt + 1));
+        continue;
+      }
+      lastError = err as Error;
     }
-    throw new Error(body.error?.message ?? `HTTP ${res.status}`);
   }
-  return res.json();
+
+  throw lastError ?? new Error('Request failed after retries');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Simple GET request helper (no retry by default).
+ */
+export async function apiGet<T>(path: string): Promise<T> {
+  return apiFetch<T>(path);
+}
+
+/**
+ * POST request helper with optional retry.
+ */
+export async function apiPost<T>(
+  path: string,
+  body: unknown,
+  options?: { retry?: boolean }
+): Promise<T> {
+  return apiFetch<T>(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    retry: options?.retry ? {} : undefined,
+  });
+}
+
+/**
+ * DELETE request helper.
+ */
+export async function apiDelete<T>(path: string): Promise<T> {
+  return apiFetch<T>(path, { method: 'DELETE' });
+}
+
+/**
+ * PATCH request helper.
+ */
+export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  return apiFetch<T>(path, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -3,10 +3,15 @@ const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
 export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'same-origin',
     ...options,
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
+    if (res.status === 401 && typeof window !== 'undefined' && window.location.pathname !== '/login') {
+      const next = encodeURIComponent(`${window.location.pathname}${window.location.search}`);
+      window.location.assign(`${BASE}/login?next=${next}`);
+    }
     throw new Error(body.error?.message ?? `HTTP ${res.status}`);
   }
   return res.json();

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -62,7 +62,7 @@ function UnifiedKeySection() {
   const [showKey, setShowKey] = useState(false)
   const [copied, setCopied] = useState(false)
 
-  const { data } = useQuery<{ apiKey: string }>({
+  const { data } = useQuery<{ apiKey: string; pinned?: boolean }>({
     queryKey: ['unified-key'],
     queryFn: () => apiFetch('/api/settings/api-key'),
   })
@@ -73,6 +73,7 @@ function UnifiedKeySection() {
   })
 
   const apiKey = data?.apiKey ?? ''
+  const pinned = data?.pinned === true
   const masked = apiKey ? apiKey.slice(0, 13) + '•'.repeat(32) : '…'
   const baseUrl = import.meta.env.DEV
     ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
@@ -97,7 +98,8 @@ function UnifiedKeySection() {
           variant="ghost"
           size="sm"
           onClick={() => regenerate.mutate()}
-          disabled={regenerate.isPending}
+          disabled={pinned || regenerate.isPending}
+          title={pinned ? 'Pinned by FREEAPI_UNIFIED_API_KEY' : 'Regenerate unified API key'}
         >
           Regenerate
         </Button>
@@ -120,6 +122,12 @@ function UnifiedKeySection() {
         <code className="font-mono">{baseUrl}</code>
         <span className="text-muted-foreground">Endpoint</span>
         <code className="font-mono">/v1/chat/completions</code>
+        {pinned ? (
+          <>
+            <span className="text-muted-foreground">Key mode</span>
+            <code className="font-mono">pinned by env</code>
+          </>
+        ) : null}
       </div>
     </section>
   )

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -5,8 +5,10 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { PageHeader } from '@/components/page-header'
-import type { ApiKey, Platform } from '../../../shared/types'
+import { Download, Upload } from 'lucide-react'
+import type { ApiKey, ApiKeyImportInput, ApiKeyImportResult, FreeLLMBackup, Platform } from '../../../shared/types'
 
 const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'google', label: 'Google AI Studio' },
@@ -40,6 +42,156 @@ const statusLabel: Record<string, string> = {
   invalid: 'invalid',
   error: 'error',
   unknown: 'unchecked',
+}
+
+type ImportMode = 'append' | 'replace'
+
+interface BackupImportResult {
+  success: boolean
+  keys: ApiKeyImportResult
+  fallback: { updated: number; skipped: number; errors: { index: number; message: string }[] }
+  unifiedApiKey: { restored: boolean; skipped: boolean; reason?: string }
+}
+
+const platformValues = new Set<string>(PLATFORMS.map(p => p.value))
+
+function isPlatform(value: string): value is Platform {
+  return platformValues.has(value)
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = []
+  let current = ''
+  let quoted = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+    if (char === '"') {
+      if (quoted && line[i + 1] === '"') {
+        current += '"'
+        i += 1
+      } else {
+        quoted = !quoted
+      }
+      continue
+    }
+    if (char === ',' && !quoted) {
+      values.push(current.trim())
+      current = ''
+      continue
+    }
+    current += char
+  }
+
+  values.push(current.trim())
+  return values
+}
+
+function parseEnabled(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value
+  if (value === undefined || value === null || value === '') return undefined
+  const normalized = String(value).trim().toLowerCase()
+  if (['1', 'true', 'yes', 'enabled', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'disabled', 'off'].includes(normalized)) return false
+  return undefined
+}
+
+function normalizeImportKey(raw: unknown): ApiKeyImportInput | null {
+  if (!raw || typeof raw !== 'object') return null
+  const entry = raw as Record<string, unknown>
+  const platform = String(entry.platform ?? '').trim()
+  const key = String(entry.key ?? entry.apiKey ?? entry.api_key ?? '').trim()
+  if (!isPlatform(platform) || !key) return null
+
+  const label = String(entry.label ?? entry.name ?? '').trim()
+  const enabled = parseEnabled(entry.enabled)
+  return {
+    platform,
+    key,
+    ...(label ? { label } : {}),
+    ...(enabled === undefined ? {} : { enabled }),
+  }
+}
+
+function parseTextImport(text: string): ApiKeyImportInput[] {
+  const lines = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#'))
+
+  if (lines.length === 0) return []
+
+  const firstRow = parseCsvLine(lines[0]).map(value => value.toLowerCase())
+  const keyHeader = firstRow.findIndex(value => ['key', 'apikey', 'api_key'].includes(value))
+  const platformHeader = firstRow.indexOf('platform')
+  const hasHeader = platformHeader >= 0 && keyHeader >= 0
+
+  if (hasHeader) {
+    const labelHeader = firstRow.indexOf('label')
+    const enabledHeader = firstRow.indexOf('enabled')
+    return lines.slice(1).flatMap(line => {
+      const row = parseCsvLine(line)
+      const parsed = normalizeImportKey({
+        platform: row[platformHeader],
+        key: row[keyHeader],
+        label: labelHeader >= 0 ? row[labelHeader] : undefined,
+        enabled: enabledHeader >= 0 ? parseEnabled(row[enabledHeader]) : undefined,
+      })
+      return parsed ? [parsed] : []
+    })
+  }
+
+  return lines.flatMap(line => {
+    const eq = line.indexOf('=')
+    if (eq > 0) {
+      const platform = line.slice(0, eq).trim()
+      const key = line.slice(eq + 1).trim()
+      const parsed = normalizeImportKey({ platform, key })
+      if (parsed) return [parsed]
+    }
+
+    const [platform, key, label, enabled] = parseCsvLine(line)
+    const parsed = normalizeImportKey({ platform, key, label, enabled: parseEnabled(enabled) })
+    return parsed ? [parsed] : []
+  })
+}
+
+function buildImportRequest(text: string, mode: ImportMode): {
+  endpoint: '/api/keys/import' | '/api/backup/import'
+  body: unknown
+} {
+  const trimmed = text.trim()
+  if (!trimmed) throw new Error('No import data')
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (Array.isArray(parsed)) {
+      return { endpoint: '/api/keys/import', body: { mode, keys: parsed } }
+    }
+    if (parsed && typeof parsed === 'object') {
+      const backup = parsed as Record<string, unknown>
+      if (Array.isArray(backup.providerKeys) || Array.isArray(backup.fallback) || typeof backup.unifiedApiKey === 'string') {
+        return { endpoint: '/api/backup/import', body: { ...backup, mode } }
+      }
+      if (Array.isArray(backup.keys)) {
+        return { endpoint: '/api/keys/import', body: { mode, keys: backup.keys } }
+      }
+    }
+  } catch {
+    // Fall back to CSV/plain text parsing.
+  }
+
+  const keys = parseTextImport(trimmed)
+  if (keys.length === 0) throw new Error('No valid keys found')
+  return { endpoint: '/api/keys/import', body: { mode, keys } }
+}
+
+function keyImportSummary(result: ApiKeyImportResult): string {
+  const parts = [`${result.inserted} imported`]
+  if (result.skipped) parts.push(`${result.skipped} skipped`)
+  if (result.replaced) parts.push(`${result.replaced} replaced`)
+  if (result.errors.length) parts.push(`${result.errors.length} errors`)
+  return parts.join(', ')
 }
 
 interface HealthPlatform {
@@ -139,6 +291,9 @@ export default function KeysPage() {
   const [apiKey, setApiKey] = useState('')
   const [accountId, setAccountId] = useState('')
   const [label, setLabel] = useState('')
+  const [bulkText, setBulkText] = useState('')
+  const [importMode, setImportMode] = useState<ImportMode>('append')
+  const [importMessage, setImportMessage] = useState('')
 
   const { data: keys = [], isLoading } = useQuery<ApiKey[]>({
     queryKey: ['keys'],
@@ -163,6 +318,35 @@ export default function KeysPage() {
       setAccountId('')
       setLabel('')
     },
+  })
+
+  const downloadBackup = useMutation({
+    mutationFn: () => apiFetch<FreeLLMBackup>('/api/backup/export'),
+    onSuccess: backup => {
+      const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `freellmapi-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`
+      link.click()
+      URL.revokeObjectURL(url)
+    },
+  })
+
+  const bulkImport = useMutation({
+    mutationFn: ({ endpoint, body }: { endpoint: '/api/keys/import' | '/api/backup/import'; body: unknown }) =>
+      apiFetch<ApiKeyImportResult | BackupImportResult>(endpoint, { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: result => {
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+      queryClient.invalidateQueries({ queryKey: ['health'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      const keyResult = 'success' in result ? result.keys : result
+      const fallbackUpdated = 'success' in result && result.fallback.updated > 0
+        ? `, ${result.fallback.updated} fallback rules updated`
+        : ''
+      setImportMessage(`${keyImportSummary(keyResult)}${fallbackUpdated}`)
+    },
+    onError: error => setImportMessage((error as Error).message),
   })
 
   const deleteKey = useMutation({
@@ -199,6 +383,29 @@ export default function KeysPage() {
     addKey.mutate({ platform, key, label: label || undefined })
   }
 
+  const handleBulkImport = (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      setImportMessage('')
+      bulkImport.mutate(buildImportRequest(bulkText, importMode))
+    } catch (error) {
+      setImportMessage((error as Error).message)
+    }
+  }
+
+  const handleImportFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+    try {
+      setBulkText(await file.text())
+      setImportMessage('')
+    } catch (error) {
+      setImportMessage((error as Error).message)
+    } finally {
+      event.target.value = ''
+    }
+  }
+
   const healthKeyMap = new Map<number, { status: string; lastCheckedAt: string | null }>()
   for (const k of healthData?.keys ?? []) healthKeyMap.set(k.id, k)
 
@@ -223,6 +430,59 @@ export default function KeysPage() {
 
       <div className="space-y-8">
         <UnifiedKeySection />
+
+        <section>
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <h2 className="text-sm font-medium">Backup and bulk import</h2>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => downloadBackup.mutate()}
+              disabled={downloadBackup.isPending}
+            >
+              <Download className="size-4" />
+              {downloadBackup.isPending ? 'Preparing' : 'Download backup'}
+            </Button>
+          </div>
+
+          <form onSubmit={handleBulkImport} className="rounded-lg border p-4 bg-card space-y-3">
+            <Textarea
+              value={bulkText}
+              onChange={event => setBulkText(event.target.value)}
+              placeholder={'platform,key,label\ngoogle,AIza...,personal\ngroq,gsk...,batch'}
+              className="min-h-[132px] font-mono text-xs"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Mode</Label>
+                <Select value={importMode} onValueChange={value => setImportMode(value as ImportMode)}>
+                  <SelectTrigger className="w-[160px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="append">Append</SelectItem>
+                    <SelectItem value="replace">Replace keys</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">File</Label>
+                <Input
+                  type="file"
+                  accept=".json,.csv,.txt,application/json,text/csv,text/plain"
+                  onChange={handleImportFile}
+                  className="w-[260px]"
+                />
+              </div>
+              <div className="flex-1" />
+              {importMessage && <span className="text-xs text-muted-foreground">{importMessage}</span>}
+              <Button type="submit" size="sm" disabled={!bulkText.trim() || bulkImport.isPending}>
+                <Upload className="size-4" />
+                {bulkImport.isPending ? 'Importing' : 'Import'}
+              </Button>
+            </div>
+          </form>
+        </section>
 
         <section>
           <h2 className="text-sm font-medium mb-3">Add a provider key</h2>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { LockKeyhole } from 'lucide-react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { apiFetch } from '@/lib/api'
+
+function safeNext(value: string | null): string {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return '/playground'
+  return value
+}
+
+export default function LoginPage() {
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+  const [username, setUsername] = useState('nguyenhoang287')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function submit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      await apiFetch('/api/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ username, password }),
+      })
+      navigate(safeNext(params.get('next')), { replace: true })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background flex items-center justify-center px-6">
+      <form onSubmit={submit} className="w-full max-w-sm rounded-lg border bg-card p-6 shadow-sm">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <LockKeyhole className="size-4" />
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold tracking-tight">FreeLLMAPI</h1>
+            <p className="text-sm text-muted-foreground">Sign in</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              autoComplete="username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mt-4 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+
+        <Button type="submit" className="mt-6 w-full" disabled={loading}>
+          {loading ? 'Signing in...' : 'Sign in'}
+        </Button>
+      </form>
+    </main>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,118 @@
+import { next } from '@vercel/functions';
+
+const SESSION_COOKIE = 'freellmapi_session';
+const DEFAULT_USERNAME = 'nguyenhoang287';
+const DEFAULT_PASSWORD = 'Matkhau1@';
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function authUsername(): string {
+  return process.env.FREELLM_AUTH_USERNAME ?? process.env.AUTH_USERNAME ?? DEFAULT_USERNAME;
+}
+
+function authPassword(): string {
+  return process.env.FREELLM_AUTH_PASSWORD ?? process.env.AUTH_PASSWORD ?? DEFAULT_PASSWORD;
+}
+
+function authSecret(): string {
+  return process.env.FREELLM_AUTH_SECRET
+    ?? process.env.AUTH_SECRET
+    ?? process.env.ENCRYPTION_KEY
+    ?? `${authUsername()}:${authPassword()}`;
+}
+
+function parseCookies(request: Request): Record<string, string> {
+  const header = request.headers.get('cookie');
+  if (!header) return {};
+
+  return header.split(';').reduce<Record<string, string>>((cookies, part) => {
+    const index = part.indexOf('=');
+    if (index === -1) return cookies;
+    const key = part.slice(0, index).trim();
+    const value = part.slice(index + 1).trim();
+    if (key) cookies[key] = value;
+    return cookies;
+  }, {});
+}
+
+function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i += 1) result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return result === 0;
+}
+
+async function sign(value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(authSecret()),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(value));
+  return bytesToBase64Url(new Uint8Array(signature));
+}
+
+async function hasValidSession(request: Request): Promise<boolean> {
+  const token = parseCookies(request)[SESSION_COOKIE];
+  if (!token) return false;
+
+  const [encoded, signature] = token.split('.');
+  if (!encoded || !signature || !safeEqual(signature, await sign(encoded))) return false;
+
+  try {
+    const payload = JSON.parse(decoder.decode(base64UrlToBytes(encoded))) as {
+      sub?: unknown;
+      exp?: unknown;
+      nonce?: unknown;
+    };
+    return typeof payload.sub === 'string'
+      && typeof payload.exp === 'number'
+      && typeof payload.nonce === 'string'
+      && payload.exp > Math.floor(Date.now() / 1000)
+      && safeEqual(payload.sub, authUsername());
+  } catch {
+    return false;
+  }
+}
+
+function isPublicPath(pathname: string): boolean {
+  if (pathname === '/login') return true;
+  if (pathname.startsWith('/api/auth/')) return true;
+  if (pathname === '/v1' || pathname.startsWith('/v1/')) return true;
+  return /\.(?:css|js|map|svg|png|jpg|jpeg|webp|ico|woff2?|ttf)$/i.test(pathname);
+}
+
+export default async function middleware(request: Request) {
+  const url = new URL(request.url);
+  if (isPublicPath(url.pathname) || await hasValidSession(request)) {
+    return next();
+  }
+
+  if (url.pathname.startsWith('/api/')) {
+    return new Response(JSON.stringify({ error: { message: 'Authentication required' } }), {
+      status: 401,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  const loginUrl = new URL('/login', request.url);
+  loginUrl.searchParams.set('next', `${url.pathname}${url.search}`);
+  return Response.redirect(loginUrl, 302);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "client"
       ],
       "dependencies": {
+        "@vercel/blob": "^2.4.0",
         "@vercel/functions": "^3.6.0"
       },
       "devDependencies": {
@@ -1198,422 +1199,6 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.3.2",
         "get-tsconfig": "^4.7.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3804,6 +3389,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.4.0.tgz",
+      "integrity": "sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@vercel/functions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
@@ -4099,6 +3700,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/balanced-match": {
@@ -6853,6 +6463,29 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -8745,6 +8378,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
@@ -9490,6 +9132,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10240,6 +9894,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
         "server",
         "client"
       ],
+      "dependencies": {
+        "@vercel/functions": "^3.6.0"
+      },
       "devDependencies": {
         "concurrently": "^9.1.2"
       }
@@ -81,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -537,6 +541,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -747,27 +752,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1228,7 +1212,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1245,7 +1228,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1262,7 +1244,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1279,7 +1260,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1296,7 +1276,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1313,7 +1292,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1330,7 +1308,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1347,7 +1324,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1364,7 +1340,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1381,7 +1356,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1398,7 +1372,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1415,7 +1388,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1432,7 +1404,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1449,7 +1420,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1466,7 +1436,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1483,7 +1452,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1500,7 +1468,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1517,7 +1484,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1534,7 +1500,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1551,7 +1516,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1568,7 +1532,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1585,7 +1548,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1602,7 +1564,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1619,7 +1580,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1636,7 +1596,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1653,7 +1612,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2191,6 +2149,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3302,6 +3261,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3494,6 +3454,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3592,6 +3553,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3842,6 +3804,35 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vercel/functions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.6.0.tgz",
+      "integrity": "sha512-Xj68JYqqJwtqFWJN7EWmFN7MOiUjv5whjw48UEKqQbg8r7hRkhuJhncTU0ba3jJCh/wxEuLWckrtsKcrHQraxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.4.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.4.1.tgz",
+      "integrity": "sha512-H6B+/ig/GoahccL3WZjiHayHw1H5KhvTJNceqYulwfK9kkz5iul2hTmYzcJ7tTCQzyd0dutuL9xYFZCyLUqsog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -3975,6 +3966,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4154,6 +4146,7 @@
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4248,6 +4241,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5772,49 +5766,6 @@
         "benchmarks"
       ]
     },
-    "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -5849,6 +5800,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6136,6 +6088,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6727,6 +6680,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7093,6 +7047,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7231,6 +7186,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -7746,6 +7702,7 @@
       "integrity": "sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -8553,6 +8510,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8562,6 +8520,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8581,6 +8540,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8714,7 +8674,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9733,7 +9694,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9750,7 +9710,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9767,7 +9726,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9784,7 +9742,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9801,7 +9758,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9818,7 +9774,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9835,7 +9790,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9852,7 +9806,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9869,7 +9822,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9886,7 +9838,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9903,7 +9854,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9920,7 +9870,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9937,7 +9886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9954,7 +9902,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9971,7 +9918,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9988,7 +9934,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10005,7 +9950,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10022,7 +9966,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10039,7 +9982,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10056,7 +9998,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10073,7 +10014,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10090,7 +10030,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10107,7 +10046,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10124,7 +10062,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10141,7 +10078,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10158,7 +10094,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10274,6 +10209,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10452,6 +10388,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11696,6 +11633,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11954,6 +11892,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vercel/functions": "^3.6.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "concurrently": "^9.1.2"
       }
     },
@@ -1835,6 +1836,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -2470,6 +2487,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -3080,6 +3104,17 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -5738,12 +5773,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6440,9 +6475,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7895,6 +7930,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -9057,6 +9139,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tabbable": {
@@ -11592,7 +11698,9 @@
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.44.2",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.1.0",
+        "swagger-ui-express": "^5.0.1",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -11600,6 +11708,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.2",
         "@types/node": "^22.15.3",
+        "@types/swagger-ui-express": "^4.1.8",
         "drizzle-kit": "^0.31.1",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "devDependencies": {
     "concurrently": "^9.1.2"
+  },
+  "dependencies": {
+    "@vercel/functions": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "concurrently": "^9.1.2"
   },
   "dependencies": {
+    "@vercel/blob": "^2.4.0",
     "@vercel/functions": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:server": "npm run build -w server"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "concurrently": "^9.1.2"
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,9 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.1.0",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^3.24.4"
   },
   "devDependencies": {
@@ -25,6 +27,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.2",
     "@types/node": "^22.15.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "drizzle-kit": "^0.31.1",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",

--- a/server/src/__tests__/routes/backup.test.ts
+++ b/server/src/__tests__/routes/backup.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, body?: any) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+describe('Backup API', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    delete process.env.FREEAPI_UNIFIED_API_KEY;
+    delete process.env.FREELLM_UNIFIED_API_KEY;
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+  });
+
+  it('GET /api/backup/export includes decrypted provider keys and fallback config', async () => {
+    await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_backup_secret',
+      label: 'Backup Key',
+    });
+
+    const { status, body } = await request(app, 'GET', '/api/backup/export');
+
+    expect(status).toBe(200);
+    expect(body.format).toBe('freellmapi-backup');
+    expect(body.providerKeys).toHaveLength(1);
+    expect(body.providerKeys[0]).toMatchObject({
+      platform: 'groq',
+      label: 'Backup Key',
+      key: 'gsk_backup_secret',
+    });
+    expect(body.fallback.length).toBeGreaterThan(0);
+  });
+
+  it('POST /api/backup/import restores exported provider keys', async () => {
+    await request(app, 'POST', '/api/keys', {
+      platform: 'google',
+      key: 'AIza_backup_restore',
+      label: 'Restore Key',
+    });
+    const { body: backup } = await request(app, 'GET', '/api/backup/export');
+
+    getDb().prepare('DELETE FROM api_keys').run();
+    expect((await request(app, 'GET', '/api/keys')).body).toHaveLength(0);
+
+    const { status, body } = await request(app, 'POST', '/api/backup/import', {
+      ...backup,
+      mode: 'replace',
+      restoreUnifiedApiKey: false,
+    });
+
+    expect(status).toBe(201);
+    expect(body.keys.inserted).toBe(1);
+
+    const { body: restored } = await request(app, 'GET', '/api/keys');
+    expect(restored).toHaveLength(1);
+    expect(restored[0].platform).toBe('google');
+    expect(restored[0].label).toBe('Restore Key');
+  });
+});

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -80,6 +80,46 @@ describe('Keys API', () => {
     expect(status).toBe(400);
   });
 
+  it('POST /api/keys/import creates many keys and skips duplicates', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys/import', {
+      keys: [
+        { platform: 'groq', key: 'gsk_bulk_1', label: 'Bulk 1' },
+        { platform: 'google', key: 'AIza_bulk_2', label: 'Bulk 2' },
+        { platform: 'groq', key: 'gsk_bulk_1', label: 'Duplicate' },
+      ],
+    });
+
+    expect(status).toBe(201);
+    expect(body.inserted).toBe(2);
+    expect(body.skipped).toBe(1);
+
+    const { body: after } = await request(app, 'GET', '/api/keys');
+    expect(after).toHaveLength(2);
+  });
+
+  it('POST /api/keys/import replace mode clears existing keys first', async () => {
+    await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_existing',
+    });
+
+    const { status, body } = await request(app, 'POST', '/api/keys/import', {
+      mode: 'replace',
+      keys: [
+        { platform: 'google', key: 'AIza_replacement_1' },
+        { platform: 'openrouter', key: 'sk-or-replacement-2' },
+      ],
+    });
+
+    expect(status).toBe(201);
+    expect(body.inserted).toBe(2);
+    expect(body.replaced).toBe(1);
+
+    const { body: after } = await request(app, 'GET', '/api/keys');
+    expect(after).toHaveLength(2);
+    expect(after.map((key: any) => key.platform).sort()).toEqual(['google', 'openrouter']);
+  });
+
   it('DELETE /api/keys/:id removes a key', async () => {
     const { body: created } = await request(app, 'POST', '/api/keys', {
       platform: 'groq',

--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -20,11 +20,11 @@ describe('Router', () => {
     }
   });
 
-  it('should throw when no keys are configured', () => {
-    expect(() => routeRequest()).toThrow(/exhausted/i);
+  it('should throw when no keys are configured', async () => {
+    await expect(routeRequest()).rejects.toThrow(/exhausted/i);
   });
 
-  it('should route to highest priority model with available key', () => {
+  it('should route to highest priority model with available key', async () => {
     const db = getDb();
     const { encrypted, iv, authTag } = encrypt('test-groq-key');
     db.prepare(`
@@ -32,12 +32,12 @@ describe('Router', () => {
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run('groq', 'test', encrypted, iv, authTag, 'healthy', 1);
 
-    const result = routeRequest();
+    const result = await routeRequest();
     expect(result.platform).toBe('groq');
     expect(result.apiKey).toBe('test-groq-key');
   });
 
-  it('should prefer higher-priority model when keys exist for multiple platforms', () => {
+  it('should prefer higher-priority model when keys exist for multiple platforms', async () => {
     const db = getDb();
 
     const googleKey = encrypt('test-google-key');
@@ -55,11 +55,11 @@ describe('Router', () => {
     // Post-V6: Google's gemini-3.1-pro-preview (rank 1, free-tier-eligible per
     // probe on 2026-04-25) outranks Groq's best free-tier model openai/gpt-oss-120b
     // (rank 6). With keys for both platforms, Google wins.
-    const result = routeRequest();
+    const result = await routeRequest();
     expect(result.platform).toBe('google');
   });
 
-  it('should skip disabled keys', () => {
+  it('should skip disabled keys', async () => {
     const db = getDb();
 
     const googleKey = encrypt('test-google-key');
@@ -74,11 +74,11 @@ describe('Router', () => {
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
 
-    const result = routeRequest();
+    const result = await routeRequest();
     expect(result.platform).toBe('groq');
   });
 
-  it('should skip invalid keys', () => {
+  it('should skip invalid keys', async () => {
     const db = getDb();
 
     const invalidKey = encrypt('invalid-key');
@@ -93,7 +93,7 @@ describe('Router', () => {
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
 
-    const result = routeRequest();
+    const result = await routeRequest();
     expect(result.platform).toBe('groq');
   });
 });

--- a/server/src/__tests__/services/routing-exhaustion.test.ts
+++ b/server/src/__tests__/services/routing-exhaustion.test.ts
@@ -24,6 +24,11 @@ vi.mock('../../lib/crypto.js', async () => {
   };
 });
 
+// Mock db-refresh to avoid side effects during tests
+vi.mock('../../lib/db-refresh.js', () => ({
+  throttledRefresh: vi.fn(() => Promise.resolve({ refreshed: false, stale: false })),
+}));
+
 describe('Routing Key Exhaustion', () => {
   beforeEach(() => {
     initDb(':memory:');
@@ -47,16 +52,16 @@ describe('Routing Key Exhaustion', () => {
     vi.clearAllMocks();
   });
 
-  it('should skip exhausted Key B and use functional Key A for the same high-priority model', () => {
+  it('should skip exhausted Key B and use functional Key A for the same high-priority model', async () => {
     const db = getDb();
     const keys = db.prepare("SELECT id, label FROM api_keys").all();
-    const keyA = keys.find(k => k.label === 'Key A');
-    const keyB = keys.find(k => k.label === 'Key B');
+    const keyA = keys.find((k: any) => k.label === 'Key A');
+    const keyB = keys.find((k: any) => k.label === 'Key B');
 
     // Mock behavior:
     // Key B is exhausted (returns false for canMakeRequest)
     // Key A is functional (returns true)
-    (ratelimit.canMakeRequest as any).mockImplementation((platform, modelId, keyId) => {
+    (ratelimit.canMakeRequest as any).mockImplementation((_platform: string, _modelId: string, keyId: number) => {
       if (keyId === keyB.id) return false;
       if (keyId === keyA.id) return true;
       return true;
@@ -64,7 +69,7 @@ describe('Routing Key Exhaustion', () => {
     (ratelimit.canUseTokens as any).mockReturnValue(true);
 
     // Act: Route request
-    const result = routeRequest(100);
+    const result = await routeRequest(100);
 
     // Assert: It should have picked the Pro model despite Key B being exhausted
     expect(result.modelId).toBe('gemini-1.5-pro');
@@ -72,12 +77,12 @@ describe('Routing Key Exhaustion', () => {
     expect(ratelimit.canMakeRequest).toHaveBeenCalled();
   });
 
-  it('should throw 429 when every key on every model is exhausted', () => {
+  it('should throw 429 when every key on every model is exhausted', async () => {
     (ratelimit.canMakeRequest as any).mockReturnValue(false);
-    expect(() => routeRequest(100)).toThrow(/All models exhausted/);
+    await expect(routeRequest(100)).rejects.toThrow(/All models exhausted/);
   });
 
-  it('should fall back to Flash when Pro is exhausted but Flash has quota', () => {
+  it('should fall back to Flash when Pro is exhausted but Flash has quota', async () => {
     (ratelimit.canMakeRequest as any).mockImplementation((_platform: string, modelId: string) => {
       if (modelId === 'gemini-1.5-pro') return false;
       if (modelId === 'gemini-1.5-flash') return true;
@@ -85,7 +90,7 @@ describe('Routing Key Exhaustion', () => {
     });
     (ratelimit.canUseTokens as any).mockReturnValue(true);
 
-    const result = routeRequest(100);
+    const result = await routeRequest(100);
     expect(result.modelId).toBe('gemini-1.5-flash');
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -11,6 +11,7 @@ import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
 import { errorHandler } from './middleware/errorHandler.js';
+import { authRouter, requireDashboardAuth } from './auth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -26,6 +27,9 @@ export function createApp() {
   app.use(helmet({ contentSecurityPolicy: false, hsts: false }));
   app.use(cors());
   app.use(express.json({ limit: '1mb' }));
+
+  app.use('/api/auth', authRouter);
+  app.use(requireDashboardAuth);
 
   // API routes
   app.use('/api/keys', keysRouter);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { fallbackRouter } from './routes/fallback.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
+import { backupRouter } from './routes/backup.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { authRouter, requireDashboardAuth } from './auth.js';
 import { refreshDbFromPersistentSnapshot } from './db/index.js';
@@ -27,7 +28,7 @@ export function createApp() {
   // (which is also not a supported deployment — see README).
   app.use(helmet({ contentSecurityPolicy: false, hsts: false }));
   app.use(cors());
-  app.use(express.json({ limit: '1mb' }));
+  app.use(express.json({ limit: '5mb' }));
 
   app.use(async (req, _res, next) => {
     if (!req.path.startsWith('/api/') && !req.path.startsWith('/v1/')) {
@@ -53,6 +54,7 @@ export function createApp() {
   app.use('/api/analytics', analyticsRouter);
   app.use('/api/health', healthRouter);
   app.use('/api/settings', settingsRouter);
+  app.use('/api/backup', backupRouter);
 
   // OpenAI-compatible proxy
   app.use('/v1', proxyRouter);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,6 +12,7 @@ import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
 import { errorHandler } from './middleware/errorHandler.js';
 import { authRouter, requireDashboardAuth } from './auth.js';
+import { refreshDbFromPersistentSnapshot } from './db/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -27,6 +28,20 @@ export function createApp() {
   app.use(helmet({ contentSecurityPolicy: false, hsts: false }));
   app.use(cors());
   app.use(express.json({ limit: '1mb' }));
+
+  app.use(async (req, _res, next) => {
+    if (!req.path.startsWith('/api/') && !req.path.startsWith('/v1/')) {
+      next();
+      return;
+    }
+
+    try {
+      await refreshDbFromPersistentSnapshot();
+      next();
+    } catch (err) {
+      next(err);
+    }
+  });
 
   app.use('/api/auth', authRouter);
   app.use(requireDashboardAuth);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,8 @@ import cors from 'cors';
 import helmet from 'helmet';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import swaggerUi from 'swagger-ui-express';
 import { keysRouter } from './routes/keys.js';
 import { modelsRouter } from './routes/models.js';
 import { proxyRouter } from './routes/proxy.js';
@@ -12,10 +14,15 @@ import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
 import { backupRouter } from './routes/backup.js';
 import { errorHandler } from './middleware/errorHandler.js';
+import { authRateLimiter, keysRateLimiter, apiRateLimiter } from './middleware/rateLimit.js';
 import { authRouter, requireDashboardAuth } from './auth.js';
-import { refreshDbFromPersistentSnapshot } from './db/index.js';
+import { throttledRefresh } from './lib/db-refresh.js';
 
+// Load OpenAPI spec at runtime
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const openapiSpec = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'docs/openapi.json'), 'utf-8')
+);
 
 export function createApp() {
   const app = express();
@@ -30,31 +37,36 @@ export function createApp() {
   app.use(cors());
   app.use(express.json({ limit: '5mb' }));
 
-  app.use(async (req, _res, next) => {
+  // Lazy DB refresh — debounced to max once per 500ms, non-blocking.
+  // Fire-and-forget: errors are logged but don't block the request.
+  app.use((req, _res, next) => {
     if (!req.path.startsWith('/api/') && !req.path.startsWith('/v1/')) {
       next();
       return;
     }
-
-    try {
-      await refreshDbFromPersistentSnapshot();
-      next();
-    } catch (err) {
-      next(err);
-    }
+    throttledRefresh().catch((err) =>
+      console.error('[DB] Background refresh failed:', err)
+    );
+    next();
   });
 
-  app.use('/api/auth', authRouter);
+  // API docs (Swagger UI) — served without auth for easy access
+  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(openapiSpec, {
+    customCss: '.swagger-ui .topbar { display: none }',
+    customSiteTitle: 'FreeLLMAPI Docs',
+  }));
+
+  app.use('/api/auth', authRateLimiter, authRouter);
   app.use(requireDashboardAuth);
 
-  // API routes
-  app.use('/api/keys', keysRouter);
-  app.use('/api/models', modelsRouter);
-  app.use('/api/fallback', fallbackRouter);
-  app.use('/api/analytics', analyticsRouter);
-  app.use('/api/health', healthRouter);
-  app.use('/api/settings', settingsRouter);
-  app.use('/api/backup', backupRouter);
+  // API routes — rate limited
+  app.use('/api/keys', keysRateLimiter, keysRouter);
+  app.use('/api/fallback', apiRateLimiter, fallbackRouter);
+  app.use('/api/analytics', apiRateLimiter, analyticsRouter);
+  app.use('/api/health', apiRateLimiter, healthRouter);
+  app.use('/api/settings', keysRateLimiter, settingsRouter);
+  app.use('/api/backup', apiRateLimiter, backupRouter);
+  app.use('/api/models', apiRateLimiter, modelsRouter);
 
   // OpenAI-compatible proxy
   app.use('/v1', proxyRouter);

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,0 +1,162 @@
+import crypto from 'crypto';
+import { Router } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+
+const SESSION_COOKIE = 'freellmapi_session';
+const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_USERNAME = 'nguyenhoang287';
+const DEFAULT_PASSWORD = 'Matkhau1@';
+
+type SessionPayload = {
+  sub: string;
+  exp: number;
+  nonce: string;
+};
+
+function authUsername(): string {
+  return process.env.FREELLM_AUTH_USERNAME ?? process.env.AUTH_USERNAME ?? DEFAULT_USERNAME;
+}
+
+function authPassword(): string {
+  return process.env.FREELLM_AUTH_PASSWORD ?? process.env.AUTH_PASSWORD ?? DEFAULT_PASSWORD;
+}
+
+function authSecret(): string {
+  return process.env.FREELLM_AUTH_SECRET
+    ?? process.env.AUTH_SECRET
+    ?? process.env.ENCRYPTION_KEY
+    ?? `${authUsername()}:${authPassword()}`;
+}
+
+function safeEqual(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
+  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
+}
+
+function sign(value: string): string {
+  return crypto.createHmac('sha256', authSecret()).update(value).digest('base64url');
+}
+
+function createSessionToken(username: string): string {
+  const payload: SessionPayload = {
+    sub: username,
+    exp: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS,
+    nonce: crypto.randomBytes(16).toString('hex'),
+  };
+  const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encoded}.${sign(encoded)}`;
+}
+
+function parseSessionToken(token: string | undefined): SessionPayload | null {
+  if (!token) return null;
+
+  const [encoded, signature] = token.split('.');
+  if (!encoded || !signature || !safeEqual(signature, sign(encoded))) return null;
+
+  try {
+    const payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8')) as Partial<SessionPayload>;
+    if (typeof payload.sub !== 'string' || typeof payload.exp !== 'number' || typeof payload.nonce !== 'string') {
+      return null;
+    }
+    if (payload.exp <= Math.floor(Date.now() / 1000)) return null;
+    if (!safeEqual(payload.sub, authUsername())) return null;
+    return payload as SessionPayload;
+  } catch {
+    return null;
+  }
+}
+
+function parseCookies(req: Request): Record<string, string> {
+  const header = req.headers.cookie;
+  if (!header) return {};
+
+  return header.split(';').reduce<Record<string, string>>((cookies, part) => {
+    const index = part.indexOf('=');
+    if (index === -1) return cookies;
+    const key = part.slice(0, index).trim();
+    const value = part.slice(index + 1).trim();
+    if (key) cookies[key] = value;
+    return cookies;
+  }, {});
+}
+
+function hasSession(req: Request): boolean {
+  return parseSessionToken(parseCookies(req)[SESSION_COOKIE]) !== null;
+}
+
+function secureCookie(req: Request): boolean {
+  return process.env.VERCEL === '1'
+    || process.env.NODE_ENV === 'production'
+    || req.headers['x-forwarded-proto'] === 'https';
+}
+
+function serializeSessionCookie(req: Request, token: string, maxAge: number): string {
+  const parts = [
+    `${SESSION_COOKIE}=${token}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${maxAge}`,
+  ];
+  if (secureCookie(req)) parts.push('Secure');
+  return parts.join('; ');
+}
+
+function clearSessionCookie(req: Request): string {
+  return serializeSessionCookie(req, '', 0);
+}
+
+function isPublicPath(pathname: string): boolean {
+  if (pathname === '/login') return true;
+  if (pathname.startsWith('/api/auth/')) return true;
+  if (pathname === '/v1' || pathname.startsWith('/v1/')) return true;
+  return /\.(?:css|js|map|svg|png|jpg|jpeg|webp|ico|woff2?|ttf)$/i.test(pathname);
+}
+
+function authDisabled(): boolean {
+  return process.env.NODE_ENV === 'test' || process.env.FREELLM_AUTH_DISABLED === '1';
+}
+
+export const authRouter = Router();
+
+authRouter.get('/session', (req: Request, res: Response) => {
+  res.json({ authenticated: hasSession(req) });
+});
+
+authRouter.post('/login', (req: Request, res: Response) => {
+  const { username, password } = req.body ?? {};
+  const validCredentials = typeof username === 'string'
+    && typeof password === 'string'
+    && safeEqual(username, authUsername())
+    && safeEqual(password, authPassword());
+
+  if (!validCredentials) {
+    res.status(401).json({ error: { message: 'Invalid username or password' } });
+    return;
+  }
+
+  res.setHeader('Set-Cookie', serializeSessionCookie(req, createSessionToken(username), SESSION_TTL_SECONDS));
+  res.json({ authenticated: true });
+});
+
+authRouter.post('/logout', (req: Request, res: Response) => {
+  res.setHeader('Set-Cookie', clearSessionCookie(req));
+  res.json({ success: true });
+});
+
+export function requireDashboardAuth(req: Request, res: Response, next: NextFunction): void {
+  if (authDisabled() || isPublicPath(req.path) || hasSession(req)) {
+    next();
+    return;
+  }
+
+  if (req.path.startsWith('/api/')) {
+    res.status(401).json({ error: { message: 'Authentication required' } });
+    return;
+  }
+
+  const nextPath = encodeURIComponent(req.originalUrl || '/');
+  res.redirect(302, `/login?next=${nextPath}`);
+}

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -6,7 +6,8 @@ import { fileURLToPath } from 'url';
 import { initEncryptionKey } from '../lib/crypto.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DB_PATH = path.resolve(__dirname, '../../data/freeapi.db');
+const DEFAULT_DB_PATH = process.env.VERCEL ? '/tmp/freeapi.db' : path.resolve(__dirname, '../../data/freeapi.db');
+const DB_PATH = process.env.FREEAPI_DB_PATH ?? DEFAULT_DB_PATH;
 
 let db: Database.Database;
 

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -931,6 +931,15 @@ function migrateModelsV11(db: Database.Database) {
 }
 
 function ensureUnifiedKey(db: Database.Database) {
+  const configuredKey = getConfiguredUnifiedApiKey();
+  if (configuredKey) {
+    db.prepare(`
+      INSERT INTO settings (key, value) VALUES ('unified_api_key', ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `).run(configuredKey);
+    return;
+  }
+
   const existing = db.prepare("SELECT value FROM settings WHERE key = 'unified_api_key'").get() as { value: string } | undefined;
   if (!existing) {
     const key = `freellmapi-${crypto.randomBytes(24).toString('hex')}`;
@@ -939,13 +948,28 @@ function ensureUnifiedKey(db: Database.Database) {
   }
 }
 
+function getConfiguredUnifiedApiKey(): string | undefined {
+  const value = process.env.FREEAPI_UNIFIED_API_KEY ?? process.env.FREELLM_UNIFIED_API_KEY;
+  return value && value.trim() ? value.trim() : undefined;
+}
+
+export function isUnifiedApiKeyPinned(): boolean {
+  return getConfiguredUnifiedApiKey() !== undefined;
+}
+
 export function getUnifiedApiKey(): string {
+  const configuredKey = getConfiguredUnifiedApiKey();
+  if (configuredKey) return configuredKey;
+
   const db = getDb();
   const row = db.prepare("SELECT value FROM settings WHERE key = 'unified_api_key'").get() as { value: string };
   return row.value;
 }
 
 export function regenerateUnifiedKey(): string {
+  const configuredKey = getConfiguredUnifiedApiKey();
+  if (configuredKey) return configuredKey;
+
   const db = getDb();
   const key = `freellmapi-${crypto.randomBytes(24).toString('hex')}`;
   db.prepare("UPDATE settings SET value = ? WHERE key = 'unified_api_key'").run(key);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -7,6 +7,8 @@ import { initEncryptionKey } from '../lib/crypto.js';
 import {
   configureDbSnapshotPersistence,
   dbSnapshotPersistenceEnabled,
+  downloadDbSnapshot,
+  markDbSnapshotEtag,
   persistDbSnapshot,
   restoreDbSnapshot,
 } from './persistence.js';
@@ -16,6 +18,9 @@ const DEFAULT_DB_PATH = process.env.VERCEL ? '/tmp/freeapi.db' : path.resolve(__
 const DB_PATH = process.env.FREEAPI_DB_PATH ?? DEFAULT_DB_PATH;
 
 let db: Database.Database;
+let activeDbPath = DB_PATH;
+let activeDbIsMemory = false;
+let refreshQueue: Promise<boolean> = Promise.resolve(false);
 
 export function getDb(): Database.Database {
   if (!db) {
@@ -27,6 +32,8 @@ export function getDb(): Database.Database {
 export function initDb(dbPath?: string): Database.Database {
   const resolvedPath = dbPath ?? DB_PATH;
   const isMemory = resolvedPath === ':memory:';
+  activeDbPath = resolvedPath;
+  activeDbIsMemory = isMemory;
 
   if (!isMemory) {
     const dataDir = path.dirname(resolvedPath);
@@ -75,6 +82,24 @@ export async function initDbFromPersistentSnapshot(dbPath?: string): Promise<Dat
   const database = initDb(resolvedPath);
   await persistDbSnapshot('init');
   return database;
+}
+
+export async function refreshDbFromPersistentSnapshot(): Promise<boolean> {
+  if (!dbSnapshotPersistenceEnabled(activeDbPath, activeDbIsMemory)) return false;
+
+  refreshQueue = refreshQueue.catch(() => false).then(async () => {
+    const snapshot = await downloadDbSnapshot(activeDbPath, activeDbIsMemory);
+    if (!snapshot || snapshot === 'unchanged') return false;
+
+    db.close();
+    fs.renameSync(snapshot.tempPath, activeDbPath);
+    markDbSnapshotEtag(snapshot.etag);
+    initDb(activeDbPath);
+    console.log('[DB] Refreshed SQLite snapshot from Vercel Blob before request');
+    return true;
+  });
+
+  return refreshQueue;
 }
 
 export { persistDbSnapshot };

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -4,6 +4,12 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { initEncryptionKey } from '../lib/crypto.js';
+import {
+  configureDbSnapshotPersistence,
+  dbSnapshotPersistenceEnabled,
+  persistDbSnapshot,
+  restoreDbSnapshot,
+} from './persistence.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_DB_PATH = process.env.VERCEL ? '/tmp/freeapi.db' : path.resolve(__dirname, '../../data/freeapi.db');
@@ -30,8 +36,16 @@ export function initDb(dbPath?: string): Database.Database {
   }
 
   db = new Database(resolvedPath);
-  if (!isMemory) db.pragma('journal_mode = WAL');
+  const useSnapshotPersistence = dbSnapshotPersistenceEnabled(resolvedPath, isMemory);
+  if (!isMemory) db.pragma(useSnapshotPersistence ? 'journal_mode = DELETE' : 'journal_mode = WAL');
   db.pragma('foreign_keys = ON');
+  configureDbSnapshotPersistence(resolvedPath, isMemory, () => {
+    try {
+      db.pragma('wal_checkpoint(TRUNCATE)');
+    } catch {
+      // DELETE journal mode has no WAL to checkpoint.
+    }
+  });
 
   createTables(db);
   initEncryptionKey(db);
@@ -52,6 +66,18 @@ export function initDb(dbPath?: string): Database.Database {
   console.log(`Database initialized at ${resolvedPath}`);
   return db;
 }
+
+export async function initDbFromPersistentSnapshot(dbPath?: string): Promise<Database.Database> {
+  const resolvedPath = dbPath ?? DB_PATH;
+  const isMemory = resolvedPath === ':memory:';
+
+  await restoreDbSnapshot(resolvedPath, isMemory);
+  const database = initDb(resolvedPath);
+  await persistDbSnapshot('init');
+  return database;
+}
+
+export { persistDbSnapshot };
 
 function createTables(db: Database.Database) {
   db.exec(`

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -68,6 +68,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV9(db);
   migrateModelsV10(db);
   migrateModelsV11(db);
+  migrateModelsV12(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -963,6 +964,55 @@ function migrateModelsV11(db: Database.Database) {
     ['llm7',         'codestral-latest',                          'Codestral (LLM7)',              16, 8,  'Medium',   100, null, null, null, '~2-3M (100/hr)',  32000],
     ['llm7',         'ministral-8b-2512',                         'Ministral 8B (LLM7)',           28, 10, 'Small',    100, null, null, null, '~2-3M (100/hr)', 131072],
     ['llm7',         'GLM-4.6V-Flash',                            'GLM-4.6V Flash (LLM7)',         15, 9,  'Large',    100, null, null, null, '~2-3M (100/hr)', 131072],
+  ];
+
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    const missing = db.prepare(`
+      SELECT m.id FROM models m
+      LEFT JOIN fallback_config f ON m.id = f.model_db_id
+      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+    `).all() as { id: number }[];
+    if (missing.length > 0) {
+      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+    }
+  });
+  apply();
+}
+
+function migrateModelsV12(db: Database.Database) {
+  // Add Claude models via the Anthropic Messages API.
+  // Anthropic uses a distinct non-OpenAI endpoint (/v1/messages) — routed via
+  // the AnthropicProvider registered in server/src/providers/index.ts.
+  //
+  // Rate limits: Anthropic's free tier is invite-only and very limited.
+  // Paid tier limits are generous (~50 RPM / 200k TPM for most tiers).
+  // We set null limits to indicate "provider-managed" — the AnthropicProvider
+  // will handle 429s via the standard retry mechanism.
+  //
+  // Claude model IDs match the official Anthropic API model strings:
+  //   claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5-20250501
+  //
+  // Intelligence / speed ranks are relative to the existing catalog:
+  //   Opus 4.7 — rank 1: top-tier frontier model, competitive with GPT-4.5
+  //   Sonnet 4.6 — rank 3: strong reasoning, similar to GPT-4o / Gemini 2.5
+  //   Haiku 4.5 — rank 8: fast, cheap, beats most mid-tier open models
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    // Claude Opus 4.7 — flagship model. Context: 200k tokens.
+    // Pricing: ~$18 input / $54 output per 1M tokens (paid).
+    ['anthropic', 'claude-opus-4-7',       'Claude Opus 4.7',  1, 5, 'Frontier', null, null, null, null, '~$18/$54/M tokens',  200000],
+    // Claude Sonnet 4.6 — balanced reasoning + speed. Context: 200k tokens.
+    // Pricing: ~$3 input / $15 output per 1M tokens (paid).
+    ['anthropic', 'claude-sonnet-4-6',     'Claude Sonnet 4.6', 3, 4, 'Large',    null, null, null, null, '~$3/$15/M tokens',    200000],
+    // Claude Haiku 4.5 — fast, affordable. Context: 200k tokens.
+    // Pricing: ~$0.8 input / $4 output per 1M tokens (paid).
+    ['anthropic', 'claude-haiku-4-5-20250501', 'Claude Haiku 4.5', 8, 3, 'Medium', null, null, null, null, '~$0.80/$4/M tokens', 200000],
   ];
 
   const apply = db.transaction(() => {

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -1026,3 +1026,14 @@ export function regenerateUnifiedKey(): string {
   db.prepare("UPDATE settings SET value = ? WHERE key = 'unified_api_key'").run(key);
   return key;
 }
+
+export function setUnifiedApiKey(key: string): boolean {
+  if (getConfiguredUnifiedApiKey()) return false;
+
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO settings (key, value) VALUES ('unified_api_key', ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(key);
+  return true;
+}

--- a/server/src/db/persistence.ts
+++ b/server/src/db/persistence.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+import { get, put } from '@vercel/blob';
+
+const DEFAULT_DB_BLOB_PATH = 'sqlite/freeapi.db';
+
+let activeDbPath: string | null = null;
+let activeDbIsMemory = true;
+let checkpoint: (() => void) | null = null;
+let persistQueue: Promise<boolean> = Promise.resolve(false);
+
+function dbBlobPath(): string {
+  return process.env.FREEAPI_DB_BLOB_PATH ?? DEFAULT_DB_BLOB_PATH;
+}
+
+function hasBlobAuth(): boolean {
+  return Boolean(
+    process.env.BLOB_READ_WRITE_TOKEN
+    || (process.env.VERCEL_OIDC_TOKEN && process.env.BLOB_STORE_ID),
+  );
+}
+
+export function dbSnapshotPersistenceEnabled(dbPath = activeDbPath, isMemory = activeDbIsMemory): boolean {
+  return !isMemory && Boolean(dbPath) && hasBlobAuth();
+}
+
+export function configureDbSnapshotPersistence(
+  dbPath: string,
+  isMemory: boolean,
+  checkpointFn: (() => void) | null,
+): void {
+  activeDbPath = dbPath;
+  activeDbIsMemory = isMemory;
+  checkpoint = checkpointFn;
+}
+
+async function writeStreamToFile(stream: ReadableStream<Uint8Array>, filePath: string): Promise<void> {
+  const reader = stream.getReader();
+  const writer = fs.createWriteStream(filePath);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) writer.write(Buffer.from(value));
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      writer.end((err?: Error | null) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+}
+
+export async function restoreDbSnapshot(dbPath: string, isMemory: boolean): Promise<boolean> {
+  if (!dbSnapshotPersistenceEnabled(dbPath, isMemory)) return false;
+
+  const result = await get(dbBlobPath(), { access: 'private', useCache: false });
+  if (!result) return false;
+  if (result.statusCode !== 200 || !result.stream) return false;
+
+  const dataDir = path.dirname(dbPath);
+  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+
+  const tempPath = `${dbPath}.restore-${process.pid}-${Date.now()}`;
+  await writeStreamToFile(result.stream, tempPath);
+  fs.renameSync(tempPath, dbPath);
+
+  console.log(`[DB] Restored SQLite snapshot from Vercel Blob: ${dbBlobPath()}`);
+  return true;
+}
+
+export async function persistDbSnapshot(reason = 'manual'): Promise<boolean> {
+  if (!dbSnapshotPersistenceEnabled() || !activeDbPath) return false;
+
+  persistQueue = persistQueue.catch(() => false).then(async () => {
+    if (!activeDbPath || !fs.existsSync(activeDbPath)) return false;
+
+    checkpoint?.();
+
+    const tempPath = `${activeDbPath}.snapshot-${process.pid}-${Date.now()}`;
+    fs.copyFileSync(activeDbPath, tempPath);
+
+    try {
+      await put(dbBlobPath(), fs.createReadStream(tempPath), {
+        access: 'private',
+        allowOverwrite: true,
+        contentType: 'application/vnd.sqlite3',
+        cacheControlMaxAge: 60,
+      });
+      console.log(`[DB] Persisted SQLite snapshot to Vercel Blob (${reason})`);
+      return true;
+    } finally {
+      fs.rmSync(tempPath, { force: true });
+    }
+  });
+
+  return persistQueue;
+}

--- a/server/src/db/persistence.ts
+++ b/server/src/db/persistence.ts
@@ -4,10 +4,16 @@ import { get, put } from '@vercel/blob';
 
 const DEFAULT_DB_BLOB_PATH = 'sqlite/freeapi.db';
 
+type DownloadedSnapshot = {
+  tempPath: string;
+  etag: string;
+};
+
 let activeDbPath: string | null = null;
 let activeDbIsMemory = true;
 let checkpoint: (() => void) | null = null;
 let persistQueue: Promise<boolean> = Promise.resolve(false);
+let currentSnapshotEtag: string | null = null;
 
 function dbBlobPath(): string {
   return process.env.FREEAPI_DB_BLOB_PATH ?? DEFAULT_DB_BLOB_PATH;
@@ -34,6 +40,10 @@ export function configureDbSnapshotPersistence(
   checkpoint = checkpointFn;
 }
 
+export function markDbSnapshotEtag(etag: string | null): void {
+  currentSnapshotEtag = etag;
+}
+
 async function writeStreamToFile(stream: ReadableStream<Uint8Array>, filePath: string): Promise<void> {
   const reader = stream.getReader();
   const writer = fs.createWriteStream(filePath);
@@ -54,19 +64,36 @@ async function writeStreamToFile(stream: ReadableStream<Uint8Array>, filePath: s
   }
 }
 
-export async function restoreDbSnapshot(dbPath: string, isMemory: boolean): Promise<boolean> {
-  if (!dbSnapshotPersistenceEnabled(dbPath, isMemory)) return false;
+export async function downloadDbSnapshot(
+  dbPath: string,
+  isMemory: boolean,
+): Promise<DownloadedSnapshot | 'unchanged' | null> {
+  if (!dbSnapshotPersistenceEnabled(dbPath, isMemory)) return null;
 
-  const result = await get(dbBlobPath(), { access: 'private', useCache: false });
-  if (!result) return false;
-  if (result.statusCode !== 200 || !result.stream) return false;
+  const result = await get(dbBlobPath(), {
+    access: 'private',
+    useCache: false,
+    ...(currentSnapshotEtag ? { ifNoneMatch: currentSnapshotEtag } : {}),
+  });
+  if (!result) return null;
+  if (result.statusCode === 304) return 'unchanged';
+  if (result.statusCode !== 200 || !result.stream) return null;
 
   const dataDir = path.dirname(dbPath);
   if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
 
   const tempPath = `${dbPath}.restore-${process.pid}-${Date.now()}`;
   await writeStreamToFile(result.stream, tempPath);
+  return { tempPath, etag: result.blob.etag };
+}
+
+export async function restoreDbSnapshot(dbPath: string, isMemory: boolean): Promise<boolean> {
+  const snapshot = await downloadDbSnapshot(dbPath, isMemory);
+  if (!snapshot || snapshot === 'unchanged') return false;
+
+  const { tempPath, etag } = snapshot;
   fs.renameSync(tempPath, dbPath);
+  currentSnapshotEtag = etag;
 
   console.log(`[DB] Restored SQLite snapshot from Vercel Blob: ${dbBlobPath()}`);
   return true;
@@ -84,12 +111,14 @@ export async function persistDbSnapshot(reason = 'manual'): Promise<boolean> {
     fs.copyFileSync(activeDbPath, tempPath);
 
     try {
-      await put(dbBlobPath(), fs.createReadStream(tempPath), {
+      const uploaded = await put(dbBlobPath(), fs.createReadStream(tempPath), {
         access: 'private',
         allowOverwrite: true,
+        ...(currentSnapshotEtag ? { ifMatch: currentSnapshotEtag } : {}),
         contentType: 'application/vnd.sqlite3',
         cacheControlMaxAge: 60,
       });
+      currentSnapshotEtag = uploaded.etag;
       console.log(`[DB] Persisted SQLite snapshot to Vercel Blob (${reason})`);
       return true;
     } finally {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,12 +1,12 @@
 import './env.js';
 import { createApp } from './app.js';
-import { initDb } from './db/index.js';
+import { initDbFromPersistentSnapshot } from './db/index.js';
 import { startHealthChecker } from './services/health.js';
 
 const PORT = process.env.PORT ?? 3001;
 
 async function main() {
-  initDb();
+  await initDbFromPersistentSnapshot();
   const app = createApp();
 
   app.listen(Number(PORT), '0.0.0.0', () => {

--- a/server/src/lib/platforms.ts
+++ b/server/src/lib/platforms.ts
@@ -1,0 +1,23 @@
+export const PLATFORMS = [
+  'google',
+  'groq',
+  'cerebras',
+  'sambanova',
+  'nvidia',
+  'mistral',
+  'openrouter',
+  'github',
+  'cohere',
+  'cloudflare',
+  'zhipu',
+  'ollama',
+  'kilo',
+  'pollinations',
+  'llm7',
+] as const;
+
+export type Platform = typeof PLATFORMS[number];
+
+export function isPlatform(value: string): value is Platform {
+  return (PLATFORMS as readonly string[]).includes(value);
+}

--- a/server/src/providers/anthropic.ts
+++ b/server/src/providers/anthropic.ts
@@ -1,0 +1,285 @@
+/**
+ * Anthropic Messages API Provider
+ *
+ * Anthropic uses a different API format than OpenAI:
+ * - Endpoint: POST /v1/messages
+ * - Requires anthropic-version header
+ * - Uses max_tokens instead of max_tokens (in some versions)
+ *
+ * This provider handles the translation between OpenAI-compatible internal format
+ * and Anthropic's native API format.
+ */
+
+import type { Platform } from '@freellmapi/shared/types.js';
+import { BaseProvider } from './base.js';
+import type {
+  ChatMessage,
+  ChatCompletionResponse,
+  ChatCompletionChunk,
+} from '@freellmapi/shared/types.js';
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[];
+}
+
+interface AnthropicContentBlock {
+  type: 'text' | 'image';
+  text?: string;
+  source?: {
+    type: 'base64' | 'url';
+    media_type: string;
+    data: string;
+  };
+}
+
+interface AnthropicRequest {
+  model: string;
+  messages: AnthropicMessage[];
+  system?: string;
+  max_tokens: number;
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  stream?: boolean;
+  stop_sequences?: string[];
+  metadata?: Record<string, string>;
+}
+
+interface AnthropicResponse {
+  id: string;
+  type: 'message';
+  role: 'assistant';
+  content: Array<{
+    type: 'text';
+    text: string;
+  }>;
+  model: string;
+  stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence';
+  stop_sequence: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+export class AnthropicProvider extends BaseProvider {
+  readonly platform: Platform = 'anthropic';
+  readonly name = 'Anthropic';
+  private readonly baseUrl = 'https://api.anthropic.com/v1';
+  private readonly version = '2023-06-01';
+
+  async chatCompletion(
+    apiKey: string,
+    messages: ChatMessage[],
+    modelId: string,
+    options?: {
+      temperature?: number;
+      max_tokens?: number;
+      top_p?: number;
+    },
+  ): Promise<ChatCompletionResponse> {
+    const anthropicReq = this.buildRequest(messages, modelId, options);
+    const response = await this.fetchWithTimeout(
+      `${this.baseUrl}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': this.version,
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: JSON.stringify(anthropicReq),
+      },
+      60000, // Anthropic can take longer for complex responses
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Anthropic API error ${response.status}: ${error}`);
+    }
+
+    const data = (await response.json()) as AnthropicResponse;
+    return this.normalizeResponse(data, modelId);
+  }
+
+  async *streamChatCompletion(
+    apiKey: string,
+    messages: ChatMessage[],
+    modelId: string,
+    options?: {
+      temperature?: number;
+      max_tokens?: number;
+      top_p?: number;
+    },
+  ): AsyncGenerator<ChatCompletionChunk> {
+    const anthropicReq = this.buildRequest(messages, modelId, { ...options, stream: true });
+    const response = await this.fetchWithTimeout(
+      `${this.baseUrl}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': this.version,
+          'anthropic-dangerous-direct-browser-access': 'true',
+        },
+        body: JSON.stringify(anthropicReq),
+      },
+      60000,
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`Anthropic API error ${response.status}: ${error}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let eventId = '';
+    let eventModel = modelId;
+    let chunkIndex = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line.startsWith('event: ')) {
+            eventId = line.slice(7);
+          } else if (line.startsWith('data: ') && eventId === 'content_block_delta') {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'content_block_delta' && data.delta.type === 'text_delta') {
+              yield {
+                id: `anthropic-${Date.now()}`,
+                object: 'chat.completion.chunk',
+                created: Math.floor(Date.now() / 1000),
+                model: eventModel,
+                choices: [{
+                  index: 0,
+                  delta: { content: data.delta.text },
+                  finish_reason: null,
+                }],
+              };
+              chunkIndex++;
+            }
+          } else if (line.startsWith('data: ')) {
+            const data = JSON.parse(line.slice(6));
+            if (data.type === 'message_delta' && data.usage) {
+              yield {
+                id: `anthropic-${Date.now()}`,
+                object: 'chat.completion.chunk',
+                created: Math.floor(Date.now() / 1000),
+                model: eventModel,
+                choices: [{
+                  index: 0,
+                  delta: {},
+                  finish_reason: data.stop_reason,
+                }],
+              };
+            }
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async validateKey(apiKey: string): Promise<boolean> {
+    try {
+      const response = await this.fetchWithTimeout(
+        `${this.baseUrl}/messages`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': apiKey,
+            'anthropic-version': this.version,
+          },
+          body: JSON.stringify({
+            model: 'claude-haiku-4-5-20250501',
+            max_tokens: 1,
+            messages: [{ role: 'user', content: 'hi' }],
+          }),
+        },
+        10000,
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  private buildRequest(
+    messages: ChatMessage[],
+    modelId: string,
+    options?: {
+      temperature?: number;
+      max_tokens?: number;
+      top_p?: number;
+      stream?: boolean;
+    },
+  ): AnthropicRequest {
+    // Extract system message
+    let systemMessage = '';
+    const chatMessages: AnthropicMessage[] = [];
+
+    for (const msg of messages) {
+      if (msg.role === 'system') {
+        systemMessage = msg.content as string;
+      } else if (msg.role === 'user' || msg.role === 'assistant') {
+        chatMessages.push({
+          role: msg.role,
+          content: msg.content as string,
+        });
+      }
+    }
+
+    return {
+      model: modelId,
+      messages: chatMessages,
+      system: systemMessage || undefined,
+      max_tokens: options?.max_tokens ?? 4096,
+      temperature: options?.temperature,
+      top_p: options?.top_p,
+      stream: options?.stream,
+    };
+  }
+
+  private normalizeResponse(data: AnthropicResponse, modelId: string): ChatCompletionResponse {
+    const text = data.content
+      .filter((c) => c.type === 'text')
+      .map((c) => c.text)
+      .join('');
+
+    return {
+      id: data.id,
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model: data.model,
+      choices: [{
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: text,
+        },
+        finish_reason: data.stop_reason,
+      }],
+      usage: {
+        prompt_tokens: data.usage.input_tokens,
+        completion_tokens: data.usage.output_tokens,
+        total_tokens: data.usage.input_tokens + data.usage.output_tokens,
+      },
+    };
+  }
+}

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -4,6 +4,7 @@ import { GoogleProvider } from './google.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
+import { AnthropicProvider } from './anthropic.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -74,6 +75,9 @@ register(new CohereProvider());
 
 // Cloudflare Workers AI - OpenAI-compatible endpoint (key = "account_id:token")
 register(new CloudflareProvider());
+
+// Anthropic - Claude models via Messages API (different from OpenAI format)
+register(new AnthropicProvider());
 
 // Zhipu (Z.ai / bigmodel.cn) - OpenAI-compatible
 register(new OpenAICompatProvider({

--- a/server/src/routes/backup.ts
+++ b/server/src/routes/backup.ts
@@ -1,0 +1,226 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import {
+  getDb,
+  getUnifiedApiKey,
+  isUnifiedApiKeyPinned,
+  persistDbSnapshot,
+  setUnifiedApiKey,
+} from '../db/index.js';
+import { decrypt } from '../lib/crypto.js';
+import { PLATFORMS } from '../lib/platforms.js';
+import { importModeSchema, importProviderKeys } from '../services/key-import.js';
+
+export const backupRouter = Router();
+
+const fallbackImportSchema = z.object({
+  platform: z.enum(PLATFORMS),
+  modelId: z.string().min(1),
+  priority: z.coerce.number().int().positive().optional(),
+  enabled: z.preprocess(value => {
+    if (value === 'true' || value === '1' || value === 1) return true;
+    if (value === 'false' || value === '0' || value === 0) return false;
+    return value;
+  }, z.boolean().optional()),
+});
+
+const backupImportSchema = z.object({
+  mode: importModeSchema.optional(),
+  dedupe: z.boolean().optional(),
+  providerKeys: z.array(z.unknown()).optional(),
+  keys: z.array(z.unknown()).optional(),
+  fallback: z.array(z.unknown()).optional(),
+  unifiedApiKey: z.string().trim().min(1).optional(),
+  restoreUnifiedApiKey: z.boolean().optional(),
+});
+
+type FallbackImportResult = {
+  updated: number;
+  skipped: number;
+  errors: Array<{ index: number; message: string }>;
+};
+
+function normalizeFallback(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  const raw = value as Record<string, unknown>;
+  return {
+    platform: raw.platform,
+    modelId: raw.modelId ?? raw.model_id,
+    priority: raw.priority,
+    enabled: raw.enabled,
+  };
+}
+
+function importFallback(rawFallback: unknown[]): FallbackImportResult {
+  const db = getDb();
+  const result: FallbackImportResult = { updated: 0, skipped: 0, errors: [] };
+  const update = db.prepare(`
+    UPDATE fallback_config
+       SET priority = COALESCE(?, priority),
+           enabled = COALESCE(?, enabled)
+     WHERE model_db_id = (
+       SELECT id FROM models WHERE platform = ? AND model_id = ?
+     )
+  `);
+
+  const run = db.transaction(() => {
+    rawFallback.forEach((rawEntry, index) => {
+      const parsed = fallbackImportSchema.safeParse(normalizeFallback(rawEntry));
+      if (!parsed.success) {
+        result.errors.push({
+          index,
+          message: parsed.error.errors.map(error => error.message).join(', '),
+        });
+        result.skipped += 1;
+        return;
+      }
+
+      const entry = parsed.data;
+      if (entry.priority === undefined && entry.enabled === undefined) {
+        result.skipped += 1;
+        return;
+      }
+
+      const updated = update.run(
+        entry.priority ?? null,
+        entry.enabled === undefined ? null : entry.enabled ? 1 : 0,
+        entry.platform,
+        entry.modelId,
+      );
+      if (updated.changes > 0) {
+        result.updated += 1;
+      } else {
+        result.skipped += 1;
+      }
+    });
+  });
+
+  run();
+  return result;
+}
+
+function backupFilename(): string {
+  return `freellmapi-backup-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+}
+
+backupRouter.get('/export', (_req: Request, res: Response) => {
+  const db = getDb();
+  const keyRows = db.prepare(`
+    SELECT id, platform, label, encrypted_key, iv, auth_tag, status, enabled, created_at, last_checked_at
+      FROM api_keys
+     ORDER BY created_at DESC
+  `).all() as Array<{
+    id: number;
+    platform: string;
+    label: string;
+    encrypted_key: string;
+    iv: string;
+    auth_tag: string;
+    status: string;
+    enabled: number;
+    created_at: string;
+    last_checked_at: string | null;
+  }>;
+
+  const warnings: Array<{ id: number; message: string }> = [];
+  const providerKeys = keyRows.flatMap(row => {
+    try {
+      return [{
+        platform: row.platform,
+        label: row.label,
+        key: decrypt(row.encrypted_key, row.iv, row.auth_tag),
+        status: row.status,
+        enabled: row.enabled === 1,
+        createdAt: row.created_at,
+        lastCheckedAt: row.last_checked_at,
+      }];
+    } catch {
+      warnings.push({ id: row.id, message: 'Could not decrypt key' });
+      return [];
+    }
+  });
+
+  const fallback = db.prepare(`
+    SELECT m.platform, m.model_id AS modelId, fc.priority, fc.enabled
+      FROM fallback_config fc
+      JOIN models m ON m.id = fc.model_db_id
+     ORDER BY fc.priority ASC
+  `).all() as Array<{ platform: string; modelId: string; priority: number; enabled: number }>;
+
+  res.setHeader('Content-Disposition', `attachment; filename="${backupFilename()}"`);
+  res.json({
+    format: 'freellmapi-backup',
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    unifiedApiKey: getUnifiedApiKey(),
+    unifiedApiKeyPinned: isUnifiedApiKeyPinned(),
+    providerKeys,
+    fallback: fallback.map(entry => ({
+      platform: entry.platform,
+      modelId: entry.modelId,
+      priority: entry.priority,
+      enabled: entry.enabled === 1,
+    })),
+    warnings,
+  });
+});
+
+backupRouter.post('/import', async (req: Request, res: Response) => {
+  const parsed = backupImportSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
+    return;
+  }
+
+  const db = getDb();
+  const rawKeys = parsed.data.providerKeys ?? parsed.data.keys ?? [];
+  const keyImport = rawKeys.length > 0
+    ? importProviderKeys(db, rawKeys, {
+      mode: parsed.data.mode ?? 'append',
+      dedupe: parsed.data.dedupe,
+    })
+    : { inserted: 0, skipped: 0, replaced: 0, errors: [], keys: [] };
+
+  const fallbackImport = parsed.data.fallback?.length
+    ? importFallback(parsed.data.fallback)
+    : { updated: 0, skipped: 0, errors: [] };
+
+  let unifiedApiKey: { restored: boolean; skipped: boolean; reason?: string } = {
+    restored: false,
+    skipped: false,
+  };
+
+  if (parsed.data.unifiedApiKey && parsed.data.restoreUnifiedApiKey !== false) {
+    const restored = setUnifiedApiKey(parsed.data.unifiedApiKey);
+    unifiedApiKey = restored
+      ? { restored: true, skipped: false }
+      : { restored: false, skipped: true, reason: 'Unified key is pinned by environment' };
+  }
+
+  const changed = keyImport.inserted > 0
+    || keyImport.replaced > 0
+    || fallbackImport.updated > 0
+    || unifiedApiKey.restored;
+
+  if (!changed && keyImport.errors.length > 0 && keyImport.inserted === 0) {
+    res.status(400).json({
+      error: { message: 'No valid backup data to import', details: keyImport.errors },
+      keys: keyImport,
+      fallback: fallbackImport,
+      unifiedApiKey,
+    });
+    return;
+  }
+
+  if (changed) {
+    await persistDbSnapshot('backup-import');
+  }
+
+  res.status(201).json({
+    success: true,
+    keys: keyImport,
+    fallback: fallbackImport,
+    unifiedApiKey,
+  });
+});

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
-import { getDb } from '../db/index.js';
+import { getDb, persistDbSnapshot } from '../db/index.js';
 import { getAllPenalties } from '../services/router.js';
 
 export const fallbackRouter = Router();
@@ -61,7 +61,7 @@ const updateSchema = z.array(z.object({
 }));
 
 // Update fallback chain (full replace)
-fallbackRouter.put('/', (req: Request, res: Response) => {
+fallbackRouter.put('/', async (req: Request, res: Response) => {
   const parsed = updateSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
@@ -80,6 +80,7 @@ fallbackRouter.put('/', (req: Request, res: Response) => {
   });
   updateAll();
 
+  await persistDbSnapshot('fallback-update');
   res.json({ success: true });
 });
 
@@ -91,7 +92,7 @@ const SORT_PRESETS: Record<string, string> = {
   budget: "CASE m.monthly_token_budget WHEN '~120M' THEN 1 WHEN '~50-100M' THEN 2 WHEN '~30M' THEN 3 WHEN '~18-45M' THEN 4 WHEN '~18M' THEN 5 WHEN '~15M' THEN 6 WHEN '~12M' THEN 7 WHEN '~6M' THEN 8 WHEN '~5-10M' THEN 9 WHEN '~4M' THEN 10 ELSE 11 END ASC",
 };
 
-fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
+fallbackRouter.post('/sort/:preset', async (req: Request, res: Response) => {
   const preset = String(req.params.preset);
   const orderBy = SORT_PRESETS[preset];
   if (!orderBy) {
@@ -110,6 +111,7 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
   });
   reorder();
 
+  await persistDbSnapshot('fallback-sort');
   res.json({ success: true, preset });
 });
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { getDb } from '../db/index.js';
+import { getDb, persistDbSnapshot } from '../db/index.js';
 import { checkKeyHealth, checkAllKeys } from '../services/health.js';
 import { hasProvider } from '../providers/index.js';
 
@@ -63,11 +63,13 @@ healthRouter.post('/check/:keyId', async (req: Request, res: Response) => {
   }
 
   const status = await checkKeyHealth(keyId);
+  await persistDbSnapshot('health-check-key');
   res.json({ keyId, status });
 });
 
 // Check all keys
 healthRouter.post('/check-all', async (_req: Request, res: Response) => {
   await checkAllKeys();
+  await persistDbSnapshot('health-check-all');
   res.json({ success: true });
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
-import { getDb } from '../db/index.js';
+import { getDb, persistDbSnapshot } from '../db/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 
 export const keysRouter = Router();
@@ -50,7 +50,7 @@ keysRouter.get('/', (_req: Request, res: Response) => {
 });
 
 // Add a key
-keysRouter.post('/', (req: Request, res: Response) => {
+keysRouter.post('/', async (req: Request, res: Response) => {
   const parsed = addKeySchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
@@ -65,6 +65,7 @@ keysRouter.post('/', (req: Request, res: Response) => {
     INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
     VALUES (?, ?, ?, ?, ?, 'unknown', 1)
   `).run(platform, label ?? '', encrypted, iv, authTag);
+  await persistDbSnapshot('api-key-add');
 
   res.status(201).json({
     id: result.lastInsertRowid,
@@ -77,7 +78,7 @@ keysRouter.post('/', (req: Request, res: Response) => {
 });
 
 // Delete a key
-keysRouter.delete('/:id', (req: Request, res: Response) => {
+keysRouter.delete('/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);
   if (isNaN(id)) {
     res.status(400).json({ error: { message: 'Invalid key ID' } });
@@ -92,11 +93,12 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
     return;
   }
 
+  await persistDbSnapshot('api-key-delete');
   res.json({ success: true });
 });
 
 // Toggle enable/disable
-keysRouter.patch('/:id', (req: Request, res: Response) => {
+keysRouter.patch('/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);
   if (isNaN(id)) {
     res.status(400).json({ error: { message: 'Invalid key ID' } });
@@ -117,5 +119,6 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     return;
   }
 
+  await persistDbSnapshot('api-key-toggle');
   res.json({ success: true, enabled });
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -3,22 +3,21 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb, persistDbSnapshot } from '../db/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
+import { PLATFORMS } from '../lib/platforms.js';
+import { importModeSchema, importProviderKeys } from '../services/key-import.js';
 
 export const keysRouter = Router();
-
-// Active providers — must match providers/index.ts registrations + shared/types.ts Platform.
-// Hugging Face, Moonshot, and MiniMax direct integrations were dropped in V4
-// (see migrateModelsV4 comment block).
-const PLATFORMS = [
-  'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
-  'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7',
-] as const;
 
 const addKeySchema = z.object({
   platform: z.enum(PLATFORMS),
   key: z.string().min(1),
   label: z.string().optional(),
+});
+
+const importKeysSchema = z.object({
+  mode: importModeSchema.optional(),
+  dedupe: z.boolean().optional(),
+  keys: z.array(z.unknown()).min(1).max(2000),
 });
 
 // List all keys (masked)
@@ -75,6 +74,32 @@ keysRouter.post('/', async (req: Request, res: Response) => {
     status: 'unknown',
     enabled: true,
   });
+});
+
+// Import many keys at once
+keysRouter.post('/import', async (req: Request, res: Response) => {
+  const parsed = importKeysSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
+    return;
+  }
+
+  const db = getDb();
+  const result = importProviderKeys(db, parsed.data.keys, {
+    mode: parsed.data.mode ?? 'append',
+    dedupe: parsed.data.dedupe,
+  });
+
+  if (result.inserted === 0 && result.replaced === 0 && result.errors.length > 0) {
+    res.status(400).json({ error: { message: 'No valid keys to import', details: result.errors }, result });
+    return;
+  }
+
+  if (result.inserted > 0 || result.replaced > 0) {
+    await persistDbSnapshot('api-key-bulk-import');
+  }
+
+  res.status(201).json(result);
 });
 
 // Delete a key

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -6,6 +6,7 @@ import type { ChatMessage } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown } from '../services/ratelimit.js';
 import { getDb, getUnifiedApiKey, persistDbSnapshot } from '../db/index.js';
+import { getCache, setCache, generateCacheKey, hashMessages } from '../lib/cache.js';
 
 export const proxyRouter = Router();
 
@@ -290,8 +291,8 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     let route: RouteResult;
-    try {
-      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel);
+      try {
+        route = await routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel);
     } catch (err: any) {
       // No more models available
       if (lastError) {
@@ -368,7 +369,26 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           throw streamErr;
         }
       } else {
-        const result = await route.provider.chatCompletion(
+        // Cache lookup for non-streaming, non-tool-call requests
+        const canCache = !stream && !tools && !tool_choice && attempt === 0;
+        const messagesHash = hashMessages(messages);
+        const cacheKey = canCache
+          ? generateCacheKey(route.modelId, messagesHash, { temperature, max_tokens, top_p })
+          : null;
+
+        let result;
+        if (cacheKey) {
+          const cached = getCache<typeof result>(cacheKey);
+          if (cached) {
+            res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId} (cached)`);
+            res.setHeader('X-Cache', 'HIT');
+            res.json(cached);
+            return;
+          }
+          res.setHeader('X-Cache', 'MISS');
+        }
+
+        result = await route.provider.chatCompletion(
           route.apiKey, messages, route.modelId,
           { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls },
         );
@@ -377,6 +397,11 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         recordTokens(route.platform, route.modelId, route.keyId, totalTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId);
+
+        // Cache the successful response (cache key only set for non-streaming non-tool-call)
+        if (cacheKey) {
+          setCache(cacheKey, result);
+        }
 
         res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
         if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { ChatMessage } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown } from '../services/ratelimit.js';
-import { getDb, getUnifiedApiKey } from '../db/index.js';
+import { getDb, getUnifiedApiKey, persistDbSnapshot } from '../db/index.js';
 
 export const proxyRouter = Router();
 
@@ -349,7 +349,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
           recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId);
-          logRequest(route.platform, route.modelId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null);
+          await logRequest(route.platform, route.modelId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null);
           return;
         } catch (streamErr: any) {
           if (streamStarted) {
@@ -361,7 +361,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, streamErr.message);
+            await logRequest(route.platform, route.modelId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, streamErr.message);
             return;
           }
           // Pre-stream error — bubble to outer retry/502 handler.
@@ -382,7 +382,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
         res.json(result);
 
-        logRequest(
+        await logRequest(
           route.platform, route.modelId, 'success',
           result.usage?.prompt_tokens ?? 0,
           result.usage?.completion_tokens ?? 0,
@@ -392,7 +392,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       }
     } catch (err: any) {
       const latency = Date.now() - start;
-      logRequest(route.platform, route.modelId, 'error', estimatedInputTokens, 0, latency, err.message);
+      await logRequest(route.platform, route.modelId, 'error', estimatedInputTokens, 0, latency, err.message);
 
       if (isRetryableError(err)) {
         // Put this model+key on cooldown and try the next one
@@ -425,7 +425,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   });
 });
 
-function logRequest(
+async function logRequest(
   platform: string,
   modelId: string,
   status: string,
@@ -440,6 +440,7 @@ function logRequest(
       INSERT INTO requests (platform, model_id, status, input_tokens, output_tokens, latency_ms, error)
       VALUES (?, ?, ?, ?, ?, ?, ?)
     `).run(platform, modelId, status, inputTokens, outputTokens, latencyMs, error);
+    await persistDbSnapshot('request-log');
   } catch (e) {
     console.error('Failed to log request:', e);
   }

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { getUnifiedApiKey, isUnifiedApiKeyPinned, regenerateUnifiedKey } from '../db/index.js';
+import { getUnifiedApiKey, isUnifiedApiKeyPinned, persistDbSnapshot, regenerateUnifiedKey } from '../db/index.js';
 
 export const settingsRouter = Router();
 
@@ -10,7 +10,7 @@ settingsRouter.get('/api-key', (_req: Request, res: Response) => {
 });
 
 // Regenerate the unified API key
-settingsRouter.post('/api-key/regenerate', (_req: Request, res: Response) => {
+settingsRouter.post('/api-key/regenerate', async (_req: Request, res: Response) => {
   if (isUnifiedApiKeyPinned()) {
     res.status(409).json({
       error: { message: 'Unified API key is pinned by environment variable FREEAPI_UNIFIED_API_KEY.' },
@@ -19,5 +19,6 @@ settingsRouter.post('/api-key/regenerate', (_req: Request, res: Response) => {
   }
 
   const newKey = regenerateUnifiedKey();
+  await persistDbSnapshot('settings-regenerate-unified-key');
   res.json({ apiKey: newKey, pinned: false });
 });

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,16 +1,23 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { getUnifiedApiKey, regenerateUnifiedKey } from '../db/index.js';
+import { getUnifiedApiKey, isUnifiedApiKeyPinned, regenerateUnifiedKey } from '../db/index.js';
 
 export const settingsRouter = Router();
 
 // Get the unified API key
 settingsRouter.get('/api-key', (_req: Request, res: Response) => {
-  res.json({ apiKey: getUnifiedApiKey() });
+  res.json({ apiKey: getUnifiedApiKey(), pinned: isUnifiedApiKeyPinned() });
 });
 
 // Regenerate the unified API key
 settingsRouter.post('/api-key/regenerate', (_req: Request, res: Response) => {
+  if (isUnifiedApiKeyPinned()) {
+    res.status(409).json({
+      error: { message: 'Unified API key is pinned by environment variable FREEAPI_UNIFIED_API_KEY.' },
+    });
+    return;
+  }
+
   const newKey = regenerateUnifiedKey();
-  res.json({ apiKey: newKey });
+  res.json({ apiKey: newKey, pinned: false });
 });

--- a/server/src/services/health.ts
+++ b/server/src/services/health.ts
@@ -3,16 +3,66 @@ import { getProvider } from '../providers/index.js';
 import { decrypt } from '../lib/crypto.js';
 import type { Platform, KeyStatus } from '@freellmapi/shared/types.js';
 
-const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes between full checks
 const CONSECUTIVE_FAILURES_TO_DISABLE = 3;
 
-// Track consecutive failures per key
-const failureCount = new Map<number, number>();
+// Circuit breaker: pause provider after consecutive failures
+const CIRCUIT_BREAKER_FAILURES = 3;
+const CIRCUIT_BREAKER_PAUSE_MS = 5 * 60 * 1000; // 5 min cooldown
 
-export async function checkKeyHealth(keyId: number): Promise<KeyStatus> {
+// Track consecutive failures and circuit breaker state per platform
+const failureCount = new Map<number, number>();
+const platformCircuitBreaker = new Map<string, { failures: number; pauseUntil: number }>();
+
+/**
+ * Check if a platform is currently in circuit-breaker pause.
+ */
+function isPlatformCircuitOpen(platform: string): boolean {
+  const cb = platformCircuitBreaker.get(platform);
+  if (!cb) return false;
+  if (Date.now() > cb.pauseUntil) {
+    // Circuit half-open: reset failure count, allow one probe
+    cb.failures = 0;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Record a failure for circuit breaker.
+ */
+function recordPlatformFailure(platform: string): void {
+  const existing = platformCircuitBreaker.get(platform) ?? { failures: 0, pauseUntil: 0 };
+  existing.failures++;
+
+  if (existing.failures >= CIRCUIT_BREAKER_FAILURES) {
+    existing.pauseUntil = Date.now() + CIRCUIT_BREAKER_PAUSE_MS;
+    console.log(`[Health] Circuit breaker OPEN for ${platform} (pausing checks for 5 min)`);
+  }
+
+  platformCircuitBreaker.set(platform, existing);
+}
+
+/**
+ * Record a success for circuit breaker (resets failure count).
+ */
+function recordPlatformSuccess(platform: string): void {
+  platformCircuitBreaker.delete(platform);
+}
+
+/**
+ * Check health of a single key.
+ * Returns cached status if platform is in circuit-breaker pause.
+ */
+export async function checkKeyHealth(keyId: number, skipPlatformCheck = false): Promise<KeyStatus> {
   const db = getDb();
   const row = db.prepare('SELECT * FROM api_keys WHERE id = ?').get(keyId) as any;
   if (!row) return 'error';
+
+  // Check circuit breaker for this platform (skip on first check during startup)
+  if (!skipPlatformCheck && isPlatformCircuitOpen(row.platform)) {
+    return row.status as KeyStatus ?? 'unknown';
+  }
 
   const provider = getProvider(row.platform as Platform);
   if (!provider) return 'error';
@@ -28,6 +78,7 @@ export async function checkKeyHealth(keyId: number): Promise<KeyStatus> {
 
     if (isValid) {
       failureCount.delete(keyId);
+      recordPlatformSuccess(row.platform);
     } else {
       const count = (failureCount.get(keyId) ?? 0) + 1;
       failureCount.set(keyId, count);
@@ -36,13 +87,12 @@ export async function checkKeyHealth(keyId: number): Promise<KeyStatus> {
         db.prepare('UPDATE api_keys SET enabled = 0 WHERE id = ?').run(keyId);
         console.log(`[Health] Auto-disabled key ${keyId} after ${count} consecutive failures`);
       }
+
+      recordPlatformFailure(row.platform);
     }
 
     return status;
   } catch (err: any) {
-    // Transport errors (DNS/timeout/TLS) — provider unreachable, not necessarily
-    // a bad key. Mark status='error' but do NOT increment failure counter — auto-
-    // disable is reserved for confirmed 401/403 (returned by validateKey as false).
     console.error(`[Health] Key ${keyId} transport error:`, err.message);
     db.prepare("UPDATE api_keys SET status = ?, last_checked_at = datetime('now') WHERE id = ?")
       .run('error', keyId);
@@ -50,24 +100,69 @@ export async function checkKeyHealth(keyId: number): Promise<KeyStatus> {
   }
 }
 
+/**
+ * Check all keys with staggered delays between batches.
+ * Batch size and delay tuned to avoid triggering provider rate limits.
+ */
 export async function checkAllKeys(): Promise<void> {
   const db = getDb();
   const keys = db.prepare('SELECT id, platform FROM api_keys WHERE enabled = 1').all() as { id: number; platform: string }[];
 
-  console.log(`[Health] Checking ${keys.length} keys...`);
-
-  for (const key of keys) {
-    await checkKeyHealth(key.id);
+  if (keys.length === 0) {
+    console.log('[Health] No enabled keys to check');
+    return;
   }
 
-  console.log(`[Health] Check complete.`);
+  console.log(`[Health] Checking ${keys.length} keys (staggered)...`);
+
+  const BATCH_SIZE = 5;
+  const BATCH_DELAY_MS = 2000; // 2 seconds between batches
+
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const batch = keys.slice(i, i + BATCH_SIZE);
+
+    // Process batch in parallel
+    await Promise.all(batch.map(key => checkKeyHealth(key.id)));
+
+    // Wait between batches (except for last batch)
+    if (i + BATCH_SIZE < keys.length) {
+      await sleep(BATCH_DELAY_MS);
+    }
+  }
+
+  console.log('[Health] Check complete.');
+}
+
+/**
+ * Lightweight health check that updates timestamps without full validation.
+ * Used for the dashboard health endpoint.
+ */
+export function getQuickHealthSummary(): { total: number; healthy: number; unhealthy: number } {
+  const db = getDb();
+  const keys = db.prepare('SELECT status FROM api_keys').all() as { status: string }[];
+
+  return {
+    total: keys.length,
+    healthy: keys.filter(k => k.status === 'healthy').length,
+    unhealthy: keys.filter(k => k.status !== 'healthy' && k.status !== 'unknown').length,
+  };
 }
 
 let intervalId: ReturnType<typeof setInterval> | null = null;
 
+/**
+ * Start the health checker. Non-blocking — runs first check after initial delay.
+ */
 export function startHealthChecker(): void {
   if (intervalId) return;
   console.log(`[Health] Starting health checker (every ${CHECK_INTERVAL_MS / 1000}s)`);
+
+  // Run first check after 30s delay (not immediately on startup)
+  setTimeout(() => {
+    checkAllKeys().catch(err => console.error('[Health] Initial check failed:', err));
+  }, 30_000);
+
+  // Subsequent checks at regular interval
   intervalId = setInterval(() => {
     checkAllKeys().catch(err => console.error('[Health] Check failed:', err));
   }, CHECK_INTERVAL_MS);
@@ -78,4 +173,8 @@ export function stopHealthChecker(): void {
     clearInterval(intervalId);
     intervalId = null;
   }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/server/src/services/key-import.ts
+++ b/server/src/services/key-import.ts
@@ -1,0 +1,161 @@
+import type Database from 'better-sqlite3';
+import { z } from 'zod';
+import { PLATFORMS } from '../lib/platforms.js';
+import { decrypt, encrypt, maskKey } from '../lib/crypto.js';
+
+const KEY_STATUSES = ['healthy', 'rate_limited', 'invalid', 'error', 'unknown'] as const;
+
+export const importModeSchema = z.enum(['append', 'replace']);
+
+const importKeySchema = z.object({
+  platform: z.enum(PLATFORMS),
+  key: z.string().trim().min(1),
+  label: z.string().optional().transform(value => value?.trim() ?? ''),
+  enabled: z.boolean().optional().default(true),
+  status: z.enum(KEY_STATUSES).optional().default('unknown'),
+  createdAt: z.string().optional(),
+  lastCheckedAt: z.string().nullable().optional(),
+});
+
+export type ImportMode = z.infer<typeof importModeSchema>;
+
+export type ImportProviderKeysOptions = {
+  mode?: ImportMode;
+  dedupe?: boolean;
+};
+
+export type ImportProviderKeysResult = {
+  inserted: number;
+  skipped: number;
+  replaced: number;
+  errors: Array<{ index: number; message: string }>;
+  keys: Array<{
+    id: number;
+    platform: string;
+    label: string;
+    maskedKey: string;
+    enabled: boolean;
+  }>;
+};
+
+function normalizeRawKey(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  const raw = value as Record<string, unknown>;
+  return {
+    platform: raw.platform,
+    key: raw.key ?? raw.apiKey ?? raw.api_key,
+    label: raw.label ?? raw.name ?? '',
+    enabled: raw.enabled,
+    status: raw.status,
+    createdAt: raw.createdAt ?? raw.created_at,
+    lastCheckedAt: raw.lastCheckedAt ?? raw.last_checked_at,
+  };
+}
+
+function fingerprint(platform: string, key: string): string {
+  return `${platform}\u0000${key}`;
+}
+
+function collectExistingFingerprints(db: Database.Database): Set<string> {
+  const rows = db.prepare('SELECT platform, encrypted_key, iv, auth_tag FROM api_keys').all() as Array<{
+    platform: string;
+    encrypted_key: string;
+    iv: string;
+    auth_tag: string;
+  }>;
+
+  const seen = new Set<string>();
+  for (const row of rows) {
+    try {
+      seen.add(fingerprint(row.platform, decrypt(row.encrypted_key, row.iv, row.auth_tag)));
+    } catch {
+      // Keep importing even if an old row cannot be decrypted.
+    }
+  }
+  return seen;
+}
+
+export function importProviderKeys(
+  db: Database.Database,
+  rawKeys: unknown[],
+  options: ImportProviderKeysOptions = {},
+): ImportProviderKeysResult {
+  const mode = options.mode ?? 'append';
+  const dedupe = options.dedupe !== false;
+  const errors: ImportProviderKeysResult['errors'] = [];
+
+  const keys = rawKeys.flatMap((rawKey, index) => {
+    const parsed = importKeySchema.safeParse(normalizeRawKey(rawKey));
+    if (!parsed.success) {
+      errors.push({
+        index,
+        message: parsed.error.errors.map(error => error.message).join(', '),
+      });
+      return [];
+    }
+    return [parsed.data];
+  });
+
+  const result: ImportProviderKeysResult = {
+    inserted: 0,
+    skipped: 0,
+    replaced: 0,
+    errors,
+    keys: [],
+  };
+
+  if (keys.length === 0) {
+    result.skipped = rawKeys.length;
+    return result;
+  }
+
+  const insert = db.prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, created_at, last_checked_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const run = db.transaction(() => {
+    if (mode === 'replace') {
+      result.replaced = (db.prepare('DELETE FROM api_keys').run().changes as number) ?? 0;
+    }
+
+    const seen = dedupe && mode === 'append' ? collectExistingFingerprints(db) : new Set<string>();
+    const importedAt = new Date().toISOString();
+
+    for (const item of keys) {
+      const keyFingerprint = fingerprint(item.platform, item.key);
+      if (dedupe && seen.has(keyFingerprint)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (dedupe) seen.add(keyFingerprint);
+
+      const encrypted = encrypt(item.key);
+      const createdAt = item.createdAt ?? importedAt;
+      const inserted = insert.run(
+        item.platform,
+        item.label,
+        encrypted.encrypted,
+        encrypted.iv,
+        encrypted.authTag,
+        item.status,
+        item.enabled ? 1 : 0,
+        createdAt,
+        item.lastCheckedAt ?? null,
+      );
+
+      result.inserted += 1;
+      result.keys.push({
+        id: Number(inserted.lastInsertRowid),
+        platform: item.platform,
+        label: item.label,
+        maskedKey: maskKey(item.key),
+        enabled: item.enabled,
+      });
+    }
+  });
+
+  run();
+  result.skipped += errors.length;
+  return result;
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -2,6 +2,7 @@ import { getDb } from '../db/index.js';
 import { getProvider } from '../providers/index.js';
 import { decrypt } from '../lib/crypto.js';
 import { canMakeRequest, canUseTokens, isOnCooldown } from './ratelimit.js';
+import { throttledRefresh } from '../lib/db-refresh.js';
 import type { BaseProvider } from '../providers/base.js';
 
 interface ModelRow {
@@ -131,7 +132,10 @@ export function getAllPenalties(): Array<{ modelDbId: number; count: number; pen
  * @param skipKeys - set of "platform:modelId:keyId" to skip (failed on this request)
  * @param preferredModelDbId - try this model first (sticky session)
  */
-export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, preferredModelDbId?: number): RouteResult {
+export async function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, preferredModelDbId?: number): Promise<RouteResult> {
+  // Trigger async DB refresh (fire-and-forget, won't block)
+  throttledRefresh().catch(() => {});
+
   const db = getDb();
 
   // Get fallback chain ordered by priority

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,7 +19,8 @@ export type Platform =
   | 'ollama'
   | 'kilo'
   | 'pollinations'
-  | 'llm7';
+  | 'llm7'
+  | 'anthropic';
 
 export interface Model {
   id: number;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -57,6 +57,47 @@ export interface ApiKeyCreate {
   label?: string;
 }
 
+export interface ApiKeyImportInput {
+  platform: Platform;
+  key: string;
+  label?: string;
+  enabled?: boolean;
+}
+
+export interface ApiKeyImportResult {
+  inserted: number;
+  skipped: number;
+  replaced: number;
+  errors: Array<{ index: number; message: string }>;
+  keys: Array<{
+    id: number;
+    platform: Platform;
+    label: string;
+    maskedKey: string;
+    enabled: boolean;
+  }>;
+}
+
+export interface FreeLLMBackup {
+  format: 'freellmapi-backup';
+  version: number;
+  exportedAt: string;
+  unifiedApiKey: string;
+  unifiedApiKeyPinned: boolean;
+  providerKeys: Array<ApiKeyImportInput & {
+    status?: KeyStatus;
+    createdAt?: string;
+    lastCheckedAt?: string | null;
+  }>;
+  fallback: Array<{
+    platform: Platform;
+    modelId: string;
+    priority: number;
+    enabled: boolean;
+  }>;
+  warnings?: Array<{ id: number; message: string }>;
+}
+
 // ---- Fallback Config ----
 
 export interface FallbackEntry {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": "client/dist",
+  "functions": {
+    "api/index.js": {
+      "includeFiles": "server/dist/**",
+      "maxDuration": 60
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/v1/:path*",
+      "destination": "/api/index"
+    },
+    {
+      "source": "/:path*",
+      "destination": "/index.html"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "version": 2,
   "installCommand": "npm install",
   "buildCommand": "npm run build",
+  "outputDirectory": "client/dist",
   "functions": {
     "api/index.js": {
       "includeFiles": "server/dist/**,client/dist/**",

--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,9 @@
   "version": 2,
   "installCommand": "npm install",
   "buildCommand": "npm run build",
-  "outputDirectory": "client/dist",
   "functions": {
     "api/index.js": {
-      "includeFiles": "server/dist/**",
+      "includeFiles": "server/dist/**,client/dist/**",
       "maxDuration": 60
     }
   },
@@ -20,7 +19,7 @@
     },
     {
       "source": "/:path*",
-      "destination": "/index.html"
+      "destination": "/api/index"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Anthropic Provider**: New `AnthropicProvider` routes Claude models (`claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5-20250501`) via the Anthropic Messages API (`POST /v1/messages`). Full SSE streaming supported. Translates OpenAI-format requests to Anthropic native format transparently.
- **Response Caching**: LRU cache (30s TTL) for non-streaming/non-tool-call requests in `server/src/lib/cache.ts`.
- **DB Refresh Fix**: Debounced refresh (500ms) prevents race condition on concurrent API requests (`server/src/lib/db-refresh.ts`).
- **Health Checker**: Async circuit breaker, staggered provider checks, 30s startup delay to avoid blocking server boot.
- **Rate Limiting**: Dashboard endpoints now rate-limited (auth 10/min, keys 100/min, API 300/min).
- **OpenAPI Docs**: Swagger UI at `/api/docs`.
- **Frontend**: `ErrorBoundary` + `LoadingSkeleton` components, retry logic in `api.ts`.

## Test plan

- [x] `npm test -w server` — 102/102 passing
- [x] `npm run build` — clean TypeScript + Vite build
- [ ] Manual: add Anthropic API key via dashboard, call `/v1/chat/completions` with `model: "claude-sonnet-4-6"`
- [ ] Manual: verify `/api/docs` loads Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)