### PR TITLE
feat(keys): allow editing key labels after creation

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform } from '../../../shared/types'
+import { Pencil } from 'lucide-react'
 
 const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'google', label: 'Google AI Studio' },
@@ -133,6 +134,9 @@ export default function KeysPage() {
   const [apiKey, setApiKey] = useState('')
   const [accountId, setAccountId] = useState('')
   const [label, setLabel] = useState('')
+  const [editingKeyId, setEditingKeyId] = useState<number | null>(null)
+  const [editingLabel, setEditingLabel] = useState('')
+  const editInputRef = useRef<HTMLInputElement>(null)
 
   const { data: keys = [], isLoading } = useQuery<ApiKey[]>({
     queryKey: ['keys'],
@@ -195,6 +199,41 @@ export default function KeysPage() {
       queryClient.invalidateQueries({ queryKey: ['fallback'] })
     },
   })
+
+  const updateKey = useMutation({
+    mutationFn: ({ id, label }: { id: number; label: string }) =>
+      apiFetch(`/api/keys/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ label }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+      setEditingKeyId(null)
+      setEditingLabel('')
+    },
+  })
+
+  function startEditing(key: ApiKey) {
+    setEditingKeyId(key.id)
+    setEditingLabel(key.label)
+  }
+
+  function cancelEditing() {
+    setEditingKeyId(null)
+    setEditingLabel('')
+  }
+
+  function saveEditing(id: number) {
+    if (editingLabel !== undefined) {
+      updateKey.mutate({ id, label: editingLabel })
+    }
+  }
+
+  useEffect(() => {
+    if (editingKeyId !== null && editInputRef.current) {
+      editInputRef.current.focus()
+    }
+  }, [editingKeyId])
 
   const needsAccountId = platform === 'cloudflare'
 
@@ -320,17 +359,40 @@ export default function KeysPage() {
                       const h = healthKeyMap.get(k.id)
                       const status = h?.status ?? k.status
                       const lastChecked = h?.lastCheckedAt
+                      const isEditing = editingKeyId === k.id
                       return (
                         <div key={k.id} className="flex items-center gap-3 px-4 py-3 hover:bg-muted/40 transition-colors">
                           <span className={`size-1.5 rounded-full flex-shrink-0 ${statusDot[status] ?? statusDot.unknown}`} />
                           <code className="text-xs font-mono flex-shrink-0">{k.maskedKey}</code>
-                          {k.label && <span className="text-xs text-muted-foreground">{k.label}</span>}
+                          {isEditing ? (
+                            <Input
+                              ref={editInputRef}
+                              value={editingLabel}
+                              onChange={e => setEditingLabel(e.target.value)}
+                              onKeyDown={e => {
+                                if (e.key === 'Enter') saveEditing(k.id)
+                                if (e.key === 'Escape') cancelEditing()
+                              }}
+                              onBlur={() => saveEditing(k.id)}
+                              className="h-6 w-[160px] text-xs"
+                              disabled={updateKey.isPending}
+                            />
+                          ) : (
+                            <>
+                              {k.label && <span className="text-xs text-muted-foreground">{k.label}</span>}
+                            </>
+                          )}
                           <span className="text-xs text-muted-foreground">{statusLabel[status] ?? status}</span>
                           <div className="flex-1" />
                           {lastChecked && (
                             <span className="text-[11px] text-muted-foreground tabular-nums">
                               {new Date(lastChecked).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                             </span>
+                          )}
+                          {!isEditing && (
+                            <Button variant="ghost" size="xs" onClick={() => startEditing(k)}>
+                              <Pencil className="size-3" />
+                            </Button>
                           )}
                           <Button variant="ghost" size="xs" onClick={() => checkKey.mutate(k.id)} disabled={checkKey.isPending}>
                             Check

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -97,4 +97,77 @@ describe('Keys API', () => {
     const { status } = await request(app, 'DELETE', '/api/keys/99999');
     expect(status).toBe(404);
   });
+
+  it('PATCH /api/keys/:id updates label', async () => {
+    const { body: created } = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_test123456789',
+    });
+
+    const { status, body } = await request(app, 'PATCH', `/api/keys/${created.id}`, {
+      label: 'Production key',
+    });
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.label).toBe('Production key');
+
+    const { body: keys } = await request(app, 'GET', '/api/keys');
+    expect(keys[0].label).toBe('Production key');
+  });
+
+  it('PATCH /api/keys/:id updates both enabled and label', async () => {
+    const { body: created } = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_test123456789',
+    });
+
+    const { status, body } = await request(app, 'PATCH', `/api/keys/${created.id}`, {
+      enabled: false,
+      label: 'Disabled key',
+    });
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.enabled).toBe(false);
+    expect(body.label).toBe('Disabled key');
+
+    const { body: keys } = await request(app, 'GET', '/api/keys');
+    expect(keys[0].enabled).toBe(false);
+    expect(keys[0].label).toBe('Disabled key');
+  });
+
+  it('PATCH /api/keys/:id clears label', async () => {
+    const { body: created } = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_test123456789',
+      label: 'Temporary label',
+    });
+
+    const { status, body } = await request(app, 'PATCH', `/api/keys/${created.id}`, {
+      label: '',
+    });
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.label).toBe('');
+
+    const { body: keys } = await request(app, 'GET', '/api/keys');
+    expect(keys[0].label).toBe('');
+  });
+
+  it('PATCH /api/keys/:id returns 400 when no fields provided', async () => {
+    const { body: created } = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_test123456789',
+    });
+
+    const { status } = await request(app, 'PATCH', `/api/keys/${created.id}`, {});
+    expect(status).toBe(400);
+  });
+
+  it('PATCH /api/keys/:id returns 404 for nonexistent key', async () => {
+    const { status } = await request(app, 'PATCH', '/api/keys/99999', { label: 'test' });
+    expect(status).toBe(404);
+  });
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -21,6 +21,13 @@ const addKeySchema = z.object({
   label: z.string().optional(),
 });
 
+const updateKeySchema = z.object({
+  enabled: z.boolean().optional(),
+  label: z.string().optional(),
+}).refine(data => data.enabled !== undefined || data.label !== undefined, {
+  message: 'At least one of enabled or label must be provided',
+});
+
 // List all keys (masked)
 keysRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
@@ -115,7 +122,7 @@ keysRouter.patch('/platform/:platform', (req: Request, res: Response) => {
   res.json({ success: true, enabled, updatedKeys: result.changes });
 });
 
-// Toggle enable/disable
+// Update key (toggle enable/disable or edit label)
 keysRouter.patch('/:id', (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);
   if (isNaN(id)) {
@@ -123,19 +130,37 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     return;
   }
 
-  const { enabled } = req.body;
-  if (typeof enabled !== 'boolean') {
-    res.status(400).json({ error: { message: 'enabled must be a boolean' } });
+  const parsed = updateKeySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
     return;
   }
 
+  const { enabled, label } = parsed.data;
+  const updates: string[] = [];
+  const values: (string | number)[] = [];
+
+  if (enabled !== undefined) {
+    updates.push('enabled = ?');
+    values.push(enabled ? 1 : 0);
+  }
+  if (label !== undefined) {
+    updates.push('label = ?');
+    values.push(label);
+  }
+
+  values.push(id);
+
   const db = getDb();
-  const result = db.prepare('UPDATE api_keys SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+  const result = db.prepare(`UPDATE api_keys SET ${updates.join(', ')} WHERE id = ?`).run(...values);
 
   if (result.changes === 0) {
     res.status(404).json({ error: { message: 'Key not found' } });
     return;
   }
 
-  res.json({ success: true, enabled });
+  const response: Record<string, unknown> = { success: true };
+  if (enabled !== undefined) response.enabled = enabled;
+  if (label !== undefined) response.label = label;
+  res.json(response);
 });


### PR DESCRIPTION
## Summary

Fixes #133 — once a provider key was added, the label could not be modified afterwards. This PR extends the backend PATCH endpoint and adds an inline editing UI on the Keys page.

## Screenshots
<img width="289" height="91" alt="image" src="https://github.com/user-attachments/assets/e5701c17-2706-4e26-8393-7fbfb195d156" />
<img width="364" height="60" alt="image" src="https://github.com/user-attachments/assets/aa8b4fef-9282-47ed-88fd-d1811e1746eb" />

### 2. Edit mode — inline input field replacing the label

<!-- Paste screenshot here: shows the same key row with an inline text input replacing the static label, focused and ready for editing -->

## Changes

### Backend (`server/src/routes/keys.ts`)
- Extended `PATCH /api/keys/:id` to accept either `enabled` (boolean), `label` (string), or both.
- Added `updateKeySchema` zod validation that requires at least one field to be present.
- Dynamically builds the SQL `UPDATE` statement based on which fields are provided, keeping the endpoint backward-compatible with existing toggle requests.
- Returns only the fields that were updated in the JSON response.

### Frontend (`client/src/pages/KeysPage.tsx`)
- Added inline label editing for each key row.
- Clicking the pencil icon replaces the static label with a small inline `<Input>`.
- Supports **Enter** to save, **Escape** to cancel, and **blur** to save.
- Added `updateKey` mutation via `react-query` that invalidates the `['keys']` cache on success.
- Uses `useRef` + `useEffect` to auto-focus the input when editing starts.

### Tests (`server/src/__tests__/routes/keys.test.ts`)
Added 5 new test cases:
1. `PATCH` updates label successfully.
2. `PATCH` updates both `enabled` and `label` simultaneously.
3. `PATCH` clears label by sending an empty string.
4. `PATCH` returns 400 when no fields are provided.
5. `PATCH` returns 404 for a nonexistent key.

## Verification
- All 148 server tests pass.
- Server TypeScript compiles cleanly (`tsc --noEmit`).
- Client lint has no new errors from these changes.

## Implementation Notes
The label is stored as a plain `TEXT` column in `api_keys` with a `NOT NULL DEFAULT ''` constraint, so clearing a label simply sets it to an empty string. The existing GET endpoint already returns the label, so no schema migrations were needed.
