### PR TITLE
fix: non-decryptable keys can block routing

### DIFF
--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -96,4 +96,26 @@ describe('Router', () => {
     const result = routeRequest();
     expect(result.platform).toBe('groq');
   });
+
+  it('should skip keys that cannot be decrypted and use a valid fallback key', () => {
+    const db = getDb();
+
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('google', 'corrupt', 'not-hex', 'not-hex', 'not-hex', 'healthy', 1);
+
+    const groqKey = encrypt('test-groq-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
+
+    const result = routeRequest();
+    const corruptKey = db.prepare("SELECT status FROM api_keys WHERE label = 'corrupt'").get() as { status: string };
+
+    expect(result.platform).toBe('groq');
+    expect(result.apiKey).toBe('test-groq-key');
+    expect(corruptKey.status).toBe('error');
+  });
 });

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -167,10 +167,10 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     const provider = getProvider(model.platform as any);
     if (!provider) continue;
 
-    // Get all healthy, enabled keys for this platform
+    // Get enabled keys that have not already failed validation or decryption.
     const keys = db.prepare(
-      'SELECT * FROM api_keys WHERE platform = ? AND enabled = 1 AND status != ?'
-    ).all(model.platform, 'invalid') as KeyRow[];
+      "SELECT * FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')"
+    ).all(model.platform) as KeyRow[];
 
     if (keys.length === 0) continue;
 
@@ -199,10 +199,17 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
       if (!canMakeRequest(model.platform, model.model_id, key.id, limits)) continue;
       if (!canUseTokens(model.platform, model.model_id, key.id, estimatedTokens, limits)) continue;
 
+      let decryptedKey: string;
+      try {
+        decryptedKey = decrypt(key.encrypted_key, key.iv, key.auth_tag);
+      } catch {
+        db.prepare("UPDATE api_keys SET status = 'error', last_checked_at = datetime('now') WHERE id = ?")
+          .run(key.id);
+        continue;
+      }
+
       // We found a working key for this model!
       roundRobinIndex.set(rrKey, idx);
-      const decryptedKey = decrypt(key.encrypted_key, key.iv, key.auth_tag);
-
       return {
         provider,
         modelId: model.model_id,


### PR DESCRIPTION
Hi,

I opened this PR to address a [RepoVista](https://github.com/nordbyte/RepoVista) finding in tashfeenahmed/freellmapi: Non-decryptable keys can block routing. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## RepoVista Patch Attempt

<!-- repovista:patch:pat_9f2c41b5bf62 -->

- Patch: pat_9f2c41b5bf62
- Status: applied
- Repository: tashfeenahmed/freellmapi
- Analyzed commit: [daf7fdc65bbd](https://github.com/tashfeenahmed/freellmapi/commit/daf7fdc65bbd6871042f4975efdcab10a7bc320f)
- RepoVista run: 2026-05-25T06-19-39-338Z
- Findings: fnd_7f0e6db93548
- Features: feat_9a250011a5c5

## Plan

Finding: fnd_7f0e6db93548 - Non-decryptable keys can block routing
Severity: medium
Feature: feat_9a250011a5c5
Affected paths: server/src/lib/crypto.ts, server/src/routes/proxy.ts, server/src/services/health.ts, server/src/services/router.ts
Minimum fix scope: server/src/services/router.ts; optionally server/src/services/health.ts for status/disable policy.
Recommended fix: Catch decrypt errors in routeRequest per key, skip the key for the current attempt, optionally set status='error' or enabled=0, and continue with the next key/model. Additionally restrict selection to usable statuses such as healthy/unknown, or route error keys only after successful revalidation.
Suggested regression test: Add a router test: seed a corrupt high-priority key and a valid fallback key; routeRequest must skip the corrupt key and return a RouteResult for the valid key.

## Files Changed

- server/src/__tests__/services/router.test.ts
- server/src/services/router.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: server/src/__tests__/, server/src/lib/crypto.ts, server/src/routes/proxy.ts, server/src/services/health.ts, server/src/services/router.ts, server/src/tests/, server/test/, server/tests/
- Violations: none

## Validation

- npm ci: 0
- npm test -w server: 0
- npm run build -w server: 0
- npm run build -w client: 0

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: README.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._
