### PR TITLE
docs: credit 8 missing contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/Sumit4codes"><img src="https://images.weserv.nl/?url=github.com/Sumit4codes.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Sumit4codes" /></a>
 <a href="https://github.com/meliani"><img src="https://images.weserv.nl/?url=github.com/meliani.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@meliani" /></a>
 <a href="https://github.com/thedavidweng"><img src="https://images.weserv.nl/?url=github.com/thedavidweng.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@thedavidweng" /></a>
+<a href="https://github.com/bharvey42"><img src="https://images.weserv.nl/?url=github.com/bharvey42.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@bharvey42" /></a>
+<a href="https://github.com/yuvrxj-afk"><img src="https://images.weserv.nl/?url=github.com/yuvrxj-afk.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@yuvrxj-afk" /></a>
+<a href="https://github.com/Tushar49"><img src="https://images.weserv.nl/?url=github.com/Tushar49.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Tushar49" /></a>
+<a href="https://github.com/nicyoong"><img src="https://images.weserv.nl/?url=github.com/nicyoong.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@nicyoong" /></a>
+<a href="https://github.com/Aldo-f"><img src="https://images.weserv.nl/?url=github.com/Aldo-f.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Aldo-f" /></a>
+<a href="https://github.com/Tazrif-Raim"><img src="https://images.weserv.nl/?url=github.com/Tazrif-Raim.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Tazrif-Raim" /></a>
+<a href="https://github.com/m1nuzz"><img src="https://images.weserv.nl/?url=github.com/m1nuzz.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@m1nuzz" /></a>
+<a href="https://github.com/LoneRifle"><img src="https://images.weserv.nl/?url=github.com/LoneRifle.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@LoneRifle" /></a>
 
 ## Terms of Service review
 


### PR DESCRIPTION
Adds contributor avatars for everyone whose work is merged/incorporated into `main` but was missing from the Contributors wall.

| Handle | Contribution |
|---|---|
| @bharvey42 | #98 — Windows IPv4 dev-proxy fix |
| @yuvrxj-afk | #102 — Markdown playground rendering |
| @Tushar49 | #105 — Gemini schema strip; #108 — validateKey timeout |
| @nicyoong | #120 — SQLite timestamp analytics |
| @Aldo-f | #128 — OpenCode Zen provider (bundled into #176) |
| @Tazrif-Raim | #170 — SQLite UTC → local-time display (bundled into #176) |
| @m1nuzz | #89 — Gemma 4 models (shipped in #181) |
| @LoneRifle | #179/#161 — Kilo `laguna-m.1` (shipped in #181) |

Verified against every commit/co-author trailer on `main` + incorporated-but-closed PRs. (`v0rtex1223` shows in GitHub's contributor graph but has no traceable commit in `main` — left out pending confirmation.)