### PR TITLE
feat(keys): add per-provider enable/disable toggle on KeysPage

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform } from '../../../shared/types'
 
@@ -182,6 +183,19 @@ export default function KeysPage() {
     },
   })
 
+  const togglePlatform = useMutation({
+    mutationFn: ({ platform, enabled }: { platform: string; enabled: boolean }) =>
+      apiFetch(`/api/keys/platform/${platform}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ enabled }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+      queryClient.invalidateQueries({ queryKey: ['health'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+    },
+  })
+
   const needsAccountId = platform === 'cloudflare'
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -286,8 +300,17 @@ export default function KeysPage() {
             <div className="space-y-6">
               {grouped.map(group => (
                 <div key={group.value}>
-                  <div className="flex items-baseline justify-between mb-2">
-                    <h3 className="text-sm font-medium">{group.label}</h3>
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={group.keys.some(k => k.enabled)}
+                        onCheckedChange={(checked) =>
+                          togglePlatform.mutate({ platform: group.value, enabled: checked })
+                        }
+                        disabled={togglePlatform.isPending}
+                      />
+                      <h3 className="text-sm font-medium">{group.label}</h3>
+                    </div>
                     <span className="text-xs text-muted-foreground tabular-nums">
                       {group.keys.length} key{group.keys.length === 1 ? '' : 's'}
                     </span>

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -95,6 +95,26 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   res.json({ success: true });
 });
 
+// Toggle all keys for a platform
+keysRouter.patch('/platform/:platform', (req: Request, res: Response) => {
+  const platform = req.params.platform as string;
+  if (!(PLATFORMS as readonly string[]).includes(platform)) {
+    res.status(400).json({ error: { message: `Invalid platform '${platform}'` } });
+    return;
+  }
+
+  const { enabled } = req.body;
+  if (typeof enabled !== 'boolean') {
+    res.status(400).json({ error: { message: 'enabled must be a boolean' } });
+    return;
+  }
+
+  const db = getDb();
+  const result = db.prepare('UPDATE api_keys SET enabled = ? WHERE platform = ?').run(enabled ? 1 : 0, platform);
+
+  res.json({ success: true, enabled, updatedKeys: result.changes });
+});
+
 // Toggle enable/disable
 keysRouter.patch('/:id', (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);


### PR DESCRIPTION
Adds a Switch toggle per provider group on the KeysPage that enables or disables all API keys for that provider at once.

**Backend**: new PATCH /api/keys/platform/:platform endpoint toggles all keys for a given platform. Validates platform against the allowlist.

**Frontend**: per-provider Switch toggle in the provider group header. Calls the new endpoint and invalidates relevant query caches.

The router already respects api_keys.enabled, so no routing changes were needed - disabled keys are automatically skipped.