### PR TITLE
chore(catalog): V14 — disable Cerebras qwen-3-235b + llama3.1-8b ahead of 2026-05-27 deprecation

### DIFF
--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -190,6 +190,24 @@ describe('Migration idempotency', () => {
     ]);
   });
 
+  it('V14: cerebras deprecation disables qwen-3-235b and llama3.1-8b but keeps gpt-oss-120b enabled', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const rows = db.prepare(`
+      SELECT model_id, enabled FROM models
+       WHERE platform = 'cerebras'
+         AND model_id IN ('qwen-3-235b-a22b-instruct-2507', 'llama3.1-8b', 'gpt-oss-120b')
+       ORDER BY model_id
+    `).all() as { model_id: string; enabled: number }[];
+
+    expect(rows).toEqual([
+      { model_id: 'gpt-oss-120b',                    enabled: 1 },
+      { model_id: 'llama3.1-8b',                     enabled: 0 },
+      { model_id: 'qwen-3-235b-a22b-instruct-2507',  enabled: 0 },
+    ]);
+  });
+
   it('all enabled catalog platforms have a registered provider', async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -48,6 +48,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV11(db);
   migrateModelsV12(db);
   migrateModelsV13(db);
+  migrateModelsV14(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1205,6 +1206,28 @@ function migrateModelsV13(db: Database.Database) {
     }
   });
   apply();
+}
+
+/**
+ * V14 (May 2026): Cerebras hard-deprecation 2026-05-27.
+ *
+ * Per inference-docs.cerebras.ai/models/overview, both
+ * `qwen-3-235b-a22b-instruct-2507` and `llama3.1-8b` hit a hard deprecation
+ * on 2026-05-27 with no announced free-tier replacement at the same
+ * parameter class. Disable both ahead of the cutover so the router stops
+ * sending traffic to them. Row kept (not deleted) so it can be re-enabled
+ * if Cerebras restores or renames either model — same pattern as V9's
+ * disable of `zai-glm-4.7`.
+ *
+ * Cerebras `gpt-oss-120b` is NOT in the deprecation list and stays enabled
+ * as the sole free-tier Cerebras route.
+ */
+function migrateModelsV14(db: Database.Database) {
+  db.prepare(`
+    UPDATE models SET enabled = 0
+     WHERE platform = 'cerebras'
+       AND model_id IN ('qwen-3-235b-a22b-instruct-2507', 'llama3.1-8b')
+  `).run();
 }
 
 function ensureUnifiedKey(db: Database.Database) {


### PR DESCRIPTION
## Summary

Per [inference-docs.cerebras.ai/models/overview](https://inference-docs.cerebras.ai/models/overview), both `qwen-3-235b-a22b-instruct-2507` and `llama3.1-8b` hit hard deprecation on 2026-05-27 (4 days from now) with no announced free-tier replacement at the same parameter class. Disable both ahead of the cutover so the router stops sending traffic to them on/before the deprecation date.

Row kept (not deleted) so each can be re-enabled if Cerebras restores or renames either model — same pattern as V9's `zai-glm-4.7` disable.

`gpt-oss-120b` is **not** in the deprecation list and remains the sole enabled free-tier Cerebras route.

## Test plan
- [x] \`npm test -w server\` — 135/135 (was 134; +1 V14 catalog assertion)
- [x] \`npm run build -w server\` clean
- [x] V14 idempotent against re-runs (covered by existing idempotency test)