### PR TITLE
fix(test): resolve vitest cli error and mock leakage

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest run --pool=forks --poolOptions.forks.singleFork=true --no-file-parallelism",
+    "test": "vitest run --pool=forks --fileParallelism=false",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -5,6 +5,7 @@ describe('GoogleProvider', () => {
   let provider: GoogleProvider;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     provider = new GoogleProvider();
   });
 


### PR DESCRIPTION
- Remove invalid `--poolOptions` vitest CLI flag which causes `CACError: Unknown option` in Vitest 3+
- Use supported `--fileParallelism=false` flag to safely run sequential sqlite tests
- Add `vi.clearAllMocks()` to google.test.ts to prevent spy leakage from previously executed sequential test files