### PR TITLE
[codex] add Agnes AI provider with media support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # FreeLLMAPI
 
-**One OpenAI-compatible endpoint. Sixteen free LLM providers. ~1.7B tokens per month.**
+**One OpenAI-compatible endpoint. Seventeen free LLM providers. ~1.7B tokens per month.**
 
-Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, and LLM7 — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
+Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, and Agnes AI — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
 [![CI](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml/badge.svg)](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
@@ -37,7 +37,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral
 
 Every serious AI lab now offers a free tier — a few million tokens a month, a few thousand requests a day. On its own each tier is a toy. Stacked together, they add up to roughly **1.7 billion tokens per month** of working inference capacity, across 100+ models from small-and-fast to reasonably capable.
 
-The problem is that stacking them by hand is painful: sixteen different SDKs, sixteen different rate limits, sixteen places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
+The problem is that stacking them by hand is painful: seventeen different SDKs, seventeen different rate limits, seventeen places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
 
 ## Supported providers
 
@@ -66,6 +66,12 @@ The problem is that stacking them by hand is painful: sixteen different SDKs, si
 <td align="center"><a href="https://pollinations.ai"><b>Pollinations</b><br/>GPT-OSS 20B (anon ok)</a></td>
 <td align="center"><a href="https://llm7.io"><b>LLM7</b><br/>GPT-OSS · Llama 3.1 · GLM (anon ok)</a></td>
 </tr>
+<tr>
+<td align="center"><a href="https://agnes-ai.com"><b>Agnes AI</b><br/>Agnes 2.0 Flash · Image 2.0 · Video V2.0</a></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
 </table>
 
 Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, a local Ollama, or a remote gateway) from the Keys page.
@@ -76,6 +82,7 @@ Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cp
 - **Responses API** — `POST /v1/responses` (the wire format current Codex CLI versions require) is implemented as a translating shim over the same router, with full streaming events and tool calls.
 - **Streaming and non-streaming** — Server-Sent Events for `stream: true`, JSON response otherwise. Every provider adapter implements both.
 - **Tool calling** — OpenAI-style `tools` / `tool_choice` requests are passed through, and assistant `tool_calls` + `tool` role follow-up messages round-trip across providers.
+- **Agnes media proxy** — Agnes AI keys unlock `POST /v1/images/generations` for `agnes-image-2.0-flash` and `POST /v1/videos` + `GET /v1/videos/:task_id` for `agnes-video-v2.0`. These are dedicated media routes, not chat fallback models.
 - **Automatic fallover** — If the chosen provider returns a 429, 5xx, or times out, the router skips it, puts the key on a short cooldown, and retries on the next model in your fallback chain (up to 20 attempts).
 - **Per-key rate tracking** — RPM, RPD, TPM, and TPD counters per `(platform, model, key)` so the router always picks a key that's under its caps.
 - **Sticky sessions** — Multi-turn conversations keep talking to the same model for 30 minutes to avoid the hallucination spike that comes from mid-conversation model switches.
@@ -92,7 +99,7 @@ Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cp
 The scope is deliberately narrow. If a feature isn't on this list and isn't below, assume it isn't there yet.
 
 - **Embeddings** (`/v1/embeddings`)
-- **Image generation** (`/v1/images/*`)
+- **Generic image generation** (`/v1/images/*`) beyond the Agnes AI image proxy
 - **Audio / speech** (`/v1/audio/*`)
 - **Legacy completions** (`/v1/completions`) — only the chat endpoint is implemented
 - **Moderation** (`/v1/moderations`)
@@ -264,6 +271,8 @@ final = client.chat.completions.create(
 print(final.choices[0].message.content)
 ```
 
+Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, SambaNova, Mistral, OpenRouter, GitHub Models, HuggingFace, Agnes AI, Cloudflare, Cohere compat) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
+
 **Vision / image input**
 
 Send images with the standard OpenAI `image_url` content blocks (base64 `data:` URLs or `http(s)` URLs). When a request contains an image, the router restricts itself to **vision-capable models** and ignores text-only ones. Vision models are tagged with a **Vision** badge on the Fallback Chain page; the current set includes Gemini (2.5 / 3.x), Llama 4 Scout/Maverick (Groq, NVIDIA, SambaNova), and GitHub's GPT-4o / GPT-4.1.
@@ -284,9 +293,32 @@ print(resp.choices[0].message.content)
 
 If no vision-capable model is enabled in your Fallback Chain, an image request returns a clear `422` (`code: "no_vision_model"`) rather than silently dropping the image. (Image input on `/v1/responses` isn't supported yet — use `/v1/chat/completions`.)
 
-Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, SambaNova, Mistral, OpenRouter, GitHub Models, HuggingFace, Cloudflare, Cohere compat) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
+Chat proxy responses carry an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
 
-Every response carries an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
+**Agnes image / video generation**
+
+Agnes AI media generation uses the same local unified API key, but routes through the Agnes provider key you add on the Keys page. Media generation is not part of the chat fallback chain. Free trial or free-tier availability is controlled by Agnes account limits.
+
+```bash
+curl http://localhost:3001/v1/images/generations \
+  -H "Authorization: Bearer freellmapi-your-unified-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "agnes-image-2.0-flash",
+    "prompt": "A compact product render of a translucent mechanical keyboard"
+  }'
+
+curl http://localhost:3001/v1/videos \
+  -H "Authorization: Bearer freellmapi-your-unified-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "agnes-video-v2.0",
+    "prompt": "A five-second dolly shot through a neon-lit server room"
+  }'
+
+curl http://localhost:3001/v1/videos/<task_id> \
+  -H "Authorization: Bearer freellmapi-your-unified-key"
+```
 
 ## Screenshots
 

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -71,6 +71,7 @@ const platformColors: Record<string, string> = {
   kilo:        '#7c3aed',
   pollinations: '#a855f7',
   llm7:        '#0ea5e9',
+  agnes:       '#111827',
   huggingface: '#ff9d00',
 }
 

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -27,6 +27,7 @@ const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'pollinations', label: 'Pollinations (anon ok)' },
   { value: 'llm7', label: 'LLM7 (anon ok)' },
   { value: 'huggingface', label: 'HuggingFace Router' },
+  { value: 'agnes', label: 'Agnes AI' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -208,6 +208,35 @@ describe('Migration idempotency', () => {
     ]);
   });
 
+  it('V17: Agnes text model is seeded with a fallback entry', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const row = db.prepare(`
+      SELECT m.platform, m.model_id, m.display_name, m.enabled, m.supports_vision, COUNT(f.id) AS fallback_count
+        FROM models m
+        LEFT JOIN fallback_config f ON f.model_db_id = m.id
+       WHERE m.platform = 'agnes' AND m.model_id = 'agnes-2.0-flash'
+       GROUP BY m.id
+    `).get() as {
+      platform: string;
+      model_id: string;
+      display_name: string;
+      enabled: number;
+      supports_vision: number;
+      fallback_count: number;
+    };
+
+    expect(row).toEqual({
+      platform: 'agnes',
+      model_id: 'agnes-2.0-flash',
+      display_name: 'Agnes 2.0 Flash',
+      enabled: 1,
+      supports_vision: 0,
+      fallback_count: 1,
+    });
+  });
+
   it('all enabled catalog platforms have a registered provider', async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -247,6 +247,7 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'openrouter', name: 'OpenRouter',    baseUrl: 'https://openrouter.ai/api/v1' },
     { platform: 'github',     name: 'GitHub Models', baseUrl: 'https://models.github.ai/inference' },
     { platform: 'zhipu',      name: 'Zhipu AI',      baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
+    { platform: 'agnes',      name: 'Agnes AI',      baseUrl: 'https://apihub.agnes-ai.com/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -59,6 +59,18 @@ describe('Keys API', () => {
     expect(body.maskedKey).toContain('...');
   });
 
+  it('POST /api/keys accepts Agnes AI keys', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'agnes',
+      key: 'agnes_test123456789',
+      label: 'My Agnes Key',
+    });
+
+    expect(status).toBe(201);
+    expect(body.platform).toBe('agnes');
+    expect(body.label).toBe('My Agnes Key');
+  });
+
   it('GET /api/keys returns the created key', async () => {
     // First create a key
     await request(app, 'POST', '/api/keys', {

--- a/server/src/__tests__/routes/media.test.ts
+++ b/server/src/__tests__/routes/media.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { encrypt } from '../../lib/crypto.js';
+
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.text();
+  server.close();
+
+  let json: any = null;
+  try { json = JSON.parse(data); } catch {}
+
+  return { status: res.status, body: json, raw: data };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
+}
+
+function addAgnesKey(apiKey = 'agnes_test_key') {
+  const { encrypted, iv, authTag } = encrypt(apiKey);
+  return getDb().prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+    VALUES ('agnes', 'test agnes', ?, ?, ?, 'healthy', 1)
+  `).run(encrypted, iv, authTag);
+}
+
+describe('Agnes media routes', () => {
+  let app: Express;
+  let origFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    origFetch = global.fetch;
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires the unified API key for image generation', async () => {
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'agnes-image-2.0-flash',
+      prompt: 'a test image',
+    });
+
+    expect(status).toBe(401);
+    expect(body.error.type).toBe('authentication_error');
+  });
+
+  it('returns a clear routing error when no Agnes key is configured', async () => {
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'agnes-image-2.0-flash',
+      prompt: 'a test image',
+    }, authHeaders());
+
+    expect(status).toBe(503);
+    expect(body.error.code).toBe('no_agnes_key');
+  });
+
+  it('forwards Agnes image generation requests with the configured provider key', async () => {
+    addAgnesKey('agnes_real_key');
+
+    let capturedUrl = '';
+    let capturedAuth = '';
+    let capturedBody: any = null;
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('apihub.agnes-ai.com/v1/images/generations')) {
+        capturedUrl = urlStr;
+        capturedAuth = String((init?.headers as Record<string, string>)?.Authorization ?? '');
+        capturedBody = JSON.parse(String(init?.body));
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({
+            created: 1780280000,
+            data: [{ url: 'https://example.test/image.png' }],
+          })),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'Agnes-Image-2.0-Flash',
+      prompt: 'a red cube',
+      size: '1024x1024',
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(capturedUrl).toBe('https://apihub.agnes-ai.com/v1/images/generations');
+    expect(capturedAuth).toBe('Bearer agnes_real_key');
+    expect(capturedBody).toMatchObject({
+      model: 'agnes-image-2.0-flash',
+      prompt: 'a red cube',
+      size: '1024x1024',
+    });
+    expect(body.data[0].url).toBe('https://example.test/image.png');
+  });
+
+  it('forwards Agnes video creation and task polling requests', async () => {
+    addAgnesKey('agnes_video_key');
+
+    const seen: Array<{ url: string; method: string; auth: string; body?: any }> = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('apihub.agnes-ai.com/v1/videos')) {
+        seen.push({
+          url: urlStr,
+          method: String(init?.method ?? 'GET'),
+          auth: String((init?.headers as Record<string, string>)?.Authorization ?? ''),
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        });
+        if (String(init?.method) === 'POST') {
+          return {
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(JSON.stringify({ id: 'video-task-1', status: 'queued' })),
+          } as any;
+        }
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ id: 'video-task-1', status: 'succeeded', video_url: 'https://example.test/video.mp4' })),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const create = await request(app, 'POST', '/v1/videos', {
+      model: 'Agnes-Video-V2.0',
+      prompt: 'a short clip',
+    }, authHeaders());
+    const poll = await request(app, 'GET', '/v1/videos/video-task-1', undefined, authHeaders());
+
+    expect(create.status).toBe(200);
+    expect(create.body.id).toBe('video-task-1');
+    expect(poll.status).toBe(200);
+    expect(poll.body.video_url).toBe('https://example.test/video.mp4');
+    expect(seen).toEqual([
+      {
+        url: 'https://apihub.agnes-ai.com/v1/videos',
+        method: 'POST',
+        auth: 'Bearer agnes_video_key',
+        body: { model: 'agnes-video-v2.0', prompt: 'a short clip' },
+      },
+      {
+        url: 'https://apihub.agnes-ai.com/v1/videos/video-task-1',
+        method: 'GET',
+        auth: 'Bearer agnes_video_key',
+        body: undefined,
+      },
+    ]);
+  });
+
+  it('requires the unified API key for video creation and task polling', async () => {
+    const create = await request(app, 'POST', '/v1/videos', {
+      model: 'agnes-video-v2.0',
+      prompt: 'a short clip',
+    });
+    const poll = await request(app, 'GET', '/v1/videos/video-task-1');
+
+    expect(create.status).toBe(401);
+    expect(create.body.error.type).toBe('authentication_error');
+    expect(poll.status).toBe(401);
+    expect(poll.body.error.type).toBe('authentication_error');
+  });
+
+  it('uses the next Agnes key when the first key cannot be decrypted', async () => {
+    const first = addAgnesKey('bad_key');
+    addAgnesKey('agnes_second_key');
+    getDb().prepare("UPDATE api_keys SET auth_tag = ? WHERE id = ?").run('a'.repeat(32), first.lastInsertRowid);
+
+    let capturedAuth = '';
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('apihub.agnes-ai.com/v1/images/generations')) {
+        capturedAuth = String((init?.headers as Record<string, string>)?.Authorization ?? '');
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ data: [{ url: 'https://example.test/image.png' }] })),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'agnes-image-2.0-flash',
+      prompt: 'a red cube',
+    }, authHeaders());
+    const firstKey = getDb().prepare('SELECT status, last_checked_at FROM api_keys WHERE id = ?')
+      .get(first.lastInsertRowid) as { status: string; last_checked_at: string | null };
+
+    expect(status).toBe(200);
+    expect(body.data[0].url).toBe('https://example.test/image.png');
+    expect(capturedAuth).toBe('Bearer agnes_second_key');
+    expect(firstKey.status).toBe('error');
+    expect(firstKey.last_checked_at).toBeTruthy();
+  });
+
+  it('uses the next Agnes key after an upstream 429', async () => {
+    addAgnesKey('agnes_rate_limited_key');
+    addAgnesKey('agnes_second_key');
+
+    const seenAuth: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('apihub.agnes-ai.com/v1/images/generations')) {
+        const auth = String((init?.headers as Record<string, string>)?.Authorization ?? '');
+        seenAuth.push(auth);
+        if (auth === 'Bearer agnes_rate_limited_key') {
+          return {
+            ok: false,
+            status: 429,
+            text: () => Promise.resolve(JSON.stringify({ error: { message: 'rate limited', type: 'rate_limit_error' } })),
+          } as any;
+        }
+        return {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify({ data: [{ url: 'https://example.test/image.png' }] })),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'agnes-image-2.0-flash',
+      prompt: 'a red cube',
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(body.data[0].url).toBe('https://example.test/image.png');
+    expect(seenAuth).toEqual(['Bearer agnes_rate_limited_key', 'Bearer agnes_second_key']);
+  });
+
+  it('requires a prompt for Agnes video creation', async () => {
+    addAgnesKey();
+
+    const { status, body } = await request(app, 'POST', '/v1/videos', {
+      model: 'agnes-video-v2.0',
+    }, authHeaders());
+
+    expect(status).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+  });
+
+  it('rejects unsupported media models instead of routing them to Agnes', async () => {
+    addAgnesKey();
+
+    const { status, body } = await request(app, 'POST', '/v1/images/generations', {
+      model: 'other-image-model',
+      prompt: 'a test image',
+    }, authHeaders());
+
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('model_not_found');
+  });
+});

--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -72,10 +72,12 @@ describe('Virtual "auto" model', () => {
 
   it('treats model:"auto" as auto-route instead of a 400', async () => {
     const origFetch = global.fetch;
+    let upstreamBody: any = null;
 
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
       if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+        upstreamBody = JSON.parse(init?.body as string);
         return {
           ok: true,
           json: () => Promise.resolve({
@@ -102,6 +104,12 @@ describe('Virtual "auto" model', () => {
 
     expect(status).toBe(200);
     expect(body.choices[0].message.content).toBe('routed via auto');
+    expect(upstreamBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
+    expect(upstreamBody.model).not.toBe('auto');
+    expect(upstreamBody.model).toEqual(expect.any(String));
+    expect(getDb()
+      .prepare('SELECT 1 FROM models WHERE platform = ? AND model_id = ? AND enabled = 1')
+      .get('groq', upstreamBody.model)).toBeTruthy();
   });
 
   it('still rejects an unknown model with model_not_found', async () => {
@@ -112,5 +120,48 @@ describe('Virtual "auto" model', () => {
 
     expect(status).toBe(400);
     expect(body.error.code).toBe('model_not_found');
+  });
+
+  it('does not silently fall back when an explicit model has no usable key', async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys WHERE platform = ?').run('groq');
+
+    const addOpenRouterKey = await request(app, 'POST', '/api/keys', {
+      platform: 'openrouter',
+      key: 'sk-or-explicit-model-fallback-test',
+      label: 'fallback-tripwire',
+    });
+    expect(addOpenRouterKey.status).toBe(201);
+
+    const origFetch = global.fetch;
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('openrouter.ai/api/v1/chat/completions')) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'chatcmpl-wrong-fallback',
+            object: 'chat.completion',
+            created: 123,
+            model: JSON.parse(init?.body as string).model,
+            choices: [{
+              index: 0,
+              message: { role: 'assistant', content: 'wrong fallback' },
+              finish_reason: 'stop',
+            }],
+            usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 },
+          }),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'openai/gpt-oss-120b',
+      messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(status).toBe(429);
+    expect(body.error.type).toBe('routing_error');
   });
 });

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 
 // Mock only routeRequest so we don't need real provider keys; keep the rest of
 // the router module (recordSuccess / recordRateLimitHit) intact.
@@ -10,10 +10,28 @@ vi.mock('../../services/router.js', async (importOriginal) => {
 
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
-import { initDb, getUnifiedApiKey } from '../../db/index.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { encrypt } from '../../lib/crypto.js';
+import { AGNES_TEXT_MODEL } from '../../providers/agnes.js';
 
-function fakeRoute(provider: any) {
-  return { provider, modelId: 'fake-model', modelDbId: 9999, apiKey: 'k', keyId: 1, platform: 'fake', displayName: 'Fake Model' };
+function fakeRoute(provider: any, overrides: Partial<{
+  modelId: string;
+  modelDbId: number;
+  apiKey: string;
+  keyId: number;
+  platform: string;
+  displayName: string;
+}> = {}) {
+  return {
+    provider,
+    modelId: 'fake-model',
+    modelDbId: 9999,
+    apiKey: 'k',
+    keyId: 1,
+    platform: 'fake',
+    displayName: 'Fake Model',
+    ...overrides,
+  };
 }
 
 async function post(app: Express, path: string, body: any, key?: string) {
@@ -26,7 +44,15 @@ async function post(app: Express, path: string, body: any, key?: string) {
   });
   const text = await res.text();
   server.close();
-  return { status: res.status, text, contentType: res.headers.get('content-type') ?? '' };
+  return { status: res.status, text, contentType: res.headers.get('content-type') ?? '', headers: res.headers };
+}
+
+function addHealthyKey(platform: string, keyValue: string) {
+  const { encrypted, iv, authTag } = encrypt(keyValue);
+  getDb().prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(platform, `${platform}-test`, encrypted, iv, authTag, 'healthy', 1);
 }
 
 describe('POST /v1/responses (#96)', () => {
@@ -38,6 +64,21 @@ describe('POST /v1/responses (#96)', () => {
     initDb(':memory:');
     app = createApp();
     key = getUnifiedApiKey();
+  });
+
+  beforeEach(() => {
+    mockRouteRequest.mockReset();
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }));
+    getDb().prepare('DELETE FROM api_keys').run();
   });
 
   it('rejects requests without a valid unified key (401)', async () => {
@@ -100,6 +141,85 @@ describe('POST /v1/responses (#96)', () => {
     expect(body.output_text).toBe('Hello from fake');
     expect(body.output[0]).toMatchObject({ type: 'message', role: 'assistant' });
     expect(body.usage.total_tokens).toBe(7);
+  });
+
+  it('routes an explicit known Agnes model to Agnes with strict pinning', async () => {
+    const agnesModel = getDb()
+      .prepare('SELECT id FROM models WHERE platform = ? AND model_id = ? AND enabled = 1')
+      .get('agnes', AGNES_TEXT_MODEL) as { id: number };
+    addHealthyKey('agnes', 'agnes_test_key');
+
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: AGNES_TEXT_MODEL,
+          choices: [{ index: 0, message: { role: 'assistant', content: 'Hello from Agnes' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }, {
+      platform: 'agnes',
+      modelId: AGNES_TEXT_MODEL,
+      modelDbId: agnesModel.id,
+      displayName: 'Agnes 2.0 Flash',
+    }));
+
+    const { status, text, headers } = await post(app, '/v1/responses', {
+      model: AGNES_TEXT_MODEL,
+      input: 'hi',
+      stream: false,
+    }, key);
+
+    expect(status).toBe(200);
+    expect(headers.get('x-routed-via')).toBe(`agnes/${AGNES_TEXT_MODEL}`);
+    expect(JSON.parse(text).model).toBe(AGNES_TEXT_MODEL);
+    expect(mockRouteRequest).toHaveBeenCalledWith(expect.any(Number), undefined, agnesModel.id, false, true);
+  });
+
+  it('returns model_not_found for an unknown explicit model', async () => {
+    const { status, text } = await post(app, '/v1/responses', {
+      model: 'definitely-not-a-real-model',
+      input: 'hi',
+    }, key);
+
+    expect(status).toBe(400);
+    const body = JSON.parse(text);
+    expect(body.error.code).toBe('model_not_found');
+    expect(mockRouteRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not fallback to another provider when an explicit model has no usable key', async () => {
+    const agnesModel = getDb()
+      .prepare('SELECT id FROM models WHERE platform = ? AND model_id = ? AND enabled = 1')
+      .get('agnes', AGNES_TEXT_MODEL) as { id: number };
+    addHealthyKey('groq', 'groq_test_key');
+    mockRouteRequest.mockImplementation((_tokens, _skip, _preferred, _vision, strictPreferred) => {
+      if (strictPreferred) {
+        const err = new Error('All models exhausted. Add more API keys or wait for rate limits to reset.') as any;
+        err.status = 429;
+        throw err;
+      }
+      return fakeRoute({
+        async chatCompletion() {
+          return {
+            id: 'c', object: 'chat.completion', created: 0, model: 'openai/gpt-oss-120b',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'fallback' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+        },
+        async *streamChatCompletion() { /* unused */ },
+      }, { platform: 'groq', modelId: 'openai/gpt-oss-120b' });
+    });
+
+    const { status, text } = await post(app, '/v1/responses', {
+      model: AGNES_TEXT_MODEL,
+      input: 'hi',
+    }, key);
+
+    expect(status).toBe(429);
+    expect(JSON.parse(text).error.type).toBe('routing_error');
+    expect(mockRouteRequest).toHaveBeenCalledWith(expect.any(Number), undefined, agnesModel.id, false, true);
   });
 
   it('stream: emits the Responses SSE event sequence', async () => {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -7,6 +7,7 @@ import { keysRouter } from './routes/keys.js';
 import { modelsRouter } from './routes/models.js';
 import { proxyRouter } from './routes/proxy.js';
 import { responsesRouter } from './routes/responses.js';
+import { mediaRouter } from './routes/media.js';
 import { fallbackRouter } from './routes/fallback.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
@@ -69,6 +70,7 @@ export function createApp() {
   // routing work. Tune via PROXY_RATE_LIMIT_RPM; 0 disables it.
   app.use('/v1', createProxyRateLimiter());
   app.use('/v1', proxyRouter);
+  app.use('/v1', mediaRouter);
   // OpenAI Responses API shim (Codex CLI requires wire_api="responses"; see #96)
   app.use('/v1', responsesRouter);
 

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { initEncryptionKey } from '../lib/crypto.js';
+import { AGNES_TEXT_MODEL } from '../providers/agnes.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = path.resolve(__dirname, '../../data/freeapi.db');
@@ -51,6 +52,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV14(db);
   migrateModelsV15(db);
   migrateModelsV16Vision(db);
+  migrateModelsV17Agnes(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1351,6 +1353,37 @@ function migrateModelsV16Vision(db: Database.Database) {
     `).run();
   });
   apply();
+}
+
+/**
+ * V17 (June 2026): Agnes AI documents hosted API access for its 2.0 Flash family.
+ *
+ * Text is OpenAI-compatible and can participate in the normal fallback chain.
+ * Image/video generation are exposed through dedicated /v1 media routes, not
+ * as chat fallback models, so only the text model is seeded here.
+ */
+function migrateModelsV17Agnes(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models
+      (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+       rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window,
+       enabled, supports_vision)
+    VALUES ('agnes', ?, 'Agnes 2.0 Flash', 6, 4, 'Large',
+            NULL, NULL, NULL, NULL, '~? (free)', 256000, 1, 0)
+  `);
+  insert.run(AGNES_TEXT_MODEL);
+
+  const row = db.prepare(`
+    SELECT id FROM models WHERE platform = 'agnes' AND model_id = ?
+  `).get(AGNES_TEXT_MODEL) as { id: number } | undefined;
+  if (!row) return;
+
+  const existing = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(row.id);
+  if (existing) return;
+
+  const max = db.prepare('SELECT COALESCE(MAX(priority), 0) AS priority FROM fallback_config').get() as { priority: number };
+  db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)')
+    .run(row.id, max.priority + 1);
 }
 
 function ensureUnifiedKey(db: Database.Database) {

--- a/server/src/lib/proxyShared.ts
+++ b/server/src/lib/proxyShared.ts
@@ -1,0 +1,53 @@
+import crypto from 'crypto';
+import type { Request } from 'express';
+import { getDb } from '../db/index.js';
+
+// Constant-time string comparison for the unified API key. Plain `===` leaks
+// length and per-character timing, which a network attacker could in principle
+// use to recover the key one byte at a time.
+export function timingSafeStringEqual(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  // Compare against a same-length buffer regardless of input length so the
+  // comparison itself runs in constant time; the explicit length check at the
+  // end is what actually decides equality when lengths differ.
+  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
+  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
+}
+
+// Extract the unified API key from an incoming request. Accepts both the
+// OpenAI-style `Authorization: Bearer <key>` header and the Anthropic-style
+// `x-api-key` header. Clients that speak the Anthropic wire format — notably
+// Claude Code routed through CC Switch (#103) — send the key in `x-api-key`
+// rather than a bearer token, and were getting a spurious "Invalid API key"
+// 401 before this fallback existed.
+export function extractApiToken(req: Request): string | undefined {
+  const bearer = req.headers.authorization?.replace(/^Bearer\s+/i, '').trim();
+  if (bearer) return bearer;
+
+  const apiKeyHeader = req.headers['x-api-key'];
+  const xApiKey = Array.isArray(apiKeyHeader) ? apiKeyHeader[0] : apiKeyHeader;
+  const trimmed = xApiKey?.trim();
+  return trimmed || undefined;
+}
+
+export function logRequest(
+  platform: string,
+  modelId: string,
+  keyId: number,
+  status: string,
+  inputTokens: number,
+  outputTokens: number,
+  latencyMs: number,
+  error: string | null,
+) {
+  try {
+    const db = getDb();
+    db.prepare(`
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error);
+  } catch (e) {
+    console.error('Failed to log request:', e);
+  }
+}

--- a/server/src/providers/agnes.ts
+++ b/server/src/providers/agnes.ts
@@ -1,0 +1,20 @@
+export const AGNES_BASE_URL = 'https://apihub.agnes-ai.com/v1';
+
+export const AGNES_TEXT_MODEL = 'agnes-2.0-flash';
+export const AGNES_IMAGE_MODEL = 'agnes-image-2.0-flash';
+export const AGNES_VIDEO_MODEL = 'agnes-video-v2.0';
+
+const AGNES_VIDEO_MODEL_ALIASES = new Set([
+  AGNES_VIDEO_MODEL,
+  'agnes-video-2.0',
+]);
+
+export function normalizeAgnesImageModel(model: string): string | null {
+  const normalized = model.trim().toLowerCase();
+  return normalized === AGNES_IMAGE_MODEL ? AGNES_IMAGE_MODEL : null;
+}
+
+export function normalizeAgnesVideoModel(model: string): string | null {
+  const normalized = model.trim().toLowerCase();
+  return AGNES_VIDEO_MODEL_ALIASES.has(normalized) ? AGNES_VIDEO_MODEL : null;
+}

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -4,6 +4,7 @@ import { GoogleProvider } from './google.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
+import { AGNES_BASE_URL } from './agnes.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -91,6 +92,15 @@ register(new OpenAICompatProvider({
   platform: 'huggingface',
   name: 'HuggingFace Router',
   baseUrl: 'https://router.huggingface.co/v1',
+}));
+
+// Agnes AI — OpenAI-compatible text endpoint. Image/video APIs are routed
+// through dedicated /v1/images and /v1/videos proxy routes because they are
+// media-generation tasks, not chat fallback models.
+register(new OpenAICompatProvider({
+  platform: 'agnes',
+  name: 'Agnes AI',
+  baseUrl: AGNES_BASE_URL,
 }));
 
 // Moonshot direct integration was dropped in V4 (paid-only); MiniMax direct

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -12,7 +12,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'agnes', 'custom',
 ] as const;
 
 const addKeySchema = z.object({

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -1,0 +1,264 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { getDb, getUnifiedApiKey } from '../db/index.js';
+import { decrypt } from '../lib/crypto.js';
+import {
+  AGNES_BASE_URL,
+  AGNES_IMAGE_MODEL,
+  AGNES_VIDEO_MODEL,
+  normalizeAgnesImageModel,
+  normalizeAgnesVideoModel,
+} from '../providers/agnes.js';
+import { extractApiToken, logRequest, timingSafeStringEqual } from '../lib/proxyShared.js';
+
+export const mediaRouter = Router();
+
+const MEDIA_TIMEOUT_MS = 120000;
+
+const imageGenerationSchema = z.object({
+  model: z.string().min(1).default(AGNES_IMAGE_MODEL),
+  prompt: z.string().min(1),
+}).passthrough();
+
+const videoCreateSchema = z.object({
+  model: z.string().min(1).default(AGNES_VIDEO_MODEL),
+  prompt: z.string().min(1),
+}).passthrough();
+
+function requireUnifiedAuth(req: Request, res: Response): boolean {
+  const token = extractApiToken(req);
+  const unifiedKey = getUnifiedApiKey();
+  if (!token || !timingSafeStringEqual(token, unifiedKey)) {
+    res.status(401).json({
+      error: { message: 'Invalid API key', type: 'authentication_error' },
+    });
+    return false;
+  }
+  return true;
+}
+
+type AgnesKeyRow = { id: number; encrypted_key: string; iv: string; auth_tag: string };
+
+function getAgnesKeyRows(): AgnesKeyRow[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT id, encrypted_key, iv, auth_tag
+      FROM api_keys
+     WHERE platform = 'agnes'
+       AND enabled = 1
+       AND status IN ('healthy', 'unknown')
+     ORDER BY CASE status WHEN 'healthy' THEN 0 ELSE 1 END, id ASC
+  `).all() as AgnesKeyRow[];
+}
+
+function markAgnesKeyError(keyId: number): void {
+  getDb().prepare("UPDATE api_keys SET status = 'error', last_checked_at = datetime('now') WHERE id = ?")
+    .run(keyId);
+}
+
+function shouldRetryAgnesStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = MEDIA_TIMEOUT_MS): Promise<globalThis.Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readJson(res: globalThis.Response): Promise<unknown> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {
+      error: {
+        message: text || res.statusText,
+        type: 'provider_error',
+      },
+    };
+  }
+}
+
+async function proxyAgnesJson(
+  req: Request,
+  res: Response,
+  opts: {
+    path: string;
+    method: 'GET' | 'POST';
+    body?: unknown;
+    modelId: string;
+  },
+): Promise<void> {
+  const started = Date.now();
+  const keys = getAgnesKeyRows();
+  if (keys.length === 0) {
+    res.status(503).json({
+      error: {
+        message: 'No enabled Agnes API key is configured. Add an Agnes AI key on the Keys page.',
+        type: 'routing_error',
+        code: 'no_agnes_key',
+      },
+    });
+    return;
+  }
+
+  let lastUpstream: { status: number; body: unknown } | null = null;
+  const failures: Array<{ keyId: number; reason: string; status?: number }> = [];
+
+  for (const key of keys) {
+    let apiKey: string;
+    try {
+      apiKey = decrypt(key.encrypted_key, key.iv, key.auth_tag);
+    } catch {
+      markAgnesKeyError(key.id);
+      failures.push({ keyId: key.id, reason: 'decrypt_failed' });
+      logRequest('agnes', opts.modelId, key.id, 'error', 0, 0, Date.now() - started, 'Failed to decrypt Agnes API key');
+      continue;
+    }
+
+    try {
+      const upstream = await fetchWithTimeout(`${AGNES_BASE_URL}${opts.path}`, {
+        method: opts.method,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          ...(opts.method === 'POST' ? { 'Content-Type': 'application/json' } : {}),
+        },
+        body: opts.method === 'POST' ? JSON.stringify(opts.body) : undefined,
+      });
+      const body = await readJson(upstream);
+
+      logRequest(
+        'agnes',
+        opts.modelId,
+        key.id,
+        upstream.ok ? 'success' : 'error',
+        0,
+        0,
+        Date.now() - started,
+        upstream.ok ? null : JSON.stringify(body).slice(0, 500),
+      );
+
+      if (!upstream.ok && shouldRetryAgnesStatus(upstream.status)) {
+        lastUpstream = { status: upstream.status, body };
+        failures.push({ keyId: key.id, reason: 'upstream_error', status: upstream.status });
+        continue;
+      }
+
+      res.status(upstream.status).json(body);
+      return;
+    } catch (err: any) {
+      const message = err?.message ?? 'Agnes media request failed';
+      failures.push({ keyId: key.id, reason: message });
+      logRequest('agnes', opts.modelId, key.id, 'error', 0, 0, Date.now() - started, message);
+    }
+  }
+
+  if (lastUpstream) {
+    res.status(lastUpstream.status).json(lastUpstream.body);
+    return;
+  }
+
+  res.status(502).json({
+    error: {
+      message: 'Provider error (Agnes AI): no Agnes key could complete the request',
+      type: 'provider_error',
+      code: 'agnes_keys_exhausted',
+      failures,
+    },
+  });
+}
+
+mediaRouter.post('/images/generations', async (req: Request, res: Response) => {
+  if (!requireUnifiedAuth(req, res)) return;
+
+  const parsed = imageGenerationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: {
+        message: `Invalid request: ${parsed.error.errors.map(e => e.message).join(', ')}`,
+        type: 'invalid_request_error',
+      },
+    });
+    return;
+  }
+
+  const model = normalizeAgnesImageModel(parsed.data.model);
+  if (!model) {
+    res.status(400).json({
+      error: {
+        message: `Model '${parsed.data.model}' is not supported by this endpoint. Use '${AGNES_IMAGE_MODEL}'.`,
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+      },
+    });
+    return;
+  }
+
+  await proxyAgnesJson(req, res, {
+    path: '/images/generations',
+    method: 'POST',
+    body: { ...parsed.data, model },
+    modelId: model,
+  });
+});
+
+mediaRouter.post('/videos', async (req: Request, res: Response) => {
+  if (!requireUnifiedAuth(req, res)) return;
+
+  const parsed = videoCreateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: {
+        message: `Invalid request: ${parsed.error.errors.map(e => e.message).join(', ')}`,
+        type: 'invalid_request_error',
+      },
+    });
+    return;
+  }
+
+  const model = normalizeAgnesVideoModel(parsed.data.model);
+  if (!model) {
+    res.status(400).json({
+      error: {
+        message: `Model '${parsed.data.model}' is not supported by this endpoint. Use '${AGNES_VIDEO_MODEL}'.`,
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+      },
+    });
+    return;
+  }
+
+  await proxyAgnesJson(req, res, {
+    path: '/videos',
+    method: 'POST',
+    body: { ...parsed.data, model },
+    modelId: model,
+  });
+});
+
+mediaRouter.get('/videos/:taskId', async (req: Request, res: Response) => {
+  if (!requireUnifiedAuth(req, res)) return;
+
+  const taskId = String(req.params.taskId ?? '').trim();
+  if (!taskId) {
+    res.status(400).json({
+      error: {
+        message: 'taskId is required',
+        type: 'invalid_request_error',
+      },
+    });
+    return;
+  }
+
+  await proxyAgnesJson(req, res, {
+    path: `/videos/${encodeURIComponent(taskId)}`,
+    method: 'GET',
+    modelId: AGNES_VIDEO_MODEL,
+  });
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -7,6 +7,7 @@ import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel,
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString, messageHasImage } from '../lib/content.js';
+import { extractApiToken, logRequest, timingSafeStringEqual } from '../lib/proxyShared.js';
 
 export const proxyRouter = Router();
 
@@ -18,35 +19,6 @@ const AUTO_MODEL_ID = 'auto';
 
 function isAutoModel(modelId: string | undefined): boolean {
   return modelId === AUTO_MODEL_ID;
-}
-
-// Constant-time string comparison for the unified API key. Plain `===` leaks
-// length and per-character timing, which a network attacker could in principle
-// use to recover the key one byte at a time.
-export function timingSafeStringEqual(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  // Compare against a same-length buffer regardless of input length so the
-  // comparison itself runs in constant time; the explicit length check at the
-  // end is what actually decides equality when lengths differ.
-  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
-  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
-}
-
-// Extract the unified API key from an incoming request. Accepts both the
-// OpenAI-style `Authorization: Bearer <key>` header and the Anthropic-style
-// `x-api-key` header. Clients that speak the Anthropic wire format — notably
-// Claude Code routed through CC Switch (#103) — send the key in `x-api-key`
-// rather than a bearer token, and were getting a spurious "Invalid API key"
-// 401 before this fallback existed.
-export function extractApiToken(req: Request): string | undefined {
-  const bearer = req.headers.authorization?.replace(/^Bearer\s+/i, '').trim();
-  if (bearer) return bearer;
-
-  const apiKeyHeader = req.headers['x-api-key'];
-  const xApiKey = Array.isArray(apiKeyHeader) ? apiKeyHeader[0] : apiKeyHeader;
-  const trimmed = xApiKey?.trim();
-  return trimmed || undefined;
 }
 
 // Sticky sessions: track which model served each "session"
@@ -349,6 +321,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // different model would be surprising to OpenAI-compatible clients.
   // Sticky-session is the fallback when no `model` field was sent at all.
   let preferredModel: number | undefined;
+  let strictPreferredModel = false;
   if (isAutoModel(requestedModel)) {
     // Explicit "auto" → behave exactly like an omitted model field.
     preferredModel = getStickyModel(messages);
@@ -357,6 +330,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     const enabled = db.prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1').get(requestedModel) as { id: number } | undefined;
     if (enabled) {
       preferredModel = enabled.id;
+      strictPreferredModel = true;
     } else {
       const disabled = db.prepare('SELECT id FROM models WHERE model_id = ?').get(requestedModel) as { id: number } | undefined;
       const reason = disabled ? 'is disabled' : 'is not in the catalog';
@@ -380,7 +354,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     let route: RouteResult;
     try {
-      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage);
+      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage, strictPreferredModel);
     } catch (err: any) {
       // No more models available
       if (lastError) {
@@ -521,24 +495,3 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     },
   });
 });
-
-export function logRequest(
-  platform: string,
-  modelId: string,
-  keyId: number,
-  status: string,
-  inputTokens: number,
-  outputTokens: number,
-  latencyMs: number,
-  error: string | null,
-) {
-  try {
-    const db = getDb();
-    db.prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error);
-  } catch (e) {
-    console.error('Failed to log request:', e);
-  }
-}

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -10,15 +10,13 @@ import type {
 } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
-import { getUnifiedApiKey } from '../db/index.js';
+import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString } from '../lib/content.js';
+import { extractApiToken, logRequest, timingSafeStringEqual } from '../lib/proxyShared.js';
 import {
   isRetryableError,
-  timingSafeStringEqual,
-  extractApiToken,
   getStickyModel,
   setStickyModel,
-  logRequest,
 } from './proxy.js';
 
 export const responsesRouter = Router();
@@ -40,6 +38,11 @@ export const responsesRouter = Router();
 // ─────────────────────────────────────────────────────────────────────────
 
 const MAX_RETRIES = 20;
+const AUTO_MODEL_ID = 'auto';
+
+function isAutoModel(modelId: string | undefined): boolean {
+  return modelId === AUTO_MODEL_ID;
+}
 
 function newId(prefix: string): string {
   return `${prefix}_${crypto.randomBytes(18).toString('hex')}`;
@@ -300,7 +303,31 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
     0,
   );
   const estimatedTotal = estimatedInputTokens + (reqData.max_output_tokens ?? 1000);
-  const preferredModel = getStickyModel(messages);
+  let preferredModel: number | undefined;
+  let strictPreferredModel = false;
+  if (isAutoModel(reqData.model)) {
+    preferredModel = getStickyModel(messages);
+  } else if (reqData.model) {
+    const db = getDb();
+    const enabled = db.prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1').get(reqData.model) as { id: number } | undefined;
+    if (enabled) {
+      preferredModel = enabled.id;
+      strictPreferredModel = true;
+    } else {
+      const disabled = db.prepare('SELECT id FROM models WHERE model_id = ?').get(reqData.model) as { id: number } | undefined;
+      const reason = disabled ? 'is disabled' : 'is not in the catalog';
+      res.status(400).json({
+        error: {
+          message: `Model '${reqData.model}' ${reason}. Use 'auto' (or omit the 'model' field) to auto-route, or call /v1/models for the available list.`,
+          type: 'invalid_request_error',
+          code: 'model_not_found',
+        },
+      });
+      return;
+    }
+  } else {
+    preferredModel = getStickyModel(messages);
+  }
 
   const responseId = newId('resp');
   const skipKeys = new Set<string>();
@@ -317,7 +344,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     let route: RouteResult;
     try {
-      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel);
+      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, false, strictPreferredModel);
     } catch (err: any) {
       const status = lastError ? 429 : (err.status ?? 503);
       const message = lastError

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -130,15 +130,24 @@ export function getAllPenalties(): Array<{ modelDbId: number; count: number; pen
  * Models are sorted by (base_priority + rate_limit_penalty) so frequently
  * rate-limited models automatically sink below working ones.
  *
- * If preferredModelDbId is set, that model gets tried FIRST (sticky sessions).
+ * If preferredModelDbId is set, that model gets tried FIRST (sticky sessions)
+ * unless strictPreferred is true, in which case only that model is considered
+ * (explicit model pinning).
  * This prevents hallucination from model switching mid-conversation.
  *
  * @param estimatedTokens - estimated total tokens for rate limit check
  * @param skipKeys - set of "platform:modelId:keyId" to skip (failed on this request)
- * @param preferredModelDbId - try this model first (sticky session)
+ * @param preferredModelDbId - try this model first
  * @param requireVision - only consider models that accept image input (#118)
+ * @param strictPreferred - only consider preferredModelDbId; used for explicit model requests
  */
-export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, preferredModelDbId?: number, requireVision = false): RouteResult {
+export function routeRequest(
+  estimatedTokens = 1000,
+  skipKeys?: Set<string>,
+  preferredModelDbId?: number,
+  requireVision = false,
+  strictPreferred = false,
+): RouteResult {
   const db = getDb();
 
   // Get fallback chain ordered by priority
@@ -154,10 +163,19 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     effectivePriority: entry.priority + getPenalty(entry.model_db_id),
   })).sort((a, b) => a.effectivePriority - b.effectivePriority);
 
-  // Sticky session: move preferred model to front of chain
+  // Preferred model: sticky sessions move it to the front; explicit `model`
+  // requests set strictPreferred and must not silently route elsewhere.
   if (preferredModelDbId) {
     const idx = sortedChain.findIndex(e => e.model_db_id === preferredModelDbId);
-    if (idx > 0) {
+    if (strictPreferred) {
+      if (idx >= 0) {
+        const [preferred] = sortedChain.splice(idx, 1);
+        sortedChain.length = 0;
+        sortedChain.push(preferred);
+      } else {
+        sortedChain.length = 0;
+      }
+    } else if (idx > 0) {
       const [preferred] = sortedChain.splice(idx, 1);
       sortedChain.unshift(preferred);
     }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -22,6 +22,7 @@ export type Platform =
   | 'pollinations'
   | 'llm7'
   | 'huggingface'
+  | 'agnes'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
## Summary
- add Agnes AI as an OpenAI-compatible text provider via `agnes-2.0-flash`
- add dedicated Agnes media proxy routes for image and video generation
- add Agnes key/UI support, model migration, README examples, and focused tests
- make explicit model pinning strict for both `/v1/chat/completions` and `/v1/responses` so requested models do not silently fall back
- make Agnes media requests try the next usable Agnes key on decrypt failures, 429s, and 5xx responses
- clarify that Agnes free-trial/free-tier availability is controlled by Agnes account limits

## Why
Agnes AI documents hosted text, image, and video APIs. This lets FreeLLMAPI route Agnes text completions through the existing chat fallback system while exposing image/video generation through provider-specific `/v1` media routes. Free or trial access is subject to the user's Agnes account limits.

## Validation
- `npm run build`
- `npm test` — 28 test files, 219 tests
- `git diff --check`
- tracked secret scan for the pasted Agnes key fragments returned no source hits
- Real local smoke test with an Agnes API key:
  - `agnes-2.0-flash` chat completion returned 200 and routed via Agnes
  - `agnes-image-2.0-flash` image generation returned 200 with an image URL
  - `agnes-video-v2.0` video task completed with `status=completed` and `progress=100`