### PR TITLE
fix(analytics): prune request history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ ENCRYPTION_KEY=your-64-char-hex-key-here
 # Server port (default: 3001)
 PORT=3001
 
+# Request analytics retention. Set either value to 0 to disable that limit.
+REQUEST_ANALYTICS_RETENTION_DAYS=90
+REQUEST_ANALYTICS_MAX_ROWS=100000
+
 # Comma-separated extra origins allowed to call the API from a browser.
 # localhost:5173, 127.0.0.1:5173, [::1]:5173 are allowed by default for the
 # Vite dev dashboard. Only set this if you serve the dashboard from a

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ npm run dev
 database-stored development key when `DEV_MODE=true` and `NODE_ENV` is not
 `production`; do not use that fallback with real provider keys.
 
+Request analytics are retained for 90 days or 100000 request rows by default,
+whichever limit prunes first. Set `REQUEST_ANALYTICS_RETENTION_DAYS=0` or
+`REQUEST_ANALYTICS_MAX_ROWS=0` in `.env` to disable either retention limit.
+
 Open http://localhost:5173 (the Vite dev UI), add your provider keys on the **Keys** page, reorder the **Fallback Chain** to taste, and grab your unified API key from the **Keys** page header. That unified key is what you point your OpenAI SDK at.
 
 For a production build:

--- a/server/src/__tests__/services/request-retention.test.ts
+++ b/server/src/__tests__/services/request-retention.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDb, getDb } from '../../db/index.js';
+import { getRequestAnalyticsRetentionConfig, pruneRequestAnalytics } from '../../services/request-retention.js';
+
+const ORIGINAL_RETENTION_DAYS = process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+const ORIGINAL_MAX_ROWS = process.env.REQUEST_ANALYTICS_MAX_ROWS;
+
+function restoreEnv() {
+  if (ORIGINAL_RETENTION_DAYS === undefined) {
+    delete process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+  } else {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = ORIGINAL_RETENTION_DAYS;
+  }
+
+  if (ORIGINAL_MAX_ROWS === undefined) {
+    delete process.env.REQUEST_ANALYTICS_MAX_ROWS;
+  } else {
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = ORIGINAL_MAX_ROWS;
+  }
+}
+
+function insertRequest(createdAt: string, marker: string) {
+  getDb().prepare(`
+    INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, created_at)
+    VALUES ('groq', 'groq/compound', 1, 'error', 0, 0, 10, ?, ?)
+  `).run(marker, createdAt);
+}
+
+describe('request analytics retention', () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare('DELETE FROM requests').run();
+    restoreEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('uses conservative defaults when env values are absent or invalid', () => {
+    delete process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+    delete process.env.REQUEST_ANALYTICS_MAX_ROWS;
+    expect(getRequestAnalyticsRetentionConfig()).toEqual({ retentionDays: 90, maxRows: 100000 });
+
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = 'bad';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '-1';
+    expect(getRequestAnalyticsRetentionConfig()).toEqual({ retentionDays: 90, maxRows: 100000 });
+  });
+
+  it('deletes request analytics older than the configured retention window', () => {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = '7';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '0';
+
+    insertRequest('2026-05-01 00:00:00', 'old');
+    insertRequest('2026-05-25 00:00:00', 'recent');
+
+    const result = pruneRequestAnalytics({
+      db: getDb(),
+      force: true,
+      now: new Date('2026-05-26T00:00:00Z'),
+    });
+
+    expect(result.deleted).toBe(1);
+    const rows = getDb().prepare('SELECT error FROM requests ORDER BY id').all() as Array<{ error: string }>;
+    expect(rows.map(row => row.error)).toEqual(['recent']);
+  });
+
+  it('keeps only the newest configured number of request rows', () => {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = '0';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '2';
+
+    insertRequest('2026-05-01 00:00:00', 'row-1');
+    insertRequest('2026-05-02 00:00:00', 'row-2');
+    insertRequest('2026-05-03 00:00:00', 'row-3');
+    insertRequest('2026-05-04 00:00:00', 'row-4');
+
+    const result = pruneRequestAnalytics({
+      db: getDb(),
+      force: true,
+      now: new Date('2026-05-26T00:00:00Z'),
+    });
+
+    expect(result.deleted).toBe(2);
+    const rows = getDb().prepare('SELECT error FROM requests ORDER BY created_at ASC').all() as Array<{ error: string }>;
+    expect(rows.map(row => row.error)).toEqual(['row-3', 'row-4']);
+  });
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { ChatMessage } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown, getNextCooldownDuration } from '../services/ratelimit.js';
+import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString } from '../lib/content.js';
 
@@ -489,6 +490,7 @@ function logRequest(
       INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error);
+    pruneRequestAnalytics({ db });
   } catch (e) {
     console.error('Failed to log request:', e);
   }

--- a/server/src/services/request-retention.ts
+++ b/server/src/services/request-retention.ts
@@ -1,0 +1,72 @@
+import { getDb } from '../db/index.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 90;
+const DEFAULT_MAX_ROWS = 100_000;
+const PRUNE_INTERVAL_MS = 60_000;
+
+type RetentionDb = ReturnType<typeof getDb>;
+
+export interface RequestAnalyticsRetentionConfig {
+  retentionDays: number;
+  maxRows: number;
+}
+
+let nextPruneAtMs = 0;
+
+function readNonNegativeInt(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return defaultValue;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) return defaultValue;
+  return parsed;
+}
+
+function toSqliteTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+export function getRequestAnalyticsRetentionConfig(): RequestAnalyticsRetentionConfig {
+  return {
+    retentionDays: readNonNegativeInt('REQUEST_ANALYTICS_RETENTION_DAYS', DEFAULT_RETENTION_DAYS),
+    maxRows: readNonNegativeInt('REQUEST_ANALYTICS_MAX_ROWS', DEFAULT_MAX_ROWS),
+  };
+}
+
+export function pruneRequestAnalytics(options: {
+  db?: RetentionDb;
+  force?: boolean;
+  now?: Date;
+} = {}): { deleted: number; skipped: boolean } {
+  const now = options.now ?? new Date();
+  const nowMs = now.getTime();
+
+  if (!options.force && nowMs < nextPruneAtMs) {
+    return { deleted: 0, skipped: true };
+  }
+  nextPruneAtMs = nowMs + PRUNE_INTERVAL_MS;
+
+  const db = options.db ?? getDb();
+  const { retentionDays, maxRows } = getRequestAnalyticsRetentionConfig();
+  let deleted = 0;
+
+  if (retentionDays > 0) {
+    const cutoff = toSqliteTimestamp(new Date(nowMs - retentionDays * DAY_MS));
+    deleted += db.prepare('DELETE FROM requests WHERE created_at < ?').run(cutoff).changes;
+  }
+
+  if (maxRows > 0) {
+    deleted += db.prepare(`
+      DELETE FROM requests
+      WHERE id IN (
+        SELECT id
+        FROM requests
+        ORDER BY created_at DESC, id DESC
+        LIMIT -1 OFFSET ?
+      )
+    `).run(maxRows).changes;
+  }
+
+  return { deleted, skipped: false };
+}


### PR DESCRIPTION
Hi,

I opened this PR to address a [RepoVista](https://github.com/nordbyte/RepoVista) finding in `tashfeenahmed/freellmapi`: request analytics can grow without a retention policy. The implementation is intended to stay focused on the affected files and the evidence from the audit.

## RepoVista Patch Attempt

<!-- repovista:patch:manual_fnd_fa4fb63c9588 -->

- Patch: manual_fnd_fa4fb63c9588
- Status: applied
- Repository: tashfeenahmed/freellmapi
- Analyzed commit: [dd46dafea3a0](https://github.com/tashfeenahmed/freellmapi/commit/dd46dafea3a0d9242129c3b7350d1727a3fb7f90)
- RepoVista run: 2026-05-26T13-50-51-089Z
- Findings: fnd_fa4fb63c9588
- Features: feat_9a250011a5c5

## Plan

Finding: fnd_fa4fb63c9588 - Request-Analytics wachsen ohne erkennbare Retention
Severity: low
Feature: feat_9a250011a5c5
Affected paths: server/src/db/index.ts, server/src/routes/analytics.ts, server/src/routes/proxy.ts
Minimum fix scope: Retention-Helper in `server/src/db/index.ts` oder `server/src/routes/proxy.ts`, Konfiguration in Env/README, DB-/Service-Test.
Recommended fix: Konfigurierbare Retention einfuehren, z. B. nach Alter oder Maximalanzahl pro Tabelle. Beim Schreiben oder periodisch alte `requests` loeschen und optional aggregierte Tagesstatistiken behalten. Dokumentieren, wie viel Historie standardmaessig gespeichert wird.
Suggested regression test: Integrationstest, der alte `requests`-Zeilen mit `created_at` ausserhalb des Retention-Fensters anlegt, Cleanup ausloest und erwartet, dass alte Zeilen geloescht und neue erhalten bleiben.

## Files Changed

- .env.example
- README.md
- server/src/__tests__/services/request-retention.test.ts
- server/src/routes/proxy.ts
- server/src/services/request-retention.ts

## Scope Gate

- Status: passed
- Max files: 12
- Allowed paths: .env.example, README.md, server/src/__tests__/, server/src/db/index.ts, server/src/routes/analytics.ts, server/src/routes/proxy.ts, server/src/services/
- Violations: none

## Validation

- npm run test -w server -- request-retention.test.ts: 0
- npm run test -w server: 0
- npm run build -w server: 0
- GitHub CI Test & build: success

## Contribution Guidelines

- Policy mode: enforce
- Sources reviewed: README.md
- Behavior proof: include reproduction, observed behavior, or validation details where applicable.

_Found with [RepoVista](https://github.com/nordbyte/RepoVista)._
