### PR TITLE
a picture is worth a thousand tokens — image generation via OpenRouter

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import KeysPage from '@/pages/KeysPage'
 import PlaygroundPage from '@/pages/PlaygroundPage'
 import FallbackPage from '@/pages/FallbackPage'
 import EmbeddingsPage from '@/pages/EmbeddingsPage'
+import ImageModelsPage from '@/pages/ImageModelsPage'
 import AnalyticsPage from '@/pages/AnalyticsPage'
 
 const queryClient = new QueryClient()
@@ -200,6 +201,7 @@ function App() {
                 <Route path="/models" element={<Navigate to="/models/chat" replace />} />
                 <Route path="/models/chat" element={<FallbackPage />} />
                 <Route path="/models/embeddings" element={<EmbeddingsPage />} />
+                <Route path="/models/images" element={<ImageModelsPage />} />
                 <Route path="/playground" element={<PlaygroundPage />} />
                 <Route path="/keys" element={<KeysPage />} />
                 <Route path="/fallback" element={<Navigate to="/models/chat" replace />} />

--- a/client/src/components/models-tabs.tsx
+++ b/client/src/components/models-tabs.tsx
@@ -11,8 +11,9 @@ export function ModelsTabs() {
     }`
   return (
     <div className="inline-flex gap-1 rounded-xl border p-1">
-      <NavLink to="/models/chat" className={({ isActive }) => tab(isActive)}>Chat models</NavLink>
+      <NavLink to="/models/chat" className={({ isActive }) => tab(isActive)}>Chat</NavLink>
       <NavLink to="/models/embeddings" className={({ isActive }) => tab(isActive)}>Embeddings</NavLink>
+      <NavLink to="/models/images" className={({ isActive }) => tab(isActive)}>Images</NavLink>
     </div>
   )
 }

--- a/client/src/pages/ImageModelsPage.tsx
+++ b/client/src/pages/ImageModelsPage.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import { PageHeader } from '@/components/page-header'
+import { ModelsTabs } from '@/components/models-tabs'
+import { Tooltip } from '@/components/tooltip'
+import { Button } from '@/components/ui/button'
+
+export interface ImageModel {
+  slug: string
+  name: string
+  shortName: string
+  author: string
+  authorDisplayName: string
+  description: string
+  contextLength: number
+  inputModalities: string[]
+  outputModalities: string[]
+  supportsReasoning: boolean
+  isFree: boolean
+  pricing: { prompt: string; completion: string } | null
+  rpmLimit: number | null
+  rpdLimit: number | null
+  providerDisplayName: string
+  providerSlug: string
+  hasKey: boolean
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export default function ImageModelsPage() {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const { data: models = [], isLoading } = useQuery<ImageModel[]>({
+    queryKey: ['image-models'],
+    queryFn: () => apiFetch('/api/image-models'),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  return (
+    <div>
+      <PageHeader
+        title="Models"
+        description="Image generation models available via OpenRouter. Only OpenRouter supports text-to-image at the moment."
+        divider={false}
+        actions={<ModelsTabs />}
+      />
+
+      <div className="space-y-4">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading image models…</p>
+        ) : models.length === 0 ? (
+          <div className="rounded-3xl border border-dashed p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No image generation models found on OpenRouter.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium">{models.length}</span> free image models available via{' '}
+              <code className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px]">OpenRouter</code>.
+            </p>
+
+            <div className="rounded-2xl border overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-muted-foreground border-b">
+                    <th className="py-2.5 pl-4 pr-3 font-medium">Model</th>
+                    <th className="py-2.5 pr-3 font-medium">
+                      <Tooltip text="Maximum context length in tokens">
+                        <span className="underline decoration-dotted underline-offset-2 cursor-help">Context</span>
+                      </Tooltip>
+                    </th>
+                    <th className="py-2.5 pr-4 font-medium">Input</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {models.map(m => {
+                    const isCopied = copied === m.slug
+                    return (
+                      <tr key={m.slug} className="border-b last:border-0 transition-colors">
+                        <td className="py-2.5 pl-4 pr-3">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-medium text-sm">{m.shortName}</span>
+                            {m.supportsReasoning && (
+                              <span
+                                title="Supports chain-of-thought reasoning"
+                                className="text-[10px] rounded-full px-1.5 py-0.5 bg-violet-600/15 text-violet-700 dark:bg-violet-400/15 dark:text-violet-400"
+                              >
+                                Reasoning
+                              </span>
+                            )}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-6 px-2 text-[10px]"
+                              onClick={() => {
+                                navigator.clipboard.writeText(m.slug)
+                                setCopied(m.slug)
+                                setTimeout(() => setCopied(null), 2000)
+                              }}
+                            >
+                              {isCopied ? 'Copied' : 'Copy'}
+                            </Button>
+                          </div>
+                          <div className="text-[11px] text-muted-foreground/70 font-mono mt-0.5">{m.slug}</div>
+                        </td>
+                        <td className="py-2.5 pr-3 font-mono text-xs text-muted-foreground tabular-nums">
+                          {m.contextLength > 0 ? formatNumber(m.contextLength) : '–'}
+                        </td>
+                        <td className="py-2.5 pr-4">
+                          <div className="flex gap-1 flex-wrap">
+                            {m.inputModalities.map(mod => (
+                              <span
+                                key={mod}
+                                className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground"
+                              >
+                                {mod}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -1,10 +1,23 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/page-header'
 import { Markdown } from '@/components/markdown'
+import { Tooltip } from '@/components/tooltip'
+
+/** Subset of the /api/image-models response shape — only the fields consumed by ImageTab.
+ *  Structural typing accepts the full API response (which has ~20 fields). */
+interface ImageModel {
+  slug: string
+  shortName: string
+  authorDisplayName: string
+  outputModalities: string[]
+  providerSlug: string
+}
 
 interface FallbackEntry {
   modelDbId: number
@@ -28,18 +41,44 @@ interface ChatMessage {
   }
 }
 
-export default function PlaygroundPage() {
+interface GeneratedImage {
+  url: string
+  prompt: string
+  model: string
+  latency: number
+  timestamp: number
+  aspectRatio: string
+  imageSize: string
+  /** True while the request is in-flight; the card shows a spinner + elapsed time. */
+  pending?: boolean
+  /** Shown on the pending card when the request fails. */
+  error?: string
+}
+
+type PlaygroundTab = 'chat' | 'image'
+
+// ── Tab switcher ─────────────────────────────────────────────────────────────
+function TabSwitcher({ active, onChange }: { active: PlaygroundTab; onChange: (t: PlaygroundTab) => void }) {
+  const tab = (isActive: boolean) =>
+    `px-3 py-1.5 text-xs rounded-lg transition-colors ${
+      isActive ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+    }`
+  return (
+    <div className="inline-flex gap-1 rounded-xl border p-1">
+      <button className={tab(active === 'chat')} onClick={() => onChange('chat')}>Chat</button>
+      <button className={tab(active === 'image')} onClick={() => onChange('image')}>Image</button>
+    </div>
+  )
+}
+
+// ── Chat tab ─────────────────────────────────────────────────────────────────
+function ChatTab({ keyData }: { keyData?: { apiKey: string } }) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>('auto')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
-
-  const { data: keyData } = useQuery<{ apiKey: string }>({
-    queryKey: ['unified-key'],
-    queryFn: () => apiFetch('/api/settings/api-key'),
-  })
 
   const { data: fallbackEntries = [] } = useQuery<FallbackEntry[]>({
     queryKey: ['fallback'],
@@ -138,116 +177,1176 @@ export default function PlaygroundPage() {
     : availableModels.find(m => m.modelId === selectedModel)?.displayName ?? selectedModel
 
   return (
+    <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0">
+      {/* Model selector + clear */}
+      <div className="flex items-center gap-2 p-3 border-b">
+        <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? 'auto')}>
+          <SelectTrigger className="w-[260px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="auto">Auto (fallback chain)</SelectItem>
+            {availableModels.map(m => (
+              <SelectItem key={m.modelDbId} value={m.modelId}>
+                <span className="flex items-center gap-2">
+                  <span>{m.displayName}</span>
+                  <span className="text-xs text-muted-foreground">{m.platform}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {messages.length > 0 && (
+          <Button variant="outline" size="sm" onClick={handleClear}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        {messages.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-center">
+            <div className="space-y-2 max-w-sm">
+              <p className="text-base font-medium">Send a message to get started.</p>
+              <p className="text-sm text-muted-foreground">
+                Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {messages.map((msg, i) => (
+              <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                    msg.role === 'user'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted'
+                  }`}
+                >
+                  {msg.role === 'assistant' ? (
+                    <Markdown>{msg.content}</Markdown>
+                  ) : (
+                    <div className="whitespace-pre-wrap">{msg.content}</div>
+                  )}
+                  {msg.meta && (
+                    <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
+                      {msg.meta.platform && <span>{msg.meta.platform}</span>}
+                      {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
+                      {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
+                      {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
+                        <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+            {loading && (
+              <div className="flex justify-start">
+                <div className="bg-muted rounded-2xl px-4 py-3">
+                  <div className="flex gap-1">
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+                  </div>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="border-t bg-background/50 p-3">
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message… (⏎ to send, ⇧⏎ for newline)"
+            rows={1}
+            className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
+            style={{ height: 'auto', overflow: 'hidden' }}
+            onInput={e => autoResizeTextarea(e.target as HTMLTextAreaElement)}
+          />
+          <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
+            {loading ? 'Sending…' : 'Send'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Image tab ────────────────────────────────────────────────────────────────
+const ASPECT_RATIOS = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'] as const
+const IMAGE_SIZES = ['0.5K', '1K', '2K', '4K'] as const
+
+/** Auto-resize a textarea to fit its content, up to maxHeight px. */
+function autoResizeTextarea(el: HTMLTextAreaElement, maxHeight = 160) {
+  el.style.height = 'auto'
+  el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px'
+}
+
+function ImageTab({ keyData }: { keyData?: { apiKey: string } }) {
+  const [prompt, setPrompt] = useState('')
+  const [, setTick] = useState(0)
+  const [selectedModel, setSelectedModel] = useState<string>('')
+  const [aspectRatio, setAspectRatio] = useState<string>('1:1')
+  const [imageSize, setImageSize] = useState<string>('1K')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  // Recraft
+  const [style, setStyle] = useState('')
+  const [strength, setStrength] = useState('')
+  const [rgbColors, setRgbColors] = useState('')
+  const [backgroundRgbColor, setBackgroundRgbColor] = useState('')
+  // Sourceful
+  const [scoringPrompt, setScoringPrompt] = useState('')
+  const [backgroundMode, setBackgroundMode] = useState('original')
+  const [backgroundHexColor, setBackgroundHexColor] = useState('')
+  const [rgbConfigError, setRgbConfigError] = useState<string | null>(null)
+  // Complex typed params (previously lumped in a generic JSON textarea)
+  const [textLayout, setTextLayout] = useState('')
+  const [fontInputs, setFontInputs] = useState('')
+  const [superResRefs, setSuperResRefs] = useState('')
+  const [scoringRubric, setScoringRubric] = useState('')
+  // Raw JSON bidirectional view
+  const [isRawJsonMode, setIsRawJsonMode] = useState(false)
+  const [rawJsonText, setRawJsonText] = useState('')
+  const [rawJsonError, setRawJsonError] = useState<string | null>(null)
+  const [history, setHistory] = useState<GeneratedImage[]>([])
+  // Input image for image-to-image generation
+  const [inputImage, setInputImage] = useState<string | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [lightbox, setLightbox] = useState<number | null>(null)
+  const [zoomLabel, setZoomLabel] = useState<string | null>(null)
+  const zoomLabelTimeout = useRef<ReturnType<typeof setTimeout>>(null)
+  const [zoomScale, setZoomScale] = useState(1)
+  const [panOffset, setPanOffset] = useState({ x: 0, y: 0 })
+  const [isPanning, setIsPanning] = useState(false)
+  const panStart = useRef({ x: 0, y: 0 })
+  const didDrag = useRef(false)
+  const imageWrapperRef = useRef<HTMLDivElement>(null)
+  // Ref for latest zoom scale so keyboard handler sees fresh value.
+  const zoomScaleRef = useRef(zoomScale)
+  zoomScaleRef.current = zoomScale
+  const [expandedPrompts, setExpandedPrompts] = useState<Set<number>>(new Set())
+  const [recentlyCompleted, setRecentlyCompleted] = useState<Set<number>>(new Set())
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const abortControllers = useRef<Map<number, AbortController>>(new Map())
+
+  const { data: imageModels = [] } = useQuery<ImageModel[]>({
+    queryKey: ['image-models'],
+    queryFn: () => apiFetch('/api/image-models'),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (imageModels.length > 0 && !selectedModel) {
+      setSelectedModel(imageModels[0].slug)
+    }
+    // eslint-disable-next-line -- only run when models load
+  }, [imageModels.length])
+
+  // Clear recently-completed highlight after the animation duration.
+  useEffect(() => {
+    if (recentlyCompleted.size === 0) return
+    const timeout = setTimeout(() => setRecentlyCompleted(new Set()), 1500)
+    return () => clearTimeout(timeout)
+  }, [recentlyCompleted])
+  const completed = history.filter(img => !img.pending && !img.error)
+  // Reset zoom/pan when navigating to a different image, and show hints briefly.
+  useEffect(() => {
+    setZoomScale(1)
+    setPanOffset({ x: 0, y: 0 })
+    setZoomLabel(null)
+    if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+  }, [lightbox])
+  useEffect(() => {
+    if (lightbox === null) return
+    // Lock body scroll while lightbox is open.
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightbox(null)
+      else if (e.key === 'ArrowLeft' && lightbox > 0) setLightbox(lightbox - 1)
+      else if (e.key === 'ArrowRight' && lightbox < completed.length - 1) setLightbox(lightbox + 1)
+      else if (e.key === '+' || e.key === '=') {
+        e.preventDefault()
+        const next = Math.min(5, zoomScaleRef.current + 0.25)
+        setZoomScale(next)
+        setZoomLabel(`${Math.round(next * 100)}%`)
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      } else if (e.key === '-') {
+        e.preventDefault()
+        const next = Math.max(1, zoomScaleRef.current - 0.25)
+        if (next === 1) setPanOffset({ x: 0, y: 0 })
+        setZoomScale(next)
+        setZoomLabel(`${Math.round(next * 100)}%`)
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      } else if (e.key === '0') {
+        e.preventDefault()
+        setZoomScale(1)
+        setPanOffset({ x: 0, y: 0 })
+        setZoomLabel('Fit')
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = ''
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [lightbox, completed.length])
+
+  // Abort all in-flight requests on unmount.
+  useEffect(() => () => {
+    abortControllers.current.forEach(c => c.abort())
+    if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+  }, [])
+  useEffect(() => {
+    if (!history.some(img => img.pending)) {
+      // No more pending requests — clean up expanded prompt state too.
+      if (expandedPrompts.size > 0) setExpandedPrompts(new Set())
+      return
+    }
+    const id = setInterval(() => setTick(t => t + 1), 1000)
+    return () => clearInterval(id)
+  }, [history])
+
+  // ── Input image handlers ──────────────────────────────────────────
+  const readFileAsDataUrl = (file: File) => {
+    const reader = new FileReader()
+    reader.onload = () => setInputImage(reader.result as string)
+    reader.onerror = () => setInputImage(null)
+    reader.readAsDataURL(file)
+  }
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault()
+        readFileAsDataUrl(item.getAsFile()!)
+        return
+      }
+    }
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer?.files?.[0]
+    if (file?.type.startsWith('image/')) readFileAsDataUrl(file)
+  }
+
+  const handleGenerate = async () => {
+    const text = prompt.trim()
+    if (!text || !selectedModel) return
+
+    const startTime = Date.now()
+    const model = selectedModel
+    const thisInputImage = inputImage // snapshot for this request
+    const thisAspectRatio = aspectRatio
+    const thisImageSize = imageSize
+
+    // Push a pending placeholder immediately so the grid shows a spinner.
+    const pendingEntry: GeneratedImage = {
+      url: '',
+      prompt: text,
+      model,
+      latency: 0,
+      timestamp: startTime,
+      aspectRatio: thisAspectRatio,
+      imageSize: thisImageSize,
+      pending: true,
+    }
+    setHistory(prev => [pendingEntry, ...prev].slice(0, 50))
+    setPrompt('')
+    setTimeout(() => inputRef.current?.focus(), 0)
+
+    const controller = new AbortController()
+    abortControllers.current.set(startTime, controller)
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (keyData?.apiKey) headers['Authorization'] = `Bearer ${keyData.apiKey}`
+
+      const body: any = {
+        model,
+        messages: [{
+          role: 'user',
+          content: thisInputImage
+            ? [
+                { type: 'image_url', image_url: { url: thisInputImage } },
+                { type: 'text', text },
+              ]
+            : text,
+        }],
+        modalities: activeModel?.outputModalities?.includes('text') ? ['image', 'text'] : ['image'],
+      }
+
+      if (aspectRatio !== '1:1' || imageSize !== '1K') {
+        body.image_config = { aspect_ratio: aspectRatio, image_size: imageSize }
+      }
+
+      // ── Advanced image_config (Recraft / Sourceful / extra JSON) ────
+      const imageConfig: Record<string, unknown> = body.image_config ? { ...body.image_config } : {}
+
+      // Always include aspect_ratio + image_size when any advanced option is set
+      const provider = activeModel?.providerSlug?.toLowerCase() ?? ''
+      const advancedConfig = isRawJsonMode ? (() => { try { return JSON.parse(rawJsonText) ?? {} } catch { return {} } })() : computedImageConfig
+      // Only include provider-specific fields when the provider matches
+      const filteredAdvanced: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(advancedConfig)) {
+        if (v == null || v === '') continue
+        // Recraft-specific: style, strength, rgb_colors, background_rgb_color, text_layout
+        if (['style', 'strength', 'rgb_colors', 'background_rgb_color', 'text_layout'].includes(k)) {
+          if (provider === 'recraft') filteredAdvanced[k] = v
+        // Sourceful-specific: scoring_prompt, scoring_rubric, font_inputs, super_resolution_references, background_mode, background_hex_color
+        } else if (['scoring_prompt', 'scoring_rubric', 'font_inputs', 'super_resolution_references', 'background_mode', 'background_hex_color'].includes(k)) {
+          if (provider === 'sourceful') filteredAdvanced[k] = v
+        } else {
+          filteredAdvanced[k] = v
+        }
+      }
+      const hasAdvanced = Object.keys(filteredAdvanced).length > 0
+      if (hasAdvanced && !imageConfig.aspect_ratio) {
+        imageConfig.aspect_ratio = aspectRatio
+        imageConfig.image_size = imageSize
+      }
+      Object.assign(imageConfig, filteredAdvanced)
+
+      if (Object.keys(imageConfig).length > 0) {
+        body.image_config = imageConfig
+      }
+
+      const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+      // ── Non-streaming path ───────────────────────────────────────────
+      const res = await fetch(`${base}/v1/chat/completions`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+
+      const latency = Date.now() - startTime
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: { message: `HTTP ${res.status}` } }))
+        const errMsg = err.error?.message ?? `HTTP ${res.status}`
+        abortControllers.current.delete(startTime)
+        setHistory(prev => prev.map(img =>
+          img.timestamp === startTime ? { ...img, pending: false, error: errMsg } : img
+        ))
+        return
+      }
+
+      abortControllers.current.delete(startTime)
+      const data = await res.json()
+      const message = data.choices?.[0]?.message
+      const images = message?.images ?? []
+
+      if (images.length === 0) {
+        // Some models return base64 in content instead of images array
+        const content = message?.content ?? ''
+        if (content.startsWith('data:image')) {
+          setHistory(prev => prev.map(img =>
+            img.timestamp === startTime ? { ...img, url: content, latency, pending: false } : img
+          ))
+          setRecentlyCompleted(prev => new Set(prev).add(startTime))
+        } else {
+          setHistory(prev => prev.map(img =>
+            img.timestamp === startTime ? { ...img, pending: false, error: 'No image returned. The model may have returned text instead.' } : img
+          ))
+        }
+        return
+      }
+
+      // Replace the pending placeholder with the first image,
+      // then push additional images as new entries.
+      let replaced = false
+      for (const img of images) {
+        const url = img.image_url?.url ?? img.url // fallback for providers omitting the image_url wrapper
+        if (!url) continue
+        if (!replaced) {
+          setHistory(prev => prev.map(e =>
+            e.timestamp === startTime ? { ...e, url, latency, pending: false } : e
+          ))
+          setRecentlyCompleted(prev => new Set(prev).add(startTime))
+          replaced = true
+        } else {
+          const ts = Date.now()
+          setHistory(prev => [{ url, prompt: text, model, latency, timestamp: ts, aspectRatio: thisAspectRatio, imageSize: thisImageSize }, ...prev].slice(0, 50))
+          setRecentlyCompleted(prev => new Set(prev).add(ts))
+        }
+      }
+    } catch (err: any) {
+      abortControllers.current.delete(startTime)
+      if (err.name === 'AbortError') {
+        // Remove the pending placeholder entirely — nothing to show.
+        setHistory(prev => prev.filter(img => img.timestamp !== startTime))
+      } else {
+        setHistory(prev => prev.map(img =>
+          img.timestamp === startTime ? { ...img, pending: false, error: err.message ?? 'Unknown error' } : img
+        ))
+      }
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleGenerate()
+    }
+  }
+
+  // ── Computed image_config from individual fields ─────────────────────
+  const computedImageConfig = useMemo(() => {
+    const config: Record<string, unknown> = {}
+    if (style.trim()) config.style = style.trim()
+    const s = parseFloat(strength)
+    if (strength.trim() && !isNaN(s) && s >= 0 && s <= 1) config.strength = s
+    if (rgbColors.trim()) {
+      try {
+        const parsed = JSON.parse(`[${rgbColors}]`)
+        if (Array.isArray(parsed) && parsed.every((c: unknown) => Array.isArray(c) && c.length === 3 && c.every((v: unknown) => typeof v === 'number'))) {
+          config.rgb_colors = parsed
+        }
+      } catch { /* ignore */ }
+    }
+    if (backgroundRgbColor.trim()) {
+      try {
+        const parsed = JSON.parse(`[${backgroundRgbColor}]`)
+        if (Array.isArray(parsed) && parsed.length === 3 && parsed.every((v: unknown) => typeof v === 'number')) {
+          config.background_rgb_color = parsed
+        }
+      } catch { /* ignore */ }
+    }
+    if (scoringPrompt.trim()) config.scoring_prompt = scoringPrompt.trim()
+    const effectiveMode = backgroundHexColor.trim() && backgroundMode === 'original' ? 'solid' : backgroundMode
+    if (effectiveMode !== 'original' || backgroundHexColor.trim()) {
+      config.background_mode = effectiveMode
+      if (effectiveMode === 'solid' && backgroundHexColor.trim()) config.background_hex_color = backgroundHexColor.trim()
+    }
+    try { if (textLayout.trim()) config.text_layout = JSON.parse(textLayout) } catch { /* ignore */ }
+    try { if (fontInputs.trim()) config.font_inputs = JSON.parse(fontInputs) } catch { /* ignore */ }
+    try { if (scoringRubric.trim()) config.scoring_rubric = JSON.parse(scoringRubric) } catch { /* ignore */ }
+    const refs = superResRefs.split('\n').map(l => l.trim()).filter(Boolean)
+    if (refs.length > 0) config.super_resolution_references = refs
+    return config
+  }, [style, strength, rgbColors, backgroundRgbColor, scoringPrompt, backgroundMode, backgroundHexColor, textLayout, fontInputs, scoringRubric, superResRefs])
+
+  // ── Raw JSON blur handler (bidirectional sync: JSON → fields) ──────
+  const handleRawJsonBlur = () => {
+    try {
+      const parsed = JSON.parse(rawJsonText)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setRawJsonError('Expected a JSON object, not an array')
+        return
+      }
+      setRawJsonError(null)
+      setStyle(parsed.style ?? '')
+      setStrength(parsed.strength != null ? String(parsed.strength) : '')
+      setRgbColors(Array.isArray(parsed.rgb_colors) ? parsed.rgb_colors.map((c: unknown) => Array.isArray(c) ? `[${(c as number[]).join(',')}]` : '').filter(Boolean).join(', ') : '')
+      setBackgroundRgbColor(Array.isArray(parsed.background_rgb_color) ? JSON.stringify(parsed.background_rgb_color).replace(/[\[\]\s]/g, '') : '')
+      setScoringPrompt(parsed.scoring_prompt ?? '')
+      setBackgroundMode(['original', 'transparent', 'solid'].includes(parsed.background_mode) ? parsed.background_mode : 'original')
+      setBackgroundHexColor(parsed.background_hex_color ?? '')
+      setTextLayout(parsed.text_layout != null ? JSON.stringify(parsed.text_layout, null, 2) : '')
+      setFontInputs(parsed.font_inputs != null ? JSON.stringify(parsed.font_inputs, null, 2) : '')
+      setScoringRubric(parsed.scoring_rubric != null ? JSON.stringify(parsed.scoring_rubric, null, 2) : '')
+      setSuperResRefs(Array.isArray(parsed.super_resolution_references) ? parsed.super_resolution_references.join('\n') : '')
+    } catch (err: any) {
+      setRawJsonError(`Invalid JSON: ${err.message}`)
+    }
+  }
+
+  const activeModel = imageModels.find(m => m.slug === selectedModel)
+
+  return (
+    <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0 relative"
+      onPaste={handlePaste}
+      onDragOver={e => {
+        e.preventDefault()
+        if (e.dataTransfer?.types?.includes('Files')) setDragOver(true)
+      }}
+      onDragLeave={e => {
+        if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
+          setDragOver(false)
+        }
+      }}
+      onDrop={handleDrop}
+    >
+      {/* Drag overlay — covers the entire card */}
+      {dragOver && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-primary/10 border-2 border-dashed border-primary backdrop-blur-[1px]">
+          <div className="text-center space-y-1">
+            <span className="text-2xl">🖼</span>
+            <p className="text-sm font-medium text-primary">Drop image here</p>
+            <p className="text-xs text-muted-foreground">Use as reference for image-to-image generation</p>
+          </div>
+        </div>
+      )}
+      {/* Controls */}
+      <div className="flex items-center gap-2 p-3 border-b flex-wrap">
+        <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? '')}>
+          <SelectTrigger className="w-[300px]">
+            <SelectValue placeholder="Select an image model…" />
+          </SelectTrigger>
+          <SelectContent>
+            {imageModels.map(m => (
+              <SelectItem key={m.slug} value={m.slug}>
+                <span className="flex items-center gap-2">
+                  <span>{m.shortName}</span>
+                  <span className="text-xs text-muted-foreground">{m.authorDisplayName}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={aspectRatio} onValueChange={(v) => setAspectRatio(v ?? '1:1')}>
+          <SelectTrigger className="w-[100px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ASPECT_RATIOS.map(r => (
+              <SelectItem key={r} value={r}>{r}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={imageSize} onValueChange={(v) => setImageSize(v ?? '1K')}>
+          <SelectTrigger className="w-[90px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {IMAGE_SIZES.map(s => (
+              <SelectItem key={s} value={s}>{s}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <button
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className={`text-xs px-2 py-1 rounded-lg transition-colors ${
+            showAdvanced ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+          }`}
+        >
+          ⚙ Advanced {showAdvanced ? '▾' : '▸'}
+        </button>
+        {history.length > 0 && (
+          <Button variant="outline" size="sm" onClick={() => setHistory([])}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Advanced options panel */}
+      {showAdvanced && (
+        <div className="border-b bg-muted/30 p-3 space-y-3 text-xs">
+          {/* Toggle: structured vs raw JSON */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                const next = !isRawJsonMode
+                if (next) { setRawJsonText(JSON.stringify(computedImageConfig, null, 2)); setRawJsonError(null) }
+                setIsRawJsonMode(next)
+              }}
+              className={`text-xs px-2 py-0.5 rounded-lg transition-colors ${
+                isRawJsonMode ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+              }`}
+            >
+              {'{ } Raw JSON'}
+            </button>
+          </div>
+
+          {isRawJsonMode ? (
+            /* ── Raw JSON view ───────────────────────────────── */
+            <div className="space-y-1">
+              <Textarea
+                value={rawJsonText}
+                onChange={e => { setRawJsonText(e.target.value); setRawJsonError(null) }}
+                onBlur={handleRawJsonBlur}
+                placeholder="{ &quot;style&quot;: &quot;Photorealism&quot;, ... }"
+                className="min-h-[120px] text-xs font-mono"
+              />
+              {rawJsonError && (
+                <p className="text-[10px] text-red-500">{rawJsonError}</p>
+              )}
+            </div>
+          ) : (
+            /* ── Structured inputs ──────────────────────────── */
+            (() => {
+              const provider = activeModel?.providerSlug?.toLowerCase() ?? ''
+              return (
+                <>
+                  {/* ── Recraft ──────────────────────────── */}
+                  {provider === 'recraft' && (
+                    <div className="space-y-2">
+                      <p className="font-medium text-muted-foreground uppercase tracking-wide">Recraft options</p>
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Style</span>
+                          <Input value={style} onChange={e => setStyle(e.target.value)} placeholder="e.g. Photorealism" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Strength (0–1)</span>
+                          <Input value={strength} onChange={e => setStrength(e.target.value)} placeholder="0.2" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">RGB colors</span>
+                          <Input
+                            value={rgbColors}
+                            onChange={e => { setRgbColors(e.target.value); setRgbConfigError(null) }}
+                            onBlur={() => {
+                              if (!rgbColors.trim()) { setRgbConfigError(null); return }
+                              try {
+                                const parsed = JSON.parse(`[${rgbColors}]`)
+                                if (!Array.isArray(parsed) || !parsed.every((c: unknown) => Array.isArray(c) && c.length === 3 && c.every((v: unknown) => typeof v === 'number'))) {
+                                  setRgbConfigError('Expected: [r,g,b], [r,g,b]')
+                                } else { setRgbConfigError(null) }
+                              } catch { setRgbConfigError('Invalid format') }
+                            }}
+                            placeholder="[255,0,0], [0,128,0]"
+                            className="h-7 text-xs"
+                          />
+                          {rgbConfigError && <p className="text-[10px] text-red-500">{rgbConfigError}</p>}
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">BG RGB color</span>
+                          <Input value={backgroundRgbColor} onChange={e => setBackgroundRgbColor(e.target.value)} placeholder="0,0,255" className="h-7 text-xs" />
+                        </label>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">text_layout (JSON)</span>
+                          <Textarea value={textLayout} onChange={e => setTextLayout(e.target.value)} placeholder='[{"text": "Hello", "bbox": [[0.3,0.45],[0.6,0.45],[0.6,0.55],[0.3,0.55]]}]' className="min-h-[40px] text-xs font-mono" />
+                        </label>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* ── Sourceful ────────────────────────── */}
+                  {provider === 'sourceful' && (
+                    <div className="space-y-2">
+                      <p className="font-medium text-muted-foreground uppercase tracking-wide">Sourceful options</p>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Scoring prompt</span>
+                          <Input value={scoringPrompt} onChange={e => setScoringPrompt(e.target.value)} placeholder="Prefer realistic materials…" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Background mode</span>
+                          <Select value={backgroundMode} onValueChange={(v) => setBackgroundMode(v ?? 'original')}>
+                            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="original">Original</SelectItem>
+                              <SelectItem value="transparent">Transparent</SelectItem>
+                              <SelectItem value="solid">Solid color</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </label>
+                        {backgroundMode === 'solid' && (
+                          <label className="space-y-1">
+                            <span className="text-muted-foreground">BG hex color</span>
+                            <Input value={backgroundHexColor} onChange={e => setBackgroundHexColor(e.target.value)} placeholder="#f6f1e8" className="h-7 text-xs" />
+                          </label>
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">font_inputs (JSON)</span>
+                          <Textarea value={fontInputs} onChange={e => setFontInputs(e.target.value)} placeholder='[{"font_url": "https://...", "text": "Hello"}]' className="min-h-[40px] text-xs font-mono" />
+                        </label>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">super_resolution_references</span>
+                          <Textarea value={superResRefs} onChange={e => setSuperResRefs(e.target.value)} placeholder="https://example.com/ref1.jpg&#10;https://example.com/ref2.jpg" className="min-h-[44px] text-xs font-mono" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">scoring_rubric (JSON)</span>
+                          <Textarea value={scoringRubric} onChange={e => setScoringRubric(e.target.value)} placeholder='[{"key": "lighting", "label": "Lighting", "description": "...", "weight": 1}]' className="min-h-[44px] text-xs font-mono" />
+                        </label>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )
+            })()
+          )}
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-6">
+        {history.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-center">
+            <div className="space-y-2 max-w-sm">
+              <p className="text-base font-medium">Describe an image to generate.</p>
+              <p className="text-sm text-muted-foreground">
+                {activeModel
+                  ? <>Using <span className="text-foreground">{activeModel.shortName}</span>.</>
+                  : 'Select a model above.'}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {history.map((img, i) => (
+              img.pending ? (
+<div key={img.timestamp} className="rounded-2xl border bg-muted/50 aspect-square flex flex-col items-center justify-center relative group p-4">
+                  {/* Cancel button */}
+                  <button
+                    onClick={e => { e.stopPropagation(); abortControllers.current.get(img.timestamp)?.abort() }}
+                    className="absolute top-2 right-2 w-7 h-7 rounded-full bg-muted-foreground/20 hover:bg-red-500/80 text-muted-foreground hover:text-white text-sm flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100 z-10"
+                    aria-label="Cancel generation"
+                    title="Cancel generation"
+                  >
+                    ×
+                  </button>
+                  {/* Spinner + status */}
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="flex gap-1 justify-center">
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+                    </div>
+                    <p className="text-xs text-muted-foreground">Generating…</p>
+                    <p className="text-[10px] text-muted-foreground/50 tabular-nums">{Math.floor((Date.now() - img.timestamp) / 1000)}s elapsed</p>
+                  </div>
+                  {/* Prompt + model — collapsible */}
+                  <div className="mt-auto w-full pt-3 border-t border-border/30">
+                    <p
+                      onClick={e => {
+                        e.stopPropagation()
+                        setExpandedPrompts(prev => {
+                          const next = new Set(prev)
+                          if (next.has(img.timestamp)) next.delete(img.timestamp)
+                          else next.add(img.timestamp)
+                          return next
+                        })
+                      }}
+                      className={`text-[11px] text-muted-foreground/70 leading-relaxed cursor-pointer transition-colors hover:text-muted-foreground ${
+                        expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                      }`}
+                      title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                    >
+                      {img.prompt}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground/40 mt-1 tabular-nums">{img.model.split('/').pop()}</p>
+                  </div>
+                </div>
+              ) : img.error ? (
+<div key={img.timestamp} className="rounded-2xl border border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950 aspect-square flex items-center justify-center relative group">
+                  {/* Dismiss button */}
+                  <button
+                    onClick={e => { e.stopPropagation(); setHistory(prev => prev.filter(h => h.timestamp !== img.timestamp)) }}
+                    className="absolute top-2 right-2 w-6 h-6 rounded-full bg-red-200/60 hover:bg-red-400/80 dark:bg-red-800/60 dark:hover:bg-red-700/80 text-red-700 dark:text-red-300 hover:text-white text-sm flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100"
+                    aria-label="Dismiss error"
+                    title="Dismiss"
+                  >
+                    ×
+                  </button>
+                  <div className="text-center space-y-3 p-4">
+                    <div className="space-y-1">
+                      <p className="text-xs text-red-700 dark:text-red-400">{img.error}</p>
+                      <p className="text-[11px] text-muted-foreground line-clamp-2">{img.prompt}</p>
+                      <p className="text-[10px] text-muted-foreground/40">{img.model.split('/').pop()}</p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-xs h-7"
+                      onClick={() => {
+                        setHistory(prev => prev.filter(h => h.timestamp !== img.timestamp))
+                        setPrompt(img.prompt)
+                        setSelectedModel(img.model)
+                        setTimeout(() => inputRef.current?.focus(), 0)
+                      }}
+                    >
+                      ↻ Retry
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+              <div key={img.timestamp} className={`rounded-2xl border overflow-hidden bg-card cursor-pointer transition-shadow ${
+                  recentlyCompleted.has(img.timestamp) ? 'ring-2 ring-emerald-400/60 shadow-lg shadow-emerald-400/20' : ''
+                }`} onClick={() => {
+                // Find this image's index in the completed list for lightbox navigation.
+                const idx = completed.findIndex(c => c.timestamp === img.timestamp)
+                if (idx !== -1) setLightbox(idx)
+              }}>
+                <div className="aspect-square relative group">
+                  <img
+                    src={img.url}
+                    alt={img.prompt}
+                    className="w-full h-full object-contain bg-black/5"
+                  />
+                  <a
+                    href={img.url}
+                    download={`image-${i}.png`}
+                    className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <Button variant="secondary" size="sm" className="text-xs h-7">
+                      ↓ Download
+                    </Button>
+                  </a>
+                </div>
+<div className="p-3 space-y-1">
+<div className="flex items-start gap-1.5">
+                    <p
+                      onClick={e => {
+                        e.stopPropagation()
+                        setExpandedPrompts(prev => {
+                          const next = new Set(prev)
+                          if (next.has(img.timestamp)) next.delete(img.timestamp)
+                          else next.add(img.timestamp)
+                          return next
+                        })
+                      }}
+                      className={`text-xs text-muted-foreground flex-1 cursor-pointer transition-colors hover:text-foreground ${
+                        expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                      }`}
+                      title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                    >
+                      {img.prompt}
+                    </p>
+<Tooltip text="Copy prompt">
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          navigator.clipboard.writeText(img.prompt)
+                          const btn = e.currentTarget
+                          btn.textContent = '✓'
+                          setTimeout(() => { btn.textContent = '📋' }, 1200)
+                        }}
+                        className="shrink-0 text-[11px] text-muted-foreground/40 hover:text-muted-foreground transition-colors leading-relaxed"
+                        aria-label="Copy prompt"
+                      >
+                        📋
+                      </button>
+                    </Tooltip>
+                  </div>
+<div className="flex items-center gap-2 text-[10px] text-muted-foreground/60 tabular-nums">
+                    <span>{img.model.split('/').pop()}</span>
+                    <span>· {img.latency} ms</span>
+                    <span>· {img.aspectRatio}</span>
+                    <span>· {img.imageSize}</span>
+<Tooltip text="Use these settings">
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          setAspectRatio(img.aspectRatio)
+                          setImageSize(img.imageSize)
+                        }}
+                        className="text-[10px] text-muted-foreground/30 hover:text-muted-foreground transition-colors cursor-pointer"
+                        aria-label="Use these settings"
+                      >
+                        ⚙
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              </div>
+            )))}
+          </div>
+        )}
+      </div>
+
+      {/* Input area */}
+      <div className="border-t bg-background/50 p-3">
+        {/* Input image preview */}
+        {inputImage && (
+          <div className="mb-2 flex items-start gap-2">
+            <div className="relative rounded-lg overflow-hidden border w-16 h-16 shrink-0">
+              <img src={inputImage} alt="Input" className="w-full h-full object-cover" />
+              <button
+                onClick={() => setInputImage(null)}
+                className="absolute top-0 right-0 w-4 h-4 bg-foreground/70 text-background rounded-bl text-[10px] leading-none flex items-center justify-center hover:bg-foreground"
+                title="Remove input image"
+              >
+                ×
+              </button>
+            </div>
+            <p className="text-[11px] text-muted-foreground">Input image — this will be used as a reference for image-to-image generation.</p>
+          </div>
+        )}
+        <div className="flex gap-2 items-end">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={e => { const f = e.target.files?.[0]; if (f) readFileAsDataUrl(f) }}
+          />
+          <Tooltip text="Upload an input image for image-to-image generation. You can also paste an image or drag & drop one onto the text area.">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 px-2.5 text-xs shrink-0"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              +
+            </Button>
+          </Tooltip>
+          <textarea
+            ref={inputRef}
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={inputImage ? 'Describe how to transform the image…' : 'Describe the image you want to generate…'}
+            rows={1}
+            className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
+            style={{ height: 'auto', overflow: 'hidden' }}
+            onInput={e => autoResizeTextarea(e.target as HTMLTextAreaElement)}
+          />
+          <Button onClick={handleGenerate} disabled={!prompt.trim() || !selectedModel} size="default">
+            Generate
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Lightbox ───────────────────────────────────────────────────── */}
+      {lightbox !== null && (() => {
+        const img = completed[lightbox]
+        if (!img) return null
+        return (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm"
+          onClick={() => setLightbox(null)}
+        >
+          {/* Close button */}
+          <button
+            onClick={() => setLightbox(null)}
+            className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+            aria-label="Close lightbox"
+          >
+            ×
+          </button>
+
+          {/* Keyboard hints */}
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-3 rounded-xl bg-black/50 backdrop-blur px-4 py-2 text-white/70 text-[11px] pointer-events-none">
+            <span><kbd className="text-white/90">Esc</kbd> close</span>
+            <span><kbd className="text-white/90">←</kbd> <kbd className="text-white/90">→</kbd> navigate</span>
+            <span><kbd className="text-white/90">Click</kbd> zoom</span>
+            <span><kbd className="text-white/90">Scroll</kbd> zoom</span>
+            <span><kbd className="text-white/90">+</kbd> <kbd className="text-white/90">−</kbd> <kbd className="text-white/90">0</kbd> zoom</span>
+            <span><kbd className="text-white/90">Drag</kbd> pan</span>
+          </div>
+
+          {/* Previous arrow */}
+          {lightbox > 0 && (
+            <button
+              onClick={e => { e.stopPropagation(); setLightbox(lightbox - 1) }}
+              className="absolute left-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+              aria-label="Previous image"
+            >
+              ‹
+            </button>
+          )}
+
+          {/* Next arrow */}
+          {lightbox < completed.length - 1 && (
+            <button
+              onClick={e => { e.stopPropagation(); setLightbox(lightbox + 1) }}
+              className="absolute right-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+              aria-label="Next image"
+            >
+              ›
+            </button>
+          )}
+
+          {/* Image */}
+          <div
+            ref={imageWrapperRef}
+            className="overflow-hidden rounded-xl"
+            onWheel={e => {
+              e.stopPropagation()
+              const delta = e.deltaY > 0 ? -0.25 : 0.25
+              const next = Math.min(5, Math.max(1, zoomScale + delta))
+              // Zoom toward cursor position.
+              if (next === 1) {
+                setPanOffset({ x: 0, y: 0 })
+              } else {
+                const rect = imageWrapperRef.current?.getBoundingClientRect()
+                if (rect) {
+                  const dx = e.clientX - rect.left - rect.width / 2
+                  const dy = e.clientY - rect.top - rect.height / 2
+                  const ratio = next / zoomScale
+                  setPanOffset({
+                    x: dx - (dx - panOffset.x) * ratio,
+                    y: dy - (dy - panOffset.y) * ratio,
+                  })
+                }
+              }
+              setZoomScale(next)
+              setZoomLabel(`${Math.round(next * 100)}%`)
+              if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+              zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+            }}
+          >
+          {/* Zoom level indicator */}
+          {zoomLabel && (
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 rounded-xl bg-black/60 backdrop-blur px-3 py-1.5 text-white text-sm font-medium tabular-nums pointer-events-none">
+              {zoomLabel}
+            </div>
+          )}
+            <img
+              src={img.url}
+              alt={img.prompt}
+              draggable={false}
+              className={`max-w-[90vw] max-h-[85vh] rounded-xl select-none ${
+                isPanning ? '' : 'transition-transform duration-200'
+              } ${
+                zoomScale > 1 ? 'cursor-grab' : 'cursor-zoom-in'
+              } ${isPanning ? 'cursor-grabbing' : ''}`}
+              style={{
+                objectFit: zoomScale > 1 ? 'none' : 'contain',
+                transform: `scale(${zoomScale}) translate(${panOffset.x / zoomScale}px, ${panOffset.y / zoomScale}px)`,
+                transformOrigin: 'center center',
+              }}
+              onClick={e => {
+                e.stopPropagation()
+                // Don't toggle zoom if the user was dragging.
+                if (didDrag.current) {
+                  didDrag.current = false
+                  return
+                }
+                if (zoomScale > 1) {
+                  setZoomScale(1)
+                  setPanOffset({ x: 0, y: 0 })
+                  setZoomLabel('Fit')
+                } else {
+                  setZoomScale(2)
+                  setZoomLabel('200%')
+                }
+                if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+                zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+              }}
+              onMouseDown={e => {
+                if (zoomScale <= 1) return
+                e.preventDefault()
+                didDrag.current = false
+                setIsPanning(true)
+                panStart.current = { x: e.clientX - panOffset.x, y: e.clientY - panOffset.y }
+              }}
+              onMouseMove={e => {
+                if (!isPanning) return
+                didDrag.current = true
+                setPanOffset({
+                  x: e.clientX - panStart.current.x,
+                  y: e.clientY - panStart.current.y,
+                })
+              }}
+              onMouseUp={() => setIsPanning(false)}
+              onMouseLeave={() => setIsPanning(false)}
+            />
+          </div>
+
+          {/* Info footer */}
+          <div
+            className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-4 rounded-xl bg-black/60 backdrop-blur px-4 py-2.5 text-white text-xs"
+            onClick={e => e.stopPropagation()}
+          >
+<div className="max-w-sm">
+              {/* Prompt — expand/collapse + copy */}
+              <div className="flex items-start gap-1.5">
+                <p
+                  onClick={() => {
+                    setExpandedPrompts(prev => {
+                      const next = new Set(prev)
+                      if (next.has(img.timestamp)) next.delete(img.timestamp)
+                      else next.add(img.timestamp)
+                      return next
+                    })
+                  }}
+                  className={`text-xs leading-relaxed cursor-pointer transition-colors hover:text-white/90 ${
+                    expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                  }`}
+                  title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                >
+                  {img.prompt}
+                </p>
+<Tooltip text="Copy prompt">
+                  <button
+                    onClick={e => {
+                      e.stopPropagation()
+                      navigator.clipboard.writeText(img.prompt)
+                      const btn = e.currentTarget
+                      btn.textContent = '✓'
+                      setTimeout(() => { btn.textContent = '📋' }, 1200)
+                    }}
+                    className="shrink-0 text-[10px] text-white/30 hover:text-white/80 transition-colors leading-relaxed"
+                    aria-label="Copy prompt"
+                  >
+                    📋
+                  </button>
+                </Tooltip>
+              </div>
+              {/* Metadata + settings */}
+              <div className="flex items-center gap-2 mt-0.5">
+                <p className="text-white/50 tabular-nums text-[11px]">
+                  {img.model.split('/').pop()} · {img.latency} ms · {img.aspectRatio} · {img.imageSize}
+                </p>
+<Tooltip text="Use these settings">
+                  <button
+                    onClick={() => {
+                      setAspectRatio(img.aspectRatio)
+                      setImageSize(img.imageSize)
+                    }}
+                    className="text-[11px] text-white/20 hover:text-white/70 transition-colors cursor-pointer"
+                    aria-label="Use these settings"
+                  >
+                    ⚙
+                  </button>
+                </Tooltip>
+              </div>
+            </div>
+            <span className="text-white/30">{lightbox + 1} / {completed.length}</span>
+            <a
+              href={img.url}
+              download={`image-${img.timestamp}.png`}
+              className="ml-2"
+            >
+              <Button variant="secondary" size="sm" className="text-xs h-7">
+                ↓ Download
+              </Button>
+            </a>
+          </div>
+        </div>
+      )})()}
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+export default function PlaygroundPage() {
+  const [tab, setTab] = useState<PlaygroundTab>('chat')
+
+  const { data: keyData } = useQuery<{ apiKey: string }>({
+    queryKey: ['unified-key'],
+    queryFn: () => apiFetch('/api/settings/api-key'),
+  })
+
+  return (
     <div className="flex flex-col h-[calc(100vh-8rem)]">
       <PageHeader
         title="Playground"
-        description="Send a chat completion through the router and see which provider serves it."
-        actions={
-          <>
-            <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? 'auto')}>
-              <SelectTrigger className="w-[260px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">Auto (fallback chain)</SelectItem>
-                {availableModels.map(m => (
-                  <SelectItem key={m.modelDbId} value={m.modelId}>
-                    <span className="flex items-center gap-2">
-                      <span>{m.displayName}</span>
-                      <span className="text-xs text-muted-foreground">{m.platform}</span>
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {messages.length > 0 && (
-              <Button variant="outline" size="sm" onClick={handleClear}>
-                Clear
-              </Button>
-            )}
-          </>
-        }
+        description={tab === 'chat'
+          ? 'Send a chat completion through the router and see which provider serves it.'
+          : 'Generate images with free text-to-image models via OpenRouter.'}
+        actions={<TabSwitcher active={tab} onChange={setTab} />}
       />
-
-      <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0">
-        <div className="flex-1 overflow-y-auto p-6 space-y-4">
-          {messages.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-center">
-              <div className="space-y-2 max-w-sm">
-                <p className="text-base font-medium">Send a message to get started.</p>
-                <p className="text-sm text-muted-foreground">
-                  Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <>
-              {messages.map((msg, i) => (
-                <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                  <div
-                    className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
-                      msg.role === 'user'
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted'
-                    }`}
-                  >
-                    {msg.role === 'assistant' ? (
-                      <Markdown>{msg.content}</Markdown>
-                    ) : (
-                      <div className="whitespace-pre-wrap">{msg.content}</div>
-                    )}
-                    {msg.meta && (
-                      <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
-                        {msg.meta.platform && <span>{msg.meta.platform}</span>}
-                        {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
-                        {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
-                        {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
-                          <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-              {loading && (
-                <div className="flex justify-start">
-                  <div className="bg-muted rounded-2xl px-4 py-3">
-                    <div className="flex gap-1">
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
-                    </div>
-                  </div>
-                </div>
-              )}
-              <div ref={messagesEndRef} />
-            </>
-          )}
-        </div>
-
-        <div className="border-t bg-background/50 p-3">
-          <div className="flex gap-2 items-end">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Type a message… (⏎ to send, ⇧⏎ for newline)"
-              rows={1}
-              className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
-              style={{ height: 'auto', overflow: 'hidden' }}
-              onInput={e => {
-                const el = e.target as HTMLTextAreaElement
-                el.style.height = 'auto'
-                el.style.height = Math.min(el.scrollHeight, 160) + 'px'
-              }}
-            />
-            <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
-              {loading ? 'Sending…' : 'Send'}
-            </Button>
-          </div>
-        </div>
-      </div>
+      {tab === 'chat' ? <ChatTab keyData={keyData} /> : <ImageTab keyData={keyData} />}
     </div>
   )
 }

--- a/server/src/__tests__/services/capabilities.test.ts
+++ b/server/src/__tests__/services/capabilities.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { findModel } from '../../services/capabilities.js';
+
+type MockModel = { slug: string; context_length: number; supports_reasoning: boolean; input_modalities: string[] };
+
+function mock(slug: string, ctx = 100_000, reasoning = false, modalities: string[] = ['text']): MockModel {
+  return { slug, context_length: ctx, supports_reasoning: reasoning, input_modalities: modalities };
+}
+
+function extractVersion(slug: string): number {
+  const match = slug.match(/(\d+)$/);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Build all three lookups like syncFromOpenRouterFrontend does. */
+function buildMaps(models: MockModel[]) {
+  const modelsBySlug = new Map<string, MockModel>();
+  const modelsByName = new Map<string, MockModel>();
+  const modelsByBaseName = new Map<string, MockModel>();
+  for (const m of models) {
+    modelsBySlug.set(m.slug.toLowerCase(), m);
+    const nameMatch = m.slug.match(/\/([^/]+)$/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1].toLowerCase();
+    const existing = modelsByName.get(name);
+    if (!existing || extractVersion(m.slug) > extractVersion(existing.slug)) {
+      modelsByName.set(name, m);
+    }
+    const baseName = name.replace(/-\d+$/, '');
+    if (baseName !== name) {
+      const existingBase = modelsByBaseName.get(baseName);
+      if (!existingBase || extractVersion(m.slug) > extractVersion(existingBase.slug)) {
+        modelsByBaseName.set(baseName, m);
+      }
+    }
+  }
+  return { modelsBySlug, modelsByName, modelsByBaseName };
+}
+
+describe('findModel matching heuristics', () => {
+  const { modelsBySlug, modelsByName, modelsByBaseName } = buildMaps([
+    mock('google/gemini-2.5-flash', 1_048_576, true, ['text', 'image']),
+    mock('meta-llama/llama-4-scout-17b-16e-instruct', 131_072, false, ['text', 'image']),
+    mock('openai/gpt-oss-120b', 131_072, false, ['text']),
+    mock('qwen/qwen3-coder', 262_144, false, ['text']),
+    mock('minimax/minimax-m3', 1_048_576, true, ['text', 'image', 'video']),
+    mock('llama-4-scout', 131_072, false, ['text']),
+    mock('mistralai/devstral-2512', 262_144, false, ['text']),
+    mock('mistralai/devstral-2505', 131_072, false, ['text']),
+    mock('mistralai/codestral-2508', 256_000, false, ['text']),
+    mock('deepseek/deepseek-v4-flash', 1_048_576, false, ['text']),
+  ]);
+
+  it('matches openrouter :free models by stripping :free suffix', () => {
+    const m = findModel('openrouter', 'google/gemini-2.5-flash:free', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  it('returns null for unknown models', () => {
+    expect(findModel('openrouter', 'unknown/model:free', modelsBySlug, modelsByName, modelsByBaseName)).toBeNull();
+  });
+
+  it('matches by reverse substring (strategy 5)', () => {
+    const m = findModel('cloudflare', '@cf/meta/llama-4-scout-17b-16e-instruct', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toMatch(/llama-4-scout/);
+  });
+
+  it('skips trivial slug matches (length < 8)', () => {
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([mock('m3', 100_000, true)]);
+    expect(findModel('opencode', 'big-pickle', s, n, b)).toBeNull();
+  });
+
+  it('strips -free suffix for non-OR platforms', () => {
+    const m = findModel('opencode', 'minimax-m3-free', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  it('strips -latest and matches highest version via base-name lookup (strategy 3)', () => {
+    const m = findModel('mistral', 'devstral-latest', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('mistralai/devstral-2512');
+    expect(m!.context_length).toBe(262_144);
+  });
+
+  it('matches codestral-latest via base-name lookup', () => {
+    const m = findModel('mistral', 'codestral-latest', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('mistralai/codestral-2508');
+    expect(m!.context_length).toBe(256_000);
+  });
+
+  it('matches model name regardless of provider prefix (strategy 4/7)', () => {
+    const m = findModel('opencode', 'deepseek-v4-flash', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  // Strategy 8: reverse name substring — our name contains OR name
+  it('matches Meta-Llama-3.3-70B-Instruct via reverse name (strategy 8)', () => {
+    // Our name 'meta-llama-3.3-70b-instruct' contains OR name 'llama-3.3-70b-instruct'
+    // from slug 'meta-llama/llama-3.3-70b-instruct'
+    const or = mock('meta-llama/llama-3.3-70b-instruct', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Meta-Llama-3.3-70B-Instruct', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-3.3-70b-instruct');
+  });
+
+  it('matches Llama-4-Maverick-17B-128E-Instruct via reverse name (strategy 8)', () => {
+    // Our name 'llama-4-maverick-17b-128e-instruct' contains OR name 'llama-4-maverick'
+    const or = mock('meta-llama/llama-4-maverick', 1_048_576);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Llama-4-Maverick-17B-128E-Instruct', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-4-maverick');
+  });
+
+  it('matches zai-glm-4.7 via reverse name (strategy 8)', () => {
+    // Our name 'zai-glm-4.7' contains OR name 'glm-4.7'
+    const or = mock('z-ai/glm-4.7', 202_752);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cerebras', 'zai-glm-4.7', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('z-ai/glm-4.7');
+  });
+
+  it('matches glm-4.5-flash via reverse name (strategy 8)', () => {
+    // Our name 'glm-4.5-flash' contains OR name 'glm-4.5'
+    const or = mock('z-ai/glm-4.5', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('zhipu', 'glm-4.5-flash', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('z-ai/glm-4.5');
+  });
+
+  it('matches llama-3.3-70b-instruct-fp8-fast via reverse name (strategy 8)', () => {
+    // Our name 'llama-3.3-70b-instruct-fp8-fast' contains OR name 'llama-3.3-70b-instruct'
+    const or = mock('meta-llama/llama-3.3-70b-instruct', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cloudflare', '@cf/meta/llama-3.3-70b-instruct-fp8-fast', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-3.3-70b-instruct');
+  });
+
+  it('matches command-a-03-2025 via reverse name (strategy 8)', () => {
+    // Our name 'command-a-03-2025' contains OR name 'command-a'
+    const or = mock('cohere/command-a', 256_000);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cohere', 'command-a-03-2025', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('cohere/command-a');
+  });
+
+  it('returns null when OR name is too short to match (< 6 chars)', () => {
+    // OR name 'llama' is only 5 chars, should not match
+    const or = mock('meta-llama/llama', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Meta-Llama-3.3-70B-Instruct', s, n, b);
+    expect(m).toBeNull();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,7 @@ import { proxyRouter } from './routes/proxy.js';
 import { responsesRouter } from './routes/responses.js';
 import { fallbackRouter } from './routes/fallback.js';
 import { embeddingsRouter } from './routes/embeddings.js';
+import { imageModelsRouter } from './routes/image-models.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
@@ -65,6 +66,7 @@ export function createApp() {
   app.use('/api/models', requireAuth, modelsRouter);
   app.use('/api/fallback', requireAuth, fallbackRouter);
   app.use('/api/embeddings', requireAuth, embeddingsRouter);
+  app.use('/api/image-models', requireAuth, imageModelsRouter);
   app.use('/api/analytics', requireAuth, analyticsRouter);
   app.use('/api/health', requireAuth, healthRouter);
   app.use('/api/settings', requireAuth, settingsRouter);

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -15,6 +15,8 @@ export interface CompletionOptions {
   tools?: ChatToolDefinition[];
   tool_choice?: ChatToolChoice;
   parallel_tool_calls?: boolean;
+  modalities?: string[];
+  image_config?: Record<string, unknown>;
 }
 
 export abstract class BaseProvider {

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -69,6 +69,8 @@ export class OpenAICompatProvider extends BaseProvider {
         tools: options?.tools,
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
+        ...(options?.modalities ? { modalities: options.modalities } : {}),
+        ...(options?.image_config ? { image_config: options.image_config } : {}),
       }),
     }, this.timeoutMs);
 
@@ -81,10 +83,6 @@ export class OpenAICompatProvider extends BaseProvider {
     try {
       data = await res.json() as ChatCompletionResponse;
     } catch {
-      // A 200 whose body isn't a single JSON document — typically a base URL
-      // pointing at a non-OpenAI-compatible API (e.g. Ollama's native NDJSON
-      // /api endpoints instead of /v1, #189). Surface what's wrong instead of
-      // the raw JSON.parse position error.
       throw new Error(
         `${this.name} returned 200 with a non-JSON body — the endpoint is not OpenAI-compatible. ` +
         `Check the base URL (for Ollama use http://host:11434/v1, for llama.cpp/vLLM/LM Studio the /v1 path).`,
@@ -118,6 +116,8 @@ export class OpenAICompatProvider extends BaseProvider {
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
         stream: true,
+        ...(options?.modalities ? { modalities: options.modalities } : {}),
+        ...(options?.image_config ? { image_config: options.image_config } : {}),
       }),
     }, this.timeoutMs);
 

--- a/server/src/routes/image-models.ts
+++ b/server/src/routes/image-models.ts
@@ -1,0 +1,209 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { getDb } from '../db/index.js';
+
+export const imageModelsRouter = Router();
+
+/**
+ * Minimal shape of the OpenRouter /api/frontend/models response we care about.
+ * Only fields used by the Image models tab are typed here.
+ */
+interface OpenRouterImageModel {
+  slug: string;
+  name: string;
+  short_name: string;
+  author: string;
+  author_display_name: string;
+  description: string;
+  context_length: number;
+  input_modalities: string[];
+  output_modalities: string[];
+  has_text_output: boolean;
+  supports_reasoning: boolean;
+  endpoint?: {
+    is_free: boolean;
+    pricing?: { prompt: string; completion: string };
+    limit_rpm?: number | null;
+    limit_rpd?: number | null;
+    provider_display_name?: string;
+    provider_slug?: string;
+    model_variant_slug?: string;
+  };
+}
+
+/**
+ * Fetch image-capable models from OpenRouter's public catalog.
+ * Filters to models whose output_modalities include "image".
+ * Cached in-memory for 10 minutes to avoid hammering the API.
+ */
+let cacheFree: { data: ImageModel[]; ts: number } | null = null;
+let cacheAll: { data: ImageModel[]; ts: number } | null = null;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+/** Check whether an image model slug is known to be free.
+ *  Used by the proxy passthrough path to reject paid image models —
+ *  image generation never bills the user's OpenRouter credits.
+ *  Matches against both the display slug (model_variant_slug) and the
+ *  raw OpenRouter slug to handle both client-visible and API forms. (#image-gen) */
+export async function isFreeImageModel(slug: string): Promise<boolean> {
+  const now = Date.now();
+  if (!cacheFree || now - cacheFree.ts >= CACHE_TTL_MS) {
+    try {
+      await refreshCacheFree();
+    } catch (err: any) {
+      console.warn('[ImageModels] isFreeImageModel: failed to refresh cache, rejecting conservatively:', err?.message ?? err);
+      return false;
+    }
+  }
+  return cacheFree!.data.some(m => m.slug === slug || m.rawSlug === slug);
+}
+
+async function refreshCacheFree(): Promise<ImageModel[]> {
+  const resp = await fetch('https://openrouter.ai/api/frontend/models', {
+    headers: { 'Accept': 'application/json' },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`OpenRouter returned ${resp.status}`);
+
+  const body = (await resp.json()) as { data?: OpenRouterImageModel[] };
+  const all: OpenRouterImageModel[] = Array.isArray(body) ? body : (body.data ?? []);
+
+  const free = all.filter(m => {
+    if (!m.output_modalities?.includes('image') || m.output_modalities.length === 0) return false;
+    return m.endpoint?.is_free === true;
+  });
+
+  const db = getDb();
+  const keyPlatforms = new Set(
+    (db.prepare(
+      "SELECT DISTINCT platform FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown')",
+    ).all() as { platform: string }[]).map(r => r.platform),
+  );
+
+  const data = free.map(m => ({
+    slug: m.endpoint?.model_variant_slug ?? m.slug,
+    // For isFreeImageModel broad matching: the raw OpenRouter slug
+    // so clients sending either form still match.
+    rawSlug: m.slug,
+    name: m.name,
+    shortName: m.short_name,
+    author: m.author,
+    authorDisplayName: m.author_display_name ?? m.author ?? m.short_name.split(':')[0] ?? m.slug.split('/')[0],
+    description: m.description ?? '',
+    contextLength: m.context_length ?? 0,
+    inputModalities: m.input_modalities ?? [],
+    outputModalities: m.output_modalities ?? [],
+    supportsReasoning: m.supports_reasoning ?? false,
+    isFree: true,
+    pricing: m.endpoint?.pricing ?? null,
+    rpmLimit: m.endpoint?.limit_rpm ?? null,
+    rpdLimit: m.endpoint?.limit_rpd ?? null,
+    providerDisplayName: m.endpoint?.provider_display_name ?? m.author ?? 'Unknown',
+    providerSlug: m.endpoint?.provider_slug ?? m.author ?? 'unknown',
+    hasKey: keyPlatforms.has('openrouter'),
+  }));
+
+  cacheFree = { data, ts: Date.now() };
+  return data;
+}
+
+interface ImageModel {
+  slug: string;
+  /** Raw OpenRouter slug (before model_variant_slug substitution).
+   *  Used by isFreeImageModel for broad matching against either form. */
+  rawSlug?: string;
+  name: string;
+  shortName: string;
+  author: string;
+  authorDisplayName: string;
+  description: string;
+  contextLength: number;
+  inputModalities: string[];
+  outputModalities: string[];
+  supportsReasoning: boolean;
+  isFree: boolean;
+  pricing: { prompt: string; completion: string } | null;
+  rpmLimit: number | null;
+  rpdLimit: number | null;
+  providerDisplayName: string;
+  providerSlug: string;
+  /** Whether we have a key for OpenRouter in the local DB.
+   *  All image models currently route through OpenRouter exclusively;
+   *  if a non-OpenRouter image model is ever added, this must become
+   *  per-model (keyed on providerSlug, not a single platform check). */
+  hasKey: boolean;
+}
+
+imageModelsRouter.get('/', async (req: Request, res: Response) => {
+  try {
+    const now = Date.now();
+    // ?free_only=0 includes paid models (requires user's own OpenRouter key)
+    const freeOnly = req.query.free_only !== '0';
+
+    if (freeOnly) {
+      // Reuse the shared free-only cache (also used by isFreeImageModel).
+      if (!cacheFree || now - cacheFree.ts >= CACHE_TTL_MS) {
+        await refreshCacheFree();
+      }
+      res.json(cacheFree!.data);
+      return;
+    }
+
+    // Paid-model list — separate cache, fetched on demand.
+    if (cacheAll && now - cacheAll.ts < CACHE_TTL_MS) {
+      res.json(cacheAll.data);
+      return;
+    }
+
+    const resp = await fetch('https://openrouter.ai/api/frontend/models', {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!resp.ok) {
+      res.status(502).json({ error: { message: `OpenRouter API returned ${resp.status}` } });
+      return;
+    }
+
+    const body = (await resp.json()) as { data?: OpenRouterImageModel[] };
+    const all: OpenRouterImageModel[] = Array.isArray(body) ? body : (body.data ?? []);
+
+    const imageModels = all.filter(m => {
+      if (!m.output_modalities?.includes('image') || m.output_modalities.length === 0) return false;
+      return true;
+    });
+
+    const db = getDb();
+    const keyPlatforms = new Set(
+      (db.prepare(
+        "SELECT DISTINCT platform FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown')",
+      ).all() as { platform: string }[]).map(r => r.platform),
+    );
+
+    const result: ImageModel[] = imageModels.map(m => ({
+      slug: m.endpoint?.model_variant_slug ?? m.slug,
+      name: m.name,
+      shortName: m.short_name,
+      author: m.author,
+      authorDisplayName: m.author_display_name ?? m.author ?? m.short_name.split(':')[0] ?? m.slug.split('/')[0],
+      description: m.description ?? '',
+      contextLength: m.context_length ?? 0,
+      inputModalities: m.input_modalities ?? [],
+      outputModalities: m.output_modalities ?? [],
+      supportsReasoning: m.supports_reasoning ?? false,
+      isFree: m.endpoint?.is_free ?? false,
+      pricing: m.endpoint?.pricing ?? null,
+      rpmLimit: m.endpoint?.limit_rpm ?? null,
+      rpdLimit: m.endpoint?.limit_rpd ?? null,
+      providerDisplayName: m.endpoint?.provider_display_name ?? m.author ?? 'Unknown',
+      providerSlug: m.endpoint?.provider_slug ?? m.author ?? 'unknown',
+      hasKey: keyPlatforms.has('openrouter'),
+    }));
+
+    cacheAll = { data: result, ts: now };
+    res.json(result);
+  } catch (err: any) {
+    console.error('[ImageModels] Failed to fetch from OpenRouter:', err?.message ?? err);
+    res.status(502).json({ error: { message: 'Failed to fetch image models from OpenRouter' } });
+  }
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -4,12 +4,15 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type { ChatMessage, ModelListRow } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
+import { getProvider } from '../providers/index.js';
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { runEmbeddings, EmbeddingsError } from '../services/embeddings.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString, messageHasImage, normalizeOutboundContent } from '../lib/content.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
+import { isFreeImageModel } from './image-models.js';
+import { decrypt } from '../lib/crypto.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 import { rescueInlineToolCalls, startsWithDialectMarker, couldBecomeDialectMarker, containsDialectMarker } from '../lib/tool-call-rescue.js';
 
@@ -221,6 +224,11 @@ const userMessageSchema = z.object({
 // them verbatim. We accept them too and coerce empty/null content to "" before
 // forwarding (see message build below) rather than 400-ing a payload OpenAI
 // would take. (#165)
+//
+// images: echoed assistant turns from image-generation responses may carry
+// the generated images array. zod strips unknown keys by default — declaring
+// the field (even as z.any()) prevents data loss when clients replay history
+// containing "images" on assistant messages. (#image-gen)
 const assistantMessageSchema = z.object({
   role: z.literal('assistant'),
   content: z.union([contentSchema, z.null()]).optional(),
@@ -229,6 +237,7 @@ const assistantMessageSchema = z.object({
   // no-tool assistant turns — aionrs (AionUI's engine) writes it into every
   // session-resumed assistant echo. Treated as absent. (#200)
   tool_calls: z.array(toolCallSchema).nullable().optional(),
+  images: z.array(z.any()).optional(),
 });
 
 // Tool results may arrive with null/missing content (a tool that returned
@@ -295,6 +304,9 @@ const chatCompletionSchema = z.object({
   tools: z.array(toolDefinitionSchema).nullable().optional(),
   tool_choice: toolChoiceSchema.nullable().optional(),
   parallel_tool_calls: z.boolean().nullable().optional(),
+  // Image generation fields — forwarded to OpenRouter as-is when present.
+  modalities: z.array(z.string()).nullable().optional(),
+  image_config: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
 export function isRetryableError(err: any): boolean {
@@ -428,7 +440,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     return;
   }
 
-  const { model: requestedModel, temperature, top_p, stream } = parsed.data;
+  const { model: requestedModel, temperature, top_p, stream, modalities, image_config } = parsed.data;
   // Agent-tolerant knob normalization (#200): max_tokens <= 0 means "no
   // limit" in several clients → unset; tool_choice 'any' is OpenAI's
   // 'required'; tool definitions get their 'function' type re-defaulted.
@@ -485,6 +497,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             thought_signature: tc.thought_signature,
           };
         }) } : {}),
+        // Preserve echoed images from image-generation history so clients
+        // that replay full conversation context (including generated images)
+        // don't lose data when forwarding to upstream providers. (#image-gen)
+        ...((m as any).images?.length ? { images: (m as any).images } : {}),
       };
     }
 
@@ -534,6 +550,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // or surfacing the generic "all models exhausted" error (#118, #125). Add a
   // rough per-image token cost so budget routing isn't skewed by content the
   // heuristic above (text-only) can't see.
+  // Image generation requests bypass catalog validation — route directly
+  // to OpenRouter which hosts the image models. (#image-gen)
+  const isImageRequest = Array.isArray(modalities) && modalities.includes('image');
+
   const hasImage = messageHasImage(messages);
   if (hasImage && !hasEnabledVisionModel()) {
     res.status(422).json({
@@ -578,6 +598,23 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // different model would be surprising to OpenAI-compatible clients.
   // Sticky-session is the fallback when no `model` field was sent at all.
   let preferredModel: number | undefined;
+  // Image generation passthrough: when the requested model is an image model
+  // not in our catalog, route directly to OpenRouter. Local models that happen
+  // to accept modalities: ["image"] are NOT hijacked — they go through normal routing.
+  // When model is 'auto' or omitted but modalities includes "image", reject with
+  // a clear message: image generation needs an explicit model (our catalog has
+  // no image models, and 'auto' can't route to OpenRouter without a model id). (#image-gen)
+  let isImagePassthrough = false;
+  if (isImageRequest && (isAutoModel(requestedModel) || !requestedModel)) {
+    res.status(400).json({
+      error: {
+        message: 'Image generation requires a specific model. Use one of the image models listed on the Models > Images page, or call GET /api/image-models for the available list.',
+        type: 'invalid_request_error',
+        code: 'image_model_required',
+      },
+    });
+    return;
+  }
   if (isAutoModel(requestedModel)) {
     // Explicit "auto" → behave exactly like an omitted model field.
     preferredModel = getStickyModel(messages, sessionIdHeader);
@@ -586,6 +623,34 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     const enabled = db.prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1').get(requestedModel) as { id: number } | undefined;
     if (enabled) {
       preferredModel = enabled.id;
+    } else if (isImageRequest) {
+      // Image generation models (e.g. sourceful/riverflow-v2.5-pro) are not
+      // in the local catalog — they live exclusively on OpenRouter. Only
+      // passthrough when the model is genuinely absent from our catalog.
+      // Enforce free-only: image generation never bills the user's OpenRouter
+      // credits. (#image-gen)
+      if (!(await isFreeImageModel(requestedModel))) {
+        res.status(400).json({
+          error: {
+            message: `Image generation is restricted to free models. '${requestedModel}' is either paid or not in the free catalog. Use one of the free models from the Models > Images page.`,
+            type: 'invalid_request_error',
+            code: 'image_model_not_free',
+          },
+        });
+        return;
+      }
+      const orKey = db.prepare("SELECT id FROM api_keys WHERE platform = 'openrouter' AND enabled = 1 AND status IN ('healthy', 'unknown') LIMIT 1").get() as { id: number } | undefined;
+      if (!orKey) {
+        res.status(400).json({
+          error: {
+            message: `Image model '${requestedModel}' requires an OpenRouter API key. Add one on the Keys page.`,
+            type: 'invalid_request_error',
+            code: 'no_openrouter_key',
+          },
+        });
+        return;
+      }
+      isImagePassthrough = true;
     } else {
       const disabled = db.prepare('SELECT id FROM models WHERE model_id = ?').get(requestedModel) as { id: number } | undefined;
       const reason = disabled ? 'is disabled' : 'is not in the catalog';
@@ -613,24 +678,67 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     let route: RouteResult;
-    try {
-      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage, wantsTools);
-    } catch (err: any) {
-      // No more models available
-      if (lastError) {
-        const safeLastError = sanitizeProviderErrorMessage(lastError.message);
-        res.status(429).json({
-          error: {
-            message: `All models rate-limited. Last error: ${safeLastError}`,
-            type: 'rate_limit_error',
-          },
-        });
-      } else {
-        res.status(err.status ?? 503).json({
-          error: { message: err.message, type: 'routing_error' },
-        });
+    // Image generation passthrough: bypass the normal routing chain and
+    // directly route to OpenRouter with the requested model slug. Image
+    // models don't exist in the local catalog, so routeRequest would
+    // either skip them or route to the wrong provider. Keys are iterated
+    // with skipKeys support so a dead OR key fails over to the next one. (#image-gen)
+    if (isImagePassthrough) {
+      const provider = getProvider('openrouter');
+      if (!provider) {
+        res.status(500).json({ error: { message: 'OpenRouter provider not configured', type: 'server_error' } });
+        return;
       }
-      return;
+      const db = getDb();
+      // Iterate OR keys in id order, skipping previously-failed ones.
+      const allKeyRows = db.prepare(
+        "SELECT id, encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'openrouter' AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id"
+      ).all() as { id: number; encrypted_key: string; iv: string; auth_tag: string }[];
+      const keyRow = allKeyRows.find(k => !skipKeys.has(`openrouter:${requestedModel!}:${k.id}`));
+      if (!keyRow) {
+        if (lastError) {
+          const safeLastError = sanitizeProviderErrorMessage(lastError.message);
+          res.status(429).json({
+            error: { message: `All OpenRouter keys exhausted for image model '${requestedModel}'. Last error: ${safeLastError}`, type: 'rate_limit_error' },
+          });
+        } else {
+          res.status(400).json({
+            error: { message: `Image model '${requestedModel}' requires an OpenRouter API key. Add one on the Keys page.`, type: 'invalid_request_error', code: 'no_openrouter_key' },
+          });
+        }
+        return;
+      }
+      route = {
+        provider,
+        modelId: requestedModel!,
+        modelDbId: 0,
+        apiKey: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
+        keyId: keyRow.id,
+        platform: 'openrouter',
+        displayName: `OpenRouter (${requestedModel!})`,
+        rpdLimit: null,
+        tpdLimit: null,
+      };
+    } else {
+      try {
+        route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage, wantsTools);
+      } catch (err: any) {
+        // No more models available
+        if (lastError) {
+          const safeLastError = sanitizeProviderErrorMessage(lastError.message);
+          res.status(429).json({
+            error: {
+              message: `All models rate-limited. Last error: ${safeLastError}`,
+              type: 'rate_limit_error',
+            },
+          });
+        } else {
+          res.status(err.status ?? 503).json({
+            error: { message: err.message, type: 'routing_error' },
+          });
+        }
+        return;
+      }
     }
 
     recordRequest(route.platform, route.modelId, route.keyId);
@@ -692,7 +800,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         try {
           const gen = route.provider.streamChatCompletion(
             route.apiKey, messages, route.modelId,
-            { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls },
+            { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls, modalities: modalities ?? undefined, image_config: image_config ?? undefined },
           );
 
           for await (const chunk of gen) {
@@ -806,8 +914,11 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             }
           }
 
+          // Image generation streams may produce no text and no tool_calls —
+          // images arrive in delta.images via real SSE streaming. Skip the
+          // empty-completion check for image requests. (#image-gen)
           const hasText = headerSent || heldText.trim().length > 0;
-          if (!hasText && completedCalls.length === 0) {
+          if (!hasText && completedCalls.length === 0 && !isImageRequest) {
             // Nothing usable came out — same failover semantics as the
             // non-stream empty-completion path. Headers can't have been sent
             // (header flush requires payload), so the client never notices.
@@ -835,7 +946,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.end();
 
           recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
-          recordSuccess(route.modelDbId);
+          if (route.modelDbId > 0) recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader);
           logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, ttfbMs, pinnedModelId);
           return;
@@ -859,19 +970,22 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       } else {
         const result = await route.provider.chatCompletion(
           route.apiKey, messages, route.modelId,
-          { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls },
+          { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls, modalities: modalities ?? undefined, image_config: image_config ?? undefined },
         );
 
         // Empty completion (no text, no tool calls) → fail over rather than
         // return a transport-level "success" the caller can't act on. Mirrors
-        // the zero-chunk streaming case above.
+        // the zero-chunk streaming case above. Image generation responses carry
+        // images on the message instead of text — skip the empty check. (#image-gen)
         const respMsg = result.choices?.[0]?.message;
         const respText = contentToString(respMsg?.content ?? '');
-        if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0) {
+        const respImages = respMsg?.images;
+        const hasImages = Array.isArray(respImages) && respImages.length > 0;
+        if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0 && !hasImages) {
           logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', null, pinnedModelId);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
-          recordRateLimitHit(route.modelDbId);
+          if (route.modelDbId > 0) recordRateLimitHit(route.modelDbId);
           lastError = new Error(`empty completion from ${route.displayName}`);
           continue;
         }
@@ -902,7 +1016,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
         const totalTokens = result.usage?.total_tokens ?? 0;
         recordTokens(route.platform, route.modelId, route.keyId, totalTokens);
-        recordSuccess(route.modelDbId);
+        if (route.modelDbId > 0) recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
 
         res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
@@ -950,7 +1064,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
                 tpd: route.tpdLimit,
               }),
         );
-        recordRateLimitHit(route.modelDbId);
+        if (route.modelDbId > 0) recordRateLimitHit(route.modelDbId);
         lastError = err;
         console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
         continue;

--- a/server/src/services/capabilities.ts
+++ b/server/src/services/capabilities.ts
@@ -1,0 +1,388 @@
+import type Database from 'better-sqlite3';
+import { execSync } from 'child_process';
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Sync model capabilities from OpenRouter's public API into the models table.
+ *
+ * This is the AUTHORITATIVE source for model metadata. When a model is found
+ * on OpenRouter, ALL its capability fields are overwritten from the API:
+ *   - context_window  (from context_length)
+ *   - supports_vision (from input_modalities containing "image")
+ *   - supports_reasoning (from supports_reasoning flag)
+ *   - rpm_limit / rpd_limit (from limit_rpm / limit_rpd)
+ *
+ * V16 (vision) and V22 (tools) LIKE rules still run BEFORE this function
+ * as a fallback baseline — but only models NOT found on OpenRouter keep
+ * those hardcoded values.
+ *
+ * The sync runs synchronously at startup (one ~2s HTTP call to a free,
+ * unauthenticated endpoint). Failures are logged but never fatal — the
+ * migration fallbacks ensure models still work if the API is unreachable.
+ */
+export interface SyncResult {
+  updated: number;
+  unmatched: { platform: string; modelId: string; displayName: string }[];
+  total: number;
+  matched: number;
+  /** Number of models enriched from platform-specific specs (post-OpenRouter sync). */
+  platformSynced: number;
+  error?: string;
+}
+
+export function syncCapabilities(db: Database.Database): void {
+  const result = syncCapabilitiesDetailed(db);
+  if (result.error) console.error('[Caps] OpenRouter sync failed, using migration fallbacks:', result.error);
+  else {
+    const parts = [`${result.matched}/${result.total} matched`];
+    if (result.updated > 0) parts.unshift(`updated ${result.updated} models`);
+    if (result.platformSynced > 0) parts.push(`${result.platformSynced} from platform specs`);
+    console.log(`[Caps] OpenRouter sync: ${parts.join(', ')}`);
+  }
+}
+
+/** Detailed sync that returns unmatched models for UI display. */
+export function syncCapabilitiesDetailed(db: Database.Database): SyncResult {
+  try {
+    const result = syncFromOpenRouterFrontend(db);
+    // After OpenRouter sync, enrich remaining unmatched models from platform specs.
+    const platformSynced = syncPlatformSpecs(db, result.unmatched);
+    return { ...result, platformSynced };
+  } catch (err) {
+    return { updated: 0, unmatched: [], total: 0, matched: 0, platformSynced: 0, error: (err as Error).message };
+  }
+}
+
+// ── OpenRouter /api/frontend/models sync ──────────────────────────────────
+
+interface OpenRouterFrontendModel {
+  slug: string;
+  context_length: number;
+  input_modalities: string[];
+  output_modalities: string[];
+  supports_reasoning: boolean;
+  reasoning_config: { effort?: string; return_reasoning?: boolean } | null;
+  limit_rpm: number;
+  limit_rpd: number;
+  hidden: boolean;
+}
+
+interface OpenRouterFrontendResponse {
+  data: OpenRouterFrontendModel[];
+}
+
+/** Internal return from the OpenRouter sync — before platform specs enrichment. */
+interface OpenRouterSyncResult {
+  updated: number;
+  unmatched: { platform: string; modelId: string; displayName: string }[];
+  total: number;
+  matched: number;
+}
+
+/**
+ * Fetch OpenRouter's public frontend model list and apply capability data
+ * to matching entries in our models table. Returns the number of rows updated.
+ *
+ * This endpoint (/api/frontend/models) is free, requires no auth, and returns
+ * rich metadata for 766+ models:
+ * - context_length: accurate context window per model
+ * - supports_reasoning: whether the model supports chain-of-thought
+ * - input_modalities: vision (image), audio, video support
+ * - limit_rpm / limit_rpd: provider rate limits
+ */
+function syncFromOpenRouterFrontend(db: Database.Database): OpenRouterSyncResult {
+  // Use a blocking fetch with timeout — this runs at boot and we need the
+  // data before the server starts accepting requests.
+  const res = fetchSync('https://openrouter.ai/api/frontend/models', 30000);
+
+  const body = res as OpenRouterFrontendResponse;
+  if (!Array.isArray(body.data)) {
+    throw new Error('OpenRouter /api/frontend/models returned unexpected shape');
+  }
+
+  // Build three lookups:
+  // 1. modelsBySlug: normalized slug → model metadata (exact match)
+  // 2. modelsByName: full model name (part after /) → best version
+  // 3. modelsByBaseName: name with trailing version stripped → best version
+  //    E.g. 'codestral-2508' → base 'codestral' → maps to the highest version
+  const modelsBySlug = new Map<string, OpenRouterFrontendModel>();
+  const modelsByName = new Map<string, OpenRouterFrontendModel>();
+  const modelsByBaseName = new Map<string, OpenRouterFrontendModel>();
+  for (const m of body.data) {
+    if (!m.slug) continue;
+    modelsBySlug.set(m.slug.toLowerCase(), m);
+    const nameMatch = m.slug.match(/\/([^/]+)$/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1].toLowerCase();
+    const existing = modelsByName.get(name);
+    if (!existing || extractVersion(m.slug) > extractVersion(existing.slug)) {
+      modelsByName.set(name, m);
+    }
+    // Base name: strip trailing version number (e.g. 'devstral-2512' → 'devstral')
+    const baseName = name.replace(/-\d+$/, '');
+    if (baseName !== name) {
+      const existingBase = modelsByBaseName.get(baseName);
+      if (!existingBase || extractVersion(m.slug) > extractVersion(existingBase.slug)) {
+        modelsByBaseName.set(baseName, m);
+      }
+    }
+  }
+
+  // Walk every enabled model, match against the OR catalog, and OVERWRITE
+  // all fields. The API is authoritative — if a model is found on OpenRouter,
+  // its API values replace any hardcoded migration values.
+  const update = db.prepare(`
+    UPDATE models SET supports_vision = ?, supports_tools = ?, supports_reasoning = ?,
+                      context_window = ?, rpm_limit = ?, rpd_limit = ?
+     WHERE id = ?
+  `);
+
+  let updated = 0;
+  const unmatched: { platform: string; modelId: string; displayName: string }[] = [];
+  let matched = 0;
+  let total = 0;
+  const apply = db.transaction(() => {
+    const rows = db.prepare(
+      'SELECT id, platform, model_id, display_name, supports_tools FROM models WHERE enabled = 1'
+    ).all() as {
+      id: number; platform: string; model_id: string; display_name: string;
+      supports_tools: number;
+    }[];
+
+    total = rows.length;
+
+    for (const row of rows) {
+      const meta = findModel(row.platform, row.model_id, modelsBySlug, modelsByName, modelsByBaseName);
+      if (!meta) {
+        unmatched.push({ platform: row.platform, modelId: row.model_id, displayName: row.display_name });
+        continue;
+      }
+      matched++;
+
+      const newVision = meta.input_modalities.includes('image') ? 1 : 0;
+      const newReasoning = meta.supports_reasoning ? 1 : 0;
+      const newCtx = meta.context_length > 0 ? meta.context_length : null;
+      const current = db.prepare(
+        'SELECT rpm_limit, rpd_limit, supports_vision, supports_reasoning, context_window FROM models WHERE id = ?'
+      ).get(row.id) as { rpm_limit: number | null; rpd_limit: number | null; supports_vision: number; supports_reasoning: number; context_window: number | null };
+      const newRpm = meta.limit_rpm > 0 ? meta.limit_rpm : current.rpm_limit;
+      const newRpd = meta.limit_rpd > 0 ? meta.limit_rpd : current.rpd_limit;
+
+      if (
+        current.supports_vision === newVision &&
+        current.supports_reasoning === newReasoning &&
+        current.context_window === newCtx
+      ) continue;
+
+      update.run(newVision, row.supports_tools, newReasoning, newCtx, newRpm, newRpd, row.id);
+      updated++;
+    }
+  });
+  apply();
+  return { updated, unmatched, total, matched };
+}
+
+/**
+ * Synchronous fetch wrapper for boot-time use. Uses Node's built-in fetch
+ * but wraps it in a blocking pattern via child_process.execSync + curl as
+ * a fallback if the runtime doesn't support sync fetch.
+ */
+function fetchSync(url: string, timeoutMs: number): unknown {
+  // Blocking fetch via curl — runs at boot before the server accepts requests.
+  const stdout = execSync(
+    `curl -s --max-time ${Math.floor(timeoutMs / 1000)} "${url}"`,
+    { encoding: 'utf8', timeout: timeoutMs + 5000, maxBuffer: 50 * 1024 * 1024 }
+  );
+  return JSON.parse(stdout);
+}
+
+/**
+ * Match a (platform, model_id) pair against the OpenRouter frontend catalog.
+ * Suffixes like `:free`, `-free`, and `-latest` are stripped before matching.
+ * Version-aware: when multiple OR slugs share a name, the highest version wins.
+ */
+export function findModel(
+  platform: string,
+  modelId: string,
+  modelsBySlug: Map<string, OpenRouterFrontendModel>,
+  modelsByName: Map<string, OpenRouterFrontendModel>,
+  modelsByBaseName: Map<string, OpenRouterFrontendModel>,
+): OpenRouterFrontendModel | null {
+  // Normalize: strip :free / -free / -latest suffixes.
+  // E.g. 'google/gemini-2.5-flash:free' → 'google/gemini-2.5-flash'
+  //       'minimax-m3-free' → 'minimax-m3'
+  //       'devstral-latest' → 'devstral'
+  const normalized = modelId.replace(/[:-]free$/i, '').replace(/-latest$/i, '').toLowerCase();
+
+  // Strategy 1: direct slug lookup with normalized ID
+  const direct = modelsBySlug.get(normalized);
+  if (direct) return direct;
+
+  // Strategy 2: direct slug lookup with original ID (no suffix stripping)
+  if (normalized !== modelId.toLowerCase()) {
+    const orig = modelsBySlug.get(modelId.toLowerCase());
+    if (orig) return orig;
+  }
+
+  // Strategy 3: base-name lookup (highest version wins)
+  // E.g. 'devstral' → matches 'mistralai/devstral-2512' (highest version)
+  const ourName = extractName(normalized);
+  if (ourName) {
+    const byBase = modelsByBaseName.get(ourName);
+    if (byBase) return byBase;
+  }
+
+  // Strategy 4: exact name lookup (e.g. 'deepseek-v4-flash' matches slug name directly)
+  if (ourName) {
+    const byName = modelsByName.get(ourName);
+    if (byName) return byName;
+  }
+
+  // Strategy 5 (reverse): our normalized model_id contains an OR slug.
+  for (const [slug, meta] of modelsBySlug) {
+    if (slug.length < 8) continue;
+    if (normalized.includes(slug)) return meta;
+  }
+
+  // Strategy 6 (loose): any OR slug contains our normalized model_id.
+  for (const [slug, meta] of modelsBySlug) {
+    if (slug.includes(normalized)) return meta;
+  }
+
+  // Strategy 7: name substring — OR slug's name contains our name.
+  // E.g. our 'deepseek-v4-flash' matches OR's 'deepseek/deepseek-v4-flash'
+  if (ourName && ourName.length >= 8) {
+    for (const [name, meta] of modelsByName) {
+      if (name.length >= 6 && name.includes(ourName)) return meta;
+    }
+  }
+
+  // Strategy 8: reverse name substring — our name contains an OR slug's name.
+  // E.g. our 'meta-llama-3.3-70b-instruct' contains OR's 'llama-3.3-70b-instruct'
+  //      our 'llama-4-maverick-17b-128e-instruct' contains OR's 'llama-4-maverick'
+  //      our 'zai-glm-4.7' contains OR's 'glm-4.7'
+  // Prefer the LONGEST matching OR name (most specific match).
+  if (ourName && ourName.length >= 8) {
+    let best: OpenRouterFrontendModel | null = null;
+    let bestLen = 0;
+    for (const [name, meta] of modelsByName) {
+      if (name.length >= 6 && name.length < ourName.length && ourName.includes(name) && name.length > bestLen) {
+        best = meta;
+        bestLen = name.length;
+      }
+    }
+    if (best) return best;
+  }
+
+  return null;
+}
+
+// ── Platform-specific model specs ───────────────────────────────────────
+
+/**
+ * Static specs for models exclusive to specific platforms (not on OpenRouter).
+ * Sourced from provider documentation:
+ *   - Groq:   https://console.groq.com/docs/models
+ *   - Cerebras: https://inference-docs.cerebras.ai/models/overview
+ *   - SambaNova: https://docs.sambanova.ai/docs/en/models/sambacloud-models
+ *   - Ollama Cloud: https://ollama.com/library (context from provider cards)
+ *   - Pollinations: https://pollinations.ai
+ *   - Cloudflare: https://developers.cloudflare.com/workers-ai/models/
+ *   - OpenCode: https://opencode.ai/zen/v1/models
+ *
+ * Key format: 'platform|model_id'. Values override migration fallbacks for
+ * models that the OpenRouter sync couldn't match. Only fields that differ
+ * from migration defaults need to be specified.
+ */
+const PLATFORM_MODEL_SPECS: Record<string, { context_window?: number; supports_vision?: boolean; supports_reasoning?: boolean; supports_tools?: boolean }> = {
+  // ── Groq ────────────────────────────────────────────────────────────
+  // Source: https://console.groq.com/docs/models
+  'groq|llama-3.3-70b-versatile':   { context_window: 131072, supports_tools: true },
+  'groq|llama-3.1-8b-instant':      { context_window: 131072, supports_tools: true },
+  'groq|groq/compound':             { context_window: 131072, supports_tools: true },
+  'groq|groq/compound-mini':        { context_window: 131072, supports_tools: true },
+
+  // ── Ollama Cloud ────────────────────────────────────────────────────
+  // Source: Ollama Cloud model cards + provider documentation
+  'ollama|cogito-2.1:671b':         { context_window: 131072, supports_tools: true },
+  'ollama|gpt-oss:120b':            { context_window: 131072, supports_tools: true },
+  'ollama|devstral-2:123b':         { context_window: 262144, supports_tools: true },
+  'ollama|gpt-oss:20b':             { context_window: 131072, supports_tools: true },
+  'ollama|gemma4:31b':              { context_window: 262144 },
+
+  // ── Pollinations ────────────────────────────────────────────────────
+  // Source: https://pollinations.ai — single anonymous model (GPT-OSS 20B)
+  'pollinations|openai-fast':       { context_window: 131072 },
+
+  // ── Cloudflare Workers AI ───────────────────────────────────────────
+  // Source: https://developers.cloudflare.com/workers-ai/models/
+  'cloudflare|@cf/nvidia/nemotron-3-120b-a12b': { context_window: 262144, supports_tools: true },
+
+  // ── OpenCode Zen ────────────────────────────────────────────────────
+  // Source: https://opencode.ai/zen/v1/models — stealth/promo models
+  'opencode|big-pickle':            { context_window: 131072 },
+};
+
+/**
+ * Apply platform-specific specs to models that weren't matched by OpenRouter.
+ * Only touches models whose (platform, model_id) has an entry in
+ * PLATFORM_MODEL_SPECS and whose current values differ from the spec.
+ * Returns the number of rows updated.
+ */
+function syncPlatformSpecs(db: Database.Database, unmatched: { platform: string; modelId: string; displayName: string }[]): number {
+  if (unmatched.length === 0) return 0;
+
+  let synced = 0;
+  const update = db.prepare(`
+    UPDATE models SET context_window = ?, supports_vision = ?, supports_reasoning = ?, supports_tools = ?
+     WHERE id = ?
+  `);
+
+  const apply = db.transaction(() => {
+    for (const u of unmatched) {
+      const key = `${u.platform}|${u.modelId}`;
+      const spec = PLATFORM_MODEL_SPECS[key];
+      if (!spec) continue;
+
+      const row = db.prepare(
+        'SELECT id, context_window, supports_vision, supports_reasoning, supports_tools FROM models WHERE platform = ? AND model_id = ?'
+      ).get(u.platform, u.modelId) as {
+        id: number; context_window: number | null;
+        supports_vision: number; supports_reasoning: number; supports_tools: number;
+      } | undefined;
+      if (!row) continue;
+
+      const newCtx = spec.context_window ?? row.context_window;
+      const newVision = spec.supports_vision !== undefined ? (spec.supports_vision ? 1 : 0) : row.supports_vision;
+      const newReasoning = spec.supports_reasoning !== undefined ? (spec.supports_reasoning ? 1 : 0) : row.supports_reasoning;
+      const newTools = spec.supports_tools !== undefined ? (spec.supports_tools ? 1 : 0) : row.supports_tools;
+
+      if (
+        row.context_window === newCtx &&
+        row.supports_vision === newVision &&
+        row.supports_reasoning === newReasoning &&
+        row.supports_tools === newTools
+      ) continue;
+
+      update.run(newCtx, newVision, newReasoning, newTools, row.id);
+      synced++;
+    }
+  });
+  apply();
+  return synced;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Extract the trailing version number from a slug (e.g. 'mistralai/devstral-2512' → 2512). */
+function extractVersion(slug: string): number {
+  const match = slug.match(/(\d+)$/);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Extract the model name from a normalized ID or slug (part after the last `/`). */
+function extractName(normalized: string): string | null {
+  const idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -138,6 +138,8 @@ export interface ChatMessage {
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatToolCall[];
+  /** Image generation responses carry generated images here (OpenRouter extension). */
+  images?: Array<{ type?: 'image_url'; image_url: { url: string; detail?: string } }>;
 }
 
 export interface ChatCompletionRequest {
@@ -150,6 +152,10 @@ export interface ChatCompletionRequest {
   tools?: ChatToolDefinition[];
   tool_choice?: ChatToolChoice;
   parallel_tool_calls?: boolean;
+  /** Image generation: output modalities (e.g. ["image", "text"]). */
+  modalities?: string[];
+  /** Image generation: model-specific config (aspect_ratio, image_size, etc.). */
+  image_config?: Record<string, unknown>;
 }
 
 export interface ChatCompletionChoice {


### PR DESCRIPTION
## What

Adds full image generation support via OpenRouter's free text-to-image models.

### Server
- New `/api/image-models` endpoint returning free-only image models
- `isFreeImageModel()` shared guard between route and proxy
- Image generation passthrough via OpenRouter with free-model enforcement
- Provider interface extended for image capabilities (base.ts, openai-compat.ts)
- Tests for capabilities service

### Client
- New `/models/images` tab with simplified image models table (copy button, no click-to-expand)
- Playground split into Chat/Image tabs
- Image tab features:
  - Concurrent generation with abort controllers per request
  - Pending cards with elapsed timer, prompt/model display, cancel button
  - Error cards with retry + dismiss
  - Completed cards with aspect ratio/image size info, copy prompt, use-same-settings
  - Drag & drop / paste / upload input image
  - Advanced options panel (Recraft/Sourceful-specific + Raw JSON mode)
  - Fullscreen lightbox: keyboard nav (arrows, Escape), zoom/pan (click toggle, cursor-position wheel zoom, +/-/0 keys, drag pan), zoom level indicator
  - Lightbox footer: expand/collapse prompt, copy prompt, use-same-settings, download
  - Completion indicator (green glow) on newly finished images
  - Always-visible keyboard hints bar
  - Tooltips on all icon buttons
- Navigation tabs: Chat / Embeddings / Images