### PR TITLE
fix(analytics): span-based 30-day savings projection

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -81,16 +81,26 @@ export default function AnalyticsPage() {
     queryFn: () => apiFetch<{ byCategory: any[]; byPlatform: any[]; detailed: any[] }>(`/api/analytics/error-distribution?range=${range}`),
   })
 
-  // Savings display as a monthly figure: shorter ranges extrapolate to 30
-  // days (24h ×30, 7d ×30/7); the 30d range shows the real number as-is.
-  // The hover hint always carries the actual period amount.
+  // Savings display as a monthly figure projected from the ACTUAL data
+  // span in the selected range (not the range length, which over-divides
+  // young installs and zeroes quiet days). Once the span reaches 30 days
+  // the real number shows as-is. The hover hint carries the whole story.
   const actualSavings = summary?.estimatedCostSavings ?? 0
-  const savingsFactor = range === '24h' ? 30 : range === '7d' ? 30 / 7 : 1
-  const savings30d = actualSavings * savingsFactor
-  const savingsHint =
-    range === '30d'
-      ? `Your actual savings over the last 30 days: $${actualSavings.toFixed(2)} — what the same tokens would have cost on paid APIs, priced per model. Not extrapolated.`
-      : `You actually saved $${actualSavings.toFixed(2)} over the last ${range === '24h' ? '24 hours' : '7 days'} — what the same tokens would have cost on paid APIs, priced per model. The number shown projects that pace over 30 days.`
+  const rangeDays = range === '24h' ? 1 : range === '7d' ? 7 : 30
+  const spanDays = (() => {
+    if (!summary?.firstRequestAt) return rangeDays
+    // SQLite stores UTC "YYYY-MM-DD HH:MM:SS"
+    const first = new Date(summary.firstRequestAt.replace(' ', 'T') + 'Z').getTime()
+    const days = (Date.now() - first) / 86_400_000
+    // Clamp: at least an hour of pace, at most the range itself
+    return Math.min(Math.max(days, 1 / 24), rangeDays)
+  })()
+  const extrapolated = spanDays < 30
+  const savings30d = extrapolated ? actualSavings * (30 / spanDays) : actualSavings
+  const spanLabel = spanDays >= 2 ? `${Math.round(spanDays)} days` : `${Math.max(1, Math.round(spanDays * 24))} hours`
+  const savingsHint = extrapolated
+    ? `You actually saved $${actualSavings.toFixed(2)} over the ${spanLabel} of data in this view. That is what the same tokens would have cost on paid APIs, priced per model. The number shown projects this pace over 30 days.`
+    : `Your actual savings over the last 30 days: $${actualSavings.toFixed(2)}. That is what the same tokens would have cost on paid APIs, priced per model. Not extrapolated.`
 
   return (
     <div>

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -99,6 +99,8 @@ describe('Analytics API', () => {
 
     expect(status).toBe(200);
     expect(body.estimatedCostSavings).toBe(2.6);
+    // Drives the client's span-based 30-day projection
+    expect(body.firstRequestAt).toBe('2026-05-29 11:00:00');
   });
 
   it('falls back to modest default pricing for unmapped models', async () => {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -42,6 +42,7 @@ analyticsRouter.get('/summary', (req: Request, res: Response) => {
       SUM(r.input_tokens) as total_input_tokens,
       SUM(r.output_tokens) as total_output_tokens,
       AVG(r.latency_ms) as avg_latency_ms,
+      MIN(r.created_at) as first_request_at,
       SUM(CASE WHEN r.status = 'success' THEN
         r.input_tokens  * COALESCE(m.paid_input_per_m,  ?) / 1000000.0 +
         r.output_tokens * COALESCE(m.paid_output_per_m, ?) / 1000000.0
@@ -61,6 +62,9 @@ analyticsRouter.get('/summary', (req: Request, res: Response) => {
     totalOutputTokens: stats.total_output_tokens ?? 0,
     avgLatencyMs: Math.round(stats.avg_latency_ms ?? 0),
     estimatedCostSavings: Math.round((stats.est_savings ?? 0) * 100) / 100,
+    // Lets the client project savings from the ACTUAL data span (a 2-day-old
+    // install shouldn't extrapolate as if the whole range had traffic).
+    firstRequestAt: stats.first_request_at ?? null,
   });
 });
 


### PR DESCRIPTION
Range-based factors (24h x30, 7d x30/7) zeroed quiet days and
over-divided young installs: a day-old DB viewed at 24h projected ~$0
while 7d projected from a window mostly without data. The summary now
returns firstRequestAt and the client projects from the real data span
in view (clamped 1h..range), showing the actual number once 30 days of
data exist. Tooltips spell out the actual amount, the span, and whether
the figure is projected. No em dashes.