### PR TITLE
Listen on both ipv4 and ipv6

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,8 +10,8 @@ async function main() {
   const app = createApp();
 
   app.listen(Number(PORT), '::', () => {
-    console.log(`Server running on http://0.0.0.0:${PORT}`);
-    console.log(`Proxy endpoint: http://0.0.0.0:${PORT}/v1/chat/completions`);
+    console.log(`Server running on http://[::]:${PORT}`);
+    console.log(`Proxy endpoint: http://[::]:${PORT}/v1/chat/completions`);
     startHealthChecker();
   });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,15 +4,35 @@ import { initDb } from './db/index.js';
 import { startHealthChecker } from './services/health.js';
 
 const PORT = process.env.PORT ?? 3001;
+// Dual-stack ('::') by default so the dashboard is reachable over both IPv4
+// and IPv6 (e.g. IPv6-enabled Docker networks — #180). Hosts with IPv6
+// disabled fall back to IPv4-only below; HOST overrides the default outright.
+const HOST = process.env.HOST ?? '::';
 
 async function main() {
   initDb();
   const app = createApp();
 
-  app.listen(Number(PORT), '::', () => {
-    console.log(`Server running on http://[::]:${PORT}`);
-    console.log(`Proxy endpoint: http://[::]:${PORT}/v1/chat/completions`);
+  const onReady = (host: string) => () => {
+    const display = host.includes(':') ? `[${host}]` : host;
+    console.log(`Server running on http://${display}:${PORT}`);
+    console.log(`Proxy endpoint: http://${display}:${PORT}/v1/chat/completions`);
     startHealthChecker();
+  };
+
+  const server = app.listen(Number(PORT), HOST, onReady(HOST));
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    // The default '::' bind fails where IPv6 is disabled (kernel
+    // ipv6.disable=1 and the like) — retry IPv4-only rather than dying.
+    // Anything else (EADDRINUSE, an explicit HOST that can't bind) keeps the
+    // fail-fast posture documented in main().catch below.
+    if (!process.env.HOST && (err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')) {
+      console.warn('[server] IPv6 unavailable on this host — falling back to 0.0.0.0 (IPv4-only)');
+      app.listen(Number(PORT), '0.0.0.0', onReady('0.0.0.0'));
+      return;
+    }
+    console.error('\n[server] Failed to start:\n  ' + (err?.message ?? err) + '\n');
+    process.exit(1);
   });
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,7 +9,7 @@ async function main() {
   initDb();
   const app = createApp();
 
-  app.listen(Number(PORT), '0.0.0.0', () => {
+  app.listen(Number(PORT), '::', () => {
     console.log(`Server running on http://0.0.0.0:${PORT}`);
     console.log(`Proxy endpoint: http://0.0.0.0:${PORT}/v1/chat/completions`);
     startHealthChecker();


### PR DESCRIPTION
Allows the web interface to be accessed if ipv6 is enabled in docker.