### PR TITLE
fix(openai-compat): raise validateKey timeout 10s -> 30s for slow upstreams (NVIDIA NIM)

### DIFF
--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -137,6 +137,11 @@ export class OpenAICompatProvider extends BaseProvider {
     // Note: transport errors (DNS / timeout / TLS) propagate to the caller.
     // health.ts catches them and marks status='error' WITHOUT incrementing
     // the consecutive-failure counter — only confirmed 401/403 disables a key.
+    //
+    // Timeout: 30s. Some providers (notably NVIDIA NIM) return a multi-KB
+    // /v1/models catalog that can take 10-15s from high-latency regions
+    // (India, Australia). The previous 10s was too aggressive and produced
+    // false-positive transport errors that flapped key status.
     const url = this.validateUrl ?? `${this.baseUrl}/models`;
     const res = await this.fetchWithTimeout(url, {
       method: 'GET',
@@ -144,7 +149,7 @@ export class OpenAICompatProvider extends BaseProvider {
         'Authorization': `Bearer ${apiKey}`,
         ...this.extraHeaders,
       },
-    }, 10000);
+    }, 30000);
     return res.status !== 401 && res.status !== 403;
   }
 }


### PR DESCRIPTION
## Problem

`OpenAICompatProvider.validateKey` uses a **hardcoded 10s timeout** on the upstream `GET /v1/models` call. NVIDIA NIM (`https://integrate.api.nvidia.com/v1/models`) returns a ~11 KB catalog that consistently takes **>10s** to respond from high-latency regions (verified ~11.2s from India). Result: `validateKey` aborts with `"This operation was aborted"`, `health.ts` marks `status='error'`, and downstream callers see the key as broken even though the underlying credential is fine.

Empirical evidence captured during a live debugging session:

```
[Health] Key 11 transport error: This operation was aborted   ← NVIDIA
[Health] Key 1  transport error: This operation was aborted   ← OpenRouter (occasionally)
[Health] Key 9  transport error: This operation was aborted   ← Cloudflare
[Health] Key 10 transport error: This operation was aborted   ← Mistral
```

All of these are NOT bad keys — they are slow `/v1/models` responses from upstreams hosted on the other side of the planet relative to the user. The same NVIDIA key used directly from opencode's native `@ai-sdk/openai-compatible` adapter (which uses a longer default timeout) works flawlessly.

Reproduced via:

```powershell
Measure-Command {
  Invoke-WebRequest -Uri "https://integrate.api.nvidia.com/v1/models" -UseBasicParsing
}
# TotalSeconds: 11.279

# Same call with the existing 10s AbortController:
node -e "const c = new AbortController(); setTimeout(() => c.abort(), 10000); fetch('https://integrate.api.nvidia.com/v1/models', { signal: c.signal }).then(r => r.text()).then(t => console.log(t.length)).catch(e => console.log(e.message));"
# Output: "This operation was aborted"
```

## Fix

Bump the `validateKey` timeout from 10s to 30s. This aligns it with the existing 15s `chatCompletion` default (which clients can already override to 30-120s via `timeoutMs`) and gives slow international `/v1/models` responses room to complete.

```diff
-    }, 10000);
+    }, 30000);
```

Includes a 4-line comment block above the change explaining the empirical motivation so future maintainers don't revert it without realizing the regression risk.

## Why 30s and not configurable?

A simpler PR. `validateKey` is called once per key on every 5-minute health cycle — even at 30s timeout the worst-case cost is ~30s per slow key per cycle, which is negligible. Making the constant configurable per-provider would be a larger refactor (touching the `OpenAICompatProvider` constructor signature, all `register()` calls in `providers/index.ts`, type definitions). Happy to follow up with that if maintainers prefer.

## Testing

- Verified locally: NVIDIA NIM key flips from `status='error'` → `status='healthy'` after applying the fix and waiting one health cycle.
- No regression to existing 95/95 test suite (no test currently asserts the exact timeout value).

## Checklist

- [x] Bug fix (non-breaking)
- [x] Verified against live upstream (NVIDIA NIM)
- [x] No changes to public API or config shape
- [x] Adds inline comment documenting empirical motivation