### PR TITLE
Guard streaming chunks that carry no choices array

### DIFF
--- a/server/src/__tests__/routes/proxy-stream-chunk.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-chunk.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { streamChunkText } from '../../routes/proxy.js';
+
+// Regression for the mid-stream crash: a streaming chunk with no `choices`
+// array (Groq and others emit usage/keepalive frames like this) used to throw
+// "Cannot read properties of undefined (reading '0')" via `chunk.choices[0]`,
+// aborting the SSE response after headers were already sent (so no fallback).
+describe('streamChunkText', () => {
+  it('extracts delta content from a normal chunk', () => {
+    expect(streamChunkText({ choices: [{ delta: { content: 'hello' } }] })).toBe('hello');
+  });
+
+  it('returns "" for a usage/keepalive chunk that has no choices array', () => {
+    expect(streamChunkText({ usage: { prompt_tokens: 1, completion_tokens: 2 } })).toBe('');
+    expect(streamChunkText({ x_groq: { usage: {} } })).toBe('');
+  });
+
+  it('returns "" for an empty choices array', () => {
+    expect(streamChunkText({ choices: [] })).toBe('');
+  });
+
+  it('returns "" for a tool-call delta with no text content', () => {
+    expect(streamChunkText({ choices: [{ delta: { tool_calls: [{ index: 0 }] } }] })).toBe('');
+  });
+
+  it('returns "" for null / undefined / malformed chunks', () => {
+    expect(streamChunkText(null)).toBe('');
+    expect(streamChunkText(undefined)).toBe('');
+    expect(streamChunkText({})).toBe('');
+    expect(streamChunkText({ choices: [{}] })).toBe('');
+  });
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -243,6 +243,16 @@ export function isRetryableError(err: any): boolean {
     || msg.includes('api error 400');
 }
 
+// Pull the incremental text out of a streaming chunk for token counting.
+// Must tolerate chunks that carry no `choices` array at all: some providers
+// (e.g. Groq) emit usage/keepalive frames shaped like `{usage:{...}}` with no
+// `choices`. Indexing `chunk.choices[0]` on those throws "Cannot read
+// properties of undefined (reading '0')", which — once the SSE stream has
+// started — aborts the response mid-flight with no chance to fall back.
+export function streamChunkText(chunk: any): string {
+  return chunk?.choices?.[0]?.delta?.content ?? '';
+}
+
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   const start = Date.now();
 
@@ -412,7 +422,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
               streamStarted = true;
             }
-            const text = chunk.choices[0]?.delta?.content ?? '';
+            const text = streamChunkText(chunk);
             totalOutputTokens += Math.ceil(text.length / 4);
             res.write(`data: ${JSON.stringify(chunk)}\n\n`);
           }


### PR DESCRIPTION
## Problem
The proxy's streaming handler read `chunk.choices[0]?.delta?.content` — the optional chain is placed **after** the `[0]` index. Some providers (Groq notably, also others) emit usage/keepalive SSE frames shaped like `{usage:{...}}` with **no `choices` array**. On those, `chunk.choices[0]` throws `Cannot read properties of undefined (reading '0')`.

Because the crash happens **after** the SSE response has started (headers already sent), the retry/fallback loop can't recover — the `catch` writes a `stream interrupted` event and the request fails. In practice this silently broke streaming tool-call requests routed to Groq.

## Fix
Extract `streamChunkText(chunk)` with the guard in the correct position (`chunk?.choices?.[0]?.delta?.content ?? ''`) and use it in the stream loop. Add unit tests for choices-less, empty-choices, tool-call-delta, and null/malformed chunks.

## Testing
- `npm run build:server` clean
- `npm run test -w server` → **200 passed** (incl. 5 new)
- Verified live: streaming tool-call to Groq llama-4-scout now completes cleanly instead of crashing mid-stream.