### PR TITLE
chore: bump better-sqlite3 to ^12.10.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -8,7 +8,7 @@
       "name": "freellmapi-desktop",
       "version": "0.1.0",
       "dependencies": {
-        "better-sqlite3": "^12.4.1"
+        "better-sqlite3": "^12.10.0"
       },
       "devDependencies": {
         "@electron/rebuild": "^3.7.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,7 +16,7 @@
     "dist:win": "npm run build:all && electron-builder --win --x64"
   },
   "dependencies": {
-    "better-sqlite3": "^12.4.1"
+    "better-sqlite3": "^12.10.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13037,10 +13037,10 @@
     },
     "server": {
       "name": "@freellmapi/server",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "dependencies": {
         "@freellmapi/shared": "*",
-        "better-sqlite3": "^12.4.1",
+        "better-sqlite3": "^12.10.0",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.44.2",

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@freellmapi/shared": "*",
-    "better-sqlite3": "^12.4.1",
+    "better-sqlite3": "^12.10.0",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.44.2",


### PR DESCRIPTION
Fresh take on the intent of #199 (closed: branched from stale main).
Lockfiles regenerated on current main; server suite green on 12.10,
desktop native module rebuilt against Electron's ABI.