### PR TITLE
feat: OpenCode Zen provider + 3 contributor fixes (#108, #128, #137, #170)

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,26 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// SQLite stores timestamps as `YYYY-MM-DD HH:MM:SS` with no timezone marker, so
+// passing them straight to `new Date(...)` makes the browser read them as LOCAL
+// time when they are actually UTC — shifting every displayed time by the
+// viewer's offset. These helpers tag the value as UTC before parsing. (#170)
+
+/** Convert a SQLite UTC datetime string into an ISO-8601 UTC string. */
+export function sqliteUtcToIso(value: string): string {
+  // Already ISO (has 'T' and a zone/offset)? Leave it alone.
+  if (value.includes('T')) return value;
+  return value.replace(' ', 'T') + 'Z';
+}
+
+/** Format a SQLite UTC datetime string as the viewer's local time-of-day. */
+export function formatSqliteUtcToLocalTime(
+  value: string | null | undefined,
+  options: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', second: '2-digit' },
+): string {
+  if (!value) return '—';
+  const date = new Date(sqliteUtcToIso(value));
+  if (isNaN(date.getTime())) return '—';
+  return date.toLocaleTimeString([], options);
+}

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/page-header'
+import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
 type TimeRange = '24h' | '7d' | '30d'
 
@@ -232,7 +233,7 @@ export default function AnalyticsPage() {
                         <TableCell className="pl-4 text-xs">{e.platform}</TableCell>
                         <TableCell className="text-xs max-w-[200px] truncate">{e.error}</TableCell>
                         <TableCell className="text-right text-xs text-muted-foreground tabular-nums pr-4">
-                          {new Date(e.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                          {formatSqliteUtcToLocalTime(e.createdAt, { hour: '2-digit', minute: '2-digit' })}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -8,32 +8,54 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform } from '../../../shared/types'
-import { Pencil } from 'lucide-react'
+import { Pencil, ExternalLink } from 'lucide-react'
+import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
-const PLATFORMS: { value: Platform; label: string }[] = [
-  { value: 'google', label: 'Google AI Studio' },
-  { value: 'groq', label: 'Groq' },
-  { value: 'cerebras', label: 'Cerebras' },
-  { value: 'sambanova', label: 'SambaNova' },
-  { value: 'nvidia', label: 'NVIDIA NIM' },
-  { value: 'mistral', label: 'Mistral' },
-  { value: 'openrouter', label: 'OpenRouter' },
-  { value: 'github', label: 'GitHub Models' },
-  { value: 'cohere', label: 'Cohere' },
-  { value: 'cloudflare', label: 'Cloudflare Workers AI' },
-  { value: 'zhipu', label: 'Zhipu AI (Z.ai)' },
-  { value: 'ollama', label: 'Ollama Cloud' },
-  { value: 'kilo', label: 'Kilo Gateway (anon ok)' },
-  { value: 'pollinations', label: 'Pollinations (anon ok)' },
-  { value: 'llm7', label: 'LLM7 (anon ok)' },
-  { value: 'huggingface', label: 'HuggingFace Router' },
+// Small "Get API key" external link shown next to a provider (#137).
+function GetKeyLink({ url }: { url: string }) {
+  if (!url) return null
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      Get API key
+      <ExternalLink className="size-3" />
+    </a>
+  )
+}
+
+// `url` points to each provider's key-management / signup page so the Keys page
+// can show a "Get API key" shortcut (#137). OpenCode Zen's key is free from
+// opencode.ai/auth — no card needed; billing only applies to paid models (#128).
+const PLATFORMS: { value: Platform; label: string; url: string }[] = [
+  { value: 'google', label: 'Google AI Studio', url: 'https://aistudio.google.com/apikey' },
+  { value: 'groq', label: 'Groq', url: 'https://console.groq.com/keys' },
+  { value: 'cerebras', label: 'Cerebras', url: 'https://cloud.cerebras.ai' },
+  { value: 'sambanova', label: 'SambaNova', url: 'https://cloud.sambanova.ai' },
+  { value: 'nvidia', label: 'NVIDIA NIM', url: 'https://build.nvidia.com/settings/api-keys' },
+  { value: 'mistral', label: 'Mistral', url: 'https://console.mistral.ai/api-keys/' },
+  { value: 'openrouter', label: 'OpenRouter', url: 'https://openrouter.ai/keys' },
+  { value: 'github', label: 'GitHub Models', url: 'https://github.com/settings/tokens' },
+  { value: 'cohere', label: 'Cohere', url: 'https://dashboard.cohere.com/api-keys' },
+  { value: 'cloudflare', label: 'Cloudflare Workers AI', url: 'https://dash.cloudflare.com' },
+  { value: 'zhipu', label: 'Zhipu AI (Z.ai)', url: 'https://z.ai/manage-apikey/apikey-list' },
+  { value: 'ollama', label: 'Ollama Cloud', url: 'https://ollama.com/settings/keys' },
+  { value: 'kilo', label: 'Kilo Gateway (anon ok)', url: 'https://app.kilo.ai' },
+  { value: 'pollinations', label: 'Pollinations (anon ok)', url: 'https://pollinations.ai' },
+  { value: 'llm7', label: 'LLM7 (anon ok)', url: 'https://llm7.io' },
+  { value: 'huggingface', label: 'HuggingFace Router', url: 'https://huggingface.co/settings/tokens' },
+  { value: 'opencode', label: 'OpenCode Zen (free key)', url: 'https://opencode.ai/auth' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the
 // generic key dropdown — but it still appears in the grouped provider list.
-const CUSTOM_GROUP: { value: Platform; label: string } = {
+const CUSTOM_GROUP: { value: Platform; label: string; url: string } = {
   value: 'custom',
   label: 'Custom (OpenAI-compatible)',
+  url: '',
 }
 
 const statusDot: Record<string, string> = {
@@ -383,6 +405,10 @@ export default function KeysPage() {
                   ))}
                 </SelectContent>
               </Select>
+              {(() => {
+                const sel = PLATFORMS.find(p => p.value === platform)
+                return sel?.url ? <div className="pt-0.5"><GetKeyLink url={sel.url} /></div> : null
+              })()}
             </div>
             {needsAccountId && (
               <div className="space-y-1.5">
@@ -449,6 +475,7 @@ export default function KeysPage() {
                         disabled={togglePlatform.isPending}
                       />
                       <h3 className="text-sm font-medium">{group.label}</h3>
+                      <GetKeyLink url={group.url} />
                     </div>
                     <span className="text-xs text-muted-foreground tabular-nums">
                       {group.keys.length} key{group.keys.length === 1 ? '' : 's'}
@@ -486,7 +513,7 @@ export default function KeysPage() {
                           <div className="flex-1" />
                           {lastChecked && (
                             <span className="text-[11px] text-muted-foreground tabular-nums">
-                              {new Date(lastChecked).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                              {formatSqliteUtcToLocalTime(lastChecked, { hour: '2-digit', minute: '2-digit' })}
                             </span>
                           )}
                           {!isEditing && (

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -247,6 +247,7 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'openrouter', name: 'OpenRouter',    baseUrl: 'https://openrouter.ai/api/v1' },
     { platform: 'github',     name: 'GitHub Models', baseUrl: 'https://models.github.ai/inference' },
     { platform: 'zhipu',      name: 'Zhipu AI',      baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
+    { platform: 'opencode',   name: 'OpenCode Zen',  baseUrl: 'https://opencode.ai/zen/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -52,6 +52,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV15(db);
   migrateModelsV16Vision(db);
   migrateModelsV17IntelligenceTiers(db);
+  migrateModelsV18OpenCodeZen(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1465,6 +1466,52 @@ function migrateModelsV17IntelligenceTiers(db: Database.Database) {
         OR LOWER(model_id) LIKE '%granite-4.0-h-micro%'
         OR LOWER(model_id) LIKE '%lfm-2.5-1.2b%'
     `).run();
+  });
+  apply();
+}
+
+// ── V18: OpenCode Zen provider (2026-06) ──
+// Adds the OpenCode Zen gateway (#128, originally contributed by @Aldo-f). Zen is
+// an OpenAI-compatible service whose paid models bill pay-as-you-go but which
+// also exposes a rotating set of *promotional* free models. Access is via a FREE
+// account key from https://opencode.ai/auth — no credit card; billing only
+// applies if you call paid models. We require that key like any other provider
+// (we do NOT use Zen's unauthenticated path).
+//
+// We seed only the four models the Zen docs explicitly label free — big-pickle,
+// deepseek-v4-flash-free, mimo-v2.5-free, nemotron-3-super-free. The live
+// /v1/models list also surfaces qwen3.6-plus-free and minimax-m3-free, but those
+// are NOT documented as free, so they're intentionally omitted (same "verified
+// only" bar as V12-V14). Tiers follow V17's bands (deepseek-v4-flash → Frontier,
+// nemotron-3-super → Large). Caveats per docs: promotional/limited-time, "trial
+// use only — not for production", and prompts/outputs may be used to improve the
+// models (NVIDIA logs Nemotron traffic). Conservative shared 20 RPM / 200 RPD,
+// matching the OpenRouter :free pool pattern. Idempotent (INSERT OR IGNORE +
+// fallback_config backfill), safe to re-run.
+function migrateModelsV18OpenCodeZen(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['opencode', 'big-pickle',             'Big Pickle (OpenCode Zen, stealth)',     10, 4, 'Large',    20, 200, null, null, 'promo (trial)', 131072],
+    ['opencode', 'deepseek-v4-flash-free', 'DeepSeek V4 Flash Free (OpenCode Zen)',   4, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', 131072],
+    ['opencode', 'mimo-v2.5-free',         'MiMo-V2.5 Free (OpenCode Zen)',          14, 4, 'Medium',   20, 200, null, null, 'promo (trial)', 131072],
+    ['opencode', 'nemotron-3-super-free',  'Nemotron 3 Super Free (OpenCode Zen)',   12, 4, 'Large',    20, 200, null, null, 'promo (trial)', 131072],
+  ];
+
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    const missing = db.prepare(`
+      SELECT m.id FROM models m
+      LEFT JOIN fallback_config f ON m.id = f.model_db_id
+      WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+    `).all() as { id: number }[];
+    if (missing.length > 0) {
+      const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+      const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+      for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+    }
   });
   apply();
 }

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -143,6 +143,18 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.llm7.io/v1',
 }));
 
+// OpenCode Zen — OpenAI-compatible gateway (https://opencode.ai/zen/v1), same
+// adapter as Groq/OpenRouter. A handful of promotional models are free for a
+// limited time; they need a free account key from https://opencode.ai/auth
+// (no card required — billing only applies to paid models). The free roster is
+// trial-only and prompts/outputs may be used to improve the models, so we seed
+// just the docs-confirmed free IDs (migrateModelsV18) with conservative limits.
+register(new OpenAICompatProvider({
+  platform: 'opencode',
+  name: 'OpenCode Zen',
+  baseUrl: 'https://opencode.ai/zen/v1',
+}));
+
 // Chutes was evaluated for V11 and dropped: probe with a free-tier key
 // returned 402 on every model — "Quota exceeded and account balance is
 // $0.0, please pay with fiat or send tao". The "free" tier requires a

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -138,13 +138,18 @@ export class OpenAICompatProvider extends BaseProvider {
     // health.ts catches them and marks status='error' WITHOUT incrementing
     // the consecutive-failure counter — only confirmed 401/403 disables a key.
     const url = this.validateUrl ?? `${this.baseUrl}/models`;
+    // 30s (not 10s): some upstreams return a large /v1/models catalog that
+    // takes >10s from high-latency regions (e.g. NVIDIA NIM measured ~11.2s
+    // from India). A 10s cap aborted those calls and health.ts marked a
+    // perfectly good key status='error'. 30s aligns with chatCompletion's
+    // own slow-upstream allowance and costs nothing for fast providers.
     const res = await this.fetchWithTimeout(url, {
       method: 'GET',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         ...this.extraHeaders,
       },
-    }, 10000);
+    }, 30000);
     return res.status !== 401 && res.status !== 403;
   }
 }

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -12,7 +12,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'custom',
 ] as const;
 
 const addKeySchema = z.object({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -22,6 +22,9 @@ export type Platform =
   | 'pollinations'
   | 'llm7'
   | 'huggingface'
+  // OpenCode Zen — OpenAI-compatible gateway. Free promotional models require a
+  // free (no-card) account key from opencode.ai/auth; see migrateModelsV18.
+  | 'opencode'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
Bundles four community contributions, each re-implemented and verified against the live providers/code. Original authors credited via `Co-Authored-By` trailers.

## #108 — validateKey timeout 10s → 30s (@Tushar49)
Slow upstreams (NVIDIA NIM ~11.2s from high-latency regions) were aborted at the hardcoded 10s cap, so `health.ts` marked valid keys `status='error'`. Bumped to 30s. Verified the code still capped at 10s before this change.

## #128 — OpenCode Zen provider (@Aldo-f)
New OpenAI-compatible provider (`https://opencode.ai/zen/v1`), standard adapter, no custom code. Migration **V18** (the PR's "V15" collided — V15–V17 are taken).

**Verified against the live catalog and docs — three corrections vs the original PR:**
- The PR's `minimax-m2.5-free` **does not exist**; the live free MiniMax is `minimax-m3-free`. Dropped it.
- `qwen3.6-plus-free` and `minimax-m3-free` are **not documented as free**, so omitted under our verified-only bar.
- Seeded only the **4 docs-confirmed free models**: `big-pickle`, `deepseek-v4-flash-free`, `mimo-v2.5-free`, `nemotron-3-super-free`.

**On "not exploiting anything":** Zen's free models work via a **free account key** (opencode.ai/auth, no card — billing only applies to paid models). We require that key like every other provider; we deliberately do **not** use Zen's unauthenticated endpoint. Free models are promotional/trial-only and prompts may be used to improve the models (noted in the migration).

## #137 — provider "Get API key" links (@thedavidweng)
Per-provider external link in the add-key form (for the selected provider) and on each configured-provider group header, via a new `url` field on `PLATFORMS`.

## #170 — SQLite UTC timestamps shown in local time (@Tazrif-Raim)
SQLite timestamps (`YYYY-MM-DD HH:MM:SS`, no tz marker) were parsed as local time. Added `sqliteUtcToIso` / `formatSqliteUtcToLocalTime` helpers, applied on Analytics + Keys pages.

## Verification
- `npm run build` (server + client) ✓
- `npm test -w server` — **263 passing**
- Migration V18 checked against a fresh DB: 4 models seeded with correct tiers (deepseek-v4-flash-free → Frontier, nemotron-3-super-free/big-pickle → Large, mimo → Medium), all in the fallback chain, **idempotent** on re-run.