### PR TITLE
fix(client): force IPv4 in Vite dev proxy for Windows

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -21,8 +21,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
-        '/api': `http://localhost:${serverPort}`,
-        '/v1': `http://localhost:${serverPort}`,
+        // Force IPv4 — on Windows + Node 17+, `localhost` resolves to ::1 first,
+        // which can collide with wslrelay / Docker Desktop listeners on the same port.
+        '/api': `http://127.0.0.1:${serverPort}`,
+        '/v1': `http://127.0.0.1:${serverPort}`,
       },
     },
   }


### PR DESCRIPTION
## Summary

- On Windows with Node 17+, `localhost` resolves to `::1` (IPv6) first.
- The Express backend binds to `0.0.0.0:3001` (IPv4 only). When something else holds an IPv6 listener on `:3001` — typically `wslrelay.exe` (WSL2 port forwarder) or `com.docker.backend.exe` (Docker Desktop) — Vite's `localhost:3001` proxy lands on the wrong listener.
- Result: every `/api/*` and `/v1/*` call from the dashboard returns 404, surfaced as "Not Found" in `apiFetch` (because the IPv6 squatter returns an HTML body, `res.statusText` is used as the error message).
- Switching the Vite proxy target to `127.0.0.1` forces IPv4 and routes correctly to the Express backend regardless of which IPv6 listener is present.

The symptom is reproducible: on the affected machine, `http://127.0.0.1:3001/api/keys` returns 200 while `http://[::1]:3001/api/keys` returns 404 from wslrelay. The fix is one line per proxy target plus a short comment so future contributors don't get burned by the same Node DNS change.

No behavioral impact on macOS/Linux — `127.0.0.1` is what `localhost` already resolved to there.

## Test plan

- [ ] On Windows with Docker Desktop or WSL2 running: `npm run dev`, open dashboard, add any provider key — should save instead of returning "Not Found".
- [ ] On macOS/Linux: `npm run dev` still works as before; dashboard reaches backend.
- [ ] Existing test suite still green (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)