### PR TITLE
[codex] Add playground chat history persistence

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, NavLink } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
+import { PlaygroundChatProvider } from '@/lib/playground-chat'
 import KeysPage from '@/pages/KeysPage'
 import PlaygroundPage from '@/pages/PlaygroundPage'
 import FallbackPage from '@/pages/FallbackPage'
@@ -69,35 +70,37 @@ function Brand() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename={import.meta.env.BASE_URL}>
-        <div className="min-h-screen bg-background">
-          <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b">
-            <div className="max-w-6xl mx-auto px-6 flex items-center">
-              <Brand />
-              <nav className="flex items-center gap-6 ml-10">
-                <NavItem to="/playground">Playground</NavItem>
-                <NavItem to="/keys">Keys</NavItem>
-                <NavItem to="/fallback">Fallback</NavItem>
-                <NavItem to="/analytics">Analytics</NavItem>
-              </nav>
-              <div className="ml-auto py-2">
-                <DarkModeToggle />
+      <PlaygroundChatProvider>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
+          <div className="min-h-screen bg-background">
+            <header className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b">
+              <div className="max-w-6xl mx-auto px-6 flex items-center">
+                <Brand />
+                <nav className="flex items-center gap-6 ml-10">
+                  <NavItem to="/playground">Playground</NavItem>
+                  <NavItem to="/keys">Keys</NavItem>
+                  <NavItem to="/fallback">Fallback</NavItem>
+                  <NavItem to="/analytics">Analytics</NavItem>
+                </nav>
+                <div className="ml-auto py-2">
+                  <DarkModeToggle />
+                </div>
               </div>
-            </div>
-          </header>
-          <main className="max-w-6xl mx-auto px-6 py-8">
-            <Routes>
-              <Route path="/" element={<Navigate to="/playground" replace />} />
-              <Route path="/playground" element={<PlaygroundPage />} />
-              <Route path="/keys" element={<KeysPage />} />
-              <Route path="/fallback" element={<FallbackPage />} />
-              <Route path="/analytics" element={<AnalyticsPage />} />
-              <Route path="/test" element={<Navigate to="/playground" replace />} />
-              <Route path="/health" element={<Navigate to="/keys" replace />} />
-            </Routes>
-          </main>
-        </div>
-      </BrowserRouter>
+            </header>
+            <main className="max-w-6xl mx-auto px-6 py-8">
+              <Routes>
+                <Route path="/" element={<Navigate to="/playground" replace />} />
+                <Route path="/playground" element={<PlaygroundPage />} />
+                <Route path="/keys" element={<KeysPage />} />
+                <Route path="/fallback" element={<FallbackPage />} />
+                <Route path="/analytics" element={<AnalyticsPage />} />
+                <Route path="/test" element={<Navigate to="/playground" replace />} />
+                <Route path="/health" element={<Navigate to="/keys" replace />} />
+              </Routes>
+            </main>
+          </div>
+        </BrowserRouter>
+      </PlaygroundChatProvider>
     </QueryClientProvider>
   )
 }

--- a/client/src/lib/playground-chat.tsx
+++ b/client/src/lib/playground-chat.tsx
@@ -1,0 +1,215 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+
+export interface ChatMessage {
+  role: 'user' | 'assistant'
+  content: string
+  meta?: {
+    platform?: string
+    model?: string
+    latency?: number
+    fallbackAttempts?: number
+  }
+}
+
+export interface ChatSessionSummary {
+  id: number
+  title: string
+  selectedModel: string
+  createdAt: string
+  updatedAt: string
+  messageCount: number
+}
+
+export interface ChatSessionDetail extends ChatSessionSummary {
+  messages: ChatMessage[]
+}
+
+interface StoredPlaygroundState {
+  currentSessionId: number | null
+  messages: ChatMessage[]
+  input: string
+  selectedModel: string
+}
+
+interface PlaygroundChatContextValue extends StoredPlaygroundState {
+  loading: boolean
+  setInput: (value: string) => void
+  setSelectedModel: (value: string) => void
+  sendMessage: () => Promise<void>
+  newChat: () => void
+  loadSession: (sessionId: number) => Promise<void>
+}
+
+const STORAGE_KEY = 'freellmapi.playground.currentChat'
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
+const PlaygroundChatContext = createContext<PlaygroundChatContextValue | null>(null)
+
+function readStoredState(): StoredPlaygroundState {
+  if (typeof window === 'undefined') {
+    return { currentSessionId: null, messages: [], input: '', selectedModel: 'auto' }
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { currentSessionId: null, messages: [], input: '', selectedModel: 'auto' }
+    const parsed = JSON.parse(raw) as Partial<StoredPlaygroundState>
+    return {
+      currentSessionId: parsed.currentSessionId ?? null,
+      messages: Array.isArray(parsed.messages) ? parsed.messages : [],
+      input: typeof parsed.input === 'string' ? parsed.input : '',
+      selectedModel: typeof parsed.selectedModel === 'string' ? parsed.selectedModel : 'auto',
+    }
+  } catch {
+    return { currentSessionId: null, messages: [], input: '', selectedModel: 'auto' }
+  }
+}
+
+export function PlaygroundChatProvider({ children }: { children: ReactNode }) {
+  const initialState = useRef<StoredPlaygroundState | null>(null)
+  if (!initialState.current) initialState.current = readStoredState()
+
+  const [currentSessionId, setCurrentSessionId] = useState<number | null>(initialState.current.currentSessionId)
+  const [messages, setMessages] = useState<ChatMessage[]>(initialState.current.messages)
+  const [input, setInput] = useState(initialState.current.input)
+  const [selectedModel, setSelectedModel] = useState(initialState.current.selectedModel)
+  const [loading, setLoading] = useState(false)
+  const queryClient = useQueryClient()
+
+  const { data: keyData } = useQuery<{ apiKey: string }>({
+    queryKey: ['unified-key'],
+    queryFn: () => apiFetch('/api/settings/api-key'),
+  })
+
+  useEffect(() => {
+    const state: StoredPlaygroundState = { currentSessionId, messages, input, selectedModel }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }, [currentSessionId, messages, input, selectedModel])
+
+  async function saveChat(nextMessages: ChatMessage[], sessionId = currentSessionId) {
+    const saved = await apiFetch<ChatSessionDetail>('/api/chats', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId,
+        selectedModel,
+        messages: nextMessages,
+      }),
+    })
+    setCurrentSessionId(saved.id)
+    queryClient.invalidateQueries({ queryKey: ['chats'] })
+    return saved
+  }
+
+  async function sendMessage() {
+    const text = input.trim()
+    if (!text || loading) return
+
+    const userMsg: ChatMessage = { role: 'user', content: text }
+    const nextMessages = [...messages, userMsg]
+    setMessages(nextMessages)
+    setInput('')
+    setLoading(true)
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (keyData?.apiKey) headers.Authorization = `Bearer ${keyData.apiKey}`
+
+      const body: any = {
+        messages: nextMessages.map(m => ({ role: m.role, content: m.content })),
+      }
+      if (selectedModel !== 'auto') body.model = selectedModel
+
+      const start = Date.now()
+      const res = await fetch(`${BASE}/v1/chat/completions`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+
+      const latency = Date.now() - start
+      const routedVia = res.headers.get('X-Routed-Via')
+      const fallbackAttempts = res.headers.get('X-Fallback-Attempts')
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: { message: `HTTP ${res.status}` } }))
+        const failedMessages = [...nextMessages, {
+          role: 'assistant' as const,
+          content: `Error: ${err.error?.message ?? 'Unknown error'}`,
+        }]
+        setMessages(failedMessages)
+        await saveChat(failedMessages)
+        return
+      }
+
+      const data = await res.json()
+      const content = data.choices?.[0]?.message?.content ?? JSON.stringify(data, null, 2)
+      const via = data._routed_via ?? (routedVia ? {
+        platform: routedVia.split('/')[0],
+        model: routedVia.split('/').slice(1).join('/'),
+      } : undefined)
+
+      const completedMessages = [...nextMessages, {
+        role: 'assistant' as const,
+        content,
+        meta: {
+          platform: via?.platform,
+          model: via?.model,
+          latency,
+          fallbackAttempts: fallbackAttempts ? parseInt(fallbackAttempts) : undefined,
+        },
+      }]
+      setMessages(completedMessages)
+      await saveChat(completedMessages)
+    } catch (err: any) {
+      const failedMessages = [...nextMessages, {
+        role: 'assistant' as const,
+        content: `Error: ${err.message}`,
+      }]
+      setMessages(failedMessages)
+      await saveChat(failedMessages).catch(() => undefined)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function newChat() {
+    setCurrentSessionId(null)
+    setMessages([])
+    setInput('')
+  }
+
+  async function loadSession(sessionId: number) {
+    const session = await apiFetch<ChatSessionDetail>(`/api/chats/${sessionId}`)
+    setCurrentSessionId(session.id)
+    setMessages(session.messages)
+    setSelectedModel(session.selectedModel || 'auto')
+    setInput('')
+  }
+
+  const value = useMemo<PlaygroundChatContextValue>(() => ({
+    currentSessionId,
+    messages,
+    input,
+    selectedModel,
+    loading,
+    setInput,
+    setSelectedModel,
+    sendMessage,
+    newChat,
+    loadSession,
+  }), [currentSessionId, messages, input, selectedModel, loading])
+
+  return (
+    <PlaygroundChatContext.Provider value={value}>
+      {children}
+    </PlaygroundChatContext.Provider>
+  )
+}
+
+export function usePlaygroundChat() {
+  const context = useContext(PlaygroundChatContext)
+  if (!context) throw new Error('usePlaygroundChat must be used inside PlaygroundChatProvider')
+  return context
+}

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { History, MessageSquarePlus } from 'lucide-react'
+import { Check, Copy, History, MessageSquarePlus, Pencil } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { usePlaygroundChat } from '@/lib/playground-chat'
 import type { ChatSessionSummary } from '@/lib/playground-chat'
@@ -44,6 +44,7 @@ export default function PlaygroundPage() {
     newChat,
     loadSession,
   } = usePlaygroundChat()
+  const [copiedMessage, setCopiedMessage] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -83,6 +84,23 @@ export default function PlaygroundPage() {
   const handleLoadSession = async (sessionId: number) => {
     await loadSession(sessionId)
     setTimeout(() => inputRef.current?.focus(), 0)
+  }
+
+  const handleCopyMessage = async (content: string, key: string) => {
+    await navigator.clipboard.writeText(content)
+    setCopiedMessage(key)
+    window.setTimeout(() => setCopiedMessage(current => current === key ? null : current), 1400)
+  }
+
+  const handleEditMessage = (content: string) => {
+    setInput(content)
+    setTimeout(() => {
+      const el = inputRef.current
+      if (!el) return
+      el.focus()
+      el.style.height = 'auto'
+      el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+    }, 0)
   }
 
   const activeModelLabel = selectedModel === 'auto'
@@ -172,23 +190,57 @@ export default function PlaygroundPage() {
                 {messages.map((msg, i) => (
                   <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                     <div
-                      className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                      className={`group/message max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
                         msg.role === 'user'
                           ? 'bg-primary text-primary-foreground'
                           : 'bg-muted'
                       }`}
                     >
                       <div className="whitespace-pre-wrap">{msg.content}</div>
-                      {msg.meta && (
-                        <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
-                          {msg.meta.platform && <span>{msg.meta.platform}</span>}
-                          {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
-                          {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
-                          {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
-                            <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
+                      <div className="mt-2 flex items-center justify-between gap-3">
+                        {msg.meta ? (
+                          <div className="flex items-center gap-2 flex-wrap text-[11px] opacity-70 tabular-nums">
+                            {msg.meta.platform && <span>{msg.meta.platform}</span>}
+                            {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
+                            {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
+                            {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
+                              <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
+                            )}
+                          </div>
+                        ) : (
+                          <div />
+                        )}
+                        <div className="flex shrink-0 items-center gap-1 opacity-70 transition-opacity group-hover/message:opacity-100 focus-within:opacity-100">
+                          {msg.role === 'user' && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className="size-6 text-current hover:bg-current/10 hover:text-current"
+                              onClick={() => handleEditMessage(msg.content)}
+                              title="Edit message"
+                              aria-label="Edit message"
+                            >
+                              <Pencil className="size-3.5" />
+                            </Button>
                           )}
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-xs"
+                            className="size-6 text-current hover:bg-current/10 hover:text-current"
+                            onClick={() => handleCopyMessage(msg.content, `${msg.role}-${i}`)}
+                            title="Copy message"
+                            aria-label="Copy message"
+                          >
+                            {copiedMessage === `${msg.role}-${i}` ? (
+                              <Check className="size-3.5" />
+                            ) : (
+                              <Copy className="size-3.5" />
+                            )}
+                          </Button>
                         </div>
-                      )}
+                      </div>
                     </div>
                   </div>
                 ))}

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -1,6 +1,10 @@
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import type { KeyboardEvent } from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { History, MessageSquarePlus } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
+import { usePlaygroundChat } from '@/lib/playground-chat'
+import type { ChatSessionSummary } from '@/lib/playground-chat'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { PageHeader } from '@/components/page-header'
@@ -16,120 +20,69 @@ interface FallbackEntry {
   keyCount: number
 }
 
-interface ChatMessage {
-  role: 'user' | 'assistant'
-  content: string
-  meta?: {
-    platform?: string
-    model?: string
-    latency?: number
-    fallbackAttempts?: number
-  }
+function formatChatDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 export default function PlaygroundPage() {
-  const [messages, setMessages] = useState<ChatMessage[]>([])
-  const [input, setInput] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [selectedModel, setSelectedModel] = useState<string>('auto')
+  const {
+    currentSessionId,
+    messages,
+    input,
+    selectedModel,
+    loading,
+    setInput,
+    setSelectedModel,
+    sendMessage,
+    newChat,
+    loadSession,
+  } = usePlaygroundChat()
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
-
-  const { data: keyData } = useQuery<{ apiKey: string }>({
-    queryKey: ['unified-key'],
-    queryFn: () => apiFetch('/api/settings/api-key'),
-  })
 
   const { data: fallbackEntries = [] } = useQuery<FallbackEntry[]>({
     queryKey: ['fallback'],
     queryFn: () => apiFetch('/api/fallback'),
   })
 
+  const { data: chats = [], isLoading: historyLoading } = useQuery<ChatSessionSummary[]>({
+    queryKey: ['chats'],
+    queryFn: () => apiFetch('/api/chats'),
+  })
+
   const availableModels = fallbackEntries.filter(e => e.keyCount > 0 && e.enabled)
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+  }, [messages, loading])
 
   const handleSend = async () => {
-    const text = input.trim()
-    if (!text || loading) return
-
-    const userMsg: ChatMessage = { role: 'user', content: text }
-    const newMessages = [...messages, userMsg]
-    setMessages(newMessages)
-    setInput('')
-    setLoading(true)
-    inputRef.current?.focus()
-
-    try {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-      if (keyData?.apiKey) headers['Authorization'] = `Bearer ${keyData.apiKey}`
-
-      const body: any = {
-        messages: newMessages.map(m => ({ role: m.role, content: m.content })),
-      }
-      if (selectedModel !== 'auto') body.model = selectedModel
-
-      const base = import.meta.env.BASE_URL.replace(/\/$/, '')
-      const start = Date.now()
-      const res = await fetch(`${base}/v1/chat/completions`, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-      })
-
-      const latency = Date.now() - start
-      const routedVia = res.headers.get('X-Routed-Via')
-      const fallbackAttempts = res.headers.get('X-Fallback-Attempts')
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: { message: `HTTP ${res.status}` } }))
-        setMessages([...newMessages, {
-          role: 'assistant',
-          content: `Error: ${err.error?.message ?? 'Unknown error'}`,
-        }])
-        return
-      }
-
-      const data = await res.json()
-      const content = data.choices?.[0]?.message?.content ?? JSON.stringify(data, null, 2)
-      const via = data._routed_via ?? (routedVia ? {
-        platform: routedVia.split('/')[0],
-        model: routedVia.split('/').slice(1).join('/'),
-      } : undefined)
-
-      setMessages([...newMessages, {
-        role: 'assistant',
-        content,
-        meta: {
-          platform: via?.platform,
-          model: via?.model,
-          latency,
-          fallbackAttempts: fallbackAttempts ? parseInt(fallbackAttempts) : undefined,
-        },
-      }])
-    } catch (err: any) {
-      setMessages([...newMessages, {
-        role: 'assistant',
-        content: `Error: ${err.message}`,
-      }])
-    } finally {
-      setLoading(false)
-      setTimeout(() => inputRef.current?.focus(), 0)
-    }
+    await sendMessage()
+    setTimeout(() => inputRef.current?.focus(), 0)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSend()
     }
   }
 
-  const handleClear = () => {
-    setMessages([])
-    inputRef.current?.focus()
+  const handleNewChat = () => {
+    newChat()
+    setTimeout(() => inputRef.current?.focus(), 0)
+  }
+
+  const handleLoadSession = async (sessionId: number) => {
+    await loadSession(sessionId)
+    setTimeout(() => inputRef.current?.focus(), 0)
   }
 
   const activeModelLabel = selectedModel === 'auto'
@@ -159,87 +112,123 @@ export default function PlaygroundPage() {
                 ))}
               </SelectContent>
             </Select>
-            {messages.length > 0 && (
-              <Button variant="outline" size="sm" onClick={handleClear}>
-                Clear
-              </Button>
-            )}
+            <Button variant="outline" size="sm" onClick={handleNewChat}>
+              <MessageSquarePlus className="size-4" />
+              New chat
+            </Button>
           </>
         }
       />
 
-      <div className="flex-1 flex flex-col rounded-lg border bg-card overflow-hidden min-h-0">
-        <div className="flex-1 overflow-y-auto p-6 space-y-4">
-          {messages.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-center">
-              <div className="space-y-2 max-w-sm">
-                <p className="text-base font-medium">Send a message to get started.</p>
-                <p className="text-sm text-muted-foreground">
-                  Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <>
-              {messages.map((msg, i) => (
-                <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                  <div
-                    className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
-                      msg.role === 'user'
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted'
+      <div className="flex-1 flex gap-4 min-h-0">
+        <aside className="w-[280px] shrink-0 rounded-lg border bg-card overflow-hidden flex flex-col min-h-0">
+          <div className="border-b px-4 py-3 flex items-center gap-2">
+            <History className="size-4 text-muted-foreground" />
+            <h2 className="text-sm font-medium">History</h2>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2">
+            {historyLoading ? (
+              <div className="px-3 py-6 text-sm text-muted-foreground">Loading history...</div>
+            ) : chats.length === 0 ? (
+              <div className="px-3 py-6 text-sm text-muted-foreground">Saved chats will appear here.</div>
+            ) : (
+              <div className="space-y-1">
+                {chats.map(chat => (
+                  <button
+                    key={chat.id}
+                    type="button"
+                    onClick={() => handleLoadSession(chat.id)}
+                    className={`w-full rounded-md px-3 py-2 text-left transition-colors ${
+                      chat.id === currentSessionId
+                        ? 'bg-muted text-foreground'
+                        : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
                     }`}
                   >
-                    <div className="whitespace-pre-wrap">{msg.content}</div>
-                    {msg.meta && (
-                      <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
-                        {msg.meta.platform && <span>{msg.meta.platform}</span>}
-                        {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
-                        {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
-                        {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
-                          <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
+                    <div className="truncate text-sm font-medium">{chat.title}</div>
+                    <div className="mt-1 flex items-center justify-between gap-2 text-xs">
+                      <span>{formatChatDate(chat.updatedAt)}</span>
+                      <span>{chat.messageCount} msgs</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <div className="flex-1 flex flex-col rounded-lg border bg-card overflow-hidden min-w-0 min-h-0">
+          <div className="flex-1 overflow-y-auto p-6 space-y-4">
+            {messages.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-center">
+                <div className="space-y-2 max-w-sm">
+                  <p className="text-base font-medium">Send a message to get started.</p>
+                  <p className="text-sm text-muted-foreground">
+                    Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
+                  </p>
                 </div>
-              ))}
-              {loading && (
-                <div className="flex justify-start">
-                  <div className="bg-muted rounded-2xl px-4 py-3">
-                    <div className="flex gap-1">
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+              </div>
+            ) : (
+              <>
+                {messages.map((msg, i) => (
+                  <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                    <div
+                      className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                        msg.role === 'user'
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted'
+                      }`}
+                    >
+                      <div className="whitespace-pre-wrap">{msg.content}</div>
+                      {msg.meta && (
+                        <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
+                          {msg.meta.platform && <span>{msg.meta.platform}</span>}
+                          {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
+                          {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
+                          {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
+                            <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
-                </div>
-              )}
-              <div ref={messagesEndRef} />
-            </>
-          )}
-        </div>
+                ))}
+                {loading && (
+                  <div className="flex justify-start">
+                    <div className="bg-muted rounded-2xl px-4 py-3">
+                      <div className="flex gap-1">
+                        <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+                        <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+                        <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+                      </div>
+                    </div>
+                  </div>
+                )}
+                <div ref={messagesEndRef} />
+              </>
+            )}
+          </div>
 
-        <div className="border-t bg-background/50 p-3">
-          <div className="flex gap-2 items-end">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Type a message… (⏎ to send, ⇧⏎ for newline)"
-              rows={1}
-              className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
-              style={{ height: 'auto', overflow: 'hidden' }}
-              onInput={e => {
-                const el = e.target as HTMLTextAreaElement
-                el.style.height = 'auto'
-                el.style.height = Math.min(el.scrollHeight, 160) + 'px'
-              }}
-            />
-            <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
-              {loading ? 'Sending…' : 'Send'}
-            </Button>
+          <div className="border-t bg-background/50 p-3">
+            <div className="flex gap-2 items-end">
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={e => setInput(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
+                rows={1}
+                className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
+                style={{ height: 'auto', overflow: 'hidden' }}
+                onInput={e => {
+                  const el = e.target as HTMLTextAreaElement
+                  el.style.height = 'auto'
+                  el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+                }}
+              />
+              <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
+                {loading ? 'Sending...' : 'Send'}
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/server/src/__tests__/routes/chats.test.ts
+++ b/server/src/__tests__/routes/chats.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, body?: any) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : {},
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+describe('Chats API', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.prepare('DELETE FROM chat_sessions').run();
+  });
+
+  it('saves a chat and returns it in history', async () => {
+    const { status, body } = await request(app, 'POST', '/api/chats', {
+      selectedModel: 'auto',
+      messages: [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: 'Hi there',
+          meta: { platform: 'google', model: 'gemini-test', latency: 123, fallbackAttempts: 1 },
+        },
+      ],
+    });
+
+    expect(status).toBe(201);
+    expect(body.id).toBeGreaterThan(0);
+    expect(body.title).toBe('Hello');
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[1].meta.platform).toBe('google');
+
+    const history = await request(app, 'GET', '/api/chats');
+    expect(history.status).toBe(200);
+    expect(history.body).toHaveLength(1);
+    expect(history.body[0].messageCount).toBe(2);
+  });
+
+  it('updates an existing chat snapshot', async () => {
+    const created = await request(app, 'POST', '/api/chats', {
+      selectedModel: 'auto',
+      messages: [
+        { role: 'user', content: 'First' },
+        { role: 'assistant', content: 'Reply' },
+      ],
+    });
+
+    const updated = await request(app, 'POST', '/api/chats', {
+      sessionId: created.body.id,
+      selectedModel: 'some-model',
+      messages: [
+        { role: 'user', content: 'First' },
+        { role: 'assistant', content: 'Reply' },
+        { role: 'user', content: 'Second' },
+      ],
+    });
+
+    expect(updated.status).toBe(200);
+    expect(updated.body.id).toBe(created.body.id);
+    expect(updated.body.selectedModel).toBe('some-model');
+    expect(updated.body.messages).toHaveLength(3);
+
+    const loaded = await request(app, 'GET', `/api/chats/${created.body.id}`);
+    expect(loaded.status).toBe(200);
+    expect(loaded.body.messages[2].content).toBe('Second');
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { fallbackRouter } from './routes/fallback.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
+import { chatsRouter } from './routes/chats.js';
 import { errorHandler } from './middleware/errorHandler.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -54,6 +55,7 @@ export function createApp() {
   app.use('/api/analytics', analyticsRouter);
   app.use('/api/health', healthRouter);
   app.use('/api/settings', settingsRouter);
+  app.use('/api/chats', chatsRouter);
 
   // OpenAI-compatible proxy
   app.use('/v1', proxyRouter);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -135,11 +135,33 @@ function createTables(db: Database.Database) {
       value TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS chat_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      selected_model TEXT NOT NULL DEFAULT 'auto',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS chat_messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id INTEGER NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+      role TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+      content TEXT NOT NULL,
+      platform TEXT,
+      model TEXT,
+      latency_ms INTEGER,
+      fallback_attempts INTEGER,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE INDEX IF NOT EXISTS idx_requests_created_at ON requests(created_at);
     CREATE INDEX IF NOT EXISTS idx_requests_platform ON requests(platform);
     CREATE INDEX IF NOT EXISTS idx_rate_limit_usage_lookup ON rate_limit_usage(platform, model_id, key_id, kind, created_at_ms);
     CREATE INDEX IF NOT EXISTS idx_rate_limit_cooldowns_expires ON rate_limit_cooldowns(expires_at_ms);
     CREATE INDEX IF NOT EXISTS idx_api_keys_platform ON api_keys(platform);
+    CREATE INDEX IF NOT EXISTS idx_chat_sessions_updated_at ON chat_sessions(updated_at);
+    CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id ON chat_messages(session_id);
   `);
 
   ensureRequestKeyIdColumn(db);

--- a/server/src/routes/chats.ts
+++ b/server/src/routes/chats.ts
@@ -1,0 +1,182 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { getDb } from '../db/index.js';
+
+export const chatsRouter = Router();
+
+const messageSchema = z.object({
+  role: z.enum(['user', 'assistant']),
+  content: z.string(),
+  meta: z.object({
+    platform: z.string().optional(),
+    model: z.string().optional(),
+    latency: z.number().int().nonnegative().optional(),
+    fallbackAttempts: z.number().int().nonnegative().optional(),
+  }).optional(),
+});
+
+const saveChatSchema = z.object({
+  sessionId: z.number().int().positive().optional().nullable(),
+  selectedModel: z.string().min(1).default('auto'),
+  messages: z.array(messageSchema).min(1),
+});
+
+function makeTitle(messages: z.infer<typeof messageSchema>[]) {
+  const firstUser = messages.find(m => m.role === 'user')?.content.trim();
+  if (!firstUser) return 'Untitled chat';
+  return firstUser.length > 80 ? `${firstUser.slice(0, 77)}...` : firstUser;
+}
+
+function readSession(sessionId: number) {
+  const db = getDb();
+  const session = db.prepare(`
+    SELECT id, title, selected_model, created_at, updated_at
+    FROM chat_sessions
+    WHERE id = ?
+  `).get(sessionId) as any;
+
+  if (!session) return null;
+
+  const messages = db.prepare(`
+    SELECT role, content, platform, model, latency_ms, fallback_attempts, created_at
+    FROM chat_messages
+    WHERE session_id = ?
+    ORDER BY id ASC
+  `).all(sessionId) as any[];
+
+  return {
+    id: session.id,
+    title: session.title,
+    selectedModel: session.selected_model,
+    createdAt: session.created_at,
+    updatedAt: session.updated_at,
+    messages: messages.map(m => ({
+      role: m.role,
+      content: m.content,
+      createdAt: m.created_at,
+      meta: {
+        platform: m.platform ?? undefined,
+        model: m.model ?? undefined,
+        latency: m.latency_ms ?? undefined,
+        fallbackAttempts: m.fallback_attempts ?? undefined,
+      },
+    })),
+  };
+}
+
+chatsRouter.get('/', (req: Request, res: Response) => {
+  const limit = Math.min(Math.max(Number(req.query.limit ?? 50), 1), 200);
+  const db = getDb();
+
+  const rows = db.prepare(`
+    SELECT
+      s.id,
+      s.title,
+      s.selected_model,
+      s.created_at,
+      s.updated_at,
+      COUNT(m.id) AS message_count
+    FROM chat_sessions s
+    LEFT JOIN chat_messages m ON m.session_id = s.id
+    GROUP BY s.id
+    ORDER BY s.updated_at DESC, s.id DESC
+    LIMIT ?
+  `).all(limit) as any[];
+
+  res.json(rows.map(r => ({
+    id: r.id,
+    title: r.title,
+    selectedModel: r.selected_model,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+    messageCount: r.message_count,
+  })));
+});
+
+chatsRouter.get('/:id', (req: Request, res: Response) => {
+  const sessionId = Number(req.params.id);
+  if (!Number.isInteger(sessionId) || sessionId <= 0) {
+    res.status(400).json({ error: { message: 'Invalid chat id' } });
+    return;
+  }
+
+  const session = readSession(sessionId);
+  if (!session) {
+    res.status(404).json({ error: { message: 'Chat not found' } });
+    return;
+  }
+
+  res.json(session);
+});
+
+chatsRouter.post('/', (req: Request, res: Response) => {
+  const parsed = saveChatSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: { message: parsed.error.message } });
+    return;
+  }
+
+  const db = getDb();
+  const { sessionId, selectedModel, messages } = parsed.data;
+  const title = makeTitle(messages);
+
+  const save = db.transaction(() => {
+    let id: number;
+    const existing = sessionId
+      ? db.prepare('SELECT id FROM chat_sessions WHERE id = ?').get(sessionId)
+      : undefined;
+
+    if (!sessionId) {
+      const result = db.prepare(`
+        INSERT INTO chat_sessions (title, selected_model, updated_at)
+        VALUES (?, ?, datetime('now'))
+      `).run(title, selectedModel);
+      id = Number(result.lastInsertRowid);
+    } else if (!existing) {
+      const result = db.prepare(`
+        INSERT INTO chat_sessions (title, selected_model, updated_at)
+        VALUES (?, ?, datetime('now'))
+      `).run(title, selectedModel);
+      id = Number(result.lastInsertRowid);
+    } else {
+      id = sessionId;
+      db.prepare(`
+        UPDATE chat_sessions
+        SET title = ?, selected_model = ?, updated_at = datetime('now')
+        WHERE id = ?
+      `).run(title, selectedModel, id);
+      db.prepare('DELETE FROM chat_messages WHERE session_id = ?').run(id);
+    }
+
+    const insertMessage = db.prepare(`
+      INSERT INTO chat_messages (
+        session_id,
+        role,
+        content,
+        platform,
+        model,
+        latency_ms,
+        fallback_attempts
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    for (const message of messages) {
+      insertMessage.run(
+        id,
+        message.role,
+        message.content,
+        message.meta?.platform ?? null,
+        message.meta?.model ?? null,
+        message.meta?.latency ?? null,
+        message.meta?.fallbackAttempts ?? null,
+      );
+    }
+
+    return id;
+  });
+
+  const savedId = save();
+  res.status(sessionId ? 200 : 201).json(readSession(savedId));
+});


### PR DESCRIPTION
﻿## What changed
- Persist Playground chat sessions and messages in SQLite.
- Add `/api/chats` endpoints to save, list, and load chat history.
- Keep the current Playground chat and draft input alive while navigating to Keys, Fallback, or Analytics.
- Add a History sidebar for reading previous Playground chats.

## Validation
- `npm run build`
- `npm run test -w server`
- Browser check on `http://127.0.0.1:3001/playground`
