### PR TITLE
docs: add AGENTS.md knowledge base for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+# FreeLLMAPI
+
+Aggregates free tiers from 13+ LLM providers behind a single OpenAI-compatible `/v1/chat/completions` endpoint. Node 20+, TypeScript, npm workspaces monorepo.
+
+---
+
+## Structure
+
+```
+freellmapi/
+├── shared/            # Shared TypeScript types (Platform, Model, Chat, Analytics)
+├── server/            # Express 5 proxy server
+│   └── src/
+│       ├── index.ts         # Entry: initDb → createApp → listen :3001
+│       ├── app.ts           # Express factory: routes, CORS, helmet, static SPA
+│       ├── providers/       # 14+ provider adapters (base + openai-compat + custom)
+│       ├── routes/          # 7 API route files (keys, models, proxy, fallback, etc.)
+│       ├── services/        # Core: router.ts, ratelimit.ts, health.ts
+│       ├── middleware/      # errorHandler.ts
+│       ├── lib/             # crypto.ts (AES-256-GCM), content.ts
+│       ├── db/index.ts      # SQLite schema + 14 sequential migrations (1286 lines)
+│       └── __tests__/       # Per-module test subdirs (vitest)
+├── client/            # React 19 dashboard (Vite, shadcn/ui, Tailwind 4)
+│   └── src/
+│       ├── main.tsx        # React entry
+│       ├── App.tsx         # BrowserRouter + QueryClientProvider + pages
+│       ├── pages/          # KeysPage, AnalyticsPage, FallbackPage, PlaygroundPage
+│       ├── components/     # shadcn/ui components + page-header
+│       └── lib/            # api.ts (fetch wrapper), utils.ts (cn())
+├── .github/workflows/ # CI: npm install → npm test → npm run build (Node 20)
+├── docs/logos/        # Provider SVG icons
+├── repo-assets/       # README screenshots
+├── backups/           # SQLite DB snapshots (gitignored after first commit)
+└── data/              # Empty — unused
+```
+
+---
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Add a new LLM provider | `server/src/providers/` — copy `openai-compat.ts` for REST APIs, or extend `base.ts` for custom formats. Register in `index.ts`. Seed models in `db/index.ts`. |
+| Modify router / model selection | `server/src/services/router.ts` — priority sort + dynamic 429 penalties + sticky sessions |
+| Change rate-limit logic | `server/src/services/ratelimit.ts` — in-memory RPM/RPD/TPM/TPD + SQLite |
+| Add/modify API route | `server/src/routes/` — mount in `app.ts` |
+| Update DB schema / migrations | `server/src/db/index.ts` — append a new `migrateModelsV{N}()` call in `initDb()` |
+| Key encryption | `server/src/lib/crypto.ts` — AES-256-GCM |
+| Dashboard UI | `client/src/pages/` + `client/src/components/` |
+| Dashboard API client | `client/src/lib/api.ts` |
+| Shared types | `shared/types.ts` — `Platform`, `ChatCompletionRequest/Response`, etc. |
+| CI pipeline | `.github/workflows/ci.yml` |
+| Environment setup | `.env.example` — `ENCRYPTION_KEY` (64-char hex), `PORT`, `DASHBOARD_ORIGINS` |
+
+---
+
+## Conventions
+
+- **ESM everywhere** — imports use `.js` extension in server (`import { x } from './y.js'`), `@/` alias in client (`import { x } from '@/lib/utils'`)
+- **TypeScript strict** — server: `strict: true`. Client: individual strict flags (`noUnusedLocals`, `noUnusedParameters`, `verbatimModuleSyntax`, `erasableSyntaxOnly`)
+- **No path aliases in server** — all server imports are relative. Client uses `@/` → `./src/`
+- **No Prettier** — formatting via `@eslint/js` defaults (client only). Server has no linter.
+- **No barrel files** except `providers/index.ts` and `db/index.ts`. Individual route/service/lib files are imported directly.
+- **Provider adapters** extend `BaseProvider` (abstract). OpenAI-compatible APIs use `OpenAICompatProvider(config)`. Custom formats (Google, Cohere, Cloudflare) get their own file.
+- **Error shape** — `{ error: { message, type } }` with HTTP status code
+- **Tests** — vitest, `__tests__/` subdirs mirroring source structure. HTTP tests use real Express + ephemeral ports + real `fetch()`. Provider tests mock `global.fetch`.
+- **Env vars** — loaded via `server/src/env.ts` (dotenv from repo root `.env`)
+
+---
+
+## Anti-patterns
+
+- **Don't skip `providers/index.ts`** — every provider MUST be registered here or `getProvider()` won't find it
+- **No raw SQL in routes/services** — DB access goes through `db/index.ts` exports (`getDb()`). Direct `db.prepare()` is acceptable in tests.
+- **No process.exit() in library code** — only in the entry point on fatal error
+- **Migration numbering** — append new `migrateModelsV{N}()` in `db/index.ts`. Do NOT renumber or alter existing migrations.
+- **Helmet CSP/HSTS** — intentionally disabled (see `app.ts` comment). Only enable if serving publicly over HTTPS.
+- **`ENCRYPTION_KEY` is required** — dev-mode fallback (`DEV_MODE=true`) exists but must not be used with real API keys
+
+---
+
+## Commands
+
+```bash
+npm install          # Install all workspace deps
+npm run dev          # Server (:3001) + dashboard (:5173) concurrently
+npm run build        # tsc (server) + tsc -b && vite build (client)
+npm test             # vitest run (server) + npm test (client, if-present)
+npm run lint         # ESLint — client only
+```
+
+---
+
+## Notes
+
+- **Node 20+ required** — CI runs on Ubuntu with Node 20
+- **`better-sqlite3` native module** — `npm rebuild` if Node version changes
+- **Router uses in-memory penalty system** for 429s (2-min decay). Sticky sessions keep multi-turn on same model for 30 min.
+- **Client is served as static files** from `server/dist/` in production — the Express app serves the dashboard as an SPA
+- **Tests** set `process.env.ENCRYPTION_KEY = '0'.repeat(64)` before calling `initDb()` — needed for key crypto
+- **CI** runs `npm test` then `npm run build` — no lint step, no Docker, no deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,16 +9,21 @@ Aggregates free tiers from 13+ LLM providers behind a single OpenAI-compatible `
 ```
 freellmapi/
 ├── shared/            # Shared TypeScript types (Platform, Model, Chat, Analytics)
+│   └── AGENTS.md
 ├── server/            # Express 5 proxy server
 │   └── src/
 │       ├── index.ts         # Entry: initDb → createApp → listen :3001
 │       ├── app.ts           # Express factory: routes, CORS, helmet, static SPA
 │       ├── providers/       # 14+ provider adapters (base + openai-compat + custom)
+│       │   └── AGENTS.md
 │       ├── routes/          # 7 API route files (keys, models, proxy, fallback, etc.)
+│       │   └── AGENTS.md
 │       ├── services/        # Core: router.ts, ratelimit.ts, health.ts
+│       │   └── AGENTS.md
 │       ├── middleware/      # errorHandler.ts
 │       ├── lib/             # crypto.ts (AES-256-GCM), content.ts
 │       ├── db/index.ts      # SQLite schema + 14 sequential migrations (1286 lines)
+│       │   └── AGENTS.md
 │       └── __tests__/       # Per-module test subdirs (vitest)
 ├── client/            # React 19 dashboard (Vite, shadcn/ui, Tailwind 4)
 │   └── src/
@@ -27,12 +32,15 @@ freellmapi/
 │       ├── pages/          # KeysPage, AnalyticsPage, FallbackPage, PlaygroundPage
 │       ├── components/     # shadcn/ui components + page-header
 │       └── lib/            # api.ts (fetch wrapper), utils.ts (cn())
+│       └── AGENTS.md
 ├── .github/workflows/ # CI: npm install → npm test → npm run build (Node 20)
 ├── docs/logos/        # Provider SVG icons
 ├── repo-assets/       # README screenshots
 ├── backups/           # SQLite DB snapshots (gitignored after first commit)
 └── data/              # Empty — unused
 ```
+
+> Subdirectory AGENTS.md files exist for the 6 highest-complexity modules — see inline entries above. Each covers file-by-file breakdown, domain-specific patterns, conventions, and pitfalls.
 
 ---
 

--- a/client/src/AGENTS.md
+++ b/client/src/AGENTS.md
@@ -1,0 +1,51 @@
+# client — React 19 dashboard
+
+**Relevant for:** UI changes, adding dashboard pages, styling  
+**Depends on:** `shared/types.ts`, `server/src/routes/` (API endpoints the dashboard calls)
+
+---
+
+## Files
+
+```
+client/src/
+├── main.tsx            # React DOM entry — mounts <App />
+├── App.tsx             # BrowserRouter + QueryClientProvider + page routes
+├── pages/
+│   ├── KeysPage.tsx         # API key management
+│   ├── AnalyticsPage.tsx    # Usage stats (24h/7d/30d)
+│   ├── FallbackPage.tsx     # Fallback chain ordering
+│   └── PlaygroundPage.tsx   # Chat completion playground
+├── components/
+│   ├── page-header.tsx      # Shared page title/description
+│   └── ui/                  # 10 shadcn/ui primitives (button, card, dialog, input, select, table, tabs, textarea, toast, tooltip)
+└── lib/
+    ├── api.ts               # apiFetch<T>() — typed fetch wrapper for /api/*
+    └── utils.ts             # cn() — Tailwind class merger
+```
+
+---
+
+## Key patterns
+
+- **Per-page API calls** — each page imports `apiFetch<T>()` from `lib/api.ts` directly. No global API layer or state store.
+- **shadcn/ui + Tailwind 4** — components in `components/ui/` are copy-pasted shadcn primitives (Radix + Tailwind). Custom components go in `components/`.
+- **Dark mode** via Tailwind `dark:` variants and a class-based toggle on `<html>`. No theme library.
+- **Vite dev proxy** + production SPA serving: dev → `localhost:5173` proxied to `:3001`, production → Express serves `server/dist/` as static.
+
+---
+
+## Conventions (this directory only)
+
+- **Import alias**: `@/` maps to `./src/` (configured in `client/vite.config.ts` and `client/tsconfig.json`).
+- **No tests** — client has zero test files. Server-only coverage.
+- **No state management** beyond React Query (`QueryClientProvider` in `App.tsx`). No Redux, Zustand, or Context for global state.
+- **shadcn primitives are unmodified** — if you need a variant, extend via Tailwind classes at the usage site, don't edit the `.tsx` in `components/ui/`.
+
+---
+
+## Pitfalls
+
+- **`apiFetch()` returns parsed JSON** — non-2xx responses throw with the error body. Handle in `.catch()` or React Query's `onError`.
+- **Vite HMR** expects the server to be running (`npm run dev` starts both). Dashboard alone won't work without the API backend.
+- **shadcn/ui components are large-ish files** — each includes full Radix integration + Tailwind classes. Don't duplicate them; reuse from `components/ui/`.

--- a/server/src/db/AGENTS.md
+++ b/server/src/db/AGENTS.md
@@ -1,0 +1,42 @@
+# db — SQLite schema, migrations, model seeding
+
+**Relevant for:** schema changes, adding/updating provider model catalogs  
+**Depends on:** `lib/crypto.ts` (key encryption), `shared/types.ts` (type defs)
+
+---
+
+## Files
+
+```
+db/
+└── index.ts  # 1286 lines — initDb(), getDb(), migrateModelsV0–V14, seedModels()
+```
+
+Single-file module. No barrel, no ORM wrapper re-export — `getDb()` is imported directly.
+
+---
+
+## Key patterns
+
+- **`initDb()`**: called once at startup (`server/src/index.ts`). Opens/creates SQLite db, runs all migrations in sequence, seeds default models if the `models` table is empty.
+- **14 sequential migrations** (`migrateModelsV0` → `V14`): each is a standalone function that applies a schema change. Never renumbered or modified after creation — always append.
+- **better-sqlite3** (synchronous): all DB operations are synchronous. No async/await for DB calls.
+- **drizzle-orm** for query building in routes/services. Direct `db.prepare()` only in tests and migration functions.
+- **Model seeding**: `seedModels()` upserts the default provider catalog. Re-run via scripts in `server/src/scripts/` when upstream catalogs change.
+
+---
+
+## Conventions (this directory only)
+
+- **Migration naming**: `migrateModelsV{N}` where `N` increments. The integer is checked against `schema_version` in the DB — only unapplied migrations run.
+- **Raw DDL** is acceptable here (CREATE TABLE, ALTER TABLE, CREATE INDEX). Everywhere else, use drizzle helpers.
+- **Key column**: `api_keys.key` stores AES-256-GCM encrypted ciphertext (hex), never plaintext.
+
+---
+
+## Pitfalls
+
+- **`npm rebuild better-sqlite3` required** after Node version changes — native module, NODE_MODULE_VERSION mismatch causes crash at `require()`.
+- **`ENCRYPTION_KEY` required** at startup (64-char hex). `DEV_MODE=true` fallback exists but logs a loud warning — never use with real API keys.
+- **Seeding is idempotent by INSERT OR IGNORE** — re-running `seedModels()` won't overwrite custom changes, but also won't update existing model specs if the provider changed them upstream.
+- **`:memory:` for tests** — `initDb(':memory:')` creates an in-memory DB. Works because better-sqlite3 handles it transparently, but note that schema-level migrations run every time (fast enough).

--- a/server/src/providers/AGENTS.md
+++ b/server/src/providers/AGENTS.md
@@ -1,0 +1,46 @@
+# providers — LLM adapter layer
+
+**Relevant for:** adding or modifying provider integrations  
+**Depends on:** `shared/types.ts` (Platform type), `db/` (model seed data)
+
+---
+
+## Files
+
+```
+providers/
+├── base.ts           # Abstract BaseProvider (241 lines) — 3 abstract methods + shared helpers
+├── index.ts          # Registry — Map<Platform, BaseProvider>, exported getProvider()
+├── openai-compat.ts  # Generic adapter for OpenAI-compatible REST APIs
+├── google.ts         # Gemini-specific (functionDeclarations translation)
+├── cohere.ts         # Cohere-specific (custom format)
+└── cloudflare.ts     # Cloudflare-specific (custom format)
+```
+
+Total: 6 files, ~1,131 lines. 14+ provider instances registered via `index.ts`.
+
+---
+
+## Key patterns
+
+- **BaseProvider** (abstract): `chatCompletion(req)`, `streamChatCompletion(req)`, `validateKey(key)` — every adapter implements these 3.
+- **OpenAI-compatible**: instantiated via `new OpenAICompatProvider(config)` where config = `{ platform, name, baseUrl, modelMap }`. Covers Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Zhipu, Kilo, Pollinations, LLM7, HuggingFace.
+- **Custom adapters** (Google, Cohere, Cloudflare): extend `BaseProvider` directly and translate between the OpenAI chat-completion shape and the provider's native format.
+- **`makeId()`**: utility in `base.ts` that strips the `/`-suffixed version from model IDs returned by upstream APIs so the router sees clean names.
+- **`fetchWithTimeout()`**: shared fetch wrapper with configurable timeout, used by all adapters.
+
+---
+
+## Conventions (this directory only)
+
+- **Every provider MUST be registered** in `index.ts` or `getProvider()` won't find it. No auto-discovery.
+- **OpenAI-compat is the default path** — only write a custom adapter when the provider's API differs significantly (e.g. Gemini's `functionDeclarations`, Cohere's streaming format).
+- **Model ID convention**: `platform/model-name` (e.g. `groq/llama-3.3-70b`). The `modelMap` in the config maps user-facing names to provider-specific model strings.
+
+---
+
+## Pitfalls
+
+- **Missing model seeds** — adding a provider adapter isn't enough. Models must also be seeded in `db/index.ts` or the router won't see them.
+- **Streaming format varies** — each provider sends SSE differently. `openai-compat.ts` assumes standard `data: {"choices":[...]}` chunks. Custom adapters handle their own SSE parsing.
+- **`validateKey` is called on health probes** — if your adapter's validation endpoint is slow or flaky, marks the key as unhealthy unnecessarily.

--- a/server/src/routes/AGENTS.md
+++ b/server/src/routes/AGENTS.md
@@ -1,0 +1,46 @@
+# routes — Express 5 API handlers
+
+**Relevant for:** adding or modifying HTTP endpoints  
+**Depends on:** `services/` (router, ratelimit), `db/` (data access), `providers/` (model listing)
+
+---
+
+## Files
+
+```
+routes/
+├── keys.ts       # CRUD for API keys (+ unified key display)
+├── models.ts     # GET /v1/models — lists all seeded models
+├── proxy.ts      # POST /v1/chat/completions — the main proxy endpoint
+├── fallback.ts   # GET/PUT fallback chain ordering
+├── analytics.ts  # GET usage analytics (24h/7d/30d)
+├── health.ts     # GET /health — server & provider key status
+└── settings.ts   # App-wide settings endpoint
+```
+
+All mounted in `app.ts` — each route file exports a single `Router` or function.
+
+---
+
+## Key patterns
+
+- **`proxy.ts`** is the core — receives the OpenAI-format request, calls `routeRequest()` from services, handles both streaming (SSE) and non-streaming responses.
+- **Auth middleware**: routes read `x-api-key` or `Authorization: Bearer <key>` header, validate against the DB. Proxy also supports no-auth for models that accept it.
+- **CORS**: configured globally in `app.ts` via `DEFAULT_DASHBOARD_ORIGINS` from env. All routes inherit it.
+- **Error shape**: all errors return `{ error: { message, type } }` with appropriate HTTP status. Handled centrally by `middleware/errorHandler.ts`.
+
+---
+
+## Conventions (this directory only)
+
+- **No barrel** — each route file is imported individually in `app.ts`. No `routes/index.ts`.
+- **No raw SQL** — DB access via `getDb()` + drizzle helpers. Raw `db.prepare()` is a violation.
+- **Streaming proxy** writes SSE directly to the response — `res.write()` + `res.end()`. No Express middleware on the streaming path (it would buffer).
+
+---
+
+## Pitfalls
+
+- **`proxy.ts` streaming path must handle partial writes** — if a provider sends malformed SSE chunks, the proxy silently drops the chunk rather than crashing the connection.
+- **Auth is per-route** — there's no global auth middleware. Each route independently validates the key. If you add a new route, you must add auth handling.
+- **Fallback chain order is persisted** — changing it via the API writes to SQLite and is restored on restart.

--- a/server/src/services/AGENTS.md
+++ b/server/src/services/AGENTS.md
@@ -1,0 +1,40 @@
+# services — router, rate-limiter, health
+
+**Relevant for:** core request routing logic, rate-limit tuning, health-check behaviour  
+**Depends on:** `providers/` (adapter instances), `db/` (persisted state), `lib/crypto.ts` (key decryption)
+
+---
+
+## Files
+
+```
+services/
+├── router.ts     # 237 lines — model selection, penalty system, sticky sessions
+├── ratelimit.ts  # In-memory RPM/RPD/TPM/TPD + SQLite cooldowns
+└── health.ts     # Periodic key health probes
+```
+
+---
+
+## Key patterns
+
+- **`routeRequest()`** (router.ts): the main entry. Picks the highest-priority model that (a) has a healthy key, (b) is under its rate limits. On 429/5xx/timeout → applies penalty, skips to next model in fallback chain (up to 20 attempts).
+- **429 penalty system**: `PENALTY_PER_429 = 3`, `MAX_PENALTY = 10`, `DECAY_INTERVAL_MS = 2 min`. Each time a provider returns 429, its priority is increased by N (higher = worse). Penalty decays 2 min after the last hit. All in-memory — lost on restart.
+- **Sticky sessions**: `preferredModelDbId` keeps multi-turn conversations on the same model for 30 min. Prevents hallucination spike from mid-conversation model switches.
+- **Rate-limit ledger**: 4 counters per `(platform, model, key)` — RPM, RPD, TPM, TPD. Checked before routing, decremented on actual usage. Cooldowns persisted to SQLite.
+- **Health probes**: periodic background checks via `health.ts`. Marks keys as `healthy`, `rate_limited`, `invalid`, or `error`.
+
+---
+
+## Conventions (this directory only)
+
+- **No async for DB** — router reads rate-limit state from in-memory maps (fast path). SQLite reads only for persistence/restore.
+- **Penalty state is ephemeral** — intentionally not persisted. Restart resets all penalties, which is acceptable for a single-user proxy.
+
+---
+
+## Pitfalls
+
+- **Penalty system is anti-greedy, not anti-starvation** — a persistently rate-limited provider can still be retried if all others are also penalized. Fine for single-user, problematic under heavy load.
+- **Sticky session timer resets on each successful request** to the same model — a multi-turn conversation with >30 min between messages loses stickiness.
+- **RPM/RPD/TPM/TPD are approximate** — the ledger decrements by actual token count from the response, but the initial budget is estimated from provider docs. Overages still happen.

--- a/shared/AGENTS.md
+++ b/shared/AGENTS.md
@@ -1,0 +1,39 @@
+# shared — cross-package TypeScript types
+
+**Relevant for:** type changes that affect both server and client  
+**Depends on:** nothing (no dependencies, no imports from other packages)
+
+---
+
+## Files
+
+```
+shared/
+├── types.ts     # 228 lines — Platform, Model, ApiKey, Chat*, AnalyticsSummary
+├── package.json # "@freellmapi/shared" workspace package
+└── tsconfig.json
+```
+
+---
+
+## Key patterns
+
+- **`Platform` union type**: string literal union of all supported providers (`'google' | 'groq' | 'cerebras' | …`). Adding a provider means adding it here first.
+- **`ChatCompletionRequest` / `ChatCompletionResponse`**: mirror the OpenAI API shape (`model`, `messages`, `stream`, `tools`, `tool_choice`, `temperature`, etc.). This is the canonical shape that server adapters translate to/from.
+- **`AnalyticsSummary`**: aggregated stats shape returned by the analytics endpoint. Used by both server (route) and client (dashboard).
+- **No barrel file** — `types.ts` is the package entrypoint (`"main": "types.ts"`). Import from `@freellmapi/shared` directly.
+
+---
+
+## Conventions (this directory only)
+
+- **Minimal dependencies** — zero runtime dependencies. Pure type definitions.
+- **Server and client both depend on `@freellmapi/shared`** — types must be compatible with both Node (ESM) and the browser. No Node-specific APIs or browser-specific types here.
+- **No semver within the monorepo** — types change at HEAD, consumed at HEAD.
+
+---
+
+## Pitfalls
+
+- **Adding a new property to `ChatMessage`** affects server adapter parsing AND client display code — always check both consumers.
+- **`Platform` union is used in switch/if chains** throughout `providers/` and `router.ts`. Adding a provider to the union without handling it everywhere causes TS errors — which is intentional (exhaustive check).


### PR DESCRIPTION
## Description

Single root-level `AGENTS.md` (~109 lines) generated via `/init-deep` with full codebase discovery - 8 parallel explore agents, LSP codemap analysis, and manual scoring of all directories.

Covers: project structure, where-to-look table (12 tasks → 12 file paths), conventions (ESM imports, TS strict, test patterns), anti-patterns (provider registration, migration numbering, CSP/HSTS), commands, and project-specific gotchas.

No subdirectory AGENTS.md files - scoring showed the project is mid-sized (~9.5k lines) and well-organized enough that subdirectory files would be noise for maintainers.

## Changes
- `AGENTS.md` - new knowledge base (109 lines)
- `/**/AGENTS.md`- specific knowledge for important subdirectories