### PR TITLE
fix: local display of SQLite UTC time in Analytics and Keys pages

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,27 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function sqliteUtcToIso(value: string | null | undefined): string | null | undefined {
+  if (!value) return value;
+
+  return value.includes('T') ? value : `${value.replace(' ', 'T')}Z`;
+}
+
+// Converts SQLite UTC datetime text to the client's local time
+export function formatSqliteUtcToLocalTime(
+  value: string | null | undefined,
+): string {
+  const dateString = sqliteUtcToIso(value);
+
+  if (!dateString) return '';
+
+  const date = new Date(dateString);
+
+  return Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+}

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/page-header'
+import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
 type TimeRange = '24h' | '7d' | '30d'
 
@@ -232,7 +233,7 @@ export default function AnalyticsPage() {
                         <TableCell className="pl-4 text-xs">{e.platform}</TableCell>
                         <TableCell className="text-xs max-w-[200px] truncate">{e.error}</TableCell>
                         <TableCell className="text-right text-xs text-muted-foreground tabular-nums pr-4">
-                          {new Date(e.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                          {formatSqliteUtcToLocalTime(e.createdAt)}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -9,6 +9,7 @@ import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform } from '../../../shared/types'
 import { Pencil } from 'lucide-react'
+import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
 const PLATFORMS: { value: Platform; label: string }[] = [
   { value: 'google', label: 'Google AI Studio' },
@@ -486,7 +487,7 @@ export default function KeysPage() {
                           <div className="flex-1" />
                           {lastChecked && (
                             <span className="text-[11px] text-muted-foreground tabular-nums">
-                              {new Date(lastChecked).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                              {formatSqliteUtcToLocalTime(lastChecked)}
                             </span>
                           )}
                           {!isEditing && (


### PR DESCRIPTION
## Description of change

Adds shared timestamp utilities for handling SQLite UTC datetime strings on the client.

SQLite stores timestamps like `YYYY-MM-DD HH:MM:SS`, which do not include a timezone marker. Passing these values directly to `new Date(...)` can make the browser treat them as local time instead of UTC.

This adds:

- `sqliteUtcToIso` to convert SQLite UTC datetime text into ISO UTC format.
- `formatSqliteUtcToLocalTime` to format SQLite UTC datetime text as the client's local time for display.

These utilities are now used in the existing timestamp displays and can be reused anywhere client-side SQLite UTC timestamps need to be shown as local time.

## Updated usage

Replaced direct usage of:

`new Date(value).toLocaleTimeString(...)`

with:

`formatSqliteUtcToLocalTime(value)`

in:

- `AnalyticsPage.tsx`
- `KeysPage.tsx`

## Screenshots

Previous:
<img width="670" height="210" alt="image" src="https://github.com/user-attachments/assets/a0936533-db5e-4a25-b05b-6e19187785de" />


fix:
<img width="700" height="214" alt="image" src="https://github.com/user-attachments/assets/52ce5a98-0b57-483c-84a5-8294cb62dbf6" />

