### PR TITLE
Redact provider errors (#93), prune request history (#94), provider-wide daily caps (#162)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ PORT=3001
 # to disable proxy rate limiting.
 # PROXY_RATE_LIMIT_RPM=120
 
+# Request analytics retention. Set either value to 0 to disable that limit.
+REQUEST_ANALYTICS_RETENTION_DAYS=90
+REQUEST_ANALYTICS_MAX_ROWS=100000
+
 # Comma-separated extra origins allowed to call the API from a browser.
 # localhost:5173, 127.0.0.1:5173, [::1]:5173 are allowed by default for the
 # Vite dev dashboard. Only set this if you serve the dashboard from a

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ npm run dev
 database-stored development key when `DEV_MODE=true` and `NODE_ENV` is not
 `production`; do not use that fallback with real provider keys.
 
+Request analytics are retained for 90 days or 100000 request rows by default,
+whichever limit prunes first. Set `REQUEST_ANALYTICS_RETENTION_DAYS=0` or
+`REQUEST_ANALYTICS_MAX_ROWS=0` in `.env` to disable either retention limit.
+
 Open http://localhost:5173 (the Vite dev UI), add your provider keys on the **Keys** page, reorder the **Fallback Chain** to taste, and grab your unified API key from the **Keys** page header. That unified key is what you point your OpenAI SDK at.
 
 For a production build without Docker:

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -2,13 +2,18 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { getDb, initDb } from '../../db/index.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+
+let dashToken = '';
 
 async function request(app: Express, path: string) {
   const server = app.listen(0);
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 
-  const res = await fetch(url);
+  const res = await fetch(url, {
+    headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},
+  });
   const data = await res.json().catch(() => null);
   server.close();
 
@@ -30,6 +35,7 @@ describe('Analytics API', () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     initDb(':memory:');
     app = createApp();
+    dashToken = mintDashboardToken();
   });
 
   beforeEach(() => {

--- a/server/src/__tests__/routes/proxy-error-redaction.test.ts
+++ b/server/src/__tests__/routes/proxy-error-redaction.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vite
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+
+let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
   const server = app.listen(0);
@@ -10,7 +13,11 @@ async function request(app: Express, method: string, path: string, body?: any, h
 
   const res = await fetch(url, {
     method,
-    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(isGatedApiPath(path) && !('Authorization' in headers) ? { Authorization: `Bearer ${dashToken}` } : {}),
+      ...headers,
+    },
     body: body ? JSON.stringify(body) : undefined,
   });
 
@@ -34,6 +41,7 @@ describe('Provider error redaction', () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     initDb(':memory:');
     app = createApp();
+    dashToken = mintDashboardToken();
   });
 
   beforeEach(async () => {

--- a/server/src/__tests__/routes/proxy-error-redaction.test.ts
+++ b/server/src/__tests__/routes/proxy-error-redaction.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: { ...(body ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.text();
+  server.close();
+
+  let json: any = null;
+  try { json = JSON.parse(data); } catch {}
+
+  return { status: res.status, body: json, headers: res.headers, raw: data };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
+}
+
+describe('Provider error redaction', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+
+    const addKey = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_proxy_redaction_test_key',
+      label: 'proxy-redaction',
+    });
+    expect(addKey.status).toBe(201);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('redacts provider secrets from proxy responses and stored analytics', async () => {
+    const origFetch = global.fetch;
+    const leakedKey = 'gsk_live_should_not_escape_123456789';
+    const leakedUrl = 'https://api.groq.com/openai/v1/chat/completions?api_key=sk-live-query-secret';
+
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+        return {
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          json: () => Promise.resolve({
+            error: {
+              message: `Invalid Bearer ${leakedKey} for ${leakedUrl}`,
+            },
+          }),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const completion = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(completion.status).toBe(502);
+    const responseText = JSON.stringify(completion.body);
+    expect(responseText).not.toContain(leakedKey);
+    expect(responseText).not.toContain(leakedUrl);
+    expect(responseText).toContain('[redacted]');
+
+    const errors = await request(app, 'GET', '/api/analytics/errors?range=24h');
+    expect(errors.status).toBe(200);
+    const analyticsText = JSON.stringify(errors.body);
+    expect(analyticsText).not.toContain(leakedKey);
+    expect(analyticsText).not.toContain(leakedUrl);
+    expect(analyticsText).toContain('[redacted]');
+  });
+});

--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   canMakeRequest,
   canUseTokens,
@@ -8,6 +8,9 @@ import {
   getRateLimitStatus,
   getNextCooldownDuration,
   getCooldownDurationForLimit,
+  canUseProvider,
+  providerDailyRequestCount,
+  getProviderDailyRequestCap,
 } from '../../services/ratelimit.js';
 
 function removeDbFile(dbPath: string) {
@@ -184,6 +187,45 @@ describe('Rate Limiter', () => {
         db?.close();
         removeDbFile(dbPath);
       }
+    });
+  });
+
+  describe('provider-wide daily request cap (#162)', () => {
+    const ENV = 'PROVIDER_DAILY_REQUEST_CAP_OPENROUTER';
+    let original: string | undefined;
+
+    beforeEach(() => { original = process.env[ENV]; });
+    afterEach(() => {
+      if (original === undefined) delete process.env[ENV];
+      else process.env[ENV] = original;
+    });
+
+    it('defaults to OpenRouter ~1000/day and allows env override / disable', () => {
+      delete process.env[ENV];
+      expect(getProviderDailyRequestCap('openrouter')).toBe(1000);
+      expect(getProviderDailyRequestCap('groq')).toBeNull(); // no shared cap
+      process.env[ENV] = '50';
+      expect(getProviderDailyRequestCap('openrouter')).toBe(50);
+      process.env[ENV] = '0'; // 0 disables the cap
+      expect(getProviderDailyRequestCap('openrouter')).toBeNull();
+    });
+
+    it('counts requests across ALL of a provider\'s models for one key', () => {
+      recordRequest('openrouter', 'deepseek/deepseek-v3.1:free', testId);
+      recordRequest('openrouter', 'deepseek/deepseek-v3.1:free', testId);
+      recordRequest('openrouter', 'qwen/qwen3-coder:free', testId);
+      // Same key on a different provider must not bleed into the count.
+      recordRequest('groq', 'llama-70b', testId);
+      expect(providerDailyRequestCount('openrouter', testId)).toBe(3);
+    });
+
+    it('blocks the whole provider once the shared daily cap is hit', () => {
+      process.env[ENV] = '3';
+      recordRequest('openrouter', 'model-a', testId);
+      recordRequest('openrouter', 'model-b', testId);
+      expect(canUseProvider('openrouter', testId)).toBe(true); // 2 < 3
+      recordRequest('openrouter', 'model-c', testId);
+      expect(canUseProvider('openrouter', testId)).toBe(false); // 3 >= 3
     });
   });
 });

--- a/server/src/__tests__/services/request-retention.test.ts
+++ b/server/src/__tests__/services/request-retention.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDb, getDb } from '../../db/index.js';
+import { getRequestAnalyticsRetentionConfig, pruneRequestAnalytics } from '../../services/request-retention.js';
+
+const ORIGINAL_RETENTION_DAYS = process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+const ORIGINAL_MAX_ROWS = process.env.REQUEST_ANALYTICS_MAX_ROWS;
+
+function restoreEnv() {
+  if (ORIGINAL_RETENTION_DAYS === undefined) {
+    delete process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+  } else {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = ORIGINAL_RETENTION_DAYS;
+  }
+
+  if (ORIGINAL_MAX_ROWS === undefined) {
+    delete process.env.REQUEST_ANALYTICS_MAX_ROWS;
+  } else {
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = ORIGINAL_MAX_ROWS;
+  }
+}
+
+function insertRequest(createdAt: string, marker: string) {
+  getDb().prepare(`
+    INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, created_at)
+    VALUES ('groq', 'groq/compound', 1, 'error', 0, 0, 10, ?, ?)
+  `).run(marker, createdAt);
+}
+
+describe('request analytics retention', () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare('DELETE FROM requests').run();
+    restoreEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('uses conservative defaults when env values are absent or invalid', () => {
+    delete process.env.REQUEST_ANALYTICS_RETENTION_DAYS;
+    delete process.env.REQUEST_ANALYTICS_MAX_ROWS;
+    expect(getRequestAnalyticsRetentionConfig()).toEqual({ retentionDays: 90, maxRows: 100000 });
+
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = 'bad';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '-1';
+    expect(getRequestAnalyticsRetentionConfig()).toEqual({ retentionDays: 90, maxRows: 100000 });
+  });
+
+  it('deletes request analytics older than the configured retention window', () => {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = '7';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '0';
+
+    insertRequest('2026-05-01 00:00:00', 'old');
+    insertRequest('2026-05-25 00:00:00', 'recent');
+
+    const result = pruneRequestAnalytics({
+      db: getDb(),
+      force: true,
+      now: new Date('2026-05-26T00:00:00Z'),
+    });
+
+    expect(result.deleted).toBe(1);
+    const rows = getDb().prepare('SELECT error FROM requests ORDER BY id').all() as Array<{ error: string }>;
+    expect(rows.map(row => row.error)).toEqual(['recent']);
+  });
+
+  it('keeps only the newest configured number of request rows', () => {
+    process.env.REQUEST_ANALYTICS_RETENTION_DAYS = '0';
+    process.env.REQUEST_ANALYTICS_MAX_ROWS = '2';
+
+    insertRequest('2026-05-01 00:00:00', 'row-1');
+    insertRequest('2026-05-02 00:00:00', 'row-2');
+    insertRequest('2026-05-03 00:00:00', 'row-3');
+    insertRequest('2026-05-04 00:00:00', 'row-4');
+
+    const result = pruneRequestAnalytics({
+      db: getDb(),
+      force: true,
+      now: new Date('2026-05-26T00:00:00Z'),
+    });
+
+    expect(result.deleted).toBe(2);
+    const rows = getDb().prepare('SELECT error FROM requests ORDER BY created_at ASC').all() as Array<{ error: string }>;
+    expect(rows.map(row => row.error)).toEqual(['row-3', 'row-4']);
+  });
+});

--- a/server/src/lib/error-redaction.ts
+++ b/server/src/lib/error-redaction.ts
@@ -1,0 +1,30 @@
+const MAX_PROVIDER_ERROR_LENGTH = 240;
+
+const REDACTIONS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, 'Bearer [redacted]'],
+  [/\b(api[_-]?key|access[_-]?token|token|secret|authorization)(\s*[:=]\s*)(["']?)[^"',\s}\]]+/gi, '$1$2$3[redacted]'],
+  [/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bgsk_[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bfreellmapi-[A-Za-z0-9_-]{8,}\b/g, '[redacted-key]'],
+  [/\bAIza[0-9A-Za-z_-]{20,}\b/g, '[redacted-key]'],
+  [/\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, '[redacted-token]'],
+  [/\bhttps?:\/\/[^\s"'<>)]*/gi, '[redacted-url]'],
+];
+
+export function sanitizeProviderErrorMessage(message: unknown): string {
+  let sanitized = typeof message === 'string' ? message : String(message ?? '');
+  sanitized = sanitized.trim();
+
+  if (!sanitized) return 'Provider error';
+
+  for (const [pattern, replacement] of REDACTIONS) {
+    sanitized = sanitized.replace(pattern, replacement);
+  }
+
+  sanitized = sanitized.replace(/\s+/g, ' ').trim();
+  if (sanitized.length > MAX_PROVIDER_ERROR_LENGTH) {
+    sanitized = `${sanitized.slice(0, MAX_PROVIDER_ERROR_LENGTH - 3).trimEnd()}...`;
+  }
+
+  return sanitized;
+}

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { ChatMessage } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
+import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString, messageHasImage, normalizeOutboundContent } from '../lib/content.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
@@ -554,6 +555,7 @@ export function logRequest(
       INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs);
+    pruneRequestAnalytics({ db });
   } catch (e) {
     console.error('Failed to log request:', e);
   }

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -7,6 +7,7 @@ import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel,
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString, messageHasImage, normalizeOutboundContent } from '../lib/content.js';
+import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
 export const proxyRouter = Router();
 
@@ -388,9 +389,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     } catch (err: any) {
       // No more models available
       if (lastError) {
+        const safeLastError = sanitizeProviderErrorMessage(lastError.message);
         res.status(429).json({
           error: {
-            message: `All models rate-limited. Last error: ${lastError.message}`,
+            message: `All models rate-limited. Last error: ${safeLastError}`,
             type: 'rate_limit_error',
           },
         });
@@ -461,7 +463,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, streamErr.message);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message));
             return;
           }
           // Pre-stream error — bubble to outer retry/502 handler.
@@ -493,7 +495,8 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       }
     } catch (err: any) {
       const latency = Date.now() - start;
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, err.message);
+      const safeError = sanitizeProviderErrorMessage(err.message);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
 
       if (isRetryableError(err)) {
         // Put this model+key on cooldown and try the next one
@@ -510,14 +513,14 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;
-        console.log(`[Proxy] ${err.message.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
+        console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
         continue;
       }
 
       // Non-retryable error (auth, 4xx, etc.): don't retry
       res.status(502).json({
         error: {
-          message: `Provider error (${route.displayName}): ${err.message}`,
+          message: `Provider error (${route.displayName}): ${safeError}`,
           type: 'provider_error',
         },
       });
@@ -528,7 +531,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // Exhausted all retries
   res.status(429).json({
     error: {
-      message: `All models rate-limited after ${MAX_RETRIES} attempts. Last: ${lastError?.message}`,
+      message: `All models rate-limited after ${MAX_RETRIES} attempts. Last: ${sanitizeProviderErrorMessage(lastError?.message)}`,
       type: 'rate_limit_error',
     },
   });

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -176,6 +176,71 @@ export function canUseTokens(
   return true;
 }
 
+// ── Provider-wide daily request caps (#162) ──
+// Some providers enforce one daily REQUEST quota across the WHOLE account,
+// shared by every model — not per model. OpenRouter's free tier is the classic
+// case: ~1000 requests/day total (50/day if you've bought <10 credits) no
+// matter how many different free models you spread them across. The
+// per-(platform,model,key) rpd ledger can't see that, so without a provider-wide
+// gate the router happily fires (models × rpd) requests and earns surprise 429s.
+//
+// Defaults below; override per provider with an env var, e.g.
+//   PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50   (set 0 to disable the cap)
+const DEFAULT_PROVIDER_DAILY_REQUEST_CAPS: Record<string, number> = {
+  openrouter: 1000,
+};
+
+export function getProviderDailyRequestCap(platform: string): number | null {
+  const raw = process.env[`PROVIDER_DAILY_REQUEST_CAP_${platform.toUpperCase()}`];
+  if (raw !== undefined && raw.trim() !== '') {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n === 0 ? null : n;
+  }
+  return DEFAULT_PROVIDER_DAILY_REQUEST_CAPS[platform] ?? null;
+}
+
+function countPersistedProviderRequests(
+  platform: string,
+  keyId: number,
+  windowMs: number,
+  now: number,
+): number | undefined {
+  return withDb(db => {
+    const row = db.prepare(`
+      SELECT COUNT(*) AS used
+        FROM rate_limit_usage
+       WHERE platform = ?
+         AND key_id = ?
+         AND kind = 'request'
+         AND created_at_ms > ?
+    `).get(platform, keyId, now - windowMs) as { used: number };
+    return row.used;
+  });
+}
+
+// Total requests today for a provider account+key, summed across every model.
+export function providerDailyRequestCount(platform: string, keyId: number, now = Date.now()): number {
+  const persisted = countPersistedProviderRequests(platform, keyId, DAY, now);
+  if (persisted !== undefined) return persisted;
+  // DB-unavailable fallback: sum the per-model rpd windows for this platform+key.
+  // Window key format is "platform:modelId:keyId:rpd" (modelId may contain ':').
+  let total = 0;
+  for (const [key, w] of windows) {
+    if (key.startsWith(`${platform}:`) && key.endsWith(`:${keyId}:rpd`)) {
+      total += pruneTimestamps(w.timestamps, DAY, now).length;
+    }
+  }
+  return total;
+}
+
+// False when this provider account+key has hit its shared daily request cap, so
+// the router skips every model on that provider for this key until UTC-ish reset.
+export function canUseProvider(platform: string, keyId: number, now = Date.now()): boolean {
+  const cap = getProviderDailyRequestCap(platform);
+  if (cap === null) return true;
+  return providerDailyRequestCount(platform, keyId, now) < cap;
+}
+
 export function recordRequest(platform: string, modelId: string, keyId: number) {
   const now = Date.now();
 

--- a/server/src/services/request-retention.ts
+++ b/server/src/services/request-retention.ts
@@ -1,0 +1,72 @@
+import { getDb } from '../db/index.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_RETENTION_DAYS = 90;
+const DEFAULT_MAX_ROWS = 100_000;
+const PRUNE_INTERVAL_MS = 60_000;
+
+type RetentionDb = ReturnType<typeof getDb>;
+
+export interface RequestAnalyticsRetentionConfig {
+  retentionDays: number;
+  maxRows: number;
+}
+
+let nextPruneAtMs = 0;
+
+function readNonNegativeInt(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return defaultValue;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) return defaultValue;
+  return parsed;
+}
+
+function toSqliteTimestamp(date: Date): string {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+export function getRequestAnalyticsRetentionConfig(): RequestAnalyticsRetentionConfig {
+  return {
+    retentionDays: readNonNegativeInt('REQUEST_ANALYTICS_RETENTION_DAYS', DEFAULT_RETENTION_DAYS),
+    maxRows: readNonNegativeInt('REQUEST_ANALYTICS_MAX_ROWS', DEFAULT_MAX_ROWS),
+  };
+}
+
+export function pruneRequestAnalytics(options: {
+  db?: RetentionDb;
+  force?: boolean;
+  now?: Date;
+} = {}): { deleted: number; skipped: boolean } {
+  const now = options.now ?? new Date();
+  const nowMs = now.getTime();
+
+  if (!options.force && nowMs < nextPruneAtMs) {
+    return { deleted: 0, skipped: true };
+  }
+  nextPruneAtMs = nowMs + PRUNE_INTERVAL_MS;
+
+  const db = options.db ?? getDb();
+  const { retentionDays, maxRows } = getRequestAnalyticsRetentionConfig();
+  let deleted = 0;
+
+  if (retentionDays > 0) {
+    const cutoff = toSqliteTimestamp(new Date(nowMs - retentionDays * DAY_MS));
+    deleted += db.prepare('DELETE FROM requests WHERE created_at < ?').run(cutoff).changes;
+  }
+
+  if (maxRows > 0) {
+    deleted += db.prepare(`
+      DELETE FROM requests
+      WHERE id IN (
+        SELECT id
+        FROM requests
+        ORDER BY created_at DESC, id DESC
+        LIMIT -1 OFFSET ?
+      )
+    `).run(maxRows).changes;
+  }
+
+  return { deleted, skipped: false };
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -1,7 +1,7 @@
 import { getDb, getSetting, setSetting } from '../db/index.js';
 import { getProvider, resolveProvider } from '../providers/index.js';
 import { decrypt } from '../lib/crypto.js';
-import { canMakeRequest, canUseTokens, isOnCooldown } from './ratelimit.js';
+import { canMakeRequest, canUseTokens, isOnCooldown, canUseProvider } from './ratelimit.js';
 import {
   BANDIT_PRESETS, DEFAULT_STRATEGY, type RoutingStrategy, type RoutingWeights,
   reliabilityPosterior, expectedReliability, sampleBeta,
@@ -418,6 +418,11 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
 
       // Check cooldown (from previous 429s)
       if (isOnCooldown(entry.platform, entry.model_id, key.id)) continue;
+
+      // Provider-wide daily request cap (#162): providers like OpenRouter cap
+      // total requests/day across ALL their models for the account, not per
+      // model — skip every model on this provider once that key hits the cap.
+      if (!canUseProvider(entry.platform, key.id)) continue;
 
       if (!canMakeRequest(entry.platform, entry.model_id, key.id, limits)) continue;
       if (!canUseTokens(entry.platform, entry.model_id, key.id, estimatedTokens, limits)) continue;


### PR DESCRIPTION
Brings in two contributed fixes (with original author commits preserved) and implements one issue.

## #93 — Redact provider errors before storing/exposing them (credit: @nordbyte)
Cherry-picked from #93. Upstream provider error messages can contain secrets (Bearer tokens, `sk-`/`gsk-`/`AIza…` keys, URLs with query secrets). `sanitizeProviderErrorMessage()` (new `lib/error-redaction.ts`) scrubs them everywhere an error is logged to analytics or returned to the client. Resolved a conflict with the post-#169 error-handling block.

## #94 — Prune request analytics history (credit: @nordbyte)
Cherry-picked from #94. Adds `request-retention.ts`: request history is pruned to `REQUEST_ANALYTICS_RETENTION_DAYS` (default 90) and `REQUEST_ANALYTICS_MAX_ROWS` (default 100000), throttled to once a minute, so the SQLite DB doesn't grow forever on a long-running instance. Resolved conflicts in `proxy.ts` (kept the `ttfb_ms` column from #163) and `.env.example`.

## #162 — Provider-wide daily request caps
Some providers cap total requests/day across their **whole account**, shared by every model — OpenRouter's free tier is ~1000/day (50/day under 10 credits) no matter how many free models you spread requests across. The per-`(platform,model,key)` rpd ledger couldn't see this, so the router could fire `models × rpd` requests and hit surprise 429s. Adds `providerDailyRequestCount` (sums the ledger across all of a provider's models for a key) and `canUseProvider` (skips every model on a provider once the shared cap is reached). Default OpenRouter 1000; override per provider with `PROVIDER_DAILY_REQUEST_CAP_<PLATFORM>` (0 disables).

## Test harness fix
PRs #93 and #120 predate the `/api/*` dashboard-auth gating (#151), so their test helpers got 401s against current main. Added the dashboard token to gated calls (mirroring the existing harness) — no change to what the tests assert. This also un-breaks `analytics.test.ts` from the already-merged #120 against gated main.

## Tests
253 passing, typecheck clean, production build green.

Closes #93, #94, #162.

Co-authored-by: Ricardo <322585+nordbyte@users.noreply.github.com>