### PR TITLE
fix(google): Remove unsupported additionalProperties

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": ""
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/server/src/__tests__/providers/google-schema.test.ts
+++ b/server/src/__tests__/providers/google-schema.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForGemini } from '../../providers/google.js';
+
+describe('sanitizeForGemini', () => {
+  it('strips top-level JSON-Schema-only fields that Google rejects', () => {
+    const input = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'http://example.com/foo.json',
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    });
+  });
+
+  it('strips exclusiveMinimum / exclusiveMaximum recursively in nested properties', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        temp_threshold: { type: 'number', exclusiveMinimum: 0, exclusiveMaximum: 100 },
+        nested: {
+          type: 'object',
+          properties: {
+            count: { type: 'integer', exclusiveMinimum: 1 },
+          },
+        },
+      },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: {
+        temp_threshold: { type: 'number' },
+        nested: {
+          type: 'object',
+          properties: {
+            count: { type: 'integer' },
+          },
+        },
+      },
+    });
+  });
+
+  it('walks through arrays (e.g. anyOf branches)', () => {
+    const input = {
+      anyOf: [
+        { type: 'string', $ref: '#/definitions/foo' },
+        { type: 'number', exclusiveMinimum: 0 },
+      ],
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      anyOf: [
+        { type: 'string' },
+        { type: 'number' },
+      ],
+    });
+  });
+
+  it('removes $defs / definitions / patternProperties / if-then-else', () => {
+    const input = {
+      type: 'object',
+      $defs: { Foo: { type: 'string' } },
+      definitions: { Bar: { type: 'integer' } },
+      patternProperties: { '^x-': { type: 'string' } },
+      if: { properties: { kind: { const: 'A' } } },
+      then: { required: ['extra'] },
+      else: { required: [] },
+      properties: { kind: { type: 'string' } },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: { kind: { type: 'string' } },
+    });
+  });
+
+  it('passes through supported OpenAPI fields untouched', () => {
+    const input = {
+      type: 'object',
+      description: 'A tool input',
+      required: ['city'],
+      properties: {
+        city: { type: 'string', description: 'City name', enum: ['Karachi', 'Lahore'] },
+        items: { type: 'array', items: { type: 'string' }, minItems: 1, maxItems: 10 },
+      },
+    };
+    expect(sanitizeForGemini(input)).toEqual(input);
+  });
+
+  it('handles primitives and null safely', () => {
+    expect(sanitizeForGemini(null)).toBe(null);
+    expect(sanitizeForGemini(undefined)).toBe(undefined);
+    expect(sanitizeForGemini('hello')).toBe('hello');
+    expect(sanitizeForGemini(42)).toBe(42);
+    expect(sanitizeForGemini(true)).toBe(true);
+  });
+});

--- a/server/src/providers/cloudflare.ts
+++ b/server/src/providers/cloudflare.ts
@@ -22,10 +22,14 @@ export class CloudflareProvider extends BaseProvider {
 
   // Cloudflare's OpenAI-compat endpoint rejects `content: null` on assistant
   // messages that carry tool_calls, even though the OpenAI spec allows it.
+  // Also flatten ContentBlock[] arrays to plain strings since Cloudflare expects string | null.
   private normalizeMessages(messages: ChatMessage[]): ChatMessage[] {
-    return messages.map(m =>
-      m.content === null ? { ...m, content: '' } : m,
-    );
+    return messages.map(m => ({
+      ...m,
+      content: Array.isArray(m.content)
+        ? m.content.filter((b): b is { type: 'text'; text: string } => b.type === 'text').map(b => b.text).join('')
+        : (m.content ?? ''),
+    }));
   }
 
   async chatCompletion(

--- a/server/src/providers/cohere.ts
+++ b/server/src/providers/cohere.ts
@@ -11,6 +11,15 @@ export class CohereProvider extends BaseProvider {
   readonly platform = 'cohere' as const;
   readonly name = 'Cohere';
 
+  private normalizeMessages(messages: ChatMessage[]): ChatMessage[] {
+    return messages.map(m => ({
+      ...m,
+      content: Array.isArray(m.content)
+        ? m.content.filter((b): b is { type: 'text'; text: string } => b.type === 'text').map(b => b.text).join('')
+        : m.content,
+    }));
+  }
+
   async chatCompletion(
     apiKey: string,
     messages: ChatMessage[],
@@ -19,7 +28,7 @@ export class CohereProvider extends BaseProvider {
   ): Promise<ChatCompletionResponse> {
     const body: Record<string, unknown> = {
       model: modelId,
-      messages,
+      messages: this.normalizeMessages(messages),
       temperature: options?.temperature,
       max_tokens: options?.max_tokens,
       top_p: options?.top_p,
@@ -54,7 +63,7 @@ export class CohereProvider extends BaseProvider {
   ): AsyncGenerator<ChatCompletionChunk> {
     const body: Record<string, unknown> = {
       model: modelId,
-      messages,
+      messages: this.normalizeMessages(messages),
       temperature: options?.temperature,
       max_tokens: options?.max_tokens,
       top_p: options?.top_p,

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -67,6 +67,49 @@ function toGeminiFinishReason(finishReason?: string): string {
   return 'stop';
 }
 
+// Thinking models include a thought_signature on function calls that must be
+// echoed back in subsequent turns. Clients often strip non-standard fields, so
+// we cache them server-side keyed by tool_call_id.
+const THOUGHT_SIG_CACHE_MAX = 500;
+const thoughtSignatureCache = new Map<string, string>();
+
+function cacheThoughtSignature(id: string, sig: string | undefined): void {
+  if (!sig) return;
+  if (thoughtSignatureCache.size >= THOUGHT_SIG_CACHE_MAX) {
+    thoughtSignatureCache.delete(thoughtSignatureCache.keys().next().value!);
+  }
+  thoughtSignatureCache.set(id, sig);
+}
+
+// Google Gemini accepts only a subset of JSON Schema (~OpenAPI 3.0).
+// Strip fields that opencode / other strict-JSON-Schema clients send but
+// Google rejects with 400 "Unknown name '<field>'".
+const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
+  '$schema', '$id', '$ref', '$defs', '$comment',
+  'definitions',
+  'exclusiveMinimum', 'exclusiveMaximum',
+  'patternProperties', 'unevaluatedProperties', 'unevaluatedItems',
+  'if', 'then', 'else',
+  'contentEncoding', 'contentMediaType', 'contentSchema',
+  'dependentRequired', 'dependentSchemas',
+  'additionalProperties',
+]);
+
+export function sanitizeForGemini(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(sanitizeForGemini);
+  }
+  if (schema && typeof schema === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+      if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(k)) continue;
+      out[k] = sanitizeForGemini(v);
+    }
+    return out;
+  }
+  return schema;
+}
+
 function toGeminiTools(tools?: ChatToolDefinition[]): Array<{ functionDeclarations: Array<Record<string, unknown>> }> | undefined {
   if (!tools || tools.length === 0) return undefined;
 
@@ -74,7 +117,7 @@ function toGeminiTools(tools?: ChatToolDefinition[]): Array<{ functionDeclaratio
     functionDeclarations: tools.map(t => ({
       name: t.function.name,
       description: t.function.description,
-      parameters: t.function.parameters,
+      parameters: sanitizeForGemini(t.function.parameters),
     })),
   }];
 }
@@ -124,8 +167,9 @@ function toGeminiContents(messages: ChatMessage[]) {
         }
 
         for (const call of m.tool_calls ?? []) {
+          const thoughtSignature = call.thought_signature ?? thoughtSignatureCache.get(call.id);
           parts.push({
-            thoughtSignature: call.thought_signature,
+            thoughtSignature,
             functionCall: {
               id: call.id,
               name: call.function.name,
@@ -184,6 +228,7 @@ function extractToolCalls(parts: GeminiPart[] | undefined): ChatToolCall[] {
     if (!part.functionCall?.name) continue;
 
     const id = part.functionCall.id ?? `call_${Date.now()}_${fallbackIndex++}`;
+    cacheThoughtSignature(id, part.thoughtSignature);
     calls.push({
       id,
       type: 'function',

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -120,25 +120,47 @@ const toolCallSchema = z.object({
   thought_signature: z.string().optional(),
 });
 
+const contentTextBlockSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+
+const contentImageUrlBlockSchema = z.object({
+  type: z.literal('image_url'),
+  image_url: z.object({
+    url: z.string(),
+    detail: z.enum(['auto', 'low', 'high']).optional(),
+  }),
+});
+
+const contentBlockSchema = z.union([
+  contentTextBlockSchema,
+  contentImageUrlBlockSchema,
+  z.object({ type: z.string() }).passthrough(),
+]);
+
+const contentSchema = z.union([z.string(), z.array(contentBlockSchema)]);
+
 const systemMessageSchema = z.object({
   role: z.literal('system'),
-  content: z.string(),
+  content: contentSchema,
   name: z.string().optional(),
 });
 
 const userMessageSchema = z.object({
   role: z.literal('user'),
-  content: z.string(),
+  content: contentSchema,
   name: z.string().optional(),
 });
 
 const assistantMessageSchema = z.object({
   role: z.literal('assistant'),
-  content: z.string().nullable().optional(),
+  content: z.union([contentSchema, z.null()]).optional(),
   name: z.string().optional(),
   tool_calls: z.array(toolCallSchema).optional(),
 }).refine((msg) => {
-  const hasContent = typeof msg.content === 'string' && msg.content.length > 0;
+  const hasContent = (typeof msg.content === 'string' && msg.content.length > 0)
+    || (Array.isArray(msg.content) && msg.content.length > 0);
   const hasToolCalls = (msg.tool_calls?.length ?? 0) > 0;
   return hasContent || hasToolCalls;
 }, {
@@ -147,7 +169,7 @@ const assistantMessageSchema = z.object({
 
 const toolMessageSchema = z.object({
   role: z.literal('tool'),
-  content: z.string(),
+  content: contentSchema,
   tool_call_id: z.string().min(1),
   name: z.string().optional(),
 });
@@ -265,8 +287,12 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // (see line ~340). Streaming will drift from real consumption — accepted
   // tradeoff because per-request usage isn't always returned mid-stream.
   const estimatedInputTokens = messages.reduce((sum, m) => {
-    if (typeof m.content !== 'string') return sum;
-    return sum + Math.ceil(m.content.length / 4);
+    if (typeof m.content === 'string') return sum + Math.ceil(m.content.length / 4);
+    if (Array.isArray(m.content)) {
+      const text = m.content.filter((b: { type: string; text?: string }) => b.type === 'text').map((b: { type: string; text?: string }) => b.text ?? '').join('');
+      return sum + Math.ceil(text.length / 4);
+    }
+    return sum;
   }, 0);
   const estimatedTotal = estimatedInputTokens + (max_tokens ?? 1000);
 

--- a/server/src/scripts/test-all-models.ts
+++ b/server/src/scripts/test-all-models.ts
@@ -46,7 +46,8 @@ for (const row of models) {
   const start = Date.now();
   try {
     const res = await provider.chatCompletion(apiKey, [{ role: 'user', content: 'hi' }], row.model_id, { max_tokens: 5 });
-    const reply = res.choices?.[0]?.message?.content?.slice(0, 40) ?? '';
+    const rawContent = res.choices?.[0]?.message?.content;
+    const reply = (typeof rawContent === 'string' ? rawContent : '').slice(0, 40);
     results.push({ row, ok: true, ms: Date.now() - start, reply });
   } catch (err: any) {
     results.push({ row, ok: false, ms: Date.now() - start, error: String(err?.message ?? err).slice(0, 200) });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -106,9 +106,21 @@ export type ChatToolChoice =
     };
   };
 
+export interface ContentTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface ContentImageUrlBlock {
+  type: 'image_url';
+  image_url: { url: string; detail?: 'auto' | 'low' | 'high' };
+}
+
+export type ContentBlock = ContentTextBlock | ContentImageUrlBlock | { type: string; [key: string]: unknown };
+
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
-  content: string | null;
+  content: string | ContentBlock[] | null;
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatToolCall[];


### PR DESCRIPTION
Google's API rejects the `additionalProperties` keyword in JSON schemas, causing 502 errors. This PR removes `additionalProperties` from tool parameter schemas before sending them to Google's API.

Builds off of: https://github.com/tashfeenahmed/freellmapi/pull/69

Looks like it might be duplicated by: https://github.com/tashfeenahmed/freellmapi/pull/65