### PR TITLE
feat: keyless Kilo free models + Gemma 4 (Google AI Studio)

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -30,7 +30,10 @@ function GetKeyLink({ url }: { url: string }) {
 // `url` points to each provider's key-management / signup page so the Keys page
 // can show a "Get API key" shortcut (#137). OpenCode Zen's key is free from
 // opencode.ai/auth — no card needed; billing only applies to paid models (#128).
-const PLATFORMS: { value: Platform; label: string; url: string }[] = [
+// `keyless: true` providers (Kilo's anonymous free tier) need no API key — the
+// form disables the key field and submits a sentinel the backend stores so
+// routing treats the platform as configured.
+const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolean }[] = [
   { value: 'google', label: 'Google AI Studio', url: 'https://aistudio.google.com/apikey' },
   { value: 'groq', label: 'Groq', url: 'https://console.groq.com/keys' },
   { value: 'cerebras', label: 'Cerebras', url: 'https://cloud.cerebras.ai' },
@@ -43,7 +46,7 @@ const PLATFORMS: { value: Platform; label: string; url: string }[] = [
   { value: 'cloudflare', label: 'Cloudflare Workers AI', url: 'https://dash.cloudflare.com' },
   { value: 'zhipu', label: 'Zhipu AI (Z.ai)', url: 'https://z.ai/manage-apikey/apikey-list' },
   { value: 'ollama', label: 'Ollama Cloud', url: 'https://ollama.com/settings/keys' },
-  { value: 'kilo', label: 'Kilo Gateway (anon ok)', url: 'https://app.kilo.ai' },
+  { value: 'kilo', label: 'Kilo Gateway (no key needed)', url: 'https://app.kilo.ai', keyless: true },
   { value: 'pollinations', label: 'Pollinations (anon ok)', url: 'https://pollinations.ai' },
   { value: 'llm7', label: 'LLM7 (anon ok)', url: 'https://llm7.io' },
   { value: 'huggingface', label: 'HuggingFace Router', url: 'https://huggingface.co/settings/tokens' },
@@ -356,12 +359,15 @@ export default function KeysPage() {
   }, [editingKeyId])
 
   const needsAccountId = platform === 'cloudflare'
+  const isKeyless = PLATFORMS.find(p => p.value === platform)?.keyless ?? false
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!platform || !apiKey) return
+    if (!platform) return
+    if (!isKeyless && !apiKey) return
     if (needsAccountId && !accountId) return
-    const key = needsAccountId ? `${accountId}:${apiKey}` : apiKey
+    // Keyless providers submit an empty key; the backend stores a sentinel.
+    const key = isKeyless ? '' : (needsAccountId ? `${accountId}:${apiKey}` : apiKey)
     addKey.mutate({ platform, key, label: label || undefined })
   }
 
@@ -425,11 +431,17 @@ export default function KeysPage() {
               <Label className="text-xs">{needsAccountId ? 'API token' : 'API key'}</Label>
               <Input
                 type="password"
-                value={apiKey}
+                value={isKeyless ? '' : apiKey}
                 onChange={e => setApiKey(e.target.value)}
-                placeholder={needsAccountId ? 'Bearer token' : 'paste key here'}
+                placeholder={isKeyless ? 'No API key needed' : (needsAccountId ? 'Bearer token' : 'paste key here')}
                 className="font-mono text-xs"
+                disabled={isKeyless}
               />
+              {isKeyless && (
+                <p className="text-[11px] text-muted-foreground">
+                  No API key needed — this provider's free tier is anonymous (rate-limited per IP).
+                </p>
+              )}
             </div>
             <div className="space-y-1.5">
               <Label className="text-xs">Label</Label>
@@ -440,8 +452,8 @@ export default function KeysPage() {
                 className="w-[160px]"
               />
             </div>
-            <Button type="submit" size="sm" disabled={!platform || !apiKey || (needsAccountId && !accountId) || addKey.isPending}>
-              {addKey.isPending ? 'Adding…' : 'Add key'}
+            <Button type="submit" size="sm" disabled={!platform || (!isKeyless && !apiKey) || (needsAccountId && !accountId) || addKey.isPending}>
+              {addKey.isPending ? 'Adding…' : isKeyless ? 'Enable' : 'Add key'}
             </Button>
           </form>
           {addKey.isError && (

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -53,6 +53,8 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV16Vision(db);
   migrateModelsV17IntelligenceTiers(db);
   migrateModelsV18OpenCodeZen(db);
+  migrateModelsV19Gemma4(db);
+  migrateModelsV20KiloFree(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1514,6 +1516,78 @@ function migrateModelsV18OpenCodeZen(db: Database.Database) {
     }
   });
   apply();
+}
+
+/**
+ * V19 (June 2026): Google Gemma 4 (released Mar 2026) on the AI Studio free tier.
+ * Both IDs are reachable with the same key as Gemini (live-probed 200). The 26B
+ * is an MoE model (~3.8B active) — Google's real id is `gemma-4-26b-a4b-it`, not
+ * a plain "26B". Tiers match V17's bands (both Large; V17 re-asserts on every
+ * boot). Free limits are now AI-Studio-dashboard-driven and were cut 50-80% in
+ * Dec 2025, so rpd/tpm are conservative. Idempotent (INSERT OR IGNORE + fallback
+ * backfill), safe to re-run.
+ */
+function migrateModelsV19Gemma4(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['google', 'gemma-4-31b-it',     'Gemma 4 31B IT', 19, 4, 'Large', 15, 1000, 250000, null, '~30M', 32768],
+    ['google', 'gemma-4-26b-a4b-it', 'Gemma 4 26B IT', 20, 4, 'Large', 15, 1000, 250000, null, '~30M', 32768],
+  ];
+
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    backfillFallback(db);
+  });
+  apply();
+}
+
+/**
+ * V20 (June 2026): Kilo Gateway anonymous free models. Live-probed keyless
+ * (no API key, cost:0); Kilo documents anonymous access for `:free` routes,
+ * rate-limited 200 req/hr per IP shared across ALL free models. Per-model rate
+ * limits are left null on purpose — the 200/hr budget is per-IP, not per-model,
+ * so we rely on Kilo's own 429s + gateway failover rather than guessing a split.
+ * Prompts/outputs are logged for training (don't send sensitive data); the 120B
+ * Nemotron is additionally flagged trial-use by Kilo. Tiers follow V17 bands
+ * (V17 re-asserts nemotron-3-super → Large on every boot). Routing also needs a
+ * 'kilo' api_keys sentinel row, added via the keyless Keys-page flow. Idempotent
+ * (INSERT OR IGNORE + fallback backfill), safe to re-run.
+ */
+function migrateModelsV20KiloFree(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['kilo', 'poolside/laguna-m.1:free',               'Poolside Laguna M.1 (Kilo)',    13, 8, 'Large',  null, null, null, null, 'free · 200/hr per IP',         262144],
+    ['kilo', 'poolside/laguna-xs.2:free',              'Poolside Laguna XS.2 (Kilo)',   16, 4, 'Medium', null, null, null, null, 'free · 200/hr per IP',         262144],
+    ['kilo', 'nvidia/nemotron-3-super-120b-a12b:free', 'Nemotron 3 Super 120B (Kilo)',  12, 5, 'Large',  null, null, null, null, 'free · 200/hr per IP (trial)', 1000000],
+    ['kilo', 'stepfun/step-3.7-flash:free',            'StepFun Step 3.7 Flash (Kilo)', 14, 3, 'Medium', null, null, null, null, 'free · 200/hr per IP',         262144],
+  ];
+
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    backfillFallback(db);
+  });
+  apply();
+}
+
+/** Append any models not yet in the fallback chain, lowest priority, ordered by
+ * intelligence_rank. Shared by the recent model migrations (V18–V20). */
+function backfillFallback(db: Database.Database) {
+  const missing = db.prepare(`
+    SELECT m.id FROM models m
+    LEFT JOIN fallback_config f ON m.id = f.model_db_id
+    WHERE f.id IS NULL ORDER BY m.intelligence_rank ASC
+  `).all() as { id: number }[];
+  if (missing.length > 0) {
+    const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+    const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+    for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+  }
 }
 
 function ensureUnifiedKey(db: Database.Database) {

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -20,6 +20,11 @@ export interface CompletionOptions {
 export abstract class BaseProvider {
   abstract readonly platform: Platform;
   abstract readonly name: string;
+  /** Providers whose free tier needs no API key (e.g. Kilo's anonymous gateway).
+   * When true, the gateway stores a sentinel key row so routing still considers
+   * the platform "configured", and the provider omits the Authorization header
+   * on outgoing requests. Defaults to false; set by subclasses. */
+  keyless = false;
 
   abstract chatCompletion(
     apiKey: string,

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -113,14 +113,20 @@ register(new OpenAICompatProvider({
   timeoutMs: 120000,
 }));
 
-// Kilo AI Gateway — OpenAI-compatible aggregator. Anonymous access works
-// (200 req/hr per IP) for the few :free routes still active; a Kilo API key
-// raises the limit. Most named "free" routes in the docs have transitioned to
-// paid ("free period ended") — probe before adding catalog rows.
+// Kilo AI Gateway — OpenAI-compatible aggregator. Kilo documents anonymous
+// (keyless) access for `:free` routes, rate-limited 200 req/hr per IP — so this
+// is registered `keyless: true`: the provider omits the Authorization header and
+// the Keys page stores a sentinel row so routing treats it as configured. Free
+// prompts/outputs are logged for training. validateUrl points at the gateway's
+// real model list (`/api/gateway/models`, no `/v1`) which answers GET keyless;
+// the `/v1/models` path only accepts POST (405). Probe before adding catalog
+// rows — most named "free" routes eventually transition to paid.
 register(new OpenAICompatProvider({
   platform: 'kilo',
   name: 'Kilo Gateway',
   baseUrl: 'https://api.kilo.ai/api/gateway/v1',
+  validateUrl: 'https://api.kilo.ai/api/gateway/models',
+  keyless: true,
 }));
 
 // Pollinations — OpenAI-compatible, anonymous tier. The chat completions

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -28,6 +28,7 @@ export class OpenAICompatProvider extends BaseProvider {
     extraHeaders?: Record<string, string>;
     validateUrl?: string;
     timeoutMs?: number;
+    keyless?: boolean;
   }) {
     super();
     this.platform = opts.platform;
@@ -36,6 +37,14 @@ export class OpenAICompatProvider extends BaseProvider {
     this.extraHeaders = opts.extraHeaders ?? {};
     this.validateUrl = opts.validateUrl;
     this.timeoutMs = opts.timeoutMs ?? 15000;
+    this.keyless = opts.keyless ?? false;
+  }
+
+  /** Keyless providers (Kilo's anonymous free tier) must send NO Authorization
+   * header — a stored sentinel like `Bearer no-key` could be treated as an
+   * invalid key. Everyone else sends the bearer as usual. */
+  private authHeader(apiKey: string): Record<string, string> {
+    return this.keyless ? {} : { 'Authorization': `Bearer ${apiKey}` };
   }
 
   async chatCompletion(
@@ -47,7 +56,7 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        ...this.authHeader(apiKey),
         'Content-Type': 'application/json',
         ...this.extraHeaders,
       },
@@ -83,7 +92,7 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        ...this.authHeader(apiKey),
         'Content-Type': 'application/json',
         ...this.extraHeaders,
       },
@@ -146,7 +155,7 @@ export class OpenAICompatProvider extends BaseProvider {
     const res = await this.fetchWithTimeout(url, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        ...this.authHeader(apiKey),
         ...this.extraHeaders,
       },
     }, 30000);

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
+import { resolveProvider } from '../providers/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 
 export const keysRouter = Router();
@@ -15,9 +16,11 @@ const PLATFORMS = [
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'custom',
 ] as const;
 
+// `key` is optional so keyless providers (Kilo's anonymous gateway) can be added
+// without one; the handler enforces a non-empty key for everyone else.
 const addKeySchema = z.object({
   platform: z.enum(PLATFORMS),
-  key: z.string().min(1),
+  key: z.string().optional(),
   label: z.string().optional(),
 });
 
@@ -65,10 +68,40 @@ keysRouter.post('/', (req: Request, res: Response) => {
     return;
   }
 
-  const { platform, key, label } = parsed.data;
-  const { encrypted, iv, authTag } = encrypt(key);
+  const { platform, label } = parsed.data;
+  const isKeyless = resolveProvider(platform)?.keyless === true;
+  const rawKey = parsed.data.key?.trim() ?? '';
+
+  if (!isKeyless && !rawKey) {
+    res.status(400).json({ error: { message: 'key is required' } });
+    return;
+  }
+
+  // Keyless providers (Kilo anon) store a sentinel so routing sees the platform
+  // as configured; the provider omits the auth header on outgoing calls.
+  const keyToStore = isKeyless ? (rawKey || 'no-key') : rawKey;
 
   const db = getDb();
+
+  // A keyless provider needs only one sentinel row — re-enable an existing one
+  // instead of piling up duplicates each time the user clicks "Add".
+  if (isKeyless) {
+    const existing = db.prepare('SELECT id FROM api_keys WHERE platform = ? LIMIT 1').get(platform) as { id: number } | undefined;
+    if (existing) {
+      db.prepare("UPDATE api_keys SET enabled = 1, status = 'unknown' WHERE id = ?").run(existing.id);
+      res.status(200).json({
+        id: existing.id,
+        platform,
+        label: label ?? '',
+        maskedKey: maskKey(keyToStore),
+        status: 'unknown',
+        enabled: true,
+      });
+      return;
+    }
+  }
+
+  const { encrypted, iv, authTag } = encrypt(keyToStore);
   const result = db.prepare(`
     INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
     VALUES (?, ?, ?, ?, ?, 'unknown', 1)
@@ -78,7 +111,7 @@ keysRouter.post('/', (req: Request, res: Response) => {
     id: result.lastInsertRowid,
     platform,
     label: label ?? '',
-    maskedKey: maskKey(key),
+    maskedKey: maskKey(keyToStore),
     status: 'unknown',
     enabled: true,
   });


### PR DESCRIPTION
Adds two genuinely-free additions surfaced from the open issues/PRs and verified by **live API probing** (anonymous, `cost: 0`, HTTP 200) plus an end-to-end routing smoke test. Closes the model-add intent of #119/#179 (Kilo laguna) and #89 (Gemma 4).

## What's added

### 1. Keyless provider support (Kilo's anonymous gateway)
Kilo documents anonymous, keyless access for `:free` routes (200 req/hr per IP) — it's their advertised "use Kilo for free" path, not an exploit. This wires that up as a first-class concept:

- **`BaseProvider.keyless`** flag; `OpenAICompatProvider` **omits the `Authorization` header** when set (a stored sentinel `Bearer no-key` could otherwise be treated as an invalid key).
- **Keys route** accepts an empty key for keyless providers, stores a **sentinel row** so the router still treats the platform as configured, and **de-dupes** (one sentinel per keyless platform). Non-keyless providers still require a key (returns 400).
- **Keys page**: the API-key field is **disabled with a "No API key needed" note**; the button reads **"Enable"**.
- Kilo registered `keyless: true`; health check validates against `/api/gateway/models` (the `/v1/models` path only accepts POST → 405).

### 2. Catalog
- **V20 — 4 free Kilo models** (anonymous, 200 req/hr per IP, prompts logged for training):
  `poolside/laguna-m.1:free`, `poolside/laguna-xs.2:free`, `nvidia/nemotron-3-super-120b-a12b:free` (trial-flagged), `stepfun/step-3.7-flash:free`.
- **V19 — Gemma 4 on Google AI Studio free tier**: `gemma-4-31b-it`, `gemma-4-26b-a4b-it` (reachable with the existing Gemini key; the 26B is MoE so the real id is `…-a4b-it`).

Tiers follow the V17 intelligence bands (laguna-m.1 / nemotron-120b / gemma-4 → Large; laguna-xs.2 / stepfun → Medium).

## Note on overlap
`poolside/laguna-m.1:free` and `nvidia/nemotron-3-super-120b-a12b:free` already exist in the catalog **via OpenRouter** (keyed, ~20/day). The Kilo rows route the same models **keyless at 200/hr** and add fallback redundancy — kept intentionally. `laguna-xs.2` and `stepfun/step-3.7-flash` are net-new.

## Verification
- `npm run build` (server + client) — clean.
- `npm test` — 263/263 pass.
- End-to-end smoke test (temp DB, real app): migrations seed 6/6 with correct tiers + fallback; keyless add → 201 sentinel (re-add → 200, no dup; `groq` no-key → 400); keyless health → `healthy`; **live `POST /v1/chat/completions` for `poolside/laguna-m.1:free` → 200 routed via kilo (keyless), and `gemma-4-26b-a4b-it` → 200 routed via google.**

## Rejected during research (not free / not an API)
SiliconFlow (#95), Astraflow (#38), Agnes AI (#157) — one-time trial credits / paid, not recurring-free. Antigravity (#82) — an IDE/CLI, not a routable API.