### PR TITLE
fix: admin APIs expose key and routing controls without authentication while...

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,13 +1,59 @@
 const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+const ADMIN_TOKEN_STORAGE_KEY = 'freellmapi.adminToken';
+let pendingAdminToken: Promise<string | null> | null = null;
 
-export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+function getAdminToken(): string {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) ?? '';
+}
+
+function rememberAdminToken(value: unknown) {
+  if (typeof window === 'undefined') return;
+  if (!value || typeof value !== 'object') return;
+
+  const apiKey = (value as { apiKey?: unknown }).apiKey;
+  if (typeof apiKey === 'string' && apiKey.length > 0) {
+    localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, apiKey);
+  }
+}
+
+function requestAdminToken(): Promise<string | null> {
+  if (typeof window === 'undefined') return Promise.resolve(null);
+  if (!pendingAdminToken) {
+    pendingAdminToken = Promise.resolve(window.prompt('Admin API key')?.trim() || null)
+      .then(token => {
+        if (token) localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, token);
+        return token;
+      })
+      .finally(() => {
+        pendingAdminToken = null;
+      });
+  }
+  return pendingAdminToken;
+}
+
+export async function apiFetch<T>(path: string, options?: RequestInit, retryAuth = true): Promise<T> {
+  const headers = new Headers(options?.headers);
+  if (!headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
+
+  const adminToken = getAdminToken();
+  if (adminToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${adminToken}`);
+  }
+
   const res = await fetch(`${BASE}${path}`, {
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
     ...options,
+    headers,
   });
+  if (res.status === 401 && retryAuth) {
+    const token = await requestAdminToken();
+    if (token) return apiFetch<T>(path, options, false);
+  }
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
     throw new Error(body.error?.message ?? `HTTP ${res.status}`);
   }
-  return res.json();
+  const body = await res.json();
+  rememberAdminToken(body);
+  return body;
 }

--- a/server/src/__tests__/routes/admin-auth.test.ts
+++ b/server/src/__tests__/routes/admin-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { getDb, getUnifiedApiKey, initDb } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, headers?: Record<string, string>) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, { method, headers });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+describe('Admin API authentication', () => {
+  let app: Express;
+
+  const protectedRoutes = [
+    ['GET', '/api/settings/api-key'],
+    ['GET', '/api/keys'],
+    ['GET', '/api/fallback'],
+    ['POST', '/api/health/check-all'],
+    ['GET', '/api/analytics/summary'],
+  ] as const;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp({ adminAuth: { allowLocalBypass: false } });
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+  });
+
+  it.each(protectedRoutes)('%s %s rejects requests without admin auth', async (method, path) => {
+    const { status, body } = await request(app, method, path);
+    expect(status).toBe(401);
+    expect(body.error.message).toBe('Admin authentication required');
+  });
+
+  it.each(protectedRoutes)('%s %s accepts the unified bearer token', async (method, path) => {
+    const { status } = await request(app, method, path, {
+      Authorization: `Bearer ${getUnifiedApiKey()}`,
+    });
+    expect(status).toBe(200);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { fallbackRouter } from './routes/fallback.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
+import { createAdminAuth, type AdminAuthOptions } from './middleware/adminAuth.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -29,9 +30,14 @@ function getAllowedCorsOrigins() {
   return new Set([...DEFAULT_DASHBOARD_ORIGINS, ...configuredOrigins]);
 }
 
-export function createApp() {
+export interface CreateAppOptions {
+  adminAuth?: AdminAuthOptions;
+}
+
+export function createApp(options: CreateAppOptions = {}) {
   const app = express();
   const allowedCorsOrigins = getAllowedCorsOrigins();
+  const adminAuth = createAdminAuth(options.adminAuth);
 
   // CSP intentionally disabled — the SPA bundles inline styles and the OG
   // image is loaded from the same origin; enabling helmet's default CSP
@@ -48,12 +54,12 @@ export function createApp() {
   app.use(express.json({ limit: '1mb' }));
 
   // API routes
-  app.use('/api/keys', keysRouter);
+  app.use('/api/keys', adminAuth, keysRouter);
   app.use('/api/models', modelsRouter);
-  app.use('/api/fallback', fallbackRouter);
-  app.use('/api/analytics', analyticsRouter);
-  app.use('/api/health', healthRouter);
-  app.use('/api/settings', settingsRouter);
+  app.use('/api/fallback', adminAuth, fallbackRouter);
+  app.use('/api/analytics', adminAuth, analyticsRouter);
+  app.use('/api/health', adminAuth, healthRouter);
+  app.use('/api/settings', adminAuth, settingsRouter);
 
   // OpenAI-compatible proxy
   app.use('/v1', proxyRouter);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,14 +4,18 @@ import { initDb } from './db/index.js';
 import { startHealthChecker } from './services/health.js';
 
 const PORT = process.env.PORT ?? 3001;
+const HOST = process.env.HOST ?? '127.0.0.1';
 
 async function main() {
   initDb();
   const app = createApp();
 
-  app.listen(Number(PORT), '0.0.0.0', () => {
-    console.log(`Server running on http://0.0.0.0:${PORT}`);
-    console.log(`Proxy endpoint: http://0.0.0.0:${PORT}/v1/chat/completions`);
+  app.listen(Number(PORT), HOST, () => {
+    console.log(`Server running on http://${HOST}:${PORT}`);
+    console.log(`Proxy endpoint: http://${HOST}:${PORT}/v1/chat/completions`);
+    if (HOST === '0.0.0.0' || HOST === '::') {
+      console.warn('[Security] HOST exposes the server beyond localhost; admin APIs require a bearer token.');
+    }
     startHealthChecker();
   });
 }

--- a/server/src/middleware/adminAuth.ts
+++ b/server/src/middleware/adminAuth.ts
@@ -1,0 +1,47 @@
+import crypto from 'crypto';
+import type { NextFunction, Request, Response } from 'express';
+import { getUnifiedApiKey } from '../db/index.js';
+
+export interface AdminAuthOptions {
+  allowLocalBypass?: boolean;
+}
+
+function timingSafeStringEqual(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
+  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
+}
+
+function bearerToken(req: Request): string | undefined {
+  const header = req.headers.authorization;
+  const match = header?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function isLocalRequest(req: Request): boolean {
+  const isLocalPeer = req.ip === '127.0.0.1' || req.ip === '::1' || req.ip === '::ffff:127.0.0.1';
+  const host = req.hostname.toLowerCase();
+  const isLocalHost = host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+  return isLocalPeer && isLocalHost;
+}
+
+export function createAdminAuth(options: AdminAuthOptions = {}) {
+  const allowLocalBypass = options.allowLocalBypass ?? true;
+
+  return function requireAdminAuth(req: Request, res: Response, next: NextFunction) {
+    if (allowLocalBypass && isLocalRequest(req)) {
+      next();
+      return;
+    }
+
+    const token = bearerToken(req);
+    if (token && timingSafeStringEqual(token, getUnifiedApiKey())) {
+      next();
+      return;
+    }
+
+    res.setHeader('WWW-Authenticate', 'Bearer realm="freellmapi-admin"');
+    res.status(401).json({ error: { message: 'Admin authentication required' } });
+  };
+}


### PR DESCRIPTION
Hi,

I opened this PR to address a [RepoVista](https://github.com/nordbyte/RepoVista) finding in tashfeenahmed/freellmapi: Admin APIs expose key and routing controls without authentication while listening on all interfaces. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## RepoVista Patch Attempt

<!-- repovista:patch:pat_401af45a1001 -->

- Patch: pat_401af45a1001
- Status: applied
- Repository: tashfeenahmed/freellmapi
- Analyzed commit: [18eb04be990b](https://github.com/tashfeenahmed/freellmapi/commit/18eb04be990bcdaca842574bf6e00a6968308761)
- RepoVista run: 2026-05-21T13-49-06-041Z
- Findings: fnd_a1e1cc536d0c
- Features: feat_9a250011a5c5

## Plan

Finding: fnd_a1e1cc536d0c - Admin APIs expose key and routing controls without authentication while listening on all interfaces
Severity: high
Feature: feat_9a250011a5c5
Affected paths: server/src/app.ts, server/src/index.ts, server/src/routes/fallback.ts, server/src/routes/health.ts, server/src/routes/keys.ts, server/src/routes/settings.ts
Minimum fix scope: `server/src/app.ts`, a new or shared auth middleware, and client fetch calls in `client/src/lib/api.ts` / dashboard pages.
Recommended fix: Add a shared admin-auth middleware before all non-public `/api/*` routes. Reuse the unified bearer-token comparison or introduce a separate `ADMIN_TOKEN`; require it for key, settings, fallback, analytics, and health mutation routes. Bind to `127.0.0.1` by default and make `HOST=0.0.0.0` an explicit opt-in documented as unsafe without auth/reverse-proxy controls.
Suggested regression test: Add route tests that call `/api/settings/api-key`, `/api/keys`, `/api/fallback`, `/api/health/check-all`, and `/api/analytics/summary` without admin auth and expect `401`; add authenticated variants that still pass.

## Files Changed

- client/src/lib/api.ts
- server/src/__tests__/routes/admin-auth.test.ts
- server/src/app.ts
- server/src/index.ts
- server/src/middleware/adminAuth.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: README.md, client/src/lib/api.ts, docs/, server/src/__tests__/, server/src/app.ts, server/src/index.ts, server/src/lib/, server/src/middleware/, server/src/middlewares/, server/src/routes/fallback.ts, server/src/routes/health.ts, server/src/routes/keys.ts, server/src/routes/settings.ts, server/src/tests/, server/src/utils/, server/test/, server/tests/
- Violations: none

## Validation

- npm ci: 0
- npm run test -w server: 0
- npm run build: 0

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: README.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._
