### PR TITLE
fix(router): treat 404 model-removed as retryable (closes #66, credits @JammyJames1234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/mybropro"><img src="https://images.weserv.nl/?url=github.com/mybropro.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@mybropro" /></a>
 <a href="https://github.com/danscMax"><img src="https://images.weserv.nl/?url=github.com/danscMax.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@danscMax" /></a>
 <a href="https://github.com/jhash"><img src="https://images.weserv.nl/?url=github.com/jhash.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@jhash" /></a>
+<a href="https://github.com/JammyJames1234"><img src="https://images.weserv.nl/?url=github.com/JammyJames1234.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@JammyJames1234" /></a>
 
 ## Terms of Service review
 

--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { isRetryableError } from '../../routes/proxy.js';
 
 describe('isRetryableError', () => {
-  describe('413 Payload Too Large (the bug this PR fixes)', () => {
+  describe('413 Payload Too Large', () => {
     it('treats explicit "413" in the error message as retryable', () => {
       expect(isRetryableError(new Error('GitHub Models API error 413: Request body too large'))).toBe(true);
       expect(isRetryableError(new Error('Cloudflare API error 413: Payload Too Large'))).toBe(true);
@@ -13,6 +13,22 @@ describe('isRetryableError', () => {
       expect(isRetryableError(new Error('Request body too large for this model'))).toBe(true);
       expect(isRetryableError(new Error('Request entity too large'))).toBe(true);
       expect(isRetryableError(new Error('Content too large'))).toBe(true);
+    });
+  });
+
+  describe('404 model removed / not found (the bug #66 fixes)', () => {
+    it('treats explicit "404" in the error message as retryable', () => {
+      expect(isRetryableError(new Error('OpenRouter API error 404: Provider returned error'))).toBe(true);
+      expect(isRetryableError(new Error('Groq API error 404: model not found'))).toBe(true);
+    });
+
+    it('catches OpenRouter\'s "No endpoints found" phrasing for deprecated models', () => {
+      expect(isRetryableError(new Error('No endpoints found for openrouter/minimax/minimax-m2.5:free'))).toBe(true);
+    });
+
+    it('catches bare "not found" phrasing (any provider, any case)', () => {
+      expect(isRetryableError(new Error('Model not found'))).toBe(true);
+      expect(isRetryableError(new Error('The requested model was not found'))).toBe(true);
     });
   });
 
@@ -30,11 +46,11 @@ describe('isRetryableError', () => {
       expect(isRetryableError(new Error('ECONNREFUSED'))).toBe(true);
     });
 
-    it('4xx other than 413/429 are NOT retryable', () => {
+    it('4xx auth/validation errors are NOT retryable', () => {
       expect(isRetryableError(new Error('401 Unauthorized'))).toBe(false);
       expect(isRetryableError(new Error('403 Forbidden'))).toBe(false);
-      expect(isRetryableError(new Error('404 Not Found'))).toBe(false);
       expect(isRetryableError(new Error('400 Bad Request'))).toBe(false);
+      expect(isRetryableError(new Error('Invalid API key'))).toBe(false);
     });
   });
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -215,7 +215,11 @@ export function isRetryableError(err: any): boolean {
     // 413: this model's payload limit is too small for the request, but another
     // provider in the fallback chain may have a larger limit. Same reasoning as 503.
     || msg.includes('413') || msg.includes('payload too large') || msg.includes('request body too large')
-    || msg.includes('request entity too large') || msg.includes('content too large');
+    || msg.includes('request entity too large') || msg.includes('content too large')
+    // 404: model deprecated/removed upstream (e.g. OpenRouter's "no endpoints found"
+    // for a model that's been pulled). Rotate to the next model in the chain —
+    // setCooldown + the health checker will avoid this model on subsequent requests.
+    || msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found');
 }
 
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary

Fixes #66. When an upstream returns 404 (deprecated/removed model, e.g. OpenRouter's `"No endpoints found for openrouter/minimax/minimax-m2.5:free"`), the proxy previously bailed with a 502 instead of rotating to the next model in the fallback chain — and because nothing marked the model unhealthy, every subsequent prompt hit the same dead model. OpenAI-compat clients like opencode just saw the same error on every request with no automatic recovery.

## Change

One-line addition to \`isRetryableError\` in \`server/src/routes/proxy.ts\`:

\`\`\`ts
|| msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
\`\`\`

Same pattern as #64 (413). The existing retry loop handles the in-flight rotation; \`setCooldown(..., 120_000)\` keeps the model out of rotation short-term; the health checker eventually marks it bad longer-term.

## Tests

3 new cases in \`proxy-retry.test.ts\`:
- explicit \`"404"\` in error text → retryable
- OpenRouter's \`"No endpoints found …"\` phrasing → retryable
- bare \`"not found"\` (any provider) → retryable

Updated the 4xx regression guard so 401 / 403 / 400 stay non-retryable.

Full suite: **132/132 passing** (was 129 → +3 new).

## Credits

- @JammyJames1234 — bug report and accurate diagnosis. Added to the contributor avatar grid.