### PR TITLE
fix(proxy): redact provider errors before analytics

### DIFF
--- a/server/src/__tests__/routes/proxy-error-redaction.test.ts
+++ b/server/src/__tests__/routes/proxy-error-redaction.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.text();
+  server.close();
+
+  let json: any = null;
+  try { json = JSON.parse(data); } catch {}
+
+  return { status: res.status, body: json, headers: res.headers, raw: data };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
+}
+
+describe('Provider error redaction', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+
+    const addKey = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_proxy_redaction_test_key',
+      label: 'proxy-redaction',
+    });
+    expect(addKey.status).toBe(201);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redacts provider secrets from proxy responses and stored analytics', async () => {
+    const origFetch = global.fetch;
+    const leakedKey = 'gsk_live_should_not_escape_123456789';
+    const leakedUrl = 'https://api.groq.com/openai/v1/chat/completions?api_key=sk-live-query-secret';
+
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: () => Promise.resolve({
+            error: {
+              message: `Invalid Bearer ${leakedKey} for ${leakedUrl}`,
+            },
+          }),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const completion = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(completion.status).toBe(502);
+    const responseText = JSON.stringify(completion.body);
+    expect(responseText).not.toContain(leakedKey);
+    expect(responseText).not.toContain(leakedUrl);
+    expect(responseText).toContain('[redacted]');
+
+    const errors = await request(app, 'GET', '/api/analytics/errors?range=24h');
+    expect(errors.status).toBe(200);
+    const analyticsText = JSON.stringify(errors.body);
+    expect(analyticsText).not.toContain(leakedKey);
+    expect(analyticsText).not.toContain(leakedUrl);
+    expect(analyticsText).toContain('[redacted]');
+  });
+});

--- a/server/src/lib/error-redaction.ts
+++ b/server/src/lib/error-redaction.ts
@@ -1,0 +1,30 @@
+const MAX_PROVIDER_ERROR_LENGTH = 240;
+
+const REDACTIONS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, 'Bearer [redacted]'],
+  [/\b(api[_-]?key|access[_-]?token|token|secret|authorization)(\s*[:=]\s*)(["']?)[^"',\s}\]]+/gi, '$1$2$3[redacted]'],
+  [/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bgsk_[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bfreellmapi-[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bAIza[0-9A-Za-z_-]{20,}\b/g, '[redacted-key]'],
+  [/\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, '[redacted-token]'],
+  [/\bhttps?:\/\/[^\s"'<>)]*/gi, '[redacted-url]'],
+];
+
+export function sanitizeProviderErrorMessage(message: unknown): string {
+  let sanitized = typeof message === 'string' ? message : String(message ?? '');
+  sanitized = sanitized.trim();
+
+  if (!sanitized) return 'Provider error';
+
+  for (const [pattern, replacement] of REDACTIONS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+
+  sanitized = sanitized.replace(/\s+/g, ' ').trim();
+  if (sanitized.length > MAX_PROVIDER_ERROR_LENGTH) {
+    sanitized = `${sanitized.slice(0, MAX_PROVIDER_ERROR_LENGTH - 3).trimEnd()}...`;
+  }
+
+  return sanitized;
+}

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -7,6 +7,7 @@ import { routeRequest, recordRateLimitHit, recordSuccess, type RouteResult } fro
 import { recordRequest, recordTokens, setCooldown, getNextCooldownDuration } from '../services/ratelimit.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString } from '../lib/content.js';
+import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
 export const proxyRouter = Router();
 
@@ -338,9 +339,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     } catch (err: any) {
       // No more models available
       if (lastError) {
+        const safeLastError = sanitizeProviderErrorMessage(lastError.message);
         res.status(429).json({
           error: {
-            message: `All models rate-limited. Last error: ${lastError.message}`,
+            message: `All models rate-limited. Last error: ${safeLastError}`,
             type: 'rate_limit_error',
           },
         });
@@ -404,7 +406,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, streamErr.message);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message));
             return;
           }
           // Pre-stream error — bubble to outer retry/502 handler.
@@ -435,7 +437,8 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       }
     } catch (err: any) {
       const latency = Date.now() - start;
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, err.message);
+      const safeError = sanitizeProviderErrorMessage(err.message);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
 
       if (isRetryableError(err)) {
         // Put this model+key on cooldown and try the next one
@@ -449,14 +452,14 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;
-        console.log(`[Proxy] ${err.message.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
+        console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
         continue;
       }
 
       // Non-retryable error (auth, 4xx, etc.): don't retry
       res.status(502).json({
         error: {
-          message: `Provider error (${route.displayName}): ${err.message}`,
+          message: `Provider error (${route.displayName}): ${safeError}`,
           type: 'provider_error',
         },
       });
@@ -467,7 +470,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // Exhausted all retries
   res.status(429).json({
     error: {
-      message: `All models rate-limited after ${MAX_RETRIES} attempts. Last: ${lastError?.message}`,
+      message: `All models rate-limited after ${MAX_RETRIES} attempts. Last: ${sanitizeProviderErrorMessage(lastError?.message)}`,
       type: 'rate_limit_error',
     },
   });


### PR DESCRIPTION
Hi,

I opened this PR to address a [RepoVista](https://github.com/nordbyte/RepoVista) finding in `tashfeenahmed/freellmapi`: upstream provider error messages are stored and exposed through analytics without redaction. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## RepoVista Patch Attempt

<!-- repovista:patch:manual_fnd_cb22865f6233 -->

- Patch: manual_fnd_cb22865f6233
- Status: applied
- Repository: tashfeenahmed/freellmapi
- Analyzed commit: [dd46dafea3a0](https://github.com/tashfeenahmed/freellmapi/commit/dd46dafea3a0d9242129c3b7350d1727a3fb7f90)
- RepoVista run: 2026-05-26T13-50-51-089Z
- Findings: fnd_cb22865f6233
- Features: feat_9a250011a5c5

## Plan

Finding: fnd_cb22865f6233 - Upstream-Fehlertexte werden unredigiert gespeichert und ueber Analytics ausgegeben
Severity: medium
Feature: feat_9a250011a5c5
Affected paths: server/src/providers/openai-compat.ts, server/src/routes/analytics.ts, server/src/routes/proxy.ts
Minimum fix scope: Fehlernormalisierung in `server/src/routes/proxy.ts` oder gemeinsamer Helper; Analytics-/Proxy-Regressionstest.
Recommended fix: Provider-Fehler vor Speicherung und Client-Ausgabe redigieren: API-Key-/Bearer-/URL-Muster entfernen, Laenge begrenzen, nur Provider, Statuscode und Fehlerkategorie speichern. Detailmeldungen hoechstens in einem expliziten lokalen Debug-Modus ausgeben.
Suggested regression test: Mock-Provider-Fehler mit `sk-test-secret` oder `Bearer test-token` erzeugen und assertieren, dass Response, Datenbankeintrag und `/api/analytics/errors` die sensitiven Fragmente redigieren.

## Files Changed

- server/src/__tests__/routes/proxy-error-redaction.test.ts
- server/src/lib/error-redaction.ts
- server/src/routes/proxy.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: server/src/__tests__/, server/src/lib/, server/src/providers/openai-compat.ts, server/src/routes/analytics.ts, server/src/routes/proxy.ts
- Violations: none

## Validation

- npm run test -w server -- proxy-error-redaction.test.ts: 0
- npm run test -w server: 0
- npm run build -w server: 0
- GitHub CI Test & build: success

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: README.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._
