### PR TITLE
fix(proxy): accept tool_calls: null on assistant echoes (aionrs/AionUI session replay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/Tazrif-Raim"><img src="https://images.weserv.nl/?url=github.com/Tazrif-Raim.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Tazrif-Raim" /></a>
 <a href="https://github.com/m1nuzz"><img src="https://images.weserv.nl/?url=github.com/m1nuzz.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@m1nuzz" /></a>
 <a href="https://github.com/LoneRifle"><img src="https://images.weserv.nl/?url=github.com/LoneRifle.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@LoneRifle" /></a>
+<a href="https://github.com/ita333"><img src="https://images.weserv.nl/?url=github.com/ita333.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@ita333" /></a>
 
 ## Terms of Service review
 

--- a/server/src/__tests__/routes/proxy-array-content.test.ts
+++ b/server/src/__tests__/routes/proxy-array-content.test.ts
@@ -277,5 +277,73 @@ describe('OpenAI multimodal array content', () => {
       expect(status).not.toBe(400);
       if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
     });
+
+    it('accepts an assistant echo with tool_calls: null (aionrs/AionUI session replay)', async () => {
+      // The exact second-turn shape captured from aionrs v0.1.28 (AionUI's
+      // engine): resumed sessions replay the assistant turn with an explicit
+      // tool_calls: null plus a reasoning_content side field.
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        max_tokens: 8192,
+        messages: [
+          { role: 'system', content: 'You are an AI assistant.' },
+          { role: 'user', content: 'ciao' },
+          {
+            role: 'assistant',
+            content: 'Ciao! Come posso aiutarti oggi?',
+            reasoning_content: 'The user is greeting me in Italian.',
+            tool_calls: null,
+          },
+          { role: 'user', content: 'Che modello sei' },
+        ],
+      }, authHeaders());
+      expect(status).not.toBe(400);
+      if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
+    });
+
+    it('accepts null top-level tool knobs (tools, tool_choice, parallel_tool_calls)', async () => {
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        tools: null,
+        tool_choice: null,
+        parallel_tool_calls: null,
+        messages: [{ role: 'user', content: 'hi' }],
+      }, authHeaders());
+      expect(status).not.toBe(400);
+      if (status === 400) throw new Error(`unexpected 400: ${JSON.stringify(body)}`);
+    });
+
+    it('drops null/empty tool_calls instead of forwarding them upstream', async () => {
+      const origFetch = global.fetch;
+      vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+          const body = JSON.parse(String((init as RequestInit).body));
+          // Strict upstreams reject tool_calls: null AND tool_calls: [] —
+          // neither may survive normalization.
+          expect(body.messages[1]).not.toHaveProperty('tool_calls');
+          expect(body.messages[2]).not.toHaveProperty('tool_calls');
+          return {
+            ok: true,
+            json: () => Promise.resolve({
+              id: 'chatcmpl-nulltc', object: 'chat.completion', created: 1, model: 'openai/gpt-oss-120b',
+              choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+              usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+            }),
+          } as any;
+        }
+        return origFetch(url, init);
+      });
+
+      const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+        model: 'auto',
+        messages: [
+          { role: 'user', content: 'ciao' },
+          { role: 'assistant', content: 'Ciao!', tool_calls: null },
+          { role: 'assistant', content: 'ancora', tool_calls: [] },
+          { role: 'user', content: 'Che modello sei' },
+        ],
+      }, authHeaders());
+      expect(status).toBe(200);
+      expect(body.choices[0].message.content).toBe('ok');
+    });
   });
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -213,7 +213,10 @@ const assistantMessageSchema = z.object({
   role: z.literal('assistant'),
   content: z.union([contentSchema, z.null()]).optional(),
   name: z.string().optional(),
-  tool_calls: z.array(toolCallSchema).optional(),
+  // tool_calls: null (not just missing) is what several agents replay for
+  // no-tool assistant turns — aionrs (AionUI's engine) writes it into every
+  // session-resumed assistant echo. Treated as absent. (#200)
+  tool_calls: z.array(toolCallSchema).nullable().optional(),
 });
 
 // Tool results may arrive with null/missing content (a tool that returned
@@ -274,9 +277,12 @@ const chatCompletionSchema = z.object({
   max_tokens: z.number().int().optional(),
   top_p: z.number().min(0).max(1).optional(),
   stream: z.boolean().optional(),
-  tools: z.array(toolDefinitionSchema).optional(),
-  tool_choice: toolChoiceSchema.optional(),
-  parallel_tool_calls: z.boolean().optional(),
+  // Top-level tool knobs may arrive as explicit nulls from clients that
+  // serialize every field of their request struct; all treated as absent
+  // and never forwarded as null. (#200)
+  tools: z.array(toolDefinitionSchema).nullable().optional(),
+  tool_choice: toolChoiceSchema.nullable().optional(),
+  parallel_tool_calls: z.boolean().nullable().optional(),
 });
 
 export function isRetryableError(err: any): boolean {
@@ -402,14 +408,15 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     return;
   }
 
-  const { model: requestedModel, temperature, top_p, stream, parallel_tool_calls } = parsed.data;
+  const { model: requestedModel, temperature, top_p, stream } = parsed.data;
   // Agent-tolerant knob normalization (#200): max_tokens <= 0 means "no
   // limit" in several clients → unset; tool_choice 'any' is OpenAI's
   // 'required'; tool definitions get their 'function' type re-defaulted.
   const max_tokens = parsed.data.max_tokens != null && parsed.data.max_tokens > 0
     ? parsed.data.max_tokens : undefined;
-  const tool_choice = parsed.data.tool_choice === 'any' ? 'required' as const : parsed.data.tool_choice;
+  const tool_choice = parsed.data.tool_choice === 'any' ? 'required' as const : parsed.data.tool_choice ?? undefined;
   const tools = parsed.data.tools?.map(t => ({ ...t, type: 'function' as const }));
+  const parallel_tool_calls = parsed.data.parallel_tool_calls ?? undefined;
 
   // Pairing state for id-less tool calls (#200): every tool_call id (given or
   // synthesized) queues up here; a tool message without a tool_call_id takes
@@ -442,7 +449,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         role: 'assistant',
         content: assistantContent,
         ...(m.name ? { name: m.name } : {}),
-        ...(m.tool_calls ? { tool_calls: m.tool_calls.map(tc => {
+        // hasToolCalls (not a bare truthiness check) so null AND empty-array
+        // tool_calls are dropped rather than forwarded — strict upstreams
+        // reject both shapes. (#200)
+        ...(hasToolCalls ? { tool_calls: m.tool_calls!.map(tc => {
           // Normalize echo-tolerant inputs back to the strict OpenAI shape
           // before forwarding (see toolCallSchema); synthesize missing ids
           // and queue every id for order-based tool-result pairing. (#200)


### PR DESCRIPTION
## Issue #200, round 3

@ita333's report after the round-2 fixes was real. Reproduced it with the actual agent binary, not just synthetic payloads.

### Reproduction

AionUI's bundled agent engine is **aionrs** ("Aion CLI", a Rust engine — the `Aionrs agent error:` prefix in the report comes from AionUI's wrapper). Built aionrs v0.1.28 (the exact version AionUI pins) from source and pointed it at a local server on current main:

- Turn 1 (`ciao`) → works
- Turn 2 (`Che modello sei`, session resumed) → **`400 Invalid request: messages.2: Invalid input`** — byte-for-byte the error in the issue

### Root cause

Captured the turn-2 payload. aionrs replays resumed sessions with an explicit `tool_calls: null` on every assistant echo:

```json
{
  "role": "assistant",
  "content": "Ciao! Come posso aiutarti oggi?",
  "reasoning_content": "...",
  "tool_calls": null
}
```

Our assistant schema accepted a *missing* `tool_calls` but not an explicit `null`, so the message failed the role union and the request 400'd. (The `reasoning_content` side field was already tolerated — non-strict schema strips it.)

### Fix

- `tool_calls` on assistant messages: nullable, null treated as absent
- Top-level `tools` / `tool_choice` / `parallel_tool_calls`: nullable too, normalized to `undefined` so a null is never forwarded upstream
- Forward guard switched from truthiness to `hasToolCalls`, so an *empty* `tool_calls` array is also dropped instead of forwarded to strict upstreams

### Verification

- The exact aionrs session that 400'd now completes turns 2 and 3 against the fixed server (real binary, real provider traffic)
- 3 new regression tests including the captured payload shape; 348 server tests passing