### PR TITLE
fix: return unique model IDs from /models endpoint and make gateway api key required

### DIFF
--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -58,7 +58,7 @@ describe('Virtual "auto" model', () => {
   });
 
   it('lists "auto" as the first /v1/models entry', async () => {
-    const { status, body } = await request(app, 'GET', '/v1/models');
+    const { status, body } = await request(app, 'GET', '/v1/models', undefined, authHeaders());
     expect(status).toBe(200);
     expect(body.object).toBe('list');
     expect(body.data[0]).toMatchObject({
@@ -70,8 +70,16 @@ describe('Virtual "auto" model', () => {
     expect(body.data.length).toBeGreaterThan(1);
   });
 
+  it('fails when authentication is missing or wrong', async () => {
+    const { status: status1 } = await request(app, 'GET', '/v1/models');
+    expect(status1).toBe(401);
+
+    const { status: status2 } = await request(app, 'GET', '/v1/models', undefined, { Authorization: 'Bearer wrongkey' });
+    expect(status2).toBe(401);
+  });
+
   it('returns unique model ids from /v1/models', async () => {
-    const { status, body } = await request(app, 'GET', '/v1/models');
+    const { status, body } = await request(app, 'GET', '/v1/models', undefined, authHeaders());
     expect(status).toBe(200);
 
     const ids = body.data.map((model: { id: string }) => model.id);

--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -70,6 +70,14 @@ describe('Virtual "auto" model', () => {
     expect(body.data.length).toBeGreaterThan(1);
   });
 
+  it('returns unique model ids from /v1/models', async () => {
+    const { status, body } = await request(app, 'GET', '/v1/models');
+    expect(status).toBe(200);
+
+    const ids = body.data.map((model: { id: string }) => model.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
   it('treats model:"auto" as auto-route instead of a 400', async () => {
     const origFetch = global.fetch;
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -103,7 +103,14 @@ export function setStickyModel(messages: ChatMessage[], modelDbId: number) {
 }
 
 // OpenAI-compatible /models endpoint (used by Hermes for metadata)
-proxyRouter.get('/models', (_req: Request, res: Response) => {
+proxyRouter.get('/models', (req: Request, res: Response) => {
+  const token = extractApiToken(req);
+  const unifiedKey = getUnifiedApiKey();
+  if (!token || !timingSafeStringEqual(token, unifiedKey)) {
+    res.status(401).json({ error: { message: 'Invalid API key', type: 'authentication_error' } });
+    return;
+  }
+
   const db = getDb();
   const models = db.prepare(`
     SELECT platform, model_id, display_name, context_window

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
-import type { ChatMessage } from '@freellmapi/shared/types.js';
+import type { ChatMessage, ModelListRow } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
@@ -105,7 +105,21 @@ export function setStickyModel(messages: ChatMessage[], modelDbId: number) {
 // OpenAI-compatible /models endpoint (used by Hermes for metadata)
 proxyRouter.get('/models', (_req: Request, res: Response) => {
   const db = getDb();
-  const models = db.prepare('SELECT platform, model_id, display_name, context_window FROM models WHERE enabled = 1 ORDER BY intelligence_rank').all() as any[];
+  const models = db.prepare(`
+    SELECT platform, model_id, display_name, context_window
+    FROM (
+      SELECT platform, model_id, display_name, context_window, intelligence_rank, id,
+             ROW_NUMBER() OVER (
+               PARTITION BY model_id
+               ORDER BY intelligence_rank ASC, id ASC
+             ) AS rn
+      FROM models
+      WHERE enabled = 1
+    )
+    WHERE rn = 1
+    ORDER BY intelligence_rank ASC, id ASC
+  `).all() as ModelListRow[];
+
   res.json({
     object: 'list',
     data: [

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -48,6 +48,13 @@ export interface Model {
   supportsTools: boolean;
 }
 
+export interface ModelListRow {
+  platform: string;
+  model_id: string;
+  display_name: string;
+  context_window: number | null;
+}
+
 export type KeyStatus = 'healthy' | 'rate_limited' | 'invalid' | 'error' | 'unknown';
 
 export interface ApiKey {


### PR DESCRIPTION
## Description of change

- When duplicate enabled models share the same `model_id`, `/models` now returns the best-ranked entry only.
- Make auth token required for `/models` endpoint

Note: Which provider the model belongs to does not really matter, because in /chat/completions you cannot select specific provider.

## Testing

Added regression coverage to ensure `/models` does not return duplicate model IDs.

Fixes #201 