### PR TITLE
fix: open CORS plus localhost auth bypass lets arbitrary browser origins use the...

### DIFF
--- a/server/src/__tests__/integration/full-flow.test.ts
+++ b/server/src/__tests__/integration/full-flow.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest';
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
-import { initDb, getDb } from '../../db/index.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 
-async function req(app: Express, method: string, path: string, body?: any) {
+async function req(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
   const server = app.listen(0);
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 
   const res = await fetch(url, {
     method,
-    headers: body ? { 'Content-Type': 'application/json' } : {},
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
     body: body ? JSON.stringify(body) : undefined,
   });
 
@@ -21,6 +21,10 @@ async function req(app: Express, method: string, path: string, body?: any) {
   try { json = JSON.parse(data); } catch {}
 
   return { status: res.status, body: json, headers: res.headers, raw: data };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
 }
 
 describe('Full Integration Flow', () => {
@@ -58,10 +62,10 @@ describe('Full Integration Flow', () => {
     expect(body[0]).toHaveProperty('enabled');
   });
 
-  it('Step 3: Proxy returns 429 with no keys', async () => {
+  it('Step 3: Authenticated proxy returns 429 with no keys', async () => {
     const { status, body } = await req(app, 'POST', '/v1/chat/completions', {
       messages: [{ role: 'user', content: 'hello' }],
-    });
+    }, authHeaders());
     // 429 (all exhausted) or 502 (provider error) or 503 (no route)
     expect([429, 502, 503]).toContain(status);
     expect(body.error).toBeDefined();
@@ -98,7 +102,7 @@ describe('Full Integration Flow', () => {
 
     const { status, body } = await req(app, 'POST', '/v1/chat/completions', {
       messages: [{ role: 'user', content: 'hello' }],
-    });
+    }, authHeaders());
 
     // 502 (provider error) or 429 (all exhausted after retries)
     expect([502, 429]).toContain(status);
@@ -145,12 +149,12 @@ describe('Full Integration Flow', () => {
   it('Step 10: Validate request schema', async () => {
     const { status } = await req(app, 'POST', '/v1/chat/completions', {
       messages: [], // empty
-    });
+    }, authHeaders());
     expect(status).toBe(400);
 
     const { status: s2 } = await req(app, 'POST', '/v1/chat/completions', {
       // missing messages entirely
-    });
+    }, authHeaders());
     expect(s2).toBe(400);
   });
 
@@ -158,7 +162,7 @@ describe('Full Integration Flow', () => {
     const { status, body } = await req(app, 'POST', '/v1/chat/completions', {
       model: 'definitely-not-a-real-model',
       messages: [{ role: 'user', content: 'hi' }],
-    });
+    }, authHeaders());
     expect(status).toBe(400);
     expect(body.error.code).toBe('model_not_found');
     expect(body.error.message).toContain('not in the catalog');
@@ -169,7 +173,7 @@ describe('Full Integration Flow', () => {
     const { status, body } = await req(app, 'POST', '/v1/chat/completions', {
       model: 'gemini-2.5-pro',
       messages: [{ role: 'user', content: 'hi' }],
-    });
+    }, authHeaders());
     expect(status).toBe(400);
     expect(body.error.code).toBe('model_not_found');
     expect(body.error.message).toContain('is disabled');

--- a/server/src/__tests__/routes/proxy-auth-cors.test.ts
+++ b/server/src/__tests__/routes/proxy-auth-cors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.text();
+  server.close();
+
+  let json: any = null;
+  try { json = JSON.parse(data); } catch {}
+
+  return { status: res.status, body: json, headers: res.headers, raw: data };
+}
+
+describe('Proxy authentication and CORS', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  it('requires the unified API key for loopback chat completions', async () => {
+    const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(status).toBe(401);
+    expect(body.error.type).toBe('authentication_error');
+  });
+
+  it('does not grant CORS access to arbitrary browser origins', async () => {
+    const { status, headers } = await request(app, 'GET', '/api/ping', undefined, {
+      Origin: 'https://attacker.example',
+    });
+
+    expect(status).toBe(200);
+    expect(headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('allows the local dashboard origin through CORS', async () => {
+    const { status, headers } = await request(app, 'GET', '/api/ping', undefined, {
+      Origin: 'http://localhost:5173',
+    });
+
+    expect(status).toBe(200);
+    expect(headers.get('access-control-allow-origin')).toBe('http://localhost:5173');
+  });
+});

--- a/server/src/__tests__/routes/proxy-tools.test.ts
+++ b/server/src/__tests__/routes/proxy-tools.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
-import { initDb, getDb } from '../../db/index.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 
-async function request(app: Express, method: string, path: string, body?: any) {
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
   const server = app.listen(0);
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 
   const res = await fetch(url, {
     method,
-    headers: body ? { 'Content-Type': 'application/json' } : {},
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
     body: body ? JSON.stringify(body) : undefined,
   });
 
@@ -21,6 +21,10 @@ async function request(app: Express, method: string, path: string, body?: any) {
   try { json = JSON.parse(data); } catch {}
 
   return { status: res.status, body: json, headers: res.headers, raw: data };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
 }
 
 describe('Proxy tool-calling support', () => {
@@ -103,7 +107,7 @@ describe('Proxy tool-calling support', () => {
         },
       }],
       tool_choice: 'required',
-    });
+    }, authHeaders());
 
     expect(status).toBe(200);
     expect(providerBody.tools).toHaveLength(1);
@@ -163,7 +167,7 @@ describe('Proxy tool-calling support', () => {
           content: '{"temp_c":30}',
         },
       ],
-    });
+    }, authHeaders());
 
     expect(status).toBe(200);
     expect(providerBody.messages[1].role).toBe('assistant');

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -14,8 +14,24 @@ import { errorHandler } from './middleware/errorHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const DEFAULT_DASHBOARD_ORIGINS = [
+  'http://localhost:5173',
+  'http://127.0.0.1:5173',
+  'http://[::1]:5173',
+];
+
+function getAllowedCorsOrigins() {
+  const configuredOrigins = (process.env.DASHBOARD_ORIGINS ?? '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  return new Set([...DEFAULT_DASHBOARD_ORIGINS, ...configuredOrigins]);
+}
+
 export function createApp() {
   const app = express();
+  const allowedCorsOrigins = getAllowedCorsOrigins();
 
   // CSP intentionally disabled — the SPA bundles inline styles and the OG
   // image is loaded from the same origin; enabling helmet's default CSP
@@ -24,7 +40,11 @@ export function createApp() {
   // stay disabled unless someone serves the proxy over HTTPS publicly
   // (which is also not a supported deployment — see README).
   app.use(helmet({ contentSecurityPolicy: false, hsts: false }));
-  app.use(cors());
+  app.use(cors({
+    origin(origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
+      callback(null, !origin || allowedCorsOrigins.has(origin));
+    },
+  }));
   app.use(express.json({ limit: '1mb' }));
 
   // API routes

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -182,24 +182,16 @@ function isRetryableError(err: any): boolean {
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   const start = Date.now();
 
-  // Authenticate with unified API key. Local requests (127.0.0.1) skip the check
-  // since they came from the same machine running the server. Non-local requests
-  // MUST present a valid Bearer token — missing or wrong → 401.
-  //
-  // Note: req.ip is the actual TCP socket peer because we never set
-  // `trust proxy`, so X-Forwarded-For cannot spoof a localhost identity.
-  // If a future change enables `trust proxy`, this localhost bypass MUST be
-  // re-evaluated.
-  const isLocal = req.ip === '127.0.0.1' || req.ip === '::1' || req.ip === '::ffff:127.0.0.1';
-  if (!isLocal) {
-    const token = req.headers.authorization?.replace(/^Bearer\s+/i, '');
-    const unifiedKey = getUnifiedApiKey();
-    if (!token || !timingSafeStringEqual(token, unifiedKey)) {
-      res.status(401).json({
-        error: { message: 'Invalid API key', type: 'authentication_error' },
-      });
-      return;
-    }
+  // Authenticate with the unified API key for every proxy request, including
+  // loopback callers. Browser pages can reach localhost, so socket locality is
+  // not a reliable authorization boundary.
+  const token = req.headers.authorization?.replace(/^Bearer\s+/i, '');
+  const unifiedKey = getUnifiedApiKey();
+  if (!token || !timingSafeStringEqual(token, unifiedKey)) {
+    res.status(401).json({
+      error: { message: 'Invalid API key', type: 'authentication_error' },
+    });
+    return;
   }
 
   // Validate request


### PR DESCRIPTION
Hi,

I opened this PR to address a [RepoVista](https://github.com/nordbyte/RepoVista) finding in tashfeenahmed/freellmapi: Open CORS plus localhost auth bypass lets arbitrary browser origins use the proxy. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## RepoVista Patch Attempt

<!-- repovista:patch:pat_5b34b669e129 -->

- Patch: pat_5b34b669e129
- Status: applied
- Repository: tashfeenahmed/freellmapi
- Analyzed commit: [18eb04be990b](https://github.com/tashfeenahmed/freellmapi/commit/18eb04be990bcdaca842574bf6e00a6968308761)
- RepoVista run: 2026-05-21T13-49-06-041Z
- Findings: fnd_c06dbd6c76d2
- Features: feat_9a250011a5c5

## Plan

Finding: fnd_c06dbd6c76d2 - Open CORS plus localhost auth bypass lets arbitrary browser origins use the proxy
Severity: high
Feature: feat_9a250011a5c5
Affected paths: server/src/app.ts, server/src/routes/proxy.ts
Minimum fix scope: `server/src/routes/proxy.ts` auth gate and `server/src/app.ts` CORS configuration.
Recommended fix: Remove the localhost bearer-token bypass, or restrict it to the dashboard origin with explicit CORS origin checks and CSRF protections. Prefer requiring the unified key for `/v1/chat/completions` consistently, including loopback, and have the dashboard attach it explicitly.
Suggested regression test: Add an integration test that sends `/v1/chat/completions` from loopback without `Authorization` and expects `401` once the bypass is removed; add CORS tests asserting only configured dashboard origins are allowed.

## Files Changed

- server/src/__tests__/integration/full-flow.test.ts
- server/src/__tests__/routes/proxy-auth-cors.test.ts
- server/src/__tests__/routes/proxy-tools.test.ts
- server/src/app.ts
- server/src/routes/proxy.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: server/src/__tests__/, server/src/app.ts, server/src/lib/, server/src/middleware/, server/src/middlewares/, server/src/routes/proxy.ts, server/src/tests/, server/src/utils/, server/test/, server/tests/
- Violations: none

## Validation

- npm ci: 0
- npm run test -w server: 0
- npm run build: 0

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: README.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._
