### PR TITLE
fix(router): fail over on 402 Payment Required instead of hard 502

### DIFF
--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isRetryableError } from '../../routes/proxy.js';
+import { isRetryableError, isPaymentRequiredError } from '../../routes/proxy.js';
 
 describe('isRetryableError', () => {
   describe('413 Payload Too Large', () => {
@@ -50,6 +50,25 @@ describe('isRetryableError', () => {
 
     it('but a bare validation "400 Bad Request" (our own schema) is still NOT retryable', () => {
       expect(isRetryableError(new Error('400 Bad Request'))).toBe(false);
+    });
+  });
+
+  describe('402 Payment Required out-of-credits fails over (graceful degradation)', () => {
+    it('treats a HuggingFace Router 402 as retryable (same model lives on other providers)', () => {
+      expect(isRetryableError(new Error('HuggingFace Router API error 402: Payment required'))).toBe(true);
+    });
+
+    it('catches common out-of-credits phrasings', () => {
+      expect(isRetryableError(new Error('Payment Required'))).toBe(true);
+      expect(isRetryableError(new Error('You exceeded your current quota: insufficient_quota'))).toBe(true);
+      expect(isRetryableError(new Error('Insufficient credit for this request'))).toBe(true);
+      expect(isRetryableError(new Error('Insufficient balance'))).toBe(true);
+    });
+
+    it('isPaymentRequiredError flags 402 (drives the long bench) but not a 429', () => {
+      expect(isPaymentRequiredError(new Error('HuggingFace Router API error 402: Payment required'))).toBe(true);
+      expect(isPaymentRequiredError(new Error('429 Too Many Requests'))).toBe(false);
+      expect(isPaymentRequiredError(new Error('503 Service Unavailable'))).toBe(false);
     });
   });
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -4,7 +4,7 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type { ChatMessage } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
-import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
+import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { runEmbeddings, EmbeddingsError } from '../services/embeddings.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
@@ -615,10 +615,12 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           route.platform,
           route.modelId,
           route.keyId,
-          getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, {
-            rpd: route.rpdLimit,
-            tpd: route.tpdLimit,
-          }),
+          isPaymentRequiredError(err)
+            ? PAYMENT_REQUIRED_COOLDOWN_MS
+            : getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, {
+                rpd: route.rpdLimit,
+                tpd: route.tpdLimit,
+              }),
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -238,7 +238,23 @@ export function isRetryableError(err: any): boolean {
     // limits, unsupported params). The matching pattern is "api error 400"
     // which comes from the OpenAI-compat provider's error formatting, not
     // a bare "400" which is deliberately non-retryable for validation errors.
-    || msg.includes('api error 400');
+    || msg.includes('api error 400')
+    // 402: this provider/key is out of credits (e.g. HuggingFace Router
+    // "API error 402: Payment required"). The SAME model often lives on another
+    // provider (Kimi K2.6 is on HF + Cloudflare + NVIDIA), so fail over instead
+    // of killing the workflow. Paired with a long cooldown (isPaymentRequiredError)
+    // so we don't re-hammer the broke key every retry.
+    || isPaymentRequiredError(err);
+}
+
+// A 402 Payment Required / out-of-credits error. Distinct from a transient 429:
+// it won't recover on the next window, so the caller benches the model+key with
+// PAYMENT_REQUIRED_COOLDOWN_MS (a full day) rather than the 90s transient cooldown.
+export function isPaymentRequiredError(err: any): boolean {
+  const msg = (err.message ?? '').toLowerCase();
+  return msg.includes('402') || msg.includes('payment required')
+    || msg.includes('insufficient_quota') || msg.includes('insufficient credit')
+    || msg.includes('insufficient balance');
 }
 
 // Pull the incremental text out of a streaming chunk for token counting.

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -9,12 +9,13 @@ import type {
   ChatToolChoice,
 } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
-import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit } from '../services/ratelimit.js';
+import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
 import { getUnifiedApiKey } from '../db/index.js';
 import { contentToString } from '../lib/content.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 import {
   isRetryableError,
+  isPaymentRequiredError,
   timingSafeStringEqual,
   extractApiToken,
   getStickyModel,
@@ -557,7 +558,9 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
 
       if (isRetryableError(err)) {
         skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
-        setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
+        setCooldown(route.platform, route.modelId, route.keyId, isPaymentRequiredError(err)
+          ? PAYMENT_REQUIRED_COOLDOWN_MS
+          : getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
         recordRateLimitHit(route.modelDbId);
         lastError = err;
         continue;

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -301,6 +301,13 @@ export function getNextCooldownDuration(platform: string, modelId: string, keyId
 // Short cooldown for a transient (per-minute) 429 — recovers within ~one window.
 const TRANSIENT_COOLDOWN_MS = 90 * 1000;
 
+// Long cooldown for a 402 Payment Required (provider/key out of credits). Unlike
+// a 429, this won't clear on the next minute/day window — it needs a top-up or
+// billing reset. Bench the model+key for a full day so the router fails over to
+// other providers instead of re-hammering a dead key every retry. Re-escalates
+// on the next 402 after expiry if still unpaid; a restart re-benches on first hit.
+export const PAYMENT_REQUIRED_COOLDOWN_MS = DAY;
+
 // Decide how long to bench a model+key after an upstream 429. Escalate to the
 // long quarantine (getNextCooldownDuration, up to 24h) ONLY when the model is
 // genuinely at its DAILY limit (RPD or TPD) — that won't recover until the


### PR DESCRIPTION
## Problem

A request to a model whose provider/key is out of credits dies with a hard 502, killing the caller's workflow:

```
API call failed after 3 retries: HTTP 502: Provider error (Kimi K2.6 (HF)):
HuggingFace Router API error 402: Payment required
```

## Root cause

`isRetryableError()` (`server/src/routes/proxy.ts`) did not match 402, so the catch block took the non-retryable path and returned 502 immediately — the request never entered the failover loop, even though other models (and, for Kimi K2.6, other providers — CF/NV) were available in the fallback chain.

402 was the odd one out: 429, 5xx, 413, 404, and provider "API error 400" all already fail over (#80, #76, #64).

## Fix

Two commits:

1. **treat 402 as retryable** — adds `isPaymentRequiredError()` (matches `402` / `payment required` / `insufficient_quota` / `insufficient credit` / `insufficient balance`) and folds it into `isRetryableError()`. The 402'd model+key is benched and `routeRequest()` advances to the next entry in the fallback chain. Chat/responses failover is **not** same-model-restricted, so this degrades gracefully even for a single-provider model. +3 tests.

2. **bench a 402 key for a full day** — a 402 is out-of-credits, not a per-minute burst, so the 90s transient cooldown re-selected the dead key every request (burning a fallback slot). Adds `PAYMENT_REQUIRED_COOLDOWN_MS` (24h) and routes 402s to it in both `/v1/chat/completions` and `/v1/responses`. Aligned with the existing "don't hammer dead keys" posture (#92, #158).

Split so the core (commit 1) stands alone if the cooldown duration (commit 2) needs discussion.

## Relationship to the catalog "drop fake-free models" convention

The seed already treats a *persistent* 402 as a curation signal to drop a model that isn't actually free (the chutes / sambanova / crucible "V21 drop" comments in `db/index.ts`). This runtime change is **complementary, not contradictory**: it covers the window where a previously-free model goes pay-gated *between* curation passes — callers degrade gracefully instead of eating a 502 until the catalog catches up. It does **not** auto-drop any model; that stays a maintainer curation call. (Note: `Kimi K2.6 (HF)` from the repro is not currently touched by `chore/prune-dead-models-v21`, which is embeddings-only.)

## Open question for the maintainer

Cooldown duration for a 402 — I went with a flat **24h**. Alternatives: reuse the existing `getNextCooldownDuration` escalation ladder (2m→10m→1h→24h), or leave it at the 90s transient. Flat 24h matches "dead until billing reset / top-up"; happy to change.

## Tests

`tsc --noEmit` clean. Full suite: **310 passed (38 files)**, including the 3 new 402 cases in `proxy-retry.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
