### PR TITLE
fix(proxy): treat 404 as retryable error to trigger fallback chain

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -196,7 +196,8 @@ function isRetryableError(err: any): boolean {
     || msg.includes('aborted') || msg.includes('timeout') || msg.includes('etimedout')
     || msg.includes('econnrefused') || msg.includes('econnreset')
     || msg.includes('503') || msg.includes('unavailable')
-    || msg.includes('500') || msg.includes('internal server error');
+    || msg.includes('500') || msg.includes('internal server error')
+    || msg.includes('404') || msg.includes('not found') || msg.includes('not_found');
 }
 
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
@@ -413,10 +414,26 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         // Put this model+key on cooldown and try the next one
         const skipId = `${route.platform}:${route.modelId}:${route.keyId}`;
         skipKeys.add(skipId);
-        setCooldown(route.platform, route.modelId, route.keyId, 120_000);
-        recordRateLimitHit(route.modelDbId);
+
+        const msg = (err.message ?? '').toLowerCase();
+        const is404 = msg.includes('404') || msg.includes('not found') || msg.includes('not_found');
+
+        if (is404) {
+          // 404 = model unavailable/removed — longer cooldown and heavier penalty
+          // to avoid wasting future requests on a dead model
+          setCooldown(route.platform, route.modelId, route.keyId, 300_000);
+          // Penalize multiple times so the model sinks hard in priority
+          recordRateLimitHit(route.modelDbId);
+          recordRateLimitHit(route.modelDbId);
+          recordRateLimitHit(route.modelDbId);
+          console.log(`[Proxy] 404 from ${route.displayName}, penalizing heavily (attempt ${attempt + 1}/${MAX_RETRIES})`);
+        } else {
+          setCooldown(route.platform, route.modelId, route.keyId, 120_000);
+          recordRateLimitHit(route.modelDbId);
+          console.log(`[Proxy] ${err.message.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
+        }
+
         lastError = err;
-        console.log(`[Proxy] ${err.message.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
         continue;
       }
 


### PR DESCRIPTION
When a provider returns a 404 (e.g. a model is removed from OpenRouter or a model endpoint is deprecated), the fallback chain did not trigger — the router returned a 502 and the client saw a permanent failure. In OpenAI-compatible clients (opencode, etc.) this manifests as repeated failures with no automatic recovery.

Changes
- Add '404', 'not found', 'not_found' to isRetryableError() so the retry loop catches these errors and falls back to the next model.
- 404 errors now apply a 5-minute cooldown (vs. 2-minutes for 429) and a 3x routing penalty (penalty=9), making the model sink in priority across subsequent requests so working models are tried first.
- The dynamic penalty decays over time, so the model recovers if it becomes available again.