### PR TITLE
fix(proxy): tolerate code-agent follow-up payloads (#200)

### DIFF
--- a/server/src/__tests__/lib/content.test.ts
+++ b/server/src/__tests__/lib/content.test.ts
@@ -27,6 +27,12 @@ describe('contentToString', () => {
     ])).toBe('describe this');
   });
 
+  it('extracts Gemini-part-style { text } blocks with no type field (#200)', () => {
+    expect(contentToString([{ text: 'hi' }, { text: ' there' }])).toBe('hi there');
+    // a typed NON-text block still gets dropped even when it carries text
+    expect(contentToString([{ type: 'reasoning', text: 'inner monologue' }, { type: 'text', text: 'ok' }])).toBe('ok');
+  });
+
   it('handles an array of bare strings (some clients send this)', () => {
     expect(contentToString(['foo', 'bar'])).toBe('foobar');
   });

--- a/server/src/__tests__/routes/proxy-array-content.test.ts
+++ b/server/src/__tests__/routes/proxy-array-content.test.ts
@@ -154,4 +154,60 @@ describe('OpenAI multimodal array content', () => {
     expect(status).not.toBe(400);
     if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
   });
+
+  // #200: code agents (AionUI, OpenCode, Qwen Code) fail on the SECOND request
+  // of a session because their follow-up history carries shapes the strict
+  // schema rejected. Each case below is a real second-turn payload pattern.
+  describe('agent second-turn shapes (#200)', () => {
+    it('accepts Gemini-part-style content blocks without a type field', async () => {
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        messages: [
+          { role: 'user', content: [{ text: 'hi' }] },
+          { role: 'assistant', content: [{ text: 'hello!' }] },
+          { role: 'user', content: [{ text: 'ok' }] },
+        ],
+      }, authHeaders());
+      expect(status).not.toBe(400);
+      if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
+    });
+
+    it('accepts echoed tool_calls without type and with object arguments', async () => {
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        messages: [
+          { role: 'user', content: 'list files' },
+          {
+            role: 'assistant',
+            content: null,
+            // type dropped + arguments already parsed to an object — the way
+            // Gemini-lineage agents replay our tool_calls back at us.
+            tool_calls: [{ id: 'call_1', function: { name: 'ls', arguments: { path: '.' } } }],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: 'file1.ts' },
+          { role: 'user', content: 'thanks' },
+        ],
+      }, authHeaders());
+      expect(status).not.toBe(400);
+      if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
+    });
+
+    it('accepts the developer role (newer OpenAI SDK system prompt)', async () => {
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        messages: [
+          { role: 'developer', content: 'You are a coding agent.' },
+          { role: 'user', content: 'hi' },
+        ],
+      }, authHeaders());
+      expect(status).not.toBe(400);
+      if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
+    });
+
+    it('reports the failing path in 400 validation errors', async () => {
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        messages: [{ role: 'user', content: 42 }],
+      }, authHeaders());
+      expect(status).toBe(400);
+      // Path-qualified detail ("messages.0...") instead of a bare "Invalid input"
+      expect(body.error.message).toMatch(/messages\.0/);
+    });
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -50,7 +50,10 @@ export function createApp() {
       callback(null, !origin || allowedCorsOrigins.has(origin));
     },
   }));
-  app.use(express.json({ limit: '1mb' }));
+  // 10mb: code agents (OpenCode, AionUI, Qwen Code) ship very large system
+  // prompts + tool schemas + repo context; 1mb cut their sessions off
+  // mid-conversation with an opaque 413. (#200)
+  app.use(express.json({ limit: '10mb' }));
 
   // Dashboard auth (#35): /api/auth/{status,setup,login} bootstrap without a
   // session; everything else under /api/* requires a logged-in dashboard user.

--- a/server/src/lib/content.ts
+++ b/server/src/lib/content.ts
@@ -16,7 +16,18 @@ export function contentToString(content: unknown): string {
   if (content == null) return '';
   if (Array.isArray(content)) {
     return content
-      .map((b) => (typeof b === 'string' ? b : (b as ContentTextBlock)?.type === 'text' ? (b as ContentTextBlock).text : ''))
+      .map((b) => {
+        if (typeof b === 'string') return b;
+        const block = b as { type?: string; text?: unknown };
+        // OpenAI blocks carry type:'text'; Gemini-lineage agents (Qwen Code,
+        // AionUI) send part-style `{ text }` with no type at all — accept any
+        // block whose `text` is a string and whose type doesn't say it's
+        // something else. (#200)
+        if (typeof block?.text === 'string' && (block.type === 'text' || block.type === undefined)) {
+          return block.text;
+        }
+        return '';
+      })
       .join('');
   }
   return '';

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -152,26 +152,45 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
 
 const MAX_RETRIES = 20;
 
+// Echo-tolerant tool calls: agents replay OUR responses back as history, and
+// not all of them preserve the strict OpenAI shape. `type` may be dropped
+// (re-added on forward), and Gemini-lineage agents (Qwen Code, AionUI) often
+// send `arguments` as a parsed object instead of a JSON string — both get
+// normalized below rather than 400-ing the whole session. (#200)
 const toolCallSchema = z.object({
   id: z.string().min(1),
-  type: z.literal('function'),
+  type: z.literal('function').optional(),
   function: z.object({
     name: z.string().min(1),
-    arguments: z.string(),
+    arguments: z.union([z.string(), z.record(z.string(), z.unknown())]),
   }),
   thought_signature: z.string().optional(),
 });
 
+const toolCallArgsToString = (args: string | Record<string, unknown>): string =>
+  typeof args === 'string' ? args : JSON.stringify(args);
+
 // OpenAI multimodal envelope. Clients like opencode / continue.dev send
-// content as an array of typed blocks even when only text is present. We
-// accept the envelope on the wire and flatten to string for providers that
-// don't support arrays (Cohere, Cloudflare). Non-text blocks pass z validation
-// but get dropped by contentToString — vision/audio still isn't supported.
-const contentBlockSchema = z.object({ type: z.string() }).passthrough();
+// content as an array of typed blocks even when only text is present, and
+// Gemini-lineage agents send part-style blocks like `{ "text": "..." }` with
+// no `type` at all. Accept any object (or bare string) as a block; flatten to
+// string for providers that don't support arrays (Cohere, Cloudflare).
+// Non-text blocks pass z validation but get dropped by contentToString —
+// vision/audio still isn't supported. (#200)
+const contentBlockSchema = z.union([z.string(), z.record(z.string(), z.unknown())]);
 const contentSchema = z.union([z.string(), z.array(contentBlockSchema)]);
 
 const systemMessageSchema = z.object({
   role: z.literal('system'),
+  content: contentSchema,
+  name: z.string().optional(),
+});
+
+// OpenAI's newer SDKs send the system prompt as role:"developer"; accept it
+// and forward as "system" — none of the routed providers know the developer
+// role. (#200)
+const developerMessageSchema = z.object({
+  role: z.literal('developer'),
   content: contentSchema,
   name: z.string().optional(),
 });
@@ -225,6 +244,7 @@ const toolChoiceSchema = z.union([
 const chatCompletionSchema = z.object({
   messages: z.array(z.union([
     systemMessageSchema,
+    developerMessageSchema,
     userMessageSchema,
     assistantMessageSchema,
     toolMessageSchema,
@@ -345,9 +365,17 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // Validate request
   const parsed = chatCompletionSchema.safeParse(req.body);
   if (!parsed.success) {
+    // Path-qualified issues ("messages.1.content: Invalid input" beats a bare
+    // "Invalid input") and a server-side breadcrumb — these rejections never
+    // reach the request log, which made #200 nearly undebuggable.
+    const detail = parsed.error.errors
+      .map(e => (e.path.length ? `${e.path.join('.')}: ${e.message}` : e.message))
+      .slice(0, 5)
+      .join(', ');
+    console.warn(`[proxy] 400 invalid /chat/completions request: ${detail}`);
     res.status(400).json({
       error: {
-        message: `Invalid request: ${parsed.error.errors.map(e => e.message).join(', ')}`,
+        message: `Invalid request: ${detail}`,
         type: 'invalid_request_error',
       },
     });
@@ -373,8 +401,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         ...(m.name ? { name: m.name } : {}),
         ...(m.tool_calls ? { tool_calls: m.tool_calls.map(tc => ({
           id: tc.id,
-          type: tc.type,
-          function: tc.function,
+          // Normalize echo-tolerant inputs back to the strict OpenAI shape
+          // before forwarding (see toolCallSchema). (#200)
+          type: 'function' as const,
+          function: { name: tc.function.name, arguments: toolCallArgsToString(tc.function.arguments) },
           thought_signature: tc.thought_signature,
         })) } : {}),
       };
@@ -390,7 +420,9 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     }
 
     return {
-      role: m.role,
+      // 'developer' is OpenAI's newer name for the system role — providers
+      // downstream only know 'system'. (#200)
+      role: m.role === 'developer' ? 'system' : m.role,
       content: m.content,
       ...(m.name ? { name: m.name } : {}),
     };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -124,10 +124,12 @@ export type ChatToolChoice =
   };
 
 // OpenAI's multimodal envelope: clients like opencode / continue.dev send
-// content as an array of typed blocks even for text-only messages. We accept
-// it on the wire and flatten to string for providers that don't support it
-// (Cohere, Cloudflare). See server/src/lib/content.ts.
-export type ChatContentBlock = { type: string; text?: string; [key: string]: unknown };
+// content as an array of typed blocks even for text-only messages, and
+// Gemini-lineage agents (Qwen Code, AionUI) send part-style `{ text }` blocks
+// with no `type` — plus bare strings inside arrays. We accept all of it on
+// the wire and flatten to string for providers that don't support arrays
+// (Cohere, Cloudflare). See server/src/lib/content.ts. (#200)
+export type ChatContentBlock = string | { type?: string; text?: string; [key: string]: unknown };
 export type ChatContent = string | null | ChatContentBlock[];
 
 export interface ChatMessage {


### PR DESCRIPTION
Code agents (AionUI, OpenCode, Qwen Code) replay our responses as
history in shapes the strict schema 400-ed on the second request of
every session, with an unhelpful bare 'Invalid input':

- content blocks: accept part-style { text } blocks with no type
  (Gemini-lineage agents) and bare strings inside arrays; flatten
  extracts text from type-less blocks too
- tool_calls echoes: type optional (re-added on forward), arguments
  accepted as object and re-stringified
- role 'developer' accepted, forwarded as 'system'
- 400s now name the failing path (messages.1.content: ...) and leave a
  console breadcrumb — these rejections never hit the request log,
  which is why the issue reported 'request does not appear in logs'
- express.json limit 1mb -> 10mb: agent system prompts + tool schemas
  + repo context exceeded it mid-session with an opaque 413