### PR TITLE
refactor(providers): unify Ollama provider with configurable base URL…

### DIFF
--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { initEncryptionKey } from '../lib/crypto.js';
+import { execSync } from 'child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = path.resolve(__dirname, '../../data/freeapi.db');

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -96,21 +96,26 @@ register(new OpenAICompatProvider({
 // Moonshot direct integration was dropped in V4 (paid-only); MiniMax direct
 // was dropped in V4 (superseded by the OpenRouter route).
 
-// Ollama Cloud — OpenAI-compatible. Free plan: 1 concurrent model, 5h session
-// caps, GPU-time-based quota (not per-token). Many catalog models on the
-// /v1/models list are subscription-only — Free returns 403 with an explicit
-// "this model requires a subscription" message. Catalog rows are filtered to
-// confirmed-Free entries.
-//
-// Frontier reasoning models (glm-4.7, kimi-k2-thinking, cogito-2.1:671b)
-// regularly take 30-90s on Ollama Cloud Free, so the timeout is bumped from
-// the default 15s. Ollama returns reasoning in `message.reasoning` (not
-// `reasoning_content`) — handled by normalizeChoices.
+// Unified Ollama provider with configurable base URL
+// Defaults to cloud endpoint but can be overridden via OLLAMA_BASE_URL env var
+// Authentication is automatically skipped for local/private network URLs
+const ollamaBaseUrl = process.env.OLLAMA_BASE_URL?.trim() || 'https://ollama.com/v1';
+
+// Detect if we should skip authentication (local/private networks)
+// Matches: localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+const shouldSkipAuth = ollamaBaseUrl.match(
+  /^https?:\/\/(localhost|127\.(?:[0-9]{1,3}\.){3}[0-9]{1,3}|10\.(?:[0-9]{1,3}\.){3}[0-9]{1,3}|172\.(?:1[6-9]|2[0-9]|3[0-1])\.(?:[0-9]{1,3}\.){3}[0-9]{1,3}|192\.168\.(?:[0-9]{1,3}\.){3}[0-9]{1,3})/
+);
+
+// Ollama — OpenAI-compatible. Works with both cloud and self-hosted instances.
+// Self-hosted instances (localhost, private IPs) skip authentication automatically.
+// Cloud instances require API key from https://ollama.com
 register(new OpenAICompatProvider({
   platform: 'ollama',
-  name: 'Ollama Cloud',
-  baseUrl: 'https://ollama.com/v1',
+  name: 'Ollama',
+  baseUrl: ollamaBaseUrl,
   timeoutMs: 120000,
+  skipAuth: shouldSkipAuth,
 }));
 
 // Kilo AI Gateway — OpenAI-compatible aggregator. Anonymous access works

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -20,6 +20,8 @@ export class OpenAICompatProvider extends BaseProvider {
   /** Per-provider HTTP timeout override. Cloud APIs finish in ~15s; locally-hosted
    * inference (llama.cpp / vLLM on CPU) can take 30-120s for long prompts. Default 15000. */
   private readonly timeoutMs: number;
+  /** Whether to skip authentication (for local/private Ollama instances) */
+  private readonly skipAuth: boolean;
 
   constructor(opts: {
     platform: Platform;
@@ -28,6 +30,7 @@ export class OpenAICompatProvider extends BaseProvider {
     extraHeaders?: Record<string, string>;
     validateUrl?: string;
     timeoutMs?: number;
+    skipAuth?: boolean;
   }) {
     super();
     this.platform = opts.platform;
@@ -36,6 +39,7 @@ export class OpenAICompatProvider extends BaseProvider {
     this.extraHeaders = opts.extraHeaders ?? {};
     this.validateUrl = opts.validateUrl;
     this.timeoutMs = opts.timeoutMs ?? 15000;
+    this.skipAuth = opts.skipAuth ?? false;
   }
 
   async chatCompletion(
@@ -47,7 +51,8 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        // Only add Authorization header if not skipping auth
+        ...(!this.skipAuth ? { 'Authorization': `Bearer ${apiKey}` } : {}),
         'Content-Type': 'application/json',
         ...this.extraHeaders,
       },
@@ -83,7 +88,8 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        // Only add Authorization header if not skipping auth
+        ...(!this.skipAuth ? { 'Authorization': `Bearer ${apiKey}` } : {}),
         'Content-Type': 'application/json',
         ...this.extraHeaders,
       },
@@ -141,7 +147,8 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(url, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        // Only add Authorization header if not skipping auth
+        ...(!this.skipAuth ? { 'Authorization': `Bearer ${apiKey}` } : {}),
         ...this.extraHeaders,
       },
     }, 10000);


### PR DESCRIPTION
… and smart auth skipping

- Collapse separate ollama/ollama-local platforms into single 'ollama' provider
- Add OLLAMA_BASE_URL env var support (defaults to https://ollama.com/v1)
- Detect local/private network URLs to skip API key requirement automatically (localhost, 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
- Add skipAuth option to OpenAICompatProvider to conditionally omit Authorization header
- Add execSync import in db/index.ts for upcoming seedLocalOllamaModels function

BREAKING: Renamed from 'Ollama Cloud' to 'Ollama' in provider registration