### PR TITLE
docs: DASHBOARD_ORIGINS + credit @nordbyte + Star History chart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@ ENCRYPTION_KEY=your-64-char-hex-key-here
 
 # Server port (default: 3001)
 PORT=3001
+
+# Comma-separated extra origins allowed to call the API from a browser.
+# localhost:5173, 127.0.0.1:5173, [::1]:5173 are allowed by default for the
+# Vite dev dashboard. Only set this if you serve the dashboard from a
+# different host than the API (e.g. http://pi.local).
+# DASHBOARD_ORIGINS=http://pi.local,http://192.168.1.50

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/zhangyu1324"><img src="https://images.weserv.nl/?url=github.com/zhangyu1324.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@zhangyu1324" /></a>
 <a href="https://github.com/jtbrennan-git"><img src="https://images.weserv.nl/?url=github.com/jtbrennan-git.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@jtbrennan-git" /></a>
 <a href="https://github.com/praveenkumarpranjal"><img src="https://images.weserv.nl/?url=github.com/praveenkumarpranjal.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@praveenkumarpranjal" /></a>
+<a href="https://github.com/nordbyte"><img src="https://images.weserv.nl/?url=github.com/nordbyte.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@nordbyte" /></a>
 
 ## Terms of Service review
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Removed since the April 2026 review: Hugging Face, Moonshot, and MiniMax direct 
 
 **This project is for personal experimentation and learning, not production.** Free tiers exist so developers can prototype against them; they aren't a stable, supported inference substrate and shouldn't be treated as one. If you build something real on top of FreeLLMAPI, swap in a paid API before you ship. Your relationship with each upstream provider is governed by the terms you accepted when you created your account — those terms still apply when the traffic is proxied through this project, and you're responsible for complying with them.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/chart?repos=tashfeenahmed/freellmapi&type=date&legend=top-left)](https://www.star-history.com/?repos=tashfeenahmed%2Ffreellmapi&type=date&legend=top-left)
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
## Summary
- **`.env.example`** — Document the new `DASHBOARD_ORIGINS` allowlist knob introduced by #55 (CORS lockdown). Defaults cover the Vite dev origins; users only need to set it when the dashboard is served from a different host than the API (e.g. Pi nginx via `pi.local`).
- **README** — Add @nordbyte to the contributor avatar grid for the security fix in #55.
- **README** — Add a Star History chart section (just above License) using star-history.com.

## Test plan
- [ ] Open the rendered README and confirm @nordbyte's avatar loads round.
- [ ] Confirm the Star History chart renders.
- [ ] Confirm `.env.example` reads clearly.