### PR TITLE
Add Docker setup and compose config (Readme and DockerIgnore)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+node_modules
+**/node_modules
+dist
+**/dist
+repo-assets
+coverage
+.env
+.env.*
+Dockerfile
+docker-compose.yml
+npm-debug.log
+pnpm-debug.log
+yarn-error.log
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,10 @@ server/data/
 .env
 .env.local
 .DS_Store
+.claude
+opencode.json
 
 # Personal deployment scripts (contain keys/credentials — kept local)
 deploy-pi.sh
 update-hermes.sh
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  freellmapi:
+    image: freellmapi
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "3001:3001"
+    env_file:
+      - .env
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+    volumes:
+      - ./server/data:/app/server/data
+      - ./.env:/app/.env:ro
+    restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-bookworm AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY server/package.json ./server/
+COPY client/package.json ./client/
+COPY shared/package.json ./shared/
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+RUN npm prune --omit=dev --workspace server --workspace shared
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3001
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/server/dist ./server/dist
+COPY --from=build /app/server/package.json ./server/package.json
+COPY --from=build /app/client/dist ./client/dist
+COPY --from=build /app/shared ./shared
+
+RUN mkdir -p /app/server/data
+
+EXPOSE 3001
+
+CMD ["node", "server/dist/index.js"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,93 @@
+# 🐋 Docker Setup
+
+This directory contains Docker configuration for the FreeLLMApi application.
+
+## Files
+
+- `Dockerfile` - Multi-stage build Dockerfile for creating the production image
+- `../docker-compose.yml` - Docker Compose configuration for local development
+
+## Quick Start
+
+### Using Docker Compose (Recommended)
+
+1. Copy the environment file:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Generate and add your API key to the newly created .env file using one of these methods:
+   - **With Node.js (if installed)**:
+     ```bash
+     node -e "console.log(require('crypto').randomBytes(32).toString('hex'))" 
+     ```
+   - **With OpenSSL (if installed)**:
+     ```bash
+     openssl rand -hex 32 
+     ```
+   - **With Windows (no installation required)**:
+     ```bash
+     powershell -Command "$bytes = [System.Byte[]]::new(32); [System.Security.Cryptography.RNGCryptoServiceProvider]::Create().GetBytes($bytes); [System.Convert]::ToBase64String($bytes)" 
+     ```
+
+3. Build and start the application:
+   ```bash
+   docker-compose up --build
+   ```
+
+4. Run in background:
+   ```bash
+   docker-compose up -d --build
+   ```
+
+5. Stop the application:
+   ```bash
+   docker-compose down
+   ```
+
+**Access the Application**: Once running, open your web browser and navigate to `http://localhost:3001`
+
+### Using Docker Directly
+
+```bash
+# Build the image
+docker build -f docker/Dockerfile -t freellmapi .
+
+# Run the container
+docker run -d \
+  --name freellmapi \
+  -p 3001:3001 \
+  --env-file .env \
+  -v ./server/data:/app/server/data \
+  -v ./.env:/app/.env:ro \
+  --restart unless-stopped \
+  freellmapi
+```
+
+## Configuration
+
+### Environment Variables
+
+The application requires environment variables defined in `.env` file:
+
+- `NODE_ENV` - Set to "production" for production builds
+- `PORT` - Application port (default: 3001)
+- Additional variables as defined in `.env.example`
+
+### Data Persistence
+
+The `/app/server/data` directory is mounted as a volume to persist application data between container restarts.
+
+## Build Process
+
+The Dockerfile uses a multi-stage build process:
+
+1. **Build Stage**: Installs all dependencies, builds the application, and prunes dev dependencies
+2. **Runtime Stage**: Copies only necessary files and creates a minimal production image
+
+## Ports
+
+- **3001** - Main application port (exposed by default)
+
+## Note: 
+If the application requires an API key to function, you can get one for free from [OpenRouter](https://openrouter.ai/keys)


### PR DESCRIPTION
Add multi-stage Dockerfile, docker-compose.yml and docker/README.md to enable containerized builds and local development. Include .dockerignore and update .gitignore to exclude local envs and tooling files. 
The Dockerfile builds the app, prunes dev deps, and produces a minimal runtime image; docker-compose provides a convenient service definition mapping port 3001 and mounting persistent data and .env.