### PR TITLE
feat(catalog): V13 — cross-provider refresh + HuggingFace router (May 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # FreeLLMAPI
 
-**One OpenAI-compatible endpoint. Eleven free LLM providers. ~1B+ tokens per month.**
+**One OpenAI-compatible endpoint. Twelve free LLM providers. ~1B+ tokens per month.**
 
-Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, and Z.ai (Zhipu) behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
+Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, and Z.ai (Zhipu) behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
 [![CI](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml/badge.svg)](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
@@ -56,7 +56,7 @@ The problem is that stacking them by hand is painful: fourteen different SDKs, f
 <td align="center"><a href="https://cohere.com"><b>Cohere</b><br/>Command R+ · Command-A (trial)</a></td>
 <td align="center"><a href="https://docs.z.ai"><b>Z.ai (Zhipu)</b><br/>GLM-4.5 · GLM-4.7 Flash</a></td>
 <td align="center"><a href="https://build.nvidia.com"><b>NVIDIA</b><br/>NIM (disabled by default)</a></td>
-<td align="center"><i>Adding another? See <a href="#contributing">Contributing</a>.</i></td>
+<td align="center"><a href="https://huggingface.co/docs/inference-providers"><b>HuggingFace</b><br/>Router → DeepSeek V4 · Kimi K2.6 · Qwen3</a></td>
 </tr>
 </table>
 

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -70,6 +70,7 @@ const platformColors: Record<string, string> = {
   kilo:        '#7c3aed',
   pollinations: '#a855f7',
   llm7:        '#0ea5e9',
+  huggingface: '#ff9d00',
 }
 
 function TokenUsageBar({ data }: { data: TokenUsageData }) {

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -24,6 +24,7 @@ const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'kilo', label: 'Kilo Gateway (anon ok)' },
   { value: 'pollinations', label: 'Pollinations (anon ok)' },
   { value: 'llm7', label: 'LLM7 (anon ok)' },
+  { value: 'huggingface', label: 'HuggingFace Router' },
 ]
 
 const statusDot: Record<string, string> = {

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -114,6 +114,82 @@ describe('Migration idempotency', () => {
     ]);
   });
 
+  it('V13: cross-provider catalog refresh applies cleanly', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    // Disables — row kept but enabled=0.
+    const disabled = db.prepare(`
+      SELECT platform, model_id, enabled FROM models
+       WHERE (platform = 'google' AND model_id = 'gemini-3.1-pro-preview')
+          OR (platform = 'ollama' AND model_id IN ('kimi-k2-thinking', 'mistral-large-3:675b', 'deepseek-v3.2'))
+       ORDER BY platform, model_id
+    `).all() as { platform: string; model_id: string; enabled: number }[];
+    expect(disabled).toHaveLength(4);
+    for (const row of disabled) expect(row.enabled).toBe(0);
+
+    // Hard removals — row is gone entirely.
+    const removed = db.prepare(`
+      SELECT model_id FROM models
+       WHERE (platform = 'sambanova' AND model_id = 'DeepSeek-V3.1-cb')
+          OR (platform = 'cloudflare' AND model_id = '@cf/moonshotai/kimi-k2.5')
+    `).all();
+    expect(removed).toEqual([]);
+
+    // New rows present across providers (incl. new huggingface platform).
+    const additions = db.prepare(`
+      SELECT platform, model_id FROM models
+       WHERE (platform, model_id) IN (VALUES
+         ('groq',        'openai/gpt-oss-safeguard-20b'),
+         ('cloudflare',  '@cf/nvidia/nemotron-3-120b-a12b'),
+         ('cloudflare',  '@cf/google/gemma-4-26b-a4b-it'),
+         ('google',      'gemini-3.5-flash'),
+         ('nvidia',      'deepseek-ai/deepseek-v4-flash'),
+         ('nvidia',      'z-ai/glm-5.1'),
+         ('nvidia',      'qwen/qwen3-coder-480b-a35b-instruct'),
+         ('mistral',     'mistral-small-latest'),
+         ('mistral',     'ministral-8b-latest'),
+         ('cohere',      'command-a-reasoning-08-2025'),
+         ('cohere',      'command-r-08-2024'),
+         ('ollama',      'qwen3-coder-next'),
+         ('huggingface', 'deepseek-ai/DeepSeek-V4-Flash'),
+         ('huggingface', 'moonshotai/Kimi-K2.6'),
+         ('huggingface', 'Qwen/Qwen3-Coder-Next')
+       )
+    `).all();
+    expect(additions).toHaveLength(15);
+
+    // Spot-check critical limit/context updates.
+    const cerebrasLimits = db.prepare(`
+      SELECT rpm_limit, rpd_limit, tpm_limit, tpd_limit FROM models
+       WHERE platform = 'cerebras' AND model_id = 'qwen-3-235b-a22b-instruct-2507'
+    `).get() as { rpm_limit: number; rpd_limit: number; tpm_limit: number; tpd_limit: number };
+    expect(cerebrasLimits).toEqual({ rpm_limit: 5, rpd_limit: 2400, tpm_limit: 30000, tpd_limit: 1000000 });
+
+    const sambanovaCtx = (db.prepare(`
+      SELECT context_window FROM models WHERE platform = 'sambanova' AND model_id = 'DeepSeek-V3.2'
+    `).get() as { context_window: number }).context_window;
+    expect(sambanovaCtx).toBe(32768);
+
+    const cfFp8Ctx = (db.prepare(`
+      SELECT context_window FROM models WHERE platform = 'cloudflare' AND model_id = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
+    `).get() as { context_window: number }).context_window;
+    expect(cfFp8Ctx).toBe(24000);
+
+    const mistralCtx = db.prepare(`
+      SELECT model_id, context_window FROM models
+       WHERE platform = 'mistral'
+         AND model_id IN ('codestral-latest', 'devstral-latest', 'magistral-medium-latest', 'mistral-large-latest')
+       ORDER BY model_id
+    `).all() as { model_id: string; context_window: number }[];
+    expect(mistralCtx).toEqual([
+      { model_id: 'codestral-latest',       context_window: 256000 },
+      { model_id: 'devstral-latest',        context_window: 262144 },
+      { model_id: 'magistral-medium-latest', context_window: 131072 },
+      { model_id: 'mistral-large-latest',   context_window: 262144 },
+    ]);
+  });
+
   it('all enabled catalog platforms have a registered provider', async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -47,6 +47,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV10(db);
   migrateModelsV11(db);
   migrateModelsV12(db);
+  migrateModelsV13(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1003,6 +1004,193 @@ function migrateModelsV12(db: Database.Database) {
     ['openrouter', 'openrouter/owl-alpha',                         'Owl Alpha (OR-house)',           5,  9, 'Frontier', 20, 200, null, null, '~6M', 1048576],
     ['openrouter', 'nousresearch/hermes-3-llama-3.1-405b:free',    'Hermes 3 405B (free)',          17,  9, 'Large',    20, 200, null, null, '~6M', 131072],
   ];
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    const missing = db.prepare(`
+      SELECT m.id FROM models m
+      LEFT JOIN fallback_config f ON m.id = f.model_db_id
+      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+    `).all() as { id: number }[];
+    if (missing.length > 0) {
+      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+    }
+  });
+  apply();
+}
+
+/**
+ * V13 (May 2026): cross-provider catalog refresh — live-probed against the
+ * user's keys for Cerebras, Groq, SambaNova, Cloudflare, Google, NVIDIA,
+ * Mistral, Cohere, Ollama, HuggingFace, Z.ai, Chutes. Z.ai/Chutes confirmed
+ * no-change (non-flash Z.ai SKUs require recharge; Chutes still gated on
+ * $0 balance).
+ *
+ * DISABLES (row kept for re-enable history; pattern follows V5/V9):
+ *   - google/gemini-3.1-pro-preview — 429 with quotaMetric `free_tier_requests`
+ *     limit=0; moved off free tier. (V6 inferred Pro was free; lapsed since.)
+ *   - ollama/kimi-k2-thinking, ollama/mistral-large-3:675b, ollama/deepseek-v3.2
+ *     — all return 403 "this model requires a subscription" on the Free plan
+ *     now. (V10 catalogued them as Free; Ollama paywalled them since.)
+ *
+ * HARD REMOVALS (model is gone, not paywalled):
+ *   - sambanova/DeepSeek-V3.1-cb — absent from live /v1/models; V8 was over-eager.
+ *   - cloudflare/@cf/moonshotai/kimi-k2.5 — CF changelog: aliases to k2.6 on
+ *     2026-05-30. Two rows for one backend wastes a fallback slot.
+ *
+ * UPDATES (numbers verified from live response headers or /v1/models):
+ *   - cerebras: all 3 enabled rows → 5 RPM / 30K TPM / 2400 RPD / 1M TPD
+ *     (V4's 30/14400/60K/1M was stale; current free pool is 5 RPM shared).
+ *   - groq/llama-3.3-70b-versatile: TPD 500K → 100K (docs).
+ *   - groq/llama-4-scout: TPM 6K → 30K (live header).
+ *   - groq/compound + groq/compound-mini: RPD 1000→250, TPM 8K→70K, TPD→null
+ *     (compound systems run on a separate budget per docs + live header).
+ *   - sambanova/DeepSeek-V3.2: ctx 131K → 32K (/v1/models reports 32768).
+ *   - cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast: ctx 131K → 24K
+ *     (CF model page: fp8-fast variant capped at 24K).
+ *   - mistral context windows (all stale vs /v1/models):
+ *       codestral-latest        32K → 256K
+ *       devstral-latest        131K → 262K
+ *       magistral-medium       40K → 131K
+ *       mistral-large-latest  131K → 262K
+ *
+ * ADDITIONS (all chat-probed; tools verified with tool_choice=auto):
+ *   - groq: openai/gpt-oss-safeguard-20b (tool-tuned 20B; same pool as gpt-oss-20b)
+ *   - cloudflare: @cf/nvidia/nemotron-3-120b-a12b, @cf/google/gemma-4-26b-a4b-it
+ *     (both 256K ctx, function_calling=true; 429'd on probe due to daily
+ *     neuron exhaustion, not model-level — same Free pool as other CF rows)
+ *   - google: gemini-3.5-flash (2026-05 release; 1M ctx; tool calls verified)
+ *   - nvidia: deepseek-ai/deepseek-v4-flash, z-ai/glm-5.1 (~2min cold start),
+ *     qwen/qwen3-coder-480b-a35b-instruct (full id — discovered via /v1/models)
+ *   - mistral: mistral-small-latest (Small 4), ministral-8b-latest (edge 8B)
+ *   - cohere: command-a-reasoning-08-2025, command-r-08-2024. README ToS
+ *     table marks Cohere "❌ Avoid for personal use" — these rows expand
+ *     fallback coverage but inherit the same caveat.
+ *   - ollama: qwen3-coder-next (~80B-A3B coder)
+ *
+ * NEW PLATFORM (huggingface):
+ *   - V4 removed HF for "tool-call format issues" on the legacy serverless
+ *     endpoint that emitted tool calls as text. The new router.huggingface.co
+ *     meta-router uses each backend's native protocol and normalizes the
+ *     response — chat-probed clean tool_calls on DeepSeek-V4-Flash, Kimi-K2.6,
+ *     Qwen3-Coder-Next, GLM-4.7, Qwen3-235B. Recurring $0.10/mo router credit
+ *     on the free tier (no card, no expiry). Budget ~1-3M tokens/mo depending
+ *     on backend. Seeded with 3 frontier rows.
+ *   - Provider registration lives in server/src/providers/index.ts.
+ *
+ * NO-CHANGE PROVIDERS (probed, nothing to update):
+ *   - openrouter (V12 just shipped)
+ *   - z.ai/zhipu — non-flash SKUs all 1113 "insufficient balance"; flash-only
+ *     pool is correctly catalogued.
+ *   - chutes — every probe 402 on $0 balance; V11 drop decision stands.
+ *
+ * DEFERRED:
+ *   - cerebras/qwen-3-235b-a22b-instruct-2507 + llama3.1-8b: docs flag
+ *     hard-deprecation 2026-05-27 (4d from migration), but both still 200
+ *     today. Disable in V14 on/after that date.
+ *   - sambanova: every chat probe returned 402 PAYMENT_METHOD_REQUIRED on the
+ *     user's account. /v1/models still lists rows so REMOVE/UPDATE above is
+ *     valid, but the SambaNova free tier may have lapsed account-wide.
+ *     Investigate before adding new SambaNova rows.
+ *   - github: gpt-5 family + xai/grok-3 both 400 "unavailable_model" on free
+ *     tier — keep gpt-4o (V2 verdict still holds).
+ */
+function migrateModelsV13(db: Database.Database) {
+  // 1) Disables (row kept; can be re-enabled without losing fallback history).
+  const disable = db.prepare(`UPDATE models SET enabled = 0 WHERE platform = ? AND model_id = ?`);
+  const disables: Array<[string, string]> = [
+    ['google', 'gemini-3.1-pro-preview'],
+    ['ollama', 'kimi-k2-thinking'],
+    ['ollama', 'mistral-large-3:675b'],
+    ['ollama', 'deepseek-v3.2'],
+  ];
+  for (const [p, m] of disables) disable.run(p, m);
+
+  // 2) Hard removals.
+  const deleteModel = db.prepare(`DELETE FROM models WHERE platform = ? AND model_id = ?`);
+  const deleteFallback = db.prepare(`
+    DELETE FROM fallback_config WHERE model_db_id IN (
+      SELECT id FROM models WHERE platform = ? AND model_id = ?
+    )
+  `);
+  const removals: Array<[string, string]> = [
+    ['sambanova', 'DeepSeek-V3.1-cb'],
+    ['cloudflare', '@cf/moonshotai/kimi-k2.5'],
+  ];
+  const applyRemovals = db.transaction(() => {
+    for (const [p, m] of removals) {
+      deleteFallback.run(p, m);
+      deleteModel.run(p, m);
+    }
+  });
+  applyRemovals();
+
+  // 3) Cerebras free-pool limit correction (3 enabled rows; zai-glm-4.7 stays
+  //    on its V5-set per-model 10/100 cap since it's gated separately).
+  db.prepare(`
+    UPDATE models
+       SET rpm_limit = 5, rpd_limit = 2400, tpm_limit = 30000, tpd_limit = 1000000
+     WHERE platform = 'cerebras'
+       AND model_id IN ('qwen-3-235b-a22b-instruct-2507', 'gpt-oss-120b', 'llama3.1-8b')
+  `).run();
+
+  // 4) Groq limit corrections.
+  db.prepare(`UPDATE models SET tpd_limit = 100000 WHERE platform = 'groq' AND model_id = 'llama-3.3-70b-versatile'`).run();
+  db.prepare(`UPDATE models SET tpm_limit = 30000 WHERE platform = 'groq' AND model_id = 'meta-llama/llama-4-scout-17b-16e-instruct'`).run();
+  db.prepare(`
+    UPDATE models SET rpd_limit = 250, tpm_limit = 70000, tpd_limit = NULL
+     WHERE platform = 'groq' AND model_id IN ('groq/compound', 'groq/compound-mini')
+  `).run();
+
+  // 5) Single-row context-window corrections.
+  db.prepare(`UPDATE models SET context_window = 32768 WHERE platform = 'sambanova' AND model_id = 'DeepSeek-V3.2'`).run();
+  db.prepare(`UPDATE models SET context_window = 24000 WHERE platform = 'cloudflare' AND model_id = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'`).run();
+
+  // 6) Mistral context-window corrections.
+  db.prepare(`UPDATE models SET context_window = 256000 WHERE platform = 'mistral' AND model_id = 'codestral-latest'`).run();
+  db.prepare(`UPDATE models SET context_window = 262144 WHERE platform = 'mistral' AND model_id = 'devstral-latest'`).run();
+  db.prepare(`UPDATE models SET context_window = 131072 WHERE platform = 'mistral' AND model_id = 'magistral-medium-latest'`).run();
+  db.prepare(`UPDATE models SET context_window = 262144 WHERE platform = 'mistral' AND model_id = 'mistral-large-latest'`).run();
+
+  // 7) Additions across providers (chat-probed; tools verified where claimed).
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    // Groq — shared 30 RPM / 1K RPD / 8K TPM / 200K TPD per-model pool.
+    ['groq',       'openai/gpt-oss-safeguard-20b',          'GPT-OSS Safeguard 20B (Groq)',   18, 2, 'Medium',   30, 1000, 8000, 200000, '~6M', 131072],
+
+    // Cloudflare — 10K Neurons/day shared free pool.
+    ['cloudflare', '@cf/nvidia/nemotron-3-120b-a12b',       'Nemotron 3 120B (CF)',            9, 11, 'Frontier', null, null, null, null, '~5-10M',  262144],
+    ['cloudflare', '@cf/google/gemma-4-26b-a4b-it',         'Gemma 4 26B-A4B it (CF)',        22, 11, 'Medium',   null, null, null, null, '~10-20M', 262144],
+
+    // Google — same 20 RPD per-model free pool. 3.5 Flash is the current Flash flagship.
+    ['google',     'gemini-3.5-flash',                      'Gemini 3.5 Flash',                3, 5, 'Large',    10, 20,  250000, null, '~3M', 1048576],
+
+    // NVIDIA NIM — credits-based; per-model 40 RPM.
+    ['nvidia',     'deepseek-ai/deepseek-v4-flash',         'DeepSeek V4 Flash (NV)',          4, 9, 'Frontier', 40, null, null, null, '~3M (credits)', 131072],
+    ['nvidia',     'z-ai/glm-5.1',                          'GLM-5.1 (NV, slow cold-start)',   5, 9, 'Frontier', 40, null, null, null, '~3M (credits)', 200000],
+    ['nvidia',     'qwen/qwen3-coder-480b-a35b-instruct',   'Qwen3-Coder 480B (NV)',           2, 9, 'Frontier', 40, null, null, null, '~3M (credits)', 262144],
+
+    // Mistral — Experiment plan 2 RPM / 500K TPM / shared ~1B/mo.
+    ['mistral',    'mistral-small-latest',                  'Mistral Small 4',                14, 8, 'Medium',   2, null, 500000, null, '~50-100M', 262144],
+    ['mistral',    'ministral-8b-latest',                   'Ministral 3 8B',                 28, 8, 'Small',    2, null, 500000, null, '~50-100M', 262144],
+
+    // Cohere — trial 20 RPM / 1000 RPM total. ToS table marks ❌ Avoid for personal use.
+    ['cohere',     'command-a-reasoning-08-2025',           'Command A Reasoning (08-2025)',  13, 11, 'Large',   20, 33, null, null, '~1-2M', 256000],
+    ['cohere',     'command-r-08-2024',                     'Command R (08-2024)',            25, 11, 'Medium',  20, 33, null, null, '~1-2M', 131072],
+
+    // Ollama Cloud — GPU-time quota.
+    ['ollama',     'qwen3-coder-next',                      'Qwen3-Coder Next (Ollama)',       3, 9, 'Large',   null, null, null, null, '~10-20M', 262144],
+
+    // HuggingFace router (new platform) — recurring $0.10/mo credit, no card.
+    ['huggingface', 'deepseek-ai/DeepSeek-V4-Flash',        'DeepSeek V4 Flash (HF)',          4, 9, 'Frontier', null, null, null, null, '~1-3M', 131072],
+    ['huggingface', 'moonshotai/Kimi-K2.6',                 'Kimi K2.6 (HF)',                  3, 9, 'Frontier', null, null, null, null, '~1-3M', 262144],
+    ['huggingface', 'Qwen/Qwen3-Coder-Next',                'Qwen3-Coder Next (HF)',           3, 9, 'Large',    null, null, null, null, '~1-3M', 262144],
+  ];
+
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);
     const missing = db.prepare(`

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -82,9 +82,19 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
 }));
 
-// Hugging Face, Moonshot, MiniMax direct integrations were dropped in V4 —
-// HF tool-call format issues; Moonshot moved to paid; MiniMax superseded by
-// the OpenRouter route (openrouter/minimax/minimax-m2.5:free).
+// Hugging Face Inference Providers router — re-added in V13. The V4 removal
+// reason ("tool-call format issues") was the legacy serverless route that
+// emitted tool calls as text; the new router.huggingface.co meta-router
+// uses each backend's native protocol then normalizes the response.
+// Recurring $0.10/mo router credit on the free tier, no card required.
+register(new OpenAICompatProvider({
+  platform: 'huggingface',
+  name: 'HuggingFace Router',
+  baseUrl: 'https://router.huggingface.co/v1',
+}));
+
+// Moonshot direct integration was dropped in V4 (paid-only); MiniMax direct
+// was dropped in V4 (superseded by the OpenRouter route).
 
 // Ollama Cloud — OpenAI-compatible. Free plan: 1 concurrent model, 5h session
 // caps, GPU-time-based quota (not per-token). Many catalog models on the

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -7,12 +7,12 @@ import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 export const keysRouter = Router();
 
 // Active providers — must match providers/index.ts registrations + shared/types.ts Platform.
-// Hugging Face, Moonshot, and MiniMax direct integrations were dropped in V4
-// (see migrateModelsV4 comment block).
+// Moonshot and MiniMax direct integrations were dropped in V4. HuggingFace
+// was dropped in V4 and re-added in V13 via the router.huggingface.co route.
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7',
+  'kilo', 'pollinations', 'llm7', 'huggingface',
 ] as const;
 
 const addKeySchema = z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2,8 +2,9 @@
 
 // Active platforms — must match server/src/providers/index.ts and
 // server/src/routes/keys.ts PLATFORMS allowlist.
-// Hugging Face, Moonshot, and MiniMax direct integrations were dropped
-// in migrateModelsV4 (see server/src/db/index.ts).
+// Moonshot and MiniMax direct integrations were dropped in migrateModelsV4
+// (see server/src/db/index.ts). HuggingFace was dropped in V4 and re-added
+// in V13 via the router.huggingface.co Inference Providers meta-router.
 export type Platform =
   | 'google'
   | 'groq'
@@ -19,7 +20,8 @@ export type Platform =
   | 'ollama'
   | 'kilo'
   | 'pollinations'
-  | 'llm7';
+  | 'llm7'
+  | 'huggingface';
 
 export interface Model {
   id: number;


### PR DESCRIPTION
## Summary

Live-probed audit against the user's keys for **12 providers**. Net change across the catalog: **−6 / +15 / 14 updates / 1 new platform**.

## Per-provider deltas

### Disables (row kept; can be re-enabled)
| Provider | model_id | Reason |
|---|---|---|
| google | `gemini-3.1-pro-preview` | 429 `quotaMetric: free_tier_requests, limit: 0` — paid-only |
| ollama | `kimi-k2-thinking` | 403 "this model requires a subscription" |
| ollama | `mistral-large-3:675b` | 403 "this model requires a subscription" |
| ollama | `deepseek-v3.2` | 403 "this model requires a subscription" |

### Hard removes
| Provider | model_id | Reason |
|---|---|---|
| sambanova | `DeepSeek-V3.1-cb` | absent from live `/v1/models` |
| cloudflare | `@cf/moonshotai/kimi-k2.5` | CF aliases to k2.6 on 2026-05-30 |

### Updates
- **cerebras** (3 rows): `rpm 30→5, tpm 60K→30K, rpd→2400, tpd→1M` (live response headers)
- **groq**: `llama-3.3-70b-versatile` TPD 500K→100K; `llama-4-scout` TPM 6K→30K; `compound[-mini]` RPD 1000→250, TPM 8K→70K, TPD→null
- **sambanova**: `DeepSeek-V3.2` ctx 131K→32K
- **cloudflare**: `@cf/meta/llama-3.3-70b-instruct-fp8-fast` ctx 131K→24K
- **mistral** (4 rows): `codestral 32K→256K`, `devstral 131K→262K`, `magistral 40K→131K`, `mistral-large 131K→262K`

### Additions (probe-verified 200 + tool_calls with `tool_choice=auto`)
| Provider | model_id | Notes |
|---|---|---|
| groq | `openai/gpt-oss-safeguard-20b` | tool-tuned variant of gpt-oss-20b |
| cloudflare | `@cf/nvidia/nemotron-3-120b-a12b` | 256K ctx, function_calling=true |
| cloudflare | `@cf/google/gemma-4-26b-a4b-it` | 256K ctx, function_calling=true |
| google | `gemini-3.5-flash` | 1M ctx, tool calls verified |
| nvidia | `deepseek-ai/deepseek-v4-flash` | frontier MoE |
| nvidia | `z-ai/glm-5.1` | flagged \`~2min cold start\` in display name |
| nvidia | `qwen/qwen3-coder-480b-a35b-instruct` | full id discovered via `/v1/models` |
| mistral | `mistral-small-latest` | Mistral Small 4, 262K |
| mistral | `ministral-8b-latest` | edge-tuned 8B, 262K |
| cohere | `command-a-reasoning-08-2025` | ⚠ ToS table still marks Cohere "Avoid for personal use" |
| cohere | `command-r-08-2024` | same caveat |
| ollama | `qwen3-coder-next` | 80B-A3B sparse coder |

### New platform: `huggingface` (router.huggingface.co/v1)

V4 removed HF because the legacy Fireworks serverless route emitted tool calls as text. The new Inference Providers meta-router normalises responses — chat-probed clean `tool_calls` on DeepSeek-V4-Flash, Kimi-K2.6, Qwen3-Coder-Next, GLM-4.7, Qwen3-235B. Recurring \$0.10/mo router credit, no card, no expiry.

Seeded rows:
- `deepseek-ai/DeepSeek-V4-Flash`
- `moonshotai/Kimi-K2.6`
- `Qwen/Qwen3-Coder-Next`

Platform registration in `server/src/providers/index.ts`; allowlist added to `shared/types.ts` `Platform`, `server/src/routes/keys.ts`, `client/src/pages/KeysPage.tsx` dropdown, `FallbackPage.tsx` color map.

## Rejected claims (probed false)
- **GitHub Models `gpt-4o`**: still 200s — KEEP
- **GitHub `gpt-5` / `gpt-5-mini`**: 400 `unavailable_model` on free tier
- **GitHub `xai/grok-3`**: 400 `unknown_model` — xai namespace gated
- **NVIDIA `meta/llama-3.1-70b-instruct`**: still 200s — KEEP
- **Z.ai `glm-4.6` and non-flash SKUs**: 429 "insufficient balance" — free pool is `-flash` only
- **Ollama `deepseek-v4-flash`/`minimax-m2.7`/`glm-5.1`**: 403 subscription-required
- **Chutes re-evaluation**: every probe 402 on \$0 balance; V11 drop decision stands

## Deferred
- **Cerebras 2026-05-27 hard-deprecation** of `qwen-3-235b-a22b-instruct-2507` and `llama3.1-8b`: both still 200 today. V14 will disable these on/after the deprecation date.
- **SambaNova account-wide 402**: every chat probe on the user's key returned `PAYMENT_METHOD_REQUIRED`. Catalog REMOVE/UPDATE above is still valid (sourced from `/v1/models`), but SambaNova free-tier eligibility on this account should be investigated before adding new SambaNova rows.

## Test plan
- [x] \`npm test -w server\` — 134/134 (was 133; +1 V13 catalog assertion)
- [x] \`npm run build -w server\` clean
- [x] \`npm run build -w client\` clean
- [x] Live probes on all 12 providers' add/remove/update candidates with `tool_choice=auto`
- [x] HF router tool-call regression check vs V4's removal reason — resolved