### PR TITLE
feat(custom-models): implement virtual platform namespace architectur…

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -203,7 +203,7 @@ function CustomProviderSection() {
       <h2 className="text-sm font-medium mb-1">Add a custom OpenAI-compatible model</h2>
       <p className="text-xs text-muted-foreground mb-3">
         Point at any OpenAI-compatible endpoint — llama.cpp, LM Studio, vLLM, a local Ollama, or a remote
-        gateway. Add each model you want routed; they all share the one endpoint. The API key is optional
+        gateway. Add each model you want routed; models sharing the same Base URL will group under the same endpoint below. The API key is optional
         (most local servers don't need one).
       </p>
       <form onSubmit={submit} className="flex flex-wrap items-end gap-3 rounded-3xl border p-4 bg-card">
@@ -380,7 +380,11 @@ export default function KeysPage() {
 
   const grouped = [...PLATFORMS, CUSTOM_GROUP].map(p => ({
     ...p,
-    keys: keys.filter(k => k.platform === p.value),
+    keys: keys.filter(k => 
+      p.value === 'custom' 
+        ? (k.platform === 'custom' || k.platform.startsWith('custom:'))
+        : k.platform === p.value
+    ),
   })).filter(p => p.keys.length > 0)
 
   return (
@@ -525,6 +529,7 @@ export default function KeysPage() {
                           ) : (
                             <>
                               {k.label && <span className="text-xs text-muted-foreground">{k.label}</span>}
+                              {k.baseUrl && <code className="text-[11px] text-muted-foreground bg-muted/50 px-1.5 py-0.5 rounded">{k.baseUrl}</code>}
                             </>
                           )}
                           <span className="text-xs text-muted-foreground">{statusLabel[status] ?? status}</span>

--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -5,6 +5,7 @@ describe('GoogleProvider', () => {
   let provider: GoogleProvider;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     provider = new GoogleProvider();
   });
 

--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -68,6 +68,7 @@ describe('resolveProvider (#117)', () => {
 
 describe('POST /api/keys/custom (#117)', () => {
   let app: Express;
+  let customKeyId: number;
 
   beforeAll(() => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
@@ -88,59 +89,62 @@ describe('POST /api/keys/custom (#117)', () => {
       displayName: 'Local Qwen3 4B',
     });
     expect(status).toBe(201);
-    expect(body.platform).toBe('custom');
-    expect(body.baseUrl).toBe('http://127.0.0.1:11434/v1'); // trailing slash trimmed
+    expect(body.platform).toMatch(/^custom:\d+$/);
+    expect(body.baseUrl).toBe('http://127.0.0.1:11434/v1'); // trailing slash stripped
     expect(body.model).toBe('qwen3:4b');
-
-    const db = getDb();
-    const key = db.prepare("SELECT * FROM api_keys WHERE platform = 'custom'").get() as any;
-    expect(key.base_url).toBe('http://127.0.0.1:11434/v1');
-    const model = db.prepare("SELECT * FROM models WHERE platform = 'custom' AND model_id = 'qwen3:4b'").get() as any;
-    expect(model).toBeDefined();
-    const fc = db.prepare('SELECT * FROM fallback_config WHERE model_db_id = ?').get(model.id);
-    expect(fc).toBeDefined();
+    expect(body.displayName).toBe('Local Qwen3 4B');
+    expect(body.maskedKey).toBe('****-key');
+    customKeyId = body.keyId;
   });
 
-  it('reuses the single custom key when a second model is added', async () => {
-    await post(app, '/api/keys/custom', { baseUrl: 'http://127.0.0.1:11434/v1', model: 'llama3:8b' });
+  it('creates a new key when a second model is added', async () => {
+    const { status, body } = await post(app, '/api/keys/custom', {
+      baseUrl: 'http://127.0.0.1:11434/v1/', // same base URL, but we no longer reuse
+      model: 'llama3:8b',
+      apiKey: 'sk-different',
+    });
+    expect(status).toBe(201);
+    expect(body.platform).toMatch(/^custom:\d+$/);
+    expect(body.platform).not.toBe(`custom:${customKeyId}`);
+
     const db = getDb();
-    const keys = db.prepare("SELECT * FROM api_keys WHERE platform = 'custom'").all();
-    expect(keys.length).toBe(1); // not a second key
-    const models = db.prepare("SELECT * FROM models WHERE platform = 'custom'").all();
+    const keys = db.prepare("SELECT * FROM api_keys WHERE platform LIKE 'custom:%'").all();
+    expect(keys.length).toBe(2); // exactly 2 keys now
+    const models = db.prepare("SELECT * FROM models WHERE platform LIKE 'custom:%'").all();
     expect(models.length).toBe(2);
   });
 
   it('surfaces baseUrl in the keys listing', async () => {
     const { body } = await get(app, '/api/keys');
-    const custom = body.find((k: any) => k.platform === 'custom');
+    const custom = body.find((k: any) => k.platform.startsWith('custom:'));
     expect(custom.baseUrl).toBe('http://127.0.0.1:11434/v1');
   });
 
   it('routes a request to the custom model through its base URL', () => {
-    // The seeded built-in models have no keys, so the only routable model is
-    // the custom one we registered above.
     const route = routeRequest(1000);
-    expect(route.platform).toBe('custom');
+    expect(route.platform).toMatch(/^custom:\d+$/);
     expect((route.provider as any).baseUrl).toBe('http://127.0.0.1:11434/v1');
     expect(['qwen3:4b', 'llama3:8b']).toContain(route.modelId);
   });
 
-  it('deleting the custom key cascades its models out of the fallback chain (#189)', async () => {
+  it('deleting the custom key cascades ONLY its own models out of the fallback chain', async () => {
     const db = getDb();
-    const key = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom'").get() as { id: number };
-    const customModelIds = (db.prepare("SELECT id FROM models WHERE platform = 'custom'").all() as { id: number }[]).map(r => r.id);
-    expect(customModelIds.length).toBe(2); // qwen3:4b + llama3:8b from earlier tests
-    const builtinModels = (db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform != 'custom'").get() as { n: number }).n;
+    const key = db.prepare("SELECT id, platform FROM api_keys WHERE platform LIKE 'custom:%' LIMIT 1").get() as { id: number; platform: string };
+    const customModelIds = (db.prepare("SELECT id FROM models WHERE platform = ?").all(key.platform) as any[]).map(r => r.id);
+    expect(customModelIds.length).toBe(1); // 1 key = 1 model now!
+
+    const builtinModels = (db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform NOT LIKE 'custom:%'").get() as any).n;
 
     const { status } = await del(app, `/api/keys/${key.id}`);
     expect(status).toBe(200);
 
-    // Custom models and their fallback entries are gone — not orphaned.
-    expect((db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform = 'custom'").get() as { n: number }).n).toBe(0);
-    const placeholders = customModelIds.map(() => '?').join(',');
-    expect((db.prepare(`SELECT COUNT(*) AS n FROM fallback_config WHERE model_db_id IN (${placeholders})`).get(...customModelIds) as { n: number }).n).toBe(0);
-    // Built-in catalog rows are untouched.
-    expect((db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform != 'custom'").get() as { n: number }).n).toBe(builtinModels);
+    const fcRemaining = db.prepare(`SELECT COUNT(*) AS n FROM fallback_config WHERE model_db_id IN (${customModelIds.join(',')})`).get() as any;
+    expect(fcRemaining.n).toBe(0);
+
+    const modelsRemaining = db.prepare(`SELECT COUNT(*) AS n FROM models WHERE platform = ?`).get(key.platform) as any;
+    expect(modelsRemaining.n).toBe(0);
+
+    expect((db.prepare(`SELECT COUNT(*) AS n FROM models WHERE platform NOT LIKE 'custom:%'`).get() as any).n).toBe(builtinModels);
   });
 
   it('deleting a built-in platform key does NOT cascade its catalog models', async () => {
@@ -164,15 +168,13 @@ describe('POST /api/keys/custom (#117)', () => {
     });
     expect(status).toBe(201);
     const db = getDb();
-    expect((db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom'").get() as { n: number }).n).toBe(1);
-    const fc = db.prepare('SELECT * FROM fallback_config WHERE model_db_id = ?').get(body.modelDbId);
+    expect((db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform LIKE 'custom:%'").get() as any).n).toBe(2); // One is still left from earlier
+    const fc = db.prepare('SELECT * FROM fallback_config WHERE model_db_id = ?').get(body.modelDbId) as any;
     expect(fc).toBeDefined();
+    expect(fc.priority).toBeGreaterThan(0); // Appended to end of chain
   });
 
   it('surfaces a clear error when the custom endpoint speaks NDJSON, not OpenAI (#189)', async () => {
-    // Real upstream that answers like Ollama's native /api/chat: HTTP 200,
-    // newline-delimited JSON documents — res.json() in the provider would die
-    // with "Unexpected non-whitespace character after JSON at position …".
     const upstream = http.createServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
       res.end(
@@ -185,7 +187,6 @@ describe('POST /api/keys/custom (#117)', () => {
     await new Promise<void>(resolve => upstream.listen(0, resolve));
     const upstreamPort = (upstream.address() as any).port;
 
-    // Point the custom provider at the NDJSON upstream and pin its model.
     const reg = await post(app, '/api/keys/custom', {
       baseUrl: `http://127.0.0.1:${upstreamPort}/v1`,
       model: 'ndjson-model',

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -58,6 +58,8 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV20KiloFree(db);
   migrateModelsV21PruneDead(db);
   migrateModelsV22Tools(db);
+  migrateModelsV23CustomNamespaces(db);
+
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1693,6 +1695,65 @@ function migrateModelsV22Tools(db: Database.Database) {
     `).run();
   });
   apply();
+}
+
+/**
+ * V23 (June 2026): Custom platform namespacing.
+ * Convert the monolithic 'custom' platform into per-endpoint namespaces
+ * (e.g., 'custom:5') so multiple local endpoints can be routed cleanly.
+ */
+function migrateModelsV23CustomNamespaces(db: Database.Database) {
+  // Find any 'custom' or 'custom:X' keys that have MULTIPLE models attached to them,
+  // which indicates they are legacy squeezed keys that need fission.
+  const customKeys = db.prepare("SELECT * FROM api_keys WHERE platform = 'custom' OR platform LIKE 'custom:%'").all() as any[];
+
+  const migrate = db.transaction(() => {
+    for (const key of customKeys) {
+      const customModels = db.prepare("SELECT * FROM models WHERE platform = ?").all(key.platform) as any[];
+
+      if (customModels.length <= 1) {
+        // If it's literally 'custom', just rename it to custom:ID
+        if (key.platform === 'custom') {
+          db.prepare("UPDATE api_keys SET platform = ? WHERE id = ?").run(`custom:${key.id}`, key.id);
+          if (customModels.length === 1) {
+            db.prepare("UPDATE models SET platform = ? WHERE id = ?").run(`custom:${key.id}`, customModels[0].id);
+            db.prepare("UPDATE requests SET platform = ? WHERE platform = 'custom' AND model_id = ?").run(`custom:${key.id}`, customModels[0].model_id);
+          }
+          db.prepare("UPDATE requests SET platform = ? WHERE platform = 'custom'").run(`custom:${key.id}`);
+        }
+        continue;
+      }
+
+      // Fission needed: this key has multiple models
+      for (let i = 0; i < customModels.length; i++) {
+        const m = customModels[i];
+        let newKeyId: number;
+
+        if (i === 0) {
+          // Reuse the existing key for the first model
+          newKeyId = key.id;
+          db.prepare("UPDATE api_keys SET platform = ?, label = ? WHERE id = ?").run(`custom:${newKeyId}`, m.display_name, newKeyId);
+        } else {
+          // Clone for the rest
+          const r = db.prepare(`
+            INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url, created_at, last_checked_at)
+            VALUES ('custom', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `).run(m.display_name, key.encrypted_key, key.iv, key.auth_tag, key.status, key.enabled, key.base_url, key.created_at, key.last_checked_at);
+          newKeyId = Number(r.lastInsertRowid);
+          db.prepare("UPDATE api_keys SET platform = ? WHERE id = ?").run(`custom:${newKeyId}`, newKeyId);
+        }
+
+        const virtualPlatform = `custom:${newKeyId}`;
+        db.prepare("UPDATE models SET platform = ? WHERE id = ?").run(virtualPlatform, m.id);
+        db.prepare("UPDATE requests SET platform = ? WHERE platform = ? AND model_id = ?").run(virtualPlatform, key.platform, m.model_id);
+      }
+      
+      // Cleanup any dangling requests for this old platform
+      db.prepare("UPDATE requests SET platform = ? WHERE platform = ?").run(`custom:${key.id}`, key.platform);
+    }
+  });
+  
+  migrate();
 }
 
 // Embeddings V1 (2026-06): per-family embedding catalog. A "family" is one

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -180,6 +180,11 @@ register(new OpenAICompatProvider({
 const CUSTOM_PROVIDER_TIMEOUT_MS = 120000;
 
 export function getProvider(platform: Platform): BaseProvider | undefined {
+  if (platform.startsWith('custom:')) {
+    // Return a dummy object just so `hasProvider` passes true if checked
+    // Normally, the custom provider is built per-key via resolveProvider()
+    return providers.get('custom');
+  }
   return providers.get(platform);
 }
 
@@ -190,12 +195,15 @@ export function getProvider(platform: Platform): BaseProvider | undefined {
  * a custom provider with no base URL configured.
  */
 export function resolveProvider(platform: Platform, baseUrl?: string | null): BaseProvider | undefined {
-  if (platform === 'custom') {
+  if (platform === 'custom' || platform.startsWith('custom:')) {
     const trimmed = baseUrl?.trim();
     if (!trimmed) return undefined;
+    
+    // Some local servers omit the '/v1' suffix or use different paths;
+    // we take the user-supplied URL as the absolute base.
     return new OpenAICompatProvider({
-      platform: 'custom',
-      name: 'Custom (OpenAI-compatible)',
+      platform: platform as Platform,
+      name: `Custom (${trimmed})`,
       baseUrl: trimmed,
       timeoutMs: CUSTOM_PROVIDER_TIMEOUT_MS,
     });
@@ -208,5 +216,8 @@ export function getAllProviders(): BaseProvider[] {
 }
 
 export function hasProvider(platform: Platform): boolean {
+  if (platform.startsWith('custom:')) return true;
   return providers.has(platform);
 }
+
+

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -116,7 +116,7 @@ analyticsRouter.get('/by-platform', (req: Request, res: Response) => {
 
   const rows = db.prepare(`
     SELECT
-      platform,
+      CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END as platform,
       COUNT(*) as requests,
       SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
       AVG(latency_ms) as avg_latency_ms,
@@ -124,7 +124,7 @@ analyticsRouter.get('/by-platform', (req: Request, res: Response) => {
       SUM(output_tokens) as total_output_tokens
     FROM requests
     WHERE created_at >= ?
-    GROUP BY platform
+    GROUP BY CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END
     ORDER BY requests DESC
   `).all(since) as any[];
 
@@ -177,7 +177,7 @@ analyticsRouter.get('/error-distribution', (req: Request, res: Response) => {
   // Group errors by category (extract the key part of the error message)
   const rows = db.prepare(`
     SELECT
-      platform,
+      CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END as platform,
       model_id,
       CASE
         WHEN error LIKE '%429%' OR error LIKE '%rate limit%' OR error LIKE '%too many%' OR error LIKE '%quota%' THEN 'Rate Limited (429)'
@@ -192,7 +192,7 @@ analyticsRouter.get('/error-distribution', (req: Request, res: Response) => {
       COUNT(*) as count
     FROM requests
     WHERE status = 'error' AND created_at >= ?
-    GROUP BY platform, error_category
+    GROUP BY CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END, error_category
     ORDER BY count DESC
   `).all(since) as any[];
 
@@ -218,10 +218,10 @@ analyticsRouter.get('/error-distribution', (req: Request, res: Response) => {
 
   // Errors by platform
   const byPlatform = db.prepare(`
-    SELECT platform, COUNT(*) as count
+    SELECT CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END as platform, COUNT(*) as count
     FROM requests
     WHERE status = 'error' AND created_at >= ?
-    GROUP BY platform
+    GROUP BY CASE WHEN platform LIKE 'custom:%' THEN 'custom' ELSE platform END
     ORDER BY count DESC
   `).all(since) as any[];
 

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -145,34 +145,34 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
 
   const db = getDb();
   const upsert = db.transaction(() => {
-    // One shared 'custom' key holds the endpoint URL. Reuse it across models;
-    // update its base_url/key when re-submitted.
-    const existing = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' LIMIT 1").get() as { id: number } | undefined;
-    let keyId: number;
-    if (existing) {
-      const { encrypted, iv, authTag } = encrypt(rawKey);
-      db.prepare("UPDATE api_keys SET base_url = ?, encrypted_key = ?, iv = ?, auth_tag = ?, status = 'unknown', enabled = 1 WHERE id = ?")
-        .run(baseUrl, encrypted, iv, authTag, existing.id);
-      keyId = existing.id;
-    } else {
-      const { encrypted, iv, authTag } = encrypt(rawKey);
-      const r = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label, encrypted, iv, authTag, baseUrl);
-      keyId = Number(r.lastInsertRowid);
-    }
+    // One model = One key. We no longer reuse custom keys. Every time the user 
+    // adds a custom model, we give it a dedicated endpoint key (with its own ID).
+    // The key's label is set to the model's display name so it's clear in the UI.
+    const keyLabel = parsed.data.label || displayName;
+    
+    const { encrypted, iv, authTag } = encrypt(rawKey);
+    const r = db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
+      VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
+    `).run(keyLabel, encrypted, iv, authTag, baseUrl);
+    
+    const keyId = Number(r.lastInsertRowid);
+    const virtualPlatform = `custom:${keyId}`;
+    
+    db.prepare("UPDATE api_keys SET platform = ? WHERE id = ?").run(virtualPlatform, keyId);
 
-    // Register the model (idempotent on platform+model_id). Custom models carry
-    // no rate limits and sort last in the intelligence preset (size_label tier).
+    // Register the model into the specific virtual namespace.
+    // Idempotent on platform+model_id.
     db.prepare(`
-      INSERT OR IGNORE INTO models
+      INSERT INTO models
         (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
          rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled)
-      VALUES ('custom', ?, ?, 50, 50, 'Custom', NULL, NULL, NULL, NULL, '', NULL, 1)
-    `).run(modelId, displayName);
+      VALUES (?, ?, ?, 50, 50, 'Custom', NULL, NULL, NULL, NULL, '', NULL, 1)
+      ON CONFLICT(platform, model_id) DO UPDATE SET
+        display_name = excluded.display_name
+    `).run(virtualPlatform, modelId, displayName);
 
-    const modelRow = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number };
+    const modelRow = db.prepare("SELECT id FROM models WHERE platform = ? AND model_id = ?").get(virtualPlatform, modelId) as { id: number };
 
     // Append to the fallback chain if not already present.
     const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
@@ -181,15 +181,15 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
       db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(modelRow.id, max.m + 1);
     }
 
-    return { keyId, modelDbId: modelRow.id };
+    return { keyId, virtualPlatform, modelDbId: modelRow.id };
   });
 
-  const { keyId, modelDbId } = upsert();
+  const { keyId, virtualPlatform, modelDbId } = upsert();
   res.status(201).json({
     success: true,
     keyId,
     modelDbId,
-    platform: 'custom',
+    platform: virtualPlatform,
     baseUrl,
     model: modelId,
     displayName,
@@ -215,16 +215,12 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   const remove = db.transaction(() => {
     db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
     // Custom models exist only because POST /custom registered them alongside
-    // this endpoint key (#117) — they can't route without it. Built-in
-    // platforms keep their seeded catalog rows, but once the last custom key
-    // is gone, orphaned custom models would linger in the fallback chain
-    // forever (#189), so cascade them away.
-    if (row.platform === 'custom') {
-      const remaining = db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom'").get() as { n: number };
-      if (remaining.n === 0) {
-        db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
-        db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
-      }
+    // this endpoint key (#117) — they can't route without it.
+    // With virtual namespaces (e.g. 'custom:5'), every endpoint is its own platform.
+    // When the key is deleted, cascade delete all models bound to this virtual platform.
+    if (row.platform.startsWith('custom:')) {
+      db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = ?)").run(row.platform);
+      db.prepare("DELETE FROM models WHERE platform = ?").run(row.platform);
     }
   });
   remove();
@@ -247,7 +243,12 @@ keysRouter.patch('/platform/:platform', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const result = db.prepare('UPDATE api_keys SET enabled = ? WHERE platform = ?').run(enabled ? 1 : 0, platform);
+  let result;
+  if (platform === 'custom') {
+    result = db.prepare('UPDATE api_keys SET enabled = ? WHERE platform LIKE \'custom:%\'').run(enabled ? 1 : 0);
+  } else {
+    result = db.prepare('UPDATE api_keys SET enabled = ? WHERE platform = ?').run(enabled ? 1 : 0, platform);
+  }
 
   res.json({ success: true, enabled, updatedKeys: result.changes });
 });

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -449,8 +449,8 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
       // For the 'custom' platform the real provider is built from this key's
       // base_url (the registered instance is just a placeholder). A custom key
       // with no base_url can't be routed — skip it.
-      const resolvedProvider = entry.platform === 'custom'
-        ? resolveProvider('custom', key.base_url)
+      const resolvedProvider = (entry.platform === 'custom' || entry.platform.startsWith('custom:'))
+        ? resolveProvider(entry.platform as any, key.base_url)
         : provider;
       if (!resolvedProvider) continue;
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -27,7 +27,9 @@ export type Platform =
   | 'opencode'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
-  | 'custom';
+  | 'custom'
+  // Virtual platform namespace for distinct custom endpoints (e.g. custom:1)
+  | `custom:${string}`;
 
 export interface Model {
   id: number;
@@ -62,6 +64,7 @@ export interface ApiKey {
   platform: Platform;
   label: string;
   maskedKey: string;
+  baseUrl?: string | null;
   status: KeyStatus;
   enabled: boolean;
   createdAt: string;


### PR DESCRIPTION
implement virtual platform namespace architectur

- Implements 1:1 key-model binding for custom models using 'custom:ID' namespace
- Resolves issue where multiple custom models overwrite each other
- Adds data migration fission to split legacy custom keys
- Aggregates custom models in analytics SQL for clean charts
- Fixes PATCH /platform/custom toggle applying to virtual namespaces
- Refactors cascade deletion to only scope to the deleted key's namespace
- Restores vitest config to prevent parallel sqlite DB locking
- Restores google.test.ts mock state isolation