### PR TITLE
fix(analytics): use SQLite timestamps for rolling ranges

### DIFF
--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { getDb, initDb } from '../../db/index.js';
+
+async function request(app: Express, path: string) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url);
+  const data = await res.json().catch(() => null);
+  server.close();
+
+  return { status: res.status, body: data };
+}
+
+function insertRequest(createdAt: string) {
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO requests (platform, model_id, status, input_tokens, output_tokens, latency_ms, error, created_at)
+    VALUES ('test', 'test-model', 'success', 1, 2, 3, NULL, ?)
+  `).run(createdAt);
+}
+
+describe('Analytics API', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM requests').run();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses a rolling 24-hour window for summary analytics', async () => {
+    insertRequest('2026-05-28 11:59:59');
+    insertRequest('2026-05-28 12:00:00');
+    insertRequest('2026-05-29 11:59:59');
+
+    const { status, body } = await request(app, '/api/analytics/summary?range=24h');
+
+    expect(status).toBe(200);
+    expect(body.totalRequests).toBe(2);
+    expect(body.totalInputTokens).toBe(2);
+    expect(body.totalOutputTokens).toBe(4);
+  });
+
+  it.each([
+    ['7d', '2026-05-22 11:59:59', '2026-05-22 12:00:00'],
+    ['30d', '2026-04-29 11:59:59', '2026-04-29 12:00:00'],
+  ])('uses a rolling %s window for summary analytics', async (range, outside, boundary) => {
+    insertRequest(outside);
+    insertRequest(boundary);
+    insertRequest('2026-05-29 11:59:59');
+
+    const { status, body } = await request(app, `/api/analytics/summary?range=${range}`);
+
+    expect(status).toBe(200);
+    expect(body.totalRequests).toBe(2);
+  });
+});

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -4,18 +4,22 @@ import { getDb } from '../db/index.js';
 
 export const analyticsRouter = Router();
 
-// Map range to a JS-computed ISO timestamp passed as a bind parameter,
-// so the SQL string never includes user-controlled fragments.
+// Format UTC timestamps the same way SQLite stores created_at text values.
+const toSqliteDateTime = (timestamp: number) =>
+    new Date(timestamp).toISOString().slice(0, 19).replace('T', ' ');
+
+// Return the rolling cutoff timestamp for the selected analytics range.
 function getSinceTimestamp(range: string): string {
   const now = Date.now();
+
   switch (range) {
     case '24h':
-      return new Date(now - 24 * 60 * 60 * 1000).toISOString();
+      return toSqliteDateTime(now - 24 * 60 * 60 * 1000);
     case '30d':
-      return new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString();
+      return toSqliteDateTime(now - 30 * 24 * 60 * 60 * 1000);
     case '7d':
     default:
-      return new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
+      return toSqliteDateTime(now - 7 * 24 * 60 * 60 * 1000);
   }
 }
 


### PR DESCRIPTION
Format analytics cutoff timestamps as SQLite-compatible UTC datetime strings before comparing against request created_at values. This makes 24h, 7d, and 30d ranges behave as true rolling windows instead of text-comparing ISO timestamps incorrectly.

Add regression coverage for boundary records around the rolling 24h, 7d, and 30d cutoffs.