### PR TITLE
chore(catalog): V21 — prune 7 dead models, re-enable zai-glm-4.7

### DIFF
--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -84,20 +84,28 @@ describe('Migration idempotency', () => {
     `).all();
     expect(dead).toEqual([]);
 
-    const live = db.prepare(`
+    // V21 pruned these three after live probing returned 404 "no endpoints found".
+    const pruned = db.prepare(`
       SELECT model_id FROM models
        WHERE platform = 'openrouter'
          AND model_id IN (
            'arcee-ai/trinity-large-thinking:free',
-           'baidu/cobuddy:free',
+           'minimax/minimax-m2.5:free',
+           'baidu/cobuddy:free'
+         )
+    `).all();
+    expect(pruned).toEqual([]);
+
+    const live = db.prepare(`
+      SELECT model_id FROM models
+       WHERE platform = 'openrouter'
+         AND model_id IN (
            'openrouter/owl-alpha',
            'nousresearch/hermes-3-llama-3.1-405b:free'
          )
        ORDER BY model_id
     `).all() as { model_id: string }[];
     expect(live.map(r => r.model_id)).toEqual([
-      'arcee-ai/trinity-large-thinking:free',
-      'baidu/cobuddy:free',
       'nousresearch/hermes-3-llama-3.1-405b:free',
       'openrouter/owl-alpha',
     ]);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -55,6 +55,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV18OpenCodeZen(db);
   migrateModelsV19Gemma4(db);
   migrateModelsV20KiloFree(db);
+  migrateModelsV21PruneDead(db);
   ensureUnifiedKey(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
@@ -1571,6 +1572,54 @@ function migrateModelsV20KiloFree(db: Database.Database) {
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);
     backfillFallback(db);
+  });
+  apply();
+}
+
+/**
+ * V21 (June 2026): Remove models confirmed DEAD by live probing (2026-06-03 with
+ * production keys), and re-enable Cerebras zai-glm-4.7 which serves free again.
+ *
+ * Deleted (fallback_config row removed first — foreign_keys=ON forbids deleting a
+ * referenced models row):
+ *   - llm7/gpt-oss-20b, llm7/meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo,
+ *     llm7/ministral-8b-2512 — LLM7 silently serves `mistral-small-3.2` for these
+ *     (200 OK but wrong model — a routing footgun).
+ *   - llm7/GLM-4.6V-Flash — now pro-gated (402 "upgrade required").
+ *   - openrouter/arcee-ai/trinity-large-thinking:free,
+ *     openrouter/minimax/minimax-m2.5:free, openrouter/baidu/cobuddy:free —
+ *     404 "no endpoints found" (delisted / moved to paid).
+ *
+ * Re-enabled: cerebras/zai-glm-4.7 (V9 disabled it; live-probed 200 free again).
+ * These ids are re-inserted by their original migrations on each boot, so this
+ * later DELETE is what keeps them out. Idempotent, safe to re-run.
+ */
+function migrateModelsV21PruneDead(db: Database.Database) {
+  const dead: Array<[string, string]> = [
+    ['llm7', 'gpt-oss-20b'],
+    ['llm7', 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo'],
+    ['llm7', 'ministral-8b-2512'],
+    ['llm7', 'GLM-4.6V-Flash'],
+    ['openrouter', 'arcee-ai/trinity-large-thinking:free'],
+    ['openrouter', 'minimax/minimax-m2.5:free'],
+    ['openrouter', 'baidu/cobuddy:free'],
+  ];
+  const apply = db.transaction(() => {
+    const getId = db.prepare('SELECT id FROM models WHERE platform = ? AND model_id = ?');
+    const delFb = db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?');
+    const delModel = db.prepare('DELETE FROM models WHERE id = ?');
+    for (const [platform, modelId] of dead) {
+      const row = getId.get(platform, modelId) as { id: number } | undefined;
+      if (!row) continue;
+      delFb.run(row.id);   // remove the fallback chain entry first (FK)
+      delModel.run(row.id);
+    }
+    // Re-enable Cerebras zai-glm-4.7 (model + its fallback chain entry).
+    db.prepare("UPDATE models SET enabled = 1 WHERE platform = 'cerebras' AND model_id = 'zai-glm-4.7'").run();
+    db.prepare(`
+      UPDATE fallback_config SET enabled = 1
+       WHERE model_db_id = (SELECT id FROM models WHERE platform = 'cerebras' AND model_id = 'zai-glm-4.7')
+    `).run();
   });
   apply();
 }


### PR DESCRIPTION
Removes models **confirmed dead by live probing** (2026-06-03, with production keys), and re-enables one that works again. Single migration `V21`.

## Deleted (7 — verified dead live)
| Provider | Model | Probe result |
|---|---|---|
| LLM7 | `gpt-oss-20b` | 200 but serves `mistral-small-3.2` (wrong model) |
| LLM7 | `meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo` | serves `mistral-small-3.2` |
| LLM7 | `ministral-8b-2512` | serves `mistral-small-3.2` |
| LLM7 | `GLM-4.6V-Flash` | 402 — now pro-gated |
| OpenRouter | `arcee-ai/trinity-large-thinking:free` | 404 no endpoints |
| OpenRouter | `minimax/minimax-m2.5:free` | 404 no endpoints |
| OpenRouter | `baidu/cobuddy:free` | 404 no endpoints |

The LLM7 silent-substitution cases were the urgent ones — they returned 200 while serving a different model.

## Re-enabled (1)
- `cerebras/zai-glm-4.7` — disabled in V9, live-probed **200 free** again.

## Kept (live-verified working, NOT removed despite research flagging them)
`sambanova/gemma-3-12b-it` (200), `openrouter/owl-alpha` (200), all Ollama 'stale' models (429 rate-limited = recovers), `llm7/codestral-latest` (200, serves itself).

## Mechanics
`foreign_keys=ON`, so each delete removes the `fallback_config` row before the `models` row. Re-running is idempotent (the original migrations re-insert these ids each boot; V21 deletes them after). Models 115 → 108.

## Verification
- `npm run build` clean; `npm test` 263/263 (updated the V12 idempotency test to expect the pruned OpenRouter rows absent).
- Fresh-DB check: 0 dead present, 0 orphan fallback rows, `zai-glm-4.7` enabled (model + fallback), kept models intact.