### PR TITLE
fix(docker): install build toolchain for better-sqlite3 native compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,14 @@ ARG NODE_IMAGE=node:20-bookworm-slim
 FROM ${NODE_IMAGE} AS deps
 WORKDIR /app
 
+# better-sqlite3 is a native module; on slim images without a usable prebuilt
+# binary (notably the linux/arm64 leg under QEMU) it compiles from source via
+# node-gyp, which needs Python + a C++ toolchain. These live only in the build
+# stages — the runtime image copies the already-compiled node_modules.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY package.json package-lock.json ./
 COPY shared/package.json ./shared/
 COPY server/package.json ./server/


### PR DESCRIPTION
## Problem

The Docker workflow has been failing on every push with:

```
npm error gyp ERR! find Python - executable path is ""
npm error gyp ERR! stack Error: Could not find any Python installation to use
npm error gyp ERR! cwd /app/node_modules/better-sqlite3
ERROR: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
```

`better-sqlite3` is a native module. The `node:20-bookworm-slim` base has no Python or C++ toolchain, so when no usable prebuilt binary is available (notably the `linux/arm64` leg built under QEMU) `node-gyp` tries to compile from source and fails.

## Fix

Install `python3 make g++` in the `deps` stage before `npm ci`. They live only in the build stages — the runtime stage copies the already-compiled `node_modules`, so the final image stays slim.

Verified green by this PR's own Docker check (builds linux/amd64 + linux/arm64).