### PR TITLE
Revert SiliconFlow: Qwen3-8B is paid, not free (#131)

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -26,7 +26,6 @@ const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'pollinations', label: 'Pollinations (anon ok)' },
   { value: 'llm7', label: 'LLM7 (anon ok)' },
   { value: 'huggingface', label: 'HuggingFace Router' },
-  { value: 'siliconflow', label: 'SiliconFlow' },
 ]
 
 const statusDot: Record<string, string> = {

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -208,21 +208,6 @@ describe('Migration idempotency', () => {
     ]);
   });
 
-  it('V15: SiliconFlow Qwen3-8B free row is present, enabled, and capped at 50 rpd', () => {
-    process.env.ENCRYPTION_KEY = '0'.repeat(64);
-    const db = initDb(':memory:');
-
-    const row = db.prepare(`
-      SELECT display_name, enabled, rpd_limit, size_label FROM models
-       WHERE platform = 'siliconflow' AND model_id = 'Qwen/Qwen3-8B'
-    `).get() as { display_name: string; enabled: number; rpd_limit: number; size_label: string } | undefined;
-
-    expect(row).toBeDefined();
-    expect(row!.enabled).toBe(1);
-    expect(row!.rpd_limit).toBe(50);
-    expect(row!.size_label).toBe('Small');
-  });
-
   it('all enabled catalog platforms have a registered provider', async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -247,7 +247,6 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'openrouter', name: 'OpenRouter',    baseUrl: 'https://openrouter.ai/api/v1' },
     { platform: 'github',     name: 'GitHub Models', baseUrl: 'https://models.github.ai/inference' },
     { platform: 'zhipu',      name: 'Zhipu AI',      baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
-    { platform: 'siliconflow', name: 'SiliconFlow',  baseUrl: 'https://api.siliconflow.com/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -49,6 +49,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV12(db);
   migrateModelsV13(db);
   migrateModelsV14(db);
+  migrateModelsV15(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1261,6 +1262,27 @@ function migrateModelsV14(db: Database.Database) {
      WHERE platform = 'cerebras'
        AND model_id IN ('qwen-3-235b-a22b-instruct-2507', 'llama3.1-8b')
   `).run();
+}
+
+/**
+ * V15 (May 2026): purge SiliconFlow.
+ *
+ * SiliconFlow was briefly added (#131) on the belief Qwen/Qwen3-8B was a $0
+ * "free model". Re-verification showed it is PAID ($0.06/M in+out): the
+ * account balance dropped 0.9999 -> 0.9998 across ~2.7K tokens, and the
+ * official pricing page lists it at $0.06/M. The earlier "zero-cost" read was
+ * a 4-decimal rounding artifact on a tiny call. SiliconFlow's .com endpoint is
+ * a one-time $1 trial credit, not a recurring free tier — same disqualifier
+ * as Chutes — so the provider was reverted. This removes any orphaned row from
+ * a DB that already ran the original V15. No-op on DBs that never had it.
+ */
+function migrateModelsV15(db: Database.Database) {
+  db.prepare(`
+    DELETE FROM fallback_config WHERE model_db_id IN (
+      SELECT id FROM models WHERE platform = 'siliconflow'
+    )
+  `).run();
+  db.prepare(`DELETE FROM models WHERE platform = 'siliconflow'`).run();
 }
 
 function ensureUnifiedKey(db: Database.Database) {

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -49,7 +49,6 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV12(db);
   migrateModelsV13(db);
   migrateModelsV14(db);
-  migrateModelsV15(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -200,8 +199,6 @@ function seedModels(db: Database.Database) {
     ['zhipu', 'glm-4.5-flash', 'GLM-4.5 Flash', 5, 4, 'Large', null, null, null, 1000000, '~30M', 131072],
     ['moonshot', 'kimi-latest', 'Kimi Latest', 4, 8, 'Large', 60, null, null, 500000, '~15M', 200000],
     ['minimax', 'MiniMax-M1', 'MiniMax M1', 5, 8, 'Large', 20, null, 1000000, null, '~30M', 200000],
-    // SiliconFlow — zero-cost free model (50 req/day, tools supported). See migrateModelsV15.
-    ['siliconflow', 'Qwen/Qwen3-8B', 'Qwen3 8B (SiliconFlow)', 30, 3, 'Small', null, 50, null, null, '50 req/day', 32768],
   ];
 
   const insertMany = db.transaction(() => {
@@ -1264,42 +1261,6 @@ function migrateModelsV14(db: Database.Database) {
      WHERE platform = 'cerebras'
        AND model_id IN ('qwen-3-235b-a22b-instruct-2507', 'llama3.1-8b')
   `).run();
-}
-
-/**
- * V15 (May 2026): add SiliconFlow (new platform).
- *
- * OpenAI-compatible at api.siliconflow.com/v1. New accounts get a one-time
- * gift balance, but a small set of models are genuinely $0 ("free models",
- * 50 req/day; 1000/day after any credit purchase). Probed 2026-05: a call to
- * Qwen/Qwen3-8B left the account balance unchanged (zero-cost) and tool calls
- * round-trip; Qwen2.5-7B-Instruct DID decrement the balance (paid), so only
- * the confirmed zero-cost row is seeded. Small 8B model — ranked low so the
- * router only falls to it near the end of the chain. No card required.
- */
-function migrateModelsV15(db: Database.Database) {
-  const insert = db.prepare(`
-    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `);
-  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
-    ['siliconflow', 'Qwen/Qwen3-8B', 'Qwen3 8B (SiliconFlow)', 30, 3, 'Small', null, 50, null, null, '50 req/day', 32768],
-  ];
-
-  const apply = db.transaction(() => {
-    for (const a of additions) insert.run(...a);
-    const missing = db.prepare(`
-      SELECT m.id FROM models m
-      LEFT JOIN fallback_config f ON m.id = f.model_db_id
-      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
-    `).all() as { id: number }[];
-    if (missing.length > 0) {
-      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
-      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
-      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
-    }
-  });
-  apply();
 }
 
 function ensureUnifiedKey(db: Database.Database) {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -143,18 +143,6 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.llm7.io/v1',
 }));
 
-// SiliconFlow — OpenAI-compatible (api.siliconflow.com/v1). New-user accounts
-// get a one-time gift balance, but a small set of models are genuinely $0
-// ("free models", 50 req/day; 1000/day after any credit purchase). Probed
-// 2026-05: balance held flat across calls to Qwen/Qwen3-8B (zero-cost) and
-// tool calls round-trip correctly; Qwen2.5-7B-Instruct DID decrement balance
-// (paid), so only the confirmed zero-cost row is seeded. No card required.
-register(new OpenAICompatProvider({
-  platform: 'siliconflow',
-  name: 'SiliconFlow',
-  baseUrl: 'https://api.siliconflow.com/v1',
-}));
-
 // Chutes was evaluated for V11 and dropped: probe with a free-tier key
 // returned 402 on every model — "Quota exceeded and account balance is
 // $0.0, please pay with fiat or send tao". The "free" tier requires a

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -12,7 +12,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'siliconflow',
+  'kilo', 'pollinations', 'llm7', 'huggingface',
 ] as const;
 
 const addKeySchema = z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -21,8 +21,7 @@ export type Platform =
   | 'kilo'
   | 'pollinations'
   | 'llm7'
-  | 'huggingface'
-  | 'siliconflow';
+  | 'huggingface';
 
 export interface Model {
   id: number;


### PR DESCRIPTION
Reverts #131. Re-verification showed SiliconFlow's `.com` endpoint has no genuinely free model.

### Evidence Qwen3-8B is paid (not $0)
- **Official pricing** (siliconflow.com/models): Qwen/Qwen3-8B listed at **$0.06/M tokens** in and out.
- **Empirical:** pushing ~2,700 tokens through Qwen3-8B dropped the account balance **0.9999 → 0.9998**. It bills against the one-time $1 signup gift.
- My earlier "zero-cost" read was a 4-decimal rounding artifact on a 28-token call — too small to move the balance.

SiliconFlow's free access is a **one-time $1 trial credit**, not a recurring free tier — the same disqualifier that kept Chutes out of the catalog.

### Changes
- `git revert` of #131 (removes provider, types entry, seed row, key enum, dropdown).
- Plus a defensive `migrateModelsV15` that **deletes any orphaned `siliconflow` rows** from a DB that already booted #131 (idempotent; no-op otherwise) — important since the catalog runs on a stateful DB.

143 tests pass; build clean.