### PR TITLE
fix(router): treat 413 Payload Too Large as retryable

### DIFF
--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isRetryableError } from '../../routes/proxy.js';
+
+describe('isRetryableError', () => {
+  describe('413 Payload Too Large (the bug this PR fixes)', () => {
+    it('treats explicit "413" in the error message as retryable', () => {
+      expect(isRetryableError(new Error('GitHub Models API error 413: Request body too large'))).toBe(true);
+      expect(isRetryableError(new Error('Cloudflare API error 413: Payload Too Large'))).toBe(true);
+    });
+
+    it('treats common 413 phrasings (no status code) as retryable', () => {
+      expect(isRetryableError(new Error('Payload Too Large'))).toBe(true);
+      expect(isRetryableError(new Error('Request body too large for this model'))).toBe(true);
+      expect(isRetryableError(new Error('Request entity too large'))).toBe(true);
+      expect(isRetryableError(new Error('Content too large'))).toBe(true);
+    });
+  });
+
+  describe('existing categories still classify correctly', () => {
+    it('429 / rate limits are retryable', () => {
+      expect(isRetryableError(new Error('429 Too Many Requests'))).toBe(true);
+      expect(isRetryableError(new Error('rate limit exceeded'))).toBe(true);
+      expect(isRetryableError(new Error('quota exhausted'))).toBe(true);
+    });
+
+    it('5xx and network errors are retryable', () => {
+      expect(isRetryableError(new Error('503 Service Unavailable'))).toBe(true);
+      expect(isRetryableError(new Error('500 Internal Server Error'))).toBe(true);
+      expect(isRetryableError(new Error('ETIMEDOUT'))).toBe(true);
+      expect(isRetryableError(new Error('ECONNREFUSED'))).toBe(true);
+    });
+
+    it('4xx other than 413/429 are NOT retryable', () => {
+      expect(isRetryableError(new Error('401 Unauthorized'))).toBe(false);
+      expect(isRetryableError(new Error('403 Forbidden'))).toBe(false);
+      expect(isRetryableError(new Error('404 Not Found'))).toBe(false);
+      expect(isRetryableError(new Error('400 Bad Request'))).toBe(false);
+    });
+  });
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -189,14 +189,18 @@ const chatCompletionSchema = z.object({
   parallel_tool_calls: z.boolean().optional(),
 });
 
-function isRetryableError(err: any): boolean {
+export function isRetryableError(err: any): boolean {
   const msg = (err.message ?? '').toLowerCase();
   return msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')
     || msg.includes('quota') || msg.includes('resource_exhausted')
     || msg.includes('aborted') || msg.includes('timeout') || msg.includes('etimedout')
     || msg.includes('econnrefused') || msg.includes('econnreset')
     || msg.includes('503') || msg.includes('unavailable')
-    || msg.includes('500') || msg.includes('internal server error');
+    || msg.includes('500') || msg.includes('internal server error')
+    // 413: this model's payload limit is too small for the request, but another
+    // provider in the fallback chain may have a larger limit. Same reasoning as 503.
+    || msg.includes('413') || msg.includes('payload too large') || msg.includes('request body too large')
+    || msg.includes('request entity too large') || msg.includes('content too large');
 }
 
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

`isRetryableError()` in `server/src/routes/proxy.ts` lists 429, 5xx, and network errors as retryable, but it forgot **413 Payload Too Large**. Semantically 413 from one provider has the same meaning as 503: "I can't serve this — try another upstream". Without it, a single oversized request to a small-limit provider (GitHub Models is the easy repro: ~32 KB body cap) gets surfaced to the client as 502, even though the fallback chain almost certainly contains a provider with a bigger limit.

## Reproduction (before patch)

1. Add a GitHub Models key. Add a Cerebras / OpenRouter / Google key too — anyone with a larger body limit.
2. POST `/v1/chat/completions` with a ~50 KB user message (e.g. an opencode session that ships its tool-system-prompt).
3. Router picks GPT-4o → GitHub returns 413 → `isRetryableError` returns `false` → proxy returns **502** to the client. The fallback chain is never consulted, even though Cerebras would have handled the request fine.

## Fix

Two extra lines in the retryable substring list: `413`, `payload too large`, `request body too large`, `request entity too large`, `content too large`. Same handling path as 503 — model+key gets cooled down, router tries the next entry.

```diff
   || msg.includes('503') || msg.includes('unavailable')
-  || msg.includes('500') || msg.includes('internal server error');
+  || msg.includes('500') || msg.includes('internal server error')
+  // 413: this model's payload limit is too small for the request, but another
+  // provider in the fallback chain may have a larger limit. Same reasoning as 503.
+  || msg.includes('413') || msg.includes('payload too large') || msg.includes('request body too large')
+  || msg.includes('request entity too large') || msg.includes('content too large');
```

## Side benefit

413 errors now feed `recordRateLimitHit()`, so providers with small body caps naturally sink in dynamic priority instead of needing the user to manually demote them in the fallback chain.

## Tests

- New file: `server/src/__tests__/routes/proxy-retry.test.ts` (5 cases covering 413 phrasings + a regression sweep of existing categories).
- Required exporting \`isRetryableError\` — single-character diff in proxy.ts.
- All tests pass locally (`npx vitest run`).

## Repro confirmed end-to-end

After this patch, the same 50 KB POST with \`model: \"auto\"\` returns HTTP 200 with \`X-Routed-Via: cerebras/qwen-3-235b-a22b-instruct-2507\` — router skipped past GitHub Models on the 413 and landed on a provider that could serve the request.