### PR TITLE
fix(google): sanitize JSON Schema fields Gemini rejects

### DIFF
--- a/server/src/__tests__/providers/google-schema.test.ts
+++ b/server/src/__tests__/providers/google-schema.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForGemini } from '../../providers/google.js';
+
+describe('sanitizeForGemini', () => {
+  it('strips top-level JSON-Schema-only fields that Google rejects', () => {
+    const input = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'http://example.com/foo.json',
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    });
+  });
+
+  it('strips exclusiveMinimum / exclusiveMaximum recursively in nested properties', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        temp_threshold: { type: 'number', exclusiveMinimum: 0, exclusiveMaximum: 100 },
+        nested: {
+          type: 'object',
+          properties: {
+            count: { type: 'integer', exclusiveMinimum: 1 },
+          },
+        },
+      },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: {
+        temp_threshold: { type: 'number' },
+        nested: {
+          type: 'object',
+          properties: {
+            count: { type: 'integer' },
+          },
+        },
+      },
+    });
+  });
+
+  it('walks through arrays (e.g. anyOf branches)', () => {
+    const input = {
+      anyOf: [
+        { type: 'string', $ref: '#/definitions/foo' },
+        { type: 'number', exclusiveMinimum: 0 },
+      ],
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      anyOf: [
+        { type: 'string' },
+        { type: 'number' },
+      ],
+    });
+  });
+
+  it('removes $defs / definitions / patternProperties / if-then-else', () => {
+    const input = {
+      type: 'object',
+      $defs: { Foo: { type: 'string' } },
+      definitions: { Bar: { type: 'integer' } },
+      patternProperties: { '^x-': { type: 'string' } },
+      if: { properties: { kind: { const: 'A' } } },
+      then: { required: ['extra'] },
+      else: { required: [] },
+      properties: { kind: { type: 'string' } },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: { kind: { type: 'string' } },
+    });
+  });
+
+  it('passes through supported OpenAPI fields untouched', () => {
+    const input = {
+      type: 'object',
+      description: 'A tool input',
+      required: ['city'],
+      properties: {
+        city: { type: 'string', description: 'City name', enum: ['Karachi', 'Lahore'] },
+        items: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 10 },
+      },
+    };
+    expect(sanitizeForGemini(input)).toEqual(input);
+  });
+
+  it('handles primitives and null safely', () => {
+    expect(sanitizeForGemini(null)).toBe(null);
+    expect(sanitizeForGemini(undefined)).toBe(undefined);
+    expect(sanitizeForGemini('hello')).toBe('hello');
+    expect(sanitizeForGemini(42)).toBe(42);
+    expect(sanitizeForGemini(true)).toBe(true);
+  });
+});

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -67,6 +67,34 @@ function toGeminiFinishReason(finishReason?: string): string {
   return 'stop';
 }
 
+// Google Gemini accepts only a subset of JSON Schema (~OpenAPI 3.0).
+// Strip fields that opencode / other strict-JSON-Schema clients send but
+// Google rejects with 400 "Unknown name '<field>'".
+const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
+  '$schema', '$id', '$ref', '$defs', '$comment',
+  'definitions',
+  'exclusiveMinimum', 'exclusiveMaximum',
+  'patternProperties', 'unevaluatedProperties', 'unevaluatedItems',
+  'if', 'then', 'else',
+  'contentEncoding', 'contentMediaType', 'contentSchema',
+  'dependentRequired', 'dependentSchemas',
+]);
+
+export function sanitizeForGemini(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeForGemini);
+  }
+  if (schema && typeof schema === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+      if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(k)) continue;
+      out[k] = sanitizeForGemini(v);
+    }
+    return out;
+  }
+  return schema;
+}
+
 function toGeminiTools(tools?: ChatToolDefinition[]): Array<{ functionDeclarations: Array<Record<string, unknown>> }> | undefined {
   if (!tools || tools.length === 0) return undefined;
 
@@ -74,7 +102,7 @@ function toGeminiTools(tools?: ChatToolDefinition[]): Array<{ functionDeclaratio
     functionDeclarations: tools.map(t => ({
       name: t.function.name,
       description: t.function.description,
-      parameters: t.function.parameters,
+      parameters: sanitizeForGemini(t.function.parameters),
     })),
   }];
 }


### PR DESCRIPTION
## Summary

`toGeminiTools()` in `server/src/providers/google.ts` forwards each tool's `parameters` schema to Google's `functionDeclarations` field as-is. Google's schema validator is OpenAPI-3.0-flavoured and rejects strict JSON-Schema-only fields with HTTP 400 \`Unknown name \"$schema\" at 'tools[0].function_declarations[0].parameters': Cannot find field.\` This breaks tool calling through Gemini for any client that emits draft 2020-12 schemas — opencode, AI SDK, Cursor's tool wrappers, Continue, etc.

## Reproduction (before patch)

```bash
curl -X POST http://localhost:3001/v1/chat/completions \
  -H "Authorization: Bearer <unified-key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemini-2.5-flash",
    "messages": [{"role":"user","content":"weather in Karachi"}],
    "tools": [{
      "type":"function",
      "function":{
        "name":"get_weather",
        "parameters":{
          "$schema":"https://json-schema.org/draft/2020-12/schema",
          "type":"object",
          "properties":{"city":{"type":"string"},"threshold":{"type":"number","exclusiveMinimum":0}},
          "required":["city"]
        }
      }
    }],
    "tool_choice":"required"
  }'
```

Response: \`502 Provider error (Gemini 2.5 Flash): Google API error 400: Invalid JSON payload received. Unknown name \"$schema\" ... Unknown name \"exclusiveMinimum\" ...\`

## Fix

Added `sanitizeForGemini()` — a small recursive walker that strips a blacklist of fields known to be unsupported by Gemini's validator. Applied to `t.function.parameters` in the single call site (`toGeminiTools`).

Blacklist (intentionally minimal — only fields with documented rejection):
- `$schema`, `$id`, `$ref`, `$defs`, `$comment`, `definitions`
- `exclusiveMinimum`, `exclusiveMaximum`
- `patternProperties`, `unevaluatedProperties`, `unevaluatedItems`
- `if`, `then`, `else`
- `contentEncoding`, `contentMediaType`, `contentSchema`
- `dependentRequired`, `dependentSchemas`

Other valid JSON Schema fields (`type`, `properties`, `required`, `description`, `enum`, `items`, `minimum`, `maximum`, `minItems`, etc.) pass through untouched — Google accepts them.

## Tests

New file: `server/src/__tests__/providers/google-schema.test.ts` (6 cases):
- top-level `$schema` / `$id` stripped
- nested `exclusiveMinimum` stripped through `properties.X.properties.Y`
- array recursion (e.g. `anyOf` branches)
- `$defs` / `definitions` / `patternProperties` / `if-then-else` all stripped
- supported OpenAPI fields untouched (passthrough)
- primitives/null safety

All pass locally (`npx vitest run`).

## End-to-end verification

After this patch, the same curl above succeeds with a `tool_calls` response — `get_weather({"city":"Karachi"})`. Verified in production-like setup with real Gemini 2.5 Flash key.

## Note

`sanitizeForGemini` is exported only for the unit test. If you prefer it stay internal, happy to wrap the test against `toGeminiTools` instead — just say the word.