### PR TITLE
Custom routing strategy with user-tunable weight sliders

### DIFF
--- a/client/src/components/tooltip.tsx
+++ b/client/src/components/tooltip.tsx
@@ -1,0 +1,55 @@
+import { useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+// Hover tooltip rendered through a portal to document.body, so it's never
+// clipped by an ancestor's overflow (e.g. a table's overflow-x-auto). Position
+// is computed from the trigger's rect and clamped to the viewport. `side`
+// picks which edge it opens from (use 'bottom' under sticky headers).
+export function Tooltip({ text, children, side = 'top', className }: {
+  text: string
+  children: ReactNode
+  side?: 'top' | 'bottom'
+  className?: string
+}) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [coords, setCoords] = useState<{ x: number; y: number } | null>(null)
+
+  function show() {
+    const el = ref.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    const half = 116 // ~half of the w-56 tooltip
+    const x = Math.min(Math.max(r.left + r.width / 2, half + 8), window.innerWidth - half - 8)
+    setCoords({ x, y: side === 'top' ? r.top : r.bottom })
+  }
+  const hide = () => setCoords(null)
+
+  return (
+    <span
+      ref={ref}
+      className={className ?? 'inline-flex'}
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      {children}
+      {coords && createPortal(
+        <span
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            left: coords.x,
+            top: side === 'top' ? coords.y - 8 : coords.y + 8,
+            transform: side === 'top' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
+            zIndex: 9999,
+          }}
+          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md"
+        >
+          {text}
+        </span>,
+        document.body,
+      )}
+    </span>
+  )
+}

--- a/client/src/components/ui/popover.tsx
+++ b/client/src/components/ui/popover.tsx
@@ -1,0 +1,43 @@
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 8,
+  children,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<PopoverPrimitive.Positioner.Props, "align" | "side" | "sideOffset">) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        sideOffset={sideOffset}
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 w-72 origin-(--transform-origin) rounded-xl bg-popover p-4 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </PopoverPrimitive.Popup>
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -8,6 +8,7 @@ import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/page-header'
+import { Tooltip as HoverTooltip } from '@/components/tooltip'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
 type TimeRange = '24h' | '7d' | '30d'
@@ -20,19 +21,15 @@ function formatTokens(n?: number): string {
 }
 
 function Stat({ label, value, hint, className }: { label: string; value: string | number; hint?: string; className?: string }) {
-  return (
-    <div className="relative group rounded-3xl border bg-card px-4 py-3">
+  const card = (
+    <div className="rounded-3xl border bg-card px-4 py-3">
       <p className="text-[11px] text-muted-foreground uppercase tracking-wider">{label}</p>
       <p className={`text-xl font-semibold tabular-nums mt-1 ${className ?? ''}`}>{value}</p>
-      {hint && (
-        // Opens BELOW the card: the stats row sits right under the sticky
-        // navbar, and an upward tooltip slides beneath it.
-        <div className="pointer-events-none absolute left-1/2 -translate-x-1/2 top-full mt-1.5 hidden group-hover:block z-50 w-56 rounded-lg border bg-popover px-3 py-2 text-xs leading-relaxed text-popover-foreground shadow-md">
-          {hint}
-        </div>
-      )}
     </div>
   )
+  // Same portal tooltip as the routing strategy chips. Opens BELOW the card:
+  // the stats row sits right under the sticky navbar.
+  return hint ? <HoverTooltip text={hint} side="bottom" className="block">{card}</HoverTooltip> : card
 }
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }) {

--- a/client/src/pages/EmbeddingsPage.tsx
+++ b/client/src/pages/EmbeddingsPage.tsx
@@ -111,7 +111,7 @@ export default function EmbeddingsPage() {
     <div>
       <PageHeader
         title="Models"
-        description="Embeddings fail over within a family only — the same model served by another provider. Vectors from different models are incompatible, so the router never swaps models on you."
+        description="Embeddings fail over within a family only: the same model served by another provider. Vectors from different models are incompatible, so the router never swaps models on you."
         divider={false}
         actions={<ModelsTabs />}
       />

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState, useRef, type ReactNode } from 'react'
-import { createPortal } from 'react-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   DndContext,
@@ -18,13 +17,15 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, SlidersHorizontal } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import { FloatingBar } from '@/components/floating-bar'
 import { ModelsTabs } from '@/components/models-tabs'
+import { Tooltip } from '@/components/tooltip'
 
 interface FallbackEntry {
   modelDbId: number
@@ -47,7 +48,9 @@ interface FallbackEntry {
   keyCount: number
 }
 
-type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable'
+type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom'
+
+type RoutingWeights = { reliability: number; speed: number; intelligence: number }
 
 interface RoutingScore {
   modelDbId: number
@@ -62,7 +65,8 @@ interface RoutingScore {
 
 interface RoutingData {
   strategy: RoutingStrategy
-  weights: { reliability: number; speed: number; intelligence: number } | null
+  weights: RoutingWeights | null
+  customWeights: RoutingWeights
   scores: (RoutingScore & { platform: string; modelId: string; displayName: string; enabled: boolean })[]
 }
 
@@ -70,12 +74,114 @@ interface RoutingData {
 type Row = FallbackEntry & Partial<RoutingScore>
 
 const STRATEGIES: { key: RoutingStrategy; label: string; blurb: string }[] = [
-  { key: 'priority', label: 'Manual', blurb: 'Route in the exact order you set below. Drag the handles to reorder. No scoring — the chain is followed top-to-bottom.' },
+  { key: 'priority', label: 'Manual', blurb: 'Route in the exact order you set below. Drag the handles to reorder. No scoring; the chain is followed top-to-bottom.' },
   { key: 'balanced', label: 'Balanced', blurb: 'Reliability leads (50%), with speed and intelligence weighted equally (25% each). A sensible all-round default.' },
   { key: 'smartest', label: 'Smartest', blurb: 'Prefer the most capable model that still works. Intelligence 55%, reliability 35%, speed 10%.' },
   { key: 'fastest', label: 'Fastest', blurb: 'Prefer the fastest model that still works. Speed 55%, reliability 35%, intelligence 10%.' },
   { key: 'reliable', label: 'Most reliable', blurb: 'Maximize success rate above all. Reliability 70%, speed and intelligence 15% each.' },
+  { key: 'custom', label: 'Custom', blurb: 'Set your own balance of reliability, speed and intelligence with sliders. Same engine as the presets, just your weights.' },
 ]
+
+// Slider axes share the colors used by the score table columns below.
+const WEIGHT_AXES: { key: keyof RoutingWeights; label: string; color: string }[] = [
+  { key: 'reliability', label: 'Reliability', color: '#22c55e' },
+  { key: 'speed', label: 'Speed', color: '#3b82f6' },
+  { key: 'intelligence', label: 'Intelligence', color: '#a855f7' },
+]
+
+// Slider popover for the 'custom' strategy. Sliders are independent (0-100)
+// and the server renormalizes any vector, so we just show each axis's
+// effective share live. Nothing is saved until Apply is pressed.
+function CustomWeightsPopover({ saved, onSave, saving }: {
+  saved: RoutingWeights
+  onSave: (w: RoutingWeights) => void
+  saving: boolean
+}) {
+  const [values, setValues] = useState<RoutingWeights>(() => fromSaved(saved))
+  const [dirty, setDirty] = useState(false)
+
+  function fromSaved(w: RoutingWeights): RoutingWeights {
+    return {
+      reliability: Math.round(w.reliability * 100),
+      speed: Math.round(w.speed * 100),
+      intelligence: Math.round(w.intelligence * 100),
+    }
+  }
+
+  function update(key: keyof RoutingWeights, v: number) {
+    setValues({ ...values, [key]: v })
+    setDirty(true)
+  }
+
+  function apply() {
+    if (sum <= 0) return
+    onSave({
+      reliability: values.reliability / 100,
+      speed: values.speed / 100,
+      intelligence: values.intelligence / 100,
+    })
+    setDirty(false)
+  }
+
+  const sum = values.reliability + values.speed + values.intelligence
+
+  return (
+    <Popover onOpenChange={open => { if (open) { setValues(fromSaved(saved)); setDirty(false) } }}>
+      <PopoverTrigger className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">
+        <SlidersHorizontal className="size-3.5" />
+        Adjust
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80">
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-sm font-medium">Custom weights</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Sliders are independent; shares auto-balance to 100%.
+            </p>
+          </div>
+          {WEIGHT_AXES.map(axis => {
+            const share = sum > 0 ? Math.round((values[axis.key] / sum) * 100) : 0
+            return (
+              <div key={axis.key}>
+                <div className="mb-1 flex items-baseline justify-between text-xs">
+                  <span className="inline-flex items-center gap-1.5">
+                    <span className="size-2 rounded-sm" style={{ background: axis.color }} />
+                    {axis.label}
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">{share}%</span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={1}
+                  value={values[axis.key]}
+                  onChange={e => update(axis.key, Number(e.target.value))}
+                  className="w-full cursor-pointer"
+                  style={{ accentColor: axis.color }}
+                  aria-label={`${axis.label} weight`}
+                />
+              </div>
+            )
+          })}
+          {sum <= 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              At least one weight must be above zero.
+            </p>
+          )}
+          <Button
+            size="sm"
+            className="w-full"
+            disabled={!dirty || sum <= 0 || saving}
+            onClick={apply}
+          >
+            {saving ? 'Applying…' : dirty ? 'Apply' : 'Applied'}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
@@ -107,47 +213,6 @@ const platformColors: Record<string, string> = {
   pollinations: '#a855f7',
   llm7:        '#0ea5e9',
   huggingface: '#ff9d00',
-}
-
-// Hover tooltip rendered through a portal to document.body, so it's never
-// clipped by an ancestor's overflow (e.g. the table's overflow-x-auto). Position
-// is computed from the trigger's rect and clamped to the viewport.
-function Tooltip({ text, children }: { text: string; children: ReactNode }) {
-  const ref = useRef<HTMLSpanElement>(null)
-  const [coords, setCoords] = useState<{ x: number; y: number } | null>(null)
-
-  function show() {
-    const el = ref.current
-    if (!el) return
-    const r = el.getBoundingClientRect()
-    const half = 116 // ~half of the w-56 tooltip
-    const x = Math.min(Math.max(r.left + r.width / 2, half + 8), window.innerWidth - half - 8)
-    setCoords({ x, y: r.top })
-  }
-  const hide = () => setCoords(null)
-
-  return (
-    <span
-      ref={ref}
-      className="inline-flex"
-      onMouseEnter={show}
-      onMouseLeave={hide}
-      onFocus={show}
-      onBlur={hide}
-    >
-      {children}
-      {coords && createPortal(
-        <span
-          role="tooltip"
-          style={{ position: 'fixed', left: coords.x, top: coords.y - 8, transform: 'translate(-50%, -100%)', zIndex: 9999 }}
-          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md"
-        >
-          {text}
-        </span>,
-        document.body,
-      )}
-    </span>
-  )
 }
 
 // A 0..1 value as a thin horizontal bar with the number beside it.
@@ -211,7 +276,7 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
         {modelsWithWidth.map((m, i) => (
           <div
             key={i}
-            title={`${m.displayName} (${m.platform}) — ${formatTokens(m.remainingTokens)} remaining`}
+            title={`${m.displayName} (${m.platform}): ${formatTokens(m.remainingTokens)} remaining`}
             style={{
               width: `${m.widthPct}%`,
               backgroundColor: platformColors[m.platform] ?? '#94a3b8',
@@ -220,7 +285,7 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
         ))}
         {totalUsed > 0 && (
           <div
-            title={`Used — ${formatTokens(totalUsed)}`}
+            title={`Used: ${formatTokens(totalUsed)}`}
             className="bg-muted-foreground/30"
             style={{ width: `${usedPct}%` }}
           />
@@ -295,7 +360,7 @@ function RowContent({
           )}
           {row.supportsTools && (
             <span
-              title="Emits structured tool calls — eligible for tool-bearing requests"
+              title="Emits structured tool calls, so it is eligible for tool-bearing requests"
               className="text-[10px] rounded-full px-1.5 py-0.5 bg-violet-600/15 text-violet-700 dark:bg-violet-400/15 dark:text-violet-400"
             >
               Tools
@@ -387,8 +452,8 @@ export default function FallbackPage() {
   })
 
   const strategyMutation = useMutation({
-    mutationFn: (strategy: RoutingStrategy) =>
-      apiFetch('/api/fallback/routing', { method: 'PUT', body: JSON.stringify({ strategy }) }),
+    mutationFn: (payload: { strategy: RoutingStrategy; weights?: RoutingWeights }) =>
+      apiFetch('/api/fallback/routing', { method: 'PUT', body: JSON.stringify(payload) }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['fallback', 'routing'] }),
   })
 
@@ -494,12 +559,12 @@ export default function FallbackPage() {
             )}
           </div>
 
-          <div className="inline-flex flex-wrap gap-1 rounded-xl border p-1">
+          <div className="inline-flex flex-wrap items-center gap-1 rounded-xl border p-1">
             {STRATEGIES.map(s => (
               <Tooltip key={s.key} text={s.blurb}>
                 <button
                   disabled={strategyMutation.isPending}
-                  onClick={() => strategyMutation.mutate(s.key)}
+                  onClick={() => strategyMutation.mutate({ strategy: s.key })}
                   className={`px-3 py-1.5 text-xs rounded-lg transition-colors ${
                     s.key === strategy
                       ? 'bg-foreground text-background font-medium'
@@ -510,6 +575,13 @@ export default function FallbackPage() {
                 </button>
               </Tooltip>
             ))}
+            {strategy === 'custom' && routing && (
+              <CustomWeightsPopover
+                saved={routing.customWeights}
+                saving={strategyMutation.isPending}
+                onSave={w => strategyMutation.mutate({ strategy: 'custom', weights: w })}
+              />
+            )}
           </div>
 
           <p className="mt-2 text-xs text-muted-foreground">

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -141,7 +141,7 @@ function UnifiedKeySection() {
       {isError ? (
         <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2.5 text-xs text-destructive">
           Can't reach the server on <code className="font-mono">{baseUrl.replace('/v1', '')}</code>. Make sure the
-          backend is running — <code className="font-mono">npm run dev</code> starts both, and the server logs print
+          backend is running. <code className="font-mono">npm run dev</code> starts both, and the server logs print
           under the <code className="font-mono">server</code> prefix.
         </div>
       ) : (
@@ -166,7 +166,7 @@ function UnifiedKeySection() {
         <span className="text-muted-foreground">Responses</span>
         <code className="font-mono">/v1/responses</code>
         <span className="text-muted-foreground">Embeddings</span>
-        <code className="font-mono">/v1/embeddings <span className="text-muted-foreground">— model: "auto" or a family from the Embeddings tab</span></code>
+        <code className="font-mono">/v1/embeddings <span className="text-muted-foreground">(model: "auto" or a family from the Embeddings tab)</span></code>
       </div>
     </section>
   )
@@ -202,7 +202,7 @@ function CustomProviderSection() {
     <section>
       <h2 className="text-sm font-medium mb-1">Add a custom OpenAI-compatible model</h2>
       <p className="text-xs text-muted-foreground mb-3">
-        Point at any OpenAI-compatible endpoint — llama.cpp, LM Studio, vLLM, a local Ollama, or a remote
+        Point at any OpenAI-compatible endpoint: llama.cpp, LM Studio, vLLM, a local Ollama, or a remote
         gateway. Add each model you want routed; they all share the one endpoint. The API key is optional
         (most local servers don't need one).
       </p>
@@ -443,7 +443,7 @@ export default function KeysPage() {
               />
               {isKeyless && (
                 <p className="text-[11px] text-muted-foreground">
-                  No API key needed — this provider's free tier is anonymous (rate-limited per IP).
+                  No API key needed: this provider's free tier is anonymous (rate-limited per IP).
                 </p>
               )}
             </div>

--- a/server/src/__tests__/services/router-bandit.test.ts
+++ b/server/src/__tests__/services/router-bandit.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   routeRequest, refreshStatsCache, getRoutingStrategy, setRoutingStrategy, getRoutingScores,
+  getCustomWeights, setCustomWeights,
 } from '../../services/router.js';
 import * as ratelimit from '../../services/ratelimit.js';
 import { getDb, initDb } from '../../db/index.js';
@@ -143,6 +144,40 @@ describe('bandit router', () => {
     refreshStatsCache(getDb(), true);
     const fastRun = pickCounts(300);
     expect((fastRun['fast'] ?? 0)).toBeGreaterThan(fastRun['smart'] ?? 0);
+  });
+
+  it('custom weights persist normalized; default to balanced until saved', () => {
+    expect(getCustomWeights()).toEqual({ reliability: 0.5, speed: 0.25, intelligence: 0.25 });
+    setCustomWeights({ reliability: 0.6, speed: 0.3, intelligence: 0.1 });
+    const w = getCustomWeights();
+    expect(w.reliability).toBeCloseTo(0.6, 10);
+    expect(w.speed).toBeCloseTo(0.3, 10);
+    expect(w.intelligence).toBeCloseTo(0.1, 10);
+    // Non-normalized input is normalized on save.
+    setCustomWeights({ reliability: 1, speed: 1, intelligence: 0 });
+    expect(getCustomWeights()).toEqual({ reliability: 0.5, speed: 0.5, intelligence: 0 });
+  });
+
+  it('custom weights reject all-zero and negative vectors', () => {
+    expect(() => setCustomWeights({ reliability: 0, speed: 0, intelligence: 0 })).toThrow();
+    expect(() => setCustomWeights({ reliability: -1, speed: 1, intelligence: 1 })).toThrow();
+  });
+
+  it('custom strategy routes with the saved weights (extreme speed wins)', () => {
+    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 9, sizeLabel: 'Small', budget: '~50M', priority: 2 });
+    addHistory('google', 'smart', { successes: 40, failures: 1, outTokens: 100, latencyMs: 3000, ttfbMs: 2500 });
+    addHistory('groq', 'fast', { successes: 40, failures: 1, outTokens: 1000, latencyMs: 1000, ttfbMs: 150 });
+
+    setRoutingStrategy('custom');
+    setCustomWeights({ reliability: 0.1, speed: 0.9, intelligence: 0 });
+    refreshStatsCache(getDb(), true);
+    const counts = pickCounts(300);
+    expect((counts['fast'] ?? 0)).toBeGreaterThan(counts['smart'] ?? 0);
+
+    const { strategy, weights } = getRoutingScores();
+    expect(strategy).toBe('custom');
+    expect(weights).toEqual({ reliability: 0.1, speed: 0.9, intelligence: 0 });
   });
 
   it('getRoutingScores returns a per-axis breakdown ranked by score', () => {

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -2,33 +2,47 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
-import { getAllPenalties, getRoutingScores, getRoutingStrategy, setRoutingStrategy } from '../services/router.js';
+import { getAllPenalties, getCustomWeights, getRoutingScores, getRoutingStrategy, setCustomWeights, setRoutingStrategy } from '../services/router.js';
 import { BANDIT_PRESETS, type RoutingStrategy } from '../services/scoring.js';
 import { parseBudget } from '../lib/budget.js';
 
 export const fallbackRouter = Router();
 
 // ── Bandit routing strategy ─────────────────────────────────────────────────
-// GET  /routing → active strategy, preset weights, and the per-model score
-//                 breakdown (reliability / speed / intelligence + guardrails).
+// GET  /routing → active strategy, preset weights, the saved custom weights,
+//                 and the per-model score breakdown (reliability / speed /
+//                 intelligence + guardrails).
 fallbackRouter.get('/routing', (_req: Request, res: Response) => {
-  res.json(getRoutingScores());
+  res.json({ ...getRoutingScores(), customWeights: getCustomWeights() });
 });
 
 const routingSchema = z.object({
-  strategy: z.enum(['priority', 'balanced', 'smartest', 'fastest', 'reliable']),
+  strategy: z.enum(['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom']),
+  // Only meaningful with strategy 'custom'. Any non-negative vector with a
+  // positive sum is accepted; the server normalizes it to sum to 1.
+  weights: z.object({
+    reliability: z.number().min(0).max(1),
+    speed: z.number().min(0).max(1),
+    intelligence: z.number().min(0).max(1),
+  }).refine(w => w.reliability + w.speed + w.intelligence > 0, {
+    message: 'weights must not all be zero',
+  }).optional(),
 });
 
 // PUT /routing → switch strategy. Presets are just weight vectors over the three
-// axes; 'priority' falls back to the legacy manual chain order.
+// axes; 'custom' uses the user-saved vector; 'priority' falls back to the legacy
+// manual chain order.
 fallbackRouter.put('/routing', (req: Request, res: Response) => {
   const parsed = routingSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
     return;
   }
+  if (parsed.data.strategy === 'custom' && parsed.data.weights) {
+    setCustomWeights(parsed.data.weights);
+  }
   setRoutingStrategy(parsed.data.strategy as RoutingStrategy);
-  res.json({ strategy: getRoutingStrategy(), presets: BANDIT_PRESETS });
+  res.json({ strategy: getRoutingStrategy(), presets: BANDIT_PRESETS, customWeights: getCustomWeights() });
 });
 
 // Get fallback chain (with dynamic penalties)

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -139,7 +139,8 @@ export function getAllPenalties(): Array<{ modelDbId: number; count: number; pen
 
 // ── Routing strategy (persisted) ────────────────────────────────────────────
 const STRATEGY_KEY = 'routing_strategy';
-const VALID_STRATEGIES: RoutingStrategy[] = ['priority', 'balanced', 'smartest', 'fastest', 'reliable'];
+const CUSTOM_WEIGHTS_KEY = 'routing_custom_weights';
+const VALID_STRATEGIES: RoutingStrategy[] = ['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom'];
 
 export function getRoutingStrategy(): RoutingStrategy {
   const raw = getSetting(STRATEGY_KEY);
@@ -155,8 +156,47 @@ export function setRoutingStrategy(strategy: RoutingStrategy): void {
   setSetting(STRATEGY_KEY, strategy);
 }
 
+// ── Custom weights (persisted) ──────────────────────────────────────────────
+// User-tuned weight vector for the 'custom' strategy. Stored normalized (sums
+// to 1) so the dashboard percentages read cleanly; combineScore would tolerate
+// any non-negative vector regardless. Falls back to the balanced preset until
+// the user has saved their own.
+export function getCustomWeights(): RoutingWeights {
+  const raw = getSetting(CUSTOM_WEIGHTS_KEY);
+  if (raw) {
+    try {
+      const w = JSON.parse(raw) as RoutingWeights;
+      if (
+        [w.reliability, w.speed, w.intelligence].every(v => Number.isFinite(v) && v >= 0) &&
+        w.reliability + w.speed + w.intelligence > 0
+      ) {
+        return { reliability: w.reliability, speed: w.speed, intelligence: w.intelligence };
+      }
+    } catch { /* corrupt setting → fall through to default */ }
+  }
+  return { ...BANDIT_PRESETS.balanced };
+}
+
+export function setCustomWeights(weights: RoutingWeights): void {
+  const { reliability, speed, intelligence } = weights;
+  if (![reliability, speed, intelligence].every(v => Number.isFinite(v) && v >= 0)) {
+    throw new Error('Custom weights must be non-negative numbers');
+  }
+  const sum = reliability + speed + intelligence;
+  if (sum <= 0) {
+    throw new Error('Custom weights must not all be zero');
+  }
+  setSetting(CUSTOM_WEIGHTS_KEY, JSON.stringify({
+    reliability: reliability / sum,
+    speed: speed / sum,
+    intelligence: intelligence / sum,
+  }));
+}
+
 function weightsFor(strategy: RoutingStrategy): RoutingWeights | null {
-  return strategy === 'priority' ? null : BANDIT_PRESETS[strategy];
+  if (strategy === 'priority') return null;
+  if (strategy === 'custom') return getCustomWeights();
+  return BANDIT_PRESETS[strategy];
 }
 
 // ── Analytics stats cache (decay-weighted) ──────────────────────────────────

--- a/server/src/services/scoring.ts
+++ b/server/src/services/scoring.ts
@@ -28,11 +28,12 @@ export interface RoutingWeights {
   intelligence: number;
 }
 
-// Strategy is either the legacy manual chain ('priority') or one of the bandit
-// presets. Each preset is just a weight vector — the engine is identical.
-export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable';
+// Strategy is either the legacy manual chain ('priority'), one of the bandit
+// presets, or 'custom' (a user-tuned weight vector persisted in settings — see
+// router.ts). Each is just a weight vector — the engine is identical.
+export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom';
 
-export const BANDIT_PRESETS: Record<Exclude<RoutingStrategy, 'priority'>, RoutingWeights> = {
+export const BANDIT_PRESETS: Record<Exclude<RoutingStrategy, 'priority' | 'custom'>, RoutingWeights> = {
   // Reliability leads; speed and intelligence split the rest evenly.
   balanced: { reliability: 0.5, speed: 0.25, intelligence: 0.25 },
   // Intelligence leads, but reliability still carries real weight so a smart


### PR DESCRIPTION
## What

Adds a **Custom** routing strategy: instead of picking a fixed preset (Balanced / Smartest / Fastest / Most reliable), you set your own balance of reliability, speed and intelligence with sliders in a popover on the Models page.

- The scoring engine already accepts any weight vector (`combineScore` renormalizes), so this is the same bandit with user weights; guardrails (quota headroom, rate-limit damping) still apply on top
- Weights persist server-side (`routing_custom_weights` setting), normalized to sum to 1, validated non-negative and not all zero
- Sliders are independent (0-100 each) and show the live normalized share per axis; changes apply with an explicit **Apply** button
- Shared portal tooltip component extracted; the Analytics savings hint now uses the same dark tooltip as the routing chips
- Em dashes removed from user-facing copy

## Testing

- 3 new server tests (persistence/normalization, validation, routing with extreme weights); 335 server tests green
- Verified end-to-end in the running app with Playwright: chip selection, slider drags fire no PUT until Apply, Apply updates header shares and re-ranks the score table live, weights survive reload, all-zero is blocked client- and server-side (400)