### PR TITLE
fix: multiply monthly token budget by key count per platform

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ import KeysPage from '@/pages/KeysPage'
 import PlaygroundPage from '@/pages/PlaygroundPage'
 import FallbackPage from '@/pages/FallbackPage'
 import EmbeddingsPage from '@/pages/EmbeddingsPage'
+import ImageModelsPage from '@/pages/ImageModelsPage'
 import AnalyticsPage from '@/pages/AnalyticsPage'
 
 const queryClient = new QueryClient()
@@ -200,6 +201,7 @@ function App() {
                 <Route path="/models" element={<Navigate to="/models/chat" replace />} />
                 <Route path="/models/chat" element={<FallbackPage />} />
                 <Route path="/models/embeddings" element={<EmbeddingsPage />} />
+                <Route path="/models/images" element={<ImageModelsPage />} />
                 <Route path="/playground" element={<PlaygroundPage />} />
                 <Route path="/keys" element={<KeysPage />} />
                 <Route path="/fallback" element={<Navigate to="/models/chat" replace />} />

--- a/client/src/components/models-tabs.tsx
+++ b/client/src/components/models-tabs.tsx
@@ -11,8 +11,9 @@ export function ModelsTabs() {
     }`
   return (
     <div className="inline-flex gap-1 rounded-xl border p-1">
-      <NavLink to="/models/chat" className={({ isActive }) => tab(isActive)}>Chat models</NavLink>
+      <NavLink to="/models/chat" className={({ isActive }) => tab(isActive)}>Chat</NavLink>
       <NavLink to="/models/embeddings" className={({ isActive }) => tab(isActive)}>Embeddings</NavLink>
+      <NavLink to="/models/images" className={({ isActive }) => tab(isActive)}>Images</NavLink>
     </div>
   )
 }

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, useRef, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   DndContext,
@@ -17,11 +17,12 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { ChevronDown, SlidersHorizontal } from 'lucide-react'
+import { ChevronDown, Copy, CopyCheck, RefreshCw, Search, SlidersHorizontal, X } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { Switch } from '@/components/ui/switch'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { PageHeader } from '@/components/page-header'
 import { FloatingBar } from '@/components/floating-bar'
 import { ModelsTabs } from '@/components/models-tabs'
@@ -45,6 +46,8 @@ interface FallbackEntry {
   monthlyTokenBudget: string
   supportsVision: boolean
   supportsTools: boolean
+  supportsReasoning: boolean
+  contextWindow: number | null
   keyCount: number
 }
 
@@ -196,6 +199,13 @@ interface TokenUsageData {
   models: { displayName: string; platform: string; budget: number }[]
 }
 
+const CONTEXT_FILTERS: { key: string; label: string; min: number; max: number | null }[] = [
+  { key: 'small',  label: '< 32K',  min: 0,      max: 32_000 },
+  { key: 'mid',    label: '32–128K', min: 32_000,  max: 128_000 },
+  { key: 'large',  label: '128–256K', min: 128_000, max: 256_000 },
+  { key: 'xlarge', label: '256K+',   min: 256_000, max: null },
+]
+
 const platformColors: Record<string, string> = {
   google:      '#4285f4',
   groq:        '#f55036',
@@ -325,6 +335,20 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
   )
 }
 
+// Highlight matching substrings in search results.
+function highlightMatch(text: string, query: string): ReactNode {
+  const q = query.trim()
+  if (!q) return text
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const re = new RegExp(`(${escaped})`, 'gi')
+  const lower = q.toLowerCase()
+  return text.split(re).map((part, i) =>
+    part.toLowerCase() === lower
+      ? <mark key={i} className="bg-amber-200/60 dark:bg-amber-500/30 text-inherit rounded-sm px-0.5">{part}</mark>
+      : part
+  )
+}
+
 // ── One row of the unified table ────────────────────────────────────────────
 function RowContent({
   row,
@@ -332,14 +356,25 @@ function RowContent({
   draggable,
   dragHandle,
   onToggle,
+  searchQuery,
 }: {
   row: Row
   rank: number
   draggable: boolean
   dragHandle?: ReactNode
   onToggle: (modelDbId: number, enabled: boolean) => void
+  searchQuery: string
 }) {
   const guard = (row.headroom ?? 1) * (row.rateLimit ?? 1)
+  const [copied, setCopied] = useState(false)
+
+  function handleCopy(e: React.MouseEvent) {
+    e.stopPropagation()
+    navigator.clipboard.writeText(row.modelId).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    }).catch(() => {})
+  }
   return (
     <>
       <td className="py-2 pl-3 pr-1 w-6 align-middle">
@@ -348,8 +383,8 @@ function RowContent({
       <td className="py-2 pr-2 w-6 text-center font-mono text-xs text-muted-foreground tabular-nums align-middle">{rank}</td>
       <td className="py-2 pr-3 align-middle">
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="font-medium text-sm">{row.displayName}</span>
-          <span className="text-xs text-muted-foreground">{row.platform}</span>
+          <span className="font-medium text-sm">{highlightMatch(row.displayName, searchQuery)}</span>
+          <span className="text-xs text-muted-foreground">{highlightMatch(row.platform, searchQuery)}</span>
           {row.supportsVision && (
             <span
               title="Accepts image input"
@@ -366,12 +401,31 @@ function RowContent({
               Tools
             </span>
           )}
+          {row.supportsReasoning && (
+            <span
+              title="Supports chain-of-thought / extended reasoning"
+              className="text-[10px] rounded-full px-1.5 py-0.5 bg-emerald-600/15 text-emerald-700 dark:bg-emerald-400/15 dark:text-emerald-400"
+            >
+              Reasoning
+            </span>
+          )}
           {(row.penalty ?? 0) > 0 && (
             <span className="text-[10px] text-amber-600 dark:text-amber-400">−{row.penalty} penalty</span>
           )}
           {row.totalRequests !== undefined && row.totalRequests > 0 && (
             <span className="text-[10px] text-muted-foreground/60 tabular-nums">{row.totalRequests} obs</span>
           )}
+        </div>
+        <div className="flex items-center gap-1.5 mt-0.5">
+          <span className="text-[11px] font-mono text-muted-foreground/60 select-all">{highlightMatch(row.modelId, searchQuery)}</span>
+          <button
+            onClick={handleCopy}
+            className="inline-flex items-center text-muted-foreground/40 hover:text-foreground transition-colors"
+            aria-label="Copy model ID"
+            title="Copy model ID"
+          >
+            {copied ? <CopyCheck className="size-3 text-green-500" /> : <Copy className="size-3" />}
+          </button>
         </div>
         <div className="text-[11px] text-muted-foreground/70 tabular-nums mt-0.5">
           {row.monthlyTokenBudget} tok/mo
@@ -382,6 +436,9 @@ function RowContent({
       <td className="py-2 pr-3 align-middle"><AxisBar value={row.reliability} color="#22c55e" /></td>
       <td className="py-2 pr-3 align-middle"><AxisBar value={row.speed} color="#3b82f6" /></td>
       <td className="py-2 pr-3 align-middle"><AxisBar value={row.intelligence} color="#a855f7" /></td>
+      <td className="py-2 pr-3 align-middle text-right font-mono text-[11px] text-muted-foreground tabular-nums">
+        {row.contextWindow != null ? (row.contextWindow >= 1_000_000 ? `${(row.contextWindow / 1_000_000).toFixed(1)}M` : row.contextWindow >= 10_000 ? `${Math.round(row.contextWindow / 1000)}K` : `${row.contextWindow}`) : '–'}
+      </td>
       <td className="py-2 pr-3 align-middle font-mono text-[11px] text-muted-foreground tabular-nums">
         {guard < 0.999 ? `×${guard.toFixed(2)}` : '—'}
       </td>
@@ -395,7 +452,7 @@ function RowContent({
   )
 }
 
-function SortableRow({ row, rank, onToggle }: { row: Row; rank: number; onToggle: (id: number, e: boolean) => void }) {
+function SortableRow({ row, rank, onToggle, searchQuery }: { row: Row; rank: number; onToggle: (id: number, e: boolean) => void; searchQuery: string }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: row.modelDbId })
   const handle = (
     <button
@@ -417,7 +474,7 @@ function SortableRow({ row, rank, onToggle }: { row: Row; rank: number; onToggle
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={`border-b last:border-0 bg-card ${isDragging ? 'opacity-50' : ''} ${row.enabled ? '' : 'opacity-50'}`}
     >
-      <RowContent row={row} rank={rank} draggable dragHandle={handle} onToggle={onToggle} />
+      <RowContent row={row} rank={rank} draggable dragHandle={handle} onToggle={onToggle} searchQuery={searchQuery} />
     </tr>
   )
 }
@@ -425,6 +482,18 @@ function SortableRow({ row, rank, onToggle }: { row: Row; rank: number; onToggle
 export default function FallbackPage() {
   const queryClient = useQueryClient()
   const [localEntries, setLocalEntries] = useState<FallbackEntry[] | null>(null)
+
+  // Filters
+  type EnabledFilter = 'all' | 'active' | 'inactive'
+  const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>('all')
+  const [platformFilter, setPlatformFilter] = useState<string>('all')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [visionOnly, setVisionOnly] = useState(false)
+  const [toolsOnly, setToolsOnly] = useState(false)
+  const [reasoningOnly, setReasoningOnly] = useState(false)
+  const [contextFilters, setContextFilters] = useState<Set<string>>(new Set())
+  const [syncResult, setSyncResult] = useState<{ updated: number; unmatched: { platform: string; modelId: string; displayName: string }[]; total: number; matched: number; platformSynced: number; error?: string } | null>(null)
+  const [showSyncModal, setShowSyncModal] = useState(false)
 
   const { data: entries = [], isLoading } = useQuery<FallbackEntry[]>({
     queryKey: ['fallback'],
@@ -457,6 +526,19 @@ export default function FallbackPage() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['fallback', 'routing'] }),
   })
 
+  const syncMutation = useMutation({
+    mutationFn: () => apiFetch('/api/fallback/sync-capabilities', { method: 'POST' }) as Promise<{ updated: number; unmatched: { platform: string; modelId: string; displayName: string }[]; total: number; matched: number; platformSynced: number; error?: string }>,
+    onSuccess: (result) => {
+      setSyncResult(result)
+      setShowSyncModal(true)
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+    },
+    onError: (err) => {
+      setSyncResult({ updated: 0, unmatched: [], total: 0, matched: 0, platformSynced: 0, error: String(err) })
+      setShowSyncModal(true)
+    },
+  })
+
   const strategy: RoutingStrategy = routing?.strategy ?? 'balanced'
   const isManual = strategy === 'priority'
 
@@ -473,6 +555,40 @@ export default function FallbackPage() {
   const ordered = isManual
     ? [...rows].sort((a, b) => a.priority - b.priority)
     : [...rows].sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+
+  // Apply filters
+  const q = searchQuery.toLowerCase().trim()
+  const filtered = ordered.filter(row => {
+    if (enabledFilter === 'active' && !row.enabled) return false
+    if (enabledFilter === 'inactive' && row.enabled) return false
+    if (platformFilter !== 'all' && row.platform !== platformFilter) return false
+    if (visionOnly && !row.supportsVision) return false
+    if (toolsOnly && !row.supportsTools) return false
+    if (reasoningOnly && !row.supportsReasoning) return false
+    if (contextFilters.size > 0) {
+      const match = CONTEXT_FILTERS.some(f => {
+        if (!contextFilters.has(f.key)) return false
+        if (row.contextWindow == null) return false
+        if (f.max != null) return row.contextWindow >= f.min && row.contextWindow < f.max
+        return row.contextWindow >= f.min
+      })
+      if (!match) return false
+    }
+    if (q && !row.displayName.toLowerCase().includes(q) && !row.modelId.toLowerCase().includes(q) && !row.platform.toLowerCase().includes(q)) return false
+    return true
+  })
+
+  // Unique platforms for the filter dropdown (only configured ones, sorted alphabetically)
+  const platforms = [...new Set(configured.map(e => e.platform))].sort()
+  const contextCounts = useMemo(() => CONTEXT_FILTERS.map(f => ({
+    ...f,
+    count: configured.filter(r => {
+      if (r.contextWindow == null) return false
+      if (f.max != null) return r.contextWindow >= f.min && r.contextWindow < f.max
+      return r.contextWindow >= f.min
+    }).length,
+  })), [configured])
+  const hasFilters = enabledFilter !== 'all' || platformFilter !== 'all' || searchQuery !== '' || visionOnly || toolsOnly || reasoningOnly || contextFilters.size > 0
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -518,6 +634,7 @@ export default function FallbackPage() {
         <th className="py-2 pr-3 font-medium">
           <span className="inline-flex items-center gap-1"><span className="size-2 rounded-sm" style={{ background: '#a855f7' }} />Intelligence</span>
         </th>
+        <th className="py-2 pr-3 font-medium text-right tabular-nums">Context</th>
         <th className="py-2 pr-3 font-medium">
           <Tooltip text="Always-on guardrails: free-quota headroom × live rate-limit penalty. Below 1.0 means the model is being held back.">
             <span className="underline decoration-dotted underline-offset-2 cursor-help">Guardrails</span>
@@ -591,13 +708,166 @@ export default function FallbackPage() {
           </p>
         </section>
 
+        {/* Filters */}
+        <section className="rounded-3xl border bg-card p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            {/* Active / Inactive / All toggle */}
+            <div className="inline-flex items-center gap-1 rounded-xl border p-1">
+              {(['all', 'active', 'inactive'] as const).map(f => (
+                <button
+                  key={f}
+                  onClick={() => setEnabledFilter(f)}
+                  className={`px-3 py-1.5 text-xs rounded-lg transition-colors capitalize ${
+                    f === enabledFilter
+                      ? 'bg-foreground text-background font-medium'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+
+            {/* Search */}
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                placeholder="Search models…"
+                className="h-8 w-48 rounded-lg border border-input bg-transparent pl-8 pr-3 text-xs outline-none transition-colors focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 placeholder:text-muted-foreground"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery('')}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="size-3" />
+                </button>
+              )}
+            </div>
+
+            {/* Capability chips */}
+            <button
+              onClick={() => setVisionOnly(v => !v)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors border ${
+                visionOnly
+                  ? 'bg-cyan-600/15 text-cyan-700 border-cyan-600/30 dark:bg-cyan-400/15 dark:text-cyan-400 dark:border-cyan-400/30'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted hover:border-border'
+              }`}
+            >
+              <span className={`size-1.5 rounded-full ${visionOnly ? 'bg-cyan-600 dark:bg-cyan-400' : 'bg-muted-foreground/40'}`} />
+              Vision
+            </button>
+            <button
+              onClick={() => setToolsOnly(t => !t)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors border ${
+                toolsOnly
+                  ? 'bg-violet-600/15 text-violet-700 border-violet-600/30 dark:bg-violet-400/15 dark:text-violet-400 dark:border-violet-400/30'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted hover:border-border'
+              }`}
+            >
+              <span className={`size-1.5 rounded-full ${toolsOnly ? 'bg-violet-600 dark:bg-violet-400' : 'bg-muted-foreground/40'}`} />
+              Tools
+            </button>
+            <button
+              onClick={() => setReasoningOnly(r => !r)}
+              className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors border ${
+                reasoningOnly
+                  ? 'bg-emerald-600/15 text-emerald-700 border-emerald-600/30 dark:bg-emerald-400/15 dark:text-emerald-400 dark:border-emerald-400/30'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted hover:border-border'
+              }`}
+            >
+              <span className={`size-1.5 rounded-full ${reasoningOnly ? 'bg-emerald-600 dark:bg-emerald-400' : 'bg-muted-foreground/40'}`} />
+              Reasoning
+            </button>
+
+            {/* Context window chips — multi-select with per-filter counts */}
+            <div className="inline-flex items-center gap-1">
+              {contextCounts.map(f => {
+                const active = contextFilters.has(f.key)
+                return (
+                  <button
+                    key={f.key}
+                    onClick={() => setContextFilters(prev => {
+                      const next = new Set(prev)
+                      if (active) next.delete(f.key)
+                      else next.add(f.key)
+                      return next
+                    })}
+                    className={`px-2.5 py-1.5 text-xs rounded-lg transition-colors border ${
+                      active
+                        ? 'bg-amber-600/15 text-amber-700 border-amber-600/30 dark:bg-amber-400/15 dark:text-amber-400 dark:border-amber-400/30'
+                        : 'text-muted-foreground border-transparent hover:text-foreground hover:bg-muted hover:border-border'
+                    }`}
+                  >
+                    <span className={`size-1.5 rounded-full ${active ? 'bg-amber-600 dark:bg-amber-400' : 'bg-muted-foreground/40'}`} />
+                    {f.label}{f.count > 0 ? ` (${f.count})` : ''}
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Provider dropdown */}
+            <Select value={platformFilter} onValueChange={v => setPlatformFilter(v ?? 'all')}>
+              <SelectTrigger size="sm" className="min-w-[140px]">
+                <SelectValue placeholder="All providers" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All providers</SelectItem>
+                {platforms.map(p => (
+                  <SelectItem key={p} value={p}>
+                    <span className="inline-flex items-center gap-2">
+                      <span
+                        className="size-2 rounded-sm flex-shrink-0"
+                        style={{ backgroundColor: platformColors[p] ?? '#94a3b8' }}
+                      />
+                      {p}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Refresh capabilities */}
+            <button
+              onClick={() => syncMutation.mutate()}
+              disabled={syncMutation.isPending}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors border text-muted-foreground border-transparent hover:text-foreground hover:bg-muted hover:border-border disabled:opacity-50"
+            >
+              <RefreshCw className={`size-3 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
+              {syncMutation.isPending ? 'Syncing…' : 'Sync API'}
+            </button>
+
+            {/* Clear filters */}
+            {hasFilters && (
+              <button
+                onClick={() => { setEnabledFilter('all'); setPlatformFilter('all'); setSearchQuery(''); setVisionOnly(false); setToolsOnly(false); setReasoningOnly(false); setContextFilters(new Set()) }}
+                className="inline-flex items-center gap-1 px-2 py-1.5 text-xs rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                <X className="size-3" />
+                Clear
+              </button>
+            )}
+
+            {/* Result count */}
+            <span className="text-xs text-muted-foreground ml-auto tabular-nums">
+              {filtered.length} of {ordered.length} models
+            </span>
+          </div>
+        </section>
+
         {/* Unified routing / fallback table */}
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading…</p>
-        ) : ordered.length === 0 ? (
+        ) : filtered.length === 0 ? (
           <div className="rounded-3xl border border-dashed p-8 text-center">
             <p className="text-sm text-muted-foreground">
-              No models available. Add API keys on the <a href="/keys" className="underline text-foreground">Keys page</a> first.
+              {hasFilters
+                ? 'No models match the current filters.'
+                : <>No models available. Add API keys on the <a href="/keys" className="underline text-foreground">Keys page</a> first.</>}
             </p>
           </div>
         ) : (
@@ -609,10 +879,10 @@ export default function FallbackPage() {
                 <div className="rounded-2xl border overflow-x-auto">
                   <table className="w-full text-sm">
                     {tableHead}
-                    <SortableContext items={ordered.map(e => e.modelDbId)} strategy={verticalListSortingStrategy}>
+                    <SortableContext items={filtered.map(e => e.modelDbId)} strategy={verticalListSortingStrategy}>
                       <tbody>
-                        {ordered.map((row, i) => (
-                          <SortableRow key={row.modelDbId} row={row} rank={i + 1} onToggle={handleToggle} />
+                        {filtered.map((row, i) => (
+                          <SortableRow key={row.modelDbId} row={row} rank={i + 1} onToggle={handleToggle} searchQuery={searchQuery} />
                         ))}
                       </tbody>
                     </SortableContext>
@@ -624,9 +894,9 @@ export default function FallbackPage() {
                 <table className="w-full text-sm">
                   {tableHead}
                   <tbody>
-                    {ordered.map((row, i) => (
+                    {filtered.map((row, i) => (
                       <tr key={row.modelDbId} className={`border-b last:border-0 ${row.enabled ? '' : 'opacity-50'}`}>
-                        <RowContent row={row} rank={i + 1} draggable={false} onToggle={handleToggle} />
+                        <RowContent row={row} rank={i + 1} draggable={false} onToggle={handleToggle} searchQuery={searchQuery} />
                       </tr>
                     ))}
                   </tbody>
@@ -646,6 +916,70 @@ export default function FallbackPage() {
 
             {unconfiguredPlatforms.length > 0 && (
               <p className="text-xs text-muted-foreground">Hidden (no keys): {unconfiguredPlatforms.join(', ')}</p>
+            )}
+
+            {/* Sync result modal */}
+            {showSyncModal && syncResult && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowSyncModal(false)}>
+                <div className="bg-card rounded-2xl border shadow-lg max-w-lg w-full mx-4 max-h-[80vh] overflow-hidden flex flex-col" onClick={e => e.stopPropagation()}>
+                  <div className="flex items-center justify-between p-4 border-b">
+                    <h2 className="text-sm font-medium">OpenRouter Sync Results</h2>
+                    <button onClick={() => setShowSyncModal(false)} className="text-muted-foreground hover:text-foreground transition-colors">
+                      <X className="size-4" />
+                    </button>
+                  </div>
+                  <div className="p-4 overflow-y-auto space-y-3">
+                    {syncResult.error ? (
+                      <p className="text-sm text-red-600 dark:text-red-400">Error: {syncResult.error}</p>
+                    ) : (
+                      <>
+                        <div className="text-xs text-muted-foreground space-y-1">
+                          <p>Total models: <span className="text-foreground font-medium">{syncResult.total}</span></p>
+                          <p>Matched on OpenRouter: <span className="text-foreground font-medium">{syncResult.matched}</span></p>
+                          <p>Updated from API: <span className="text-foreground font-medium">{syncResult.updated}</span></p>
+                          {syncResult.platformSynced > 0 && (
+                            <p>Enriched from platform specs: <span className="text-foreground font-medium">{syncResult.platformSynced}</span></p>
+                          )}
+                          <p>Not found: <span className="text-foreground font-medium">{syncResult.unmatched.length}</span></p>
+                        </div>
+                        {syncResult.unmatched.length > 0 && (
+                          <div>
+                            <h3 className="text-xs font-medium text-muted-foreground mb-2">Models not found on OpenRouter:</h3>
+                            <div className="rounded-lg border overflow-hidden">
+                              <table className="w-full text-xs">
+                                <thead>
+                                  <tr className="text-left text-muted-foreground border-b bg-muted/50">
+                                    <th className="py-1.5 px-2 font-medium">Platform</th>
+                                    <th className="py-1.5 px-2 font-medium">Model ID</th>
+                                    <th className="py-1.5 px-2 font-medium">Display Name</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {syncResult.unmatched.map((m, i) => (
+                                    <tr key={i} className="border-b last:border-0">
+                                      <td className="py-1.5 px-2">
+                                        <span className="inline-flex items-center gap-1.5">
+                                          <span className="size-1.5 rounded-full" style={{ backgroundColor: platformColors[m.platform] ?? '#94a3b8' }} />
+                                          {m.platform}
+                                        </span>
+                                      </td>
+                                      <td className="py-1.5 px-2 font-mono text-muted-foreground select-all">{m.modelId}</td>
+                                      <td className="py-1.5 px-2 text-muted-foreground">{m.displayName}</td>
+                                    </tr>
+                                  ))}
+                                </tbody>
+                              </table>
+                            </div>
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+                  <div className="p-4 border-t flex justify-end">
+                    <Button size="sm" onClick={() => setShowSyncModal(false)}>Close</Button>
+                  </div>
+                </div>
+              </div>
             )}
           </>
         )}

--- a/client/src/pages/ImageModelsPage.tsx
+++ b/client/src/pages/ImageModelsPage.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/lib/api'
+import { PageHeader } from '@/components/page-header'
+import { ModelsTabs } from '@/components/models-tabs'
+import { Tooltip } from '@/components/tooltip'
+import { Button } from '@/components/ui/button'
+
+export interface ImageModel {
+  slug: string
+  name: string
+  shortName: string
+  author: string
+  authorDisplayName: string
+  description: string
+  contextLength: number
+  inputModalities: string[]
+  outputModalities: string[]
+  supportsReasoning: boolean
+  isFree: boolean
+  pricing: { prompt: string; completion: string } | null
+  rpmLimit: number | null
+  rpdLimit: number | null
+  providerDisplayName: string
+  providerSlug: string
+  hasKey: boolean
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export default function ImageModelsPage() {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const { data: models = [], isLoading } = useQuery<ImageModel[]>({
+    queryKey: ['image-models'],
+    queryFn: () => apiFetch('/api/image-models'),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  return (
+    <div>
+      <PageHeader
+        title="Models"
+        description="Image generation models available via OpenRouter. Only OpenRouter supports text-to-image at the moment."
+        divider={false}
+        actions={<ModelsTabs />}
+      />
+
+      <div className="space-y-4">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading image models…</p>
+        ) : models.length === 0 ? (
+          <div className="rounded-3xl border border-dashed p-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No image generation models found on OpenRouter.
+            </p>
+          </div>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              <span className="font-medium">{models.length}</span> free image models available via{' '}
+              <code className="rounded-md bg-muted px-1.5 py-0.5 font-mono text-[11px]">OpenRouter</code>.
+            </p>
+
+            <div className="rounded-2xl border overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-muted-foreground border-b">
+                    <th className="py-2.5 pl-4 pr-3 font-medium">Model</th>
+                    <th className="py-2.5 pr-3 font-medium">
+                      <Tooltip text="Maximum context length in tokens">
+                        <span className="underline decoration-dotted underline-offset-2 cursor-help">Context</span>
+                      </Tooltip>
+                    </th>
+                    <th className="py-2.5 pr-4 font-medium">Input</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {models.map(m => {
+                    const isCopied = copied === m.slug
+                    return (
+                      <tr key={m.slug} className="border-b last:border-0 transition-colors">
+                        <td className="py-2.5 pl-4 pr-3">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-medium text-sm">{m.shortName}</span>
+                            {m.supportsReasoning && (
+                              <span
+                                title="Supports chain-of-thought reasoning"
+                                className="text-[10px] rounded-full px-1.5 py-0.5 bg-violet-600/15 text-violet-700 dark:bg-violet-400/15 dark:text-violet-400"
+                              >
+                                Reasoning
+                              </span>
+                            )}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-6 px-2 text-[10px]"
+                              onClick={() => {
+                                navigator.clipboard.writeText(m.slug)
+                                setCopied(m.slug)
+                                setTimeout(() => setCopied(null), 2000)
+                              }}
+                            >
+                              {isCopied ? 'Copied' : 'Copy'}
+                            </Button>
+                          </div>
+                          <div className="text-[11px] text-muted-foreground/70 font-mono mt-0.5">{m.slug}</div>
+                        </td>
+                        <td className="py-2.5 pr-3 font-mono text-xs text-muted-foreground tabular-nums">
+                          {m.contextLength > 0 ? formatNumber(m.contextLength) : '–'}
+                        </td>
+                        <td className="py-2.5 pr-4">
+                          <div className="flex gap-1 flex-wrap">
+                            {m.inputModalities.map(mod => (
+                              <span
+                                key={mod}
+                                className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground"
+                              >
+                                {mod}
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform } from '../../../shared/types'
-import { Pencil, ExternalLink } from 'lucide-react'
+import { Pencil, ExternalLink, Globe } from 'lucide-react'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 
 // Small "Get API key" external link shown next to a provider (#137).
@@ -167,6 +167,102 @@ function UnifiedKeySection() {
         <code className="font-mono">/v1/responses</code>
         <span className="text-muted-foreground">Embeddings</span>
         <code className="font-mono">/v1/embeddings <span className="text-muted-foreground">(model: "auto" or a family from the Embeddings tab)</span></code>
+      </div>
+    </section>
+  )
+}
+
+function ProxySettingsSection() {
+  const queryClient = useQueryClient()
+  const [proxyUrl, setProxyUrl] = useState('')
+
+  const { data, isError } = useQuery<{ proxyUrl: string; enabled: boolean; bypassPlatforms: string[]; active: boolean }>({
+    queryKey: ['proxy-url'],
+    queryFn: () => apiFetch('/api/settings/proxy'),
+  })
+
+  // Sync from server when the query refetches; keep the user's typed value
+  // in between (controlled input).
+  useEffect(() => {
+    if (data) setProxyUrl(data.proxyUrl)
+  }, [data?.proxyUrl])
+
+  const saveProxy = useMutation({
+    mutationFn: (body: { proxyUrl?: string; enabled?: boolean; bypassPlatforms?: string[] }) =>
+      apiFetch('/api/settings/proxy', { method: 'PUT', body: JSON.stringify(body) }),
+    onSuccess: (result: { proxyUrl: string; enabled: boolean; bypassPlatforms: string[]; active: boolean }) => {
+      queryClient.invalidateQueries({ queryKey: ['proxy-url'] })
+      setProxyUrl(result.proxyUrl)
+    },
+  })
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    saveProxy.mutate({ proxyUrl })
+  }
+
+  const enabled = data?.enabled ?? true
+  const active = data?.active ?? false
+
+  return (
+    <section className="rounded-3xl border bg-card p-5">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <div>
+          <h2 className="text-sm font-medium flex items-center gap-2">
+            <Globe className="size-3.5 text-muted-foreground" />
+            Outbound proxy
+          </h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Route outbound LLM requests through a proxy. Supports SOCKS5, HTTP, and HTTPS.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={enabled}
+            onCheckedChange={(checked) => saveProxy.mutate({ enabled: checked })}
+            disabled={saveProxy.isPending || !data}
+          />
+          {active && enabled && (
+            <span className="text-[11px] px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 font-medium">
+              Active
+            </span>
+          )}
+        </div>
+      </div>
+
+      {isError ? (
+        <p className="text-xs text-muted-foreground">Could not load proxy settings.</p>
+      ) : (
+        <form onSubmit={submit} className="flex items-end gap-3">
+          <div className="space-y-1.5 flex-1">
+            <Label className="text-xs">Proxy URL</Label>
+            <Input
+              value={proxyUrl}
+              onChange={e => setProxyUrl(e.target.value)}
+              placeholder="socks5://127.0.0.1:1080"
+              className="font-mono text-xs"
+            />
+          </div>
+          <Button type="submit" size="sm" disabled={saveProxy.isPending}>
+            {saveProxy.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </form>
+      )}
+
+      {saveProxy.isError && (
+        <p className="text-destructive text-xs mt-2">{(saveProxy.error as Error).message}</p>
+      )}
+
+      <div className="mt-3 text-[11px] text-muted-foreground">
+        <p>
+          Also configurable via the <code className="font-mono">PROXY_URL</code> environment variable
+          (takes precedence). Leave blank to disable. Examples:
+        </p>
+        <ul className="list-disc list-inside mt-1 space-y-0.5">
+          <li><code className="font-mono">socks5://127.0.0.1:1080</code></li>
+          <li><code className="font-mono">http://proxy.corp.com:8080</code></li>
+          <li><code className="font-mono">socks5://user:pass@proxy:1080</code></li>
+        </ul>
       </div>
     </section>
   )
@@ -378,6 +474,24 @@ export default function KeysPage() {
   const healthKeyMap = new Map<number, { status: string; lastCheckedAt: string | null }>()
   for (const k of healthData?.keys ?? []) healthKeyMap.set(k.id, k)
 
+  // Proxy bypass: shared query with ProxySettingsSection (same queryKey).
+  const { data: proxyData } = useQuery<{ proxyUrl: string; enabled: boolean; bypassPlatforms: string[]; active: boolean }>({
+    queryKey: ['proxy-url'],
+    queryFn: () => apiFetch('/api/settings/proxy'),
+  })
+  const bypassPlatforms = proxyData?.bypassPlatforms ?? []
+  const proxyEnabled = proxyData?.enabled ?? true
+
+  const toggleBypass = useMutation({
+    mutationFn: (platform: string) => {
+      const next = bypassPlatforms.includes(platform)
+        ? bypassPlatforms.filter(p => p !== platform)
+        : [...bypassPlatforms, platform]
+      return apiFetch('/api/settings/proxy', { method: 'PUT', body: JSON.stringify({ bypassPlatforms: next }) })
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['proxy-url'] }),
+  })
+
   const grouped = [...PLATFORMS, CUSTOM_GROUP].map(p => ({
     ...p,
     keys: keys.filter(k => k.platform === p.value),
@@ -399,6 +513,8 @@ export default function KeysPage() {
 
       <div className="space-y-8">
         <UnifiedKeySection />
+
+        <ProxySettingsSection />
 
         <section>
           <h2 className="text-sm font-medium mb-3">Add a provider key</h2>
@@ -493,6 +609,16 @@ export default function KeysPage() {
                         disabled={togglePlatform.isPending}
                       />
                       <h3 className="text-sm font-medium">{group.label}</h3>
+                      {proxyEnabled && (
+                        <div className="inline-flex items-center gap-1.5 ml-1">
+                          <span className="text-[10px] text-muted-foreground">proxy</span>
+                          <Switch
+                            checked={!bypassPlatforms.includes(group.value)}
+                            onCheckedChange={() => toggleBypass.mutate(group.value)}
+                            disabled={toggleBypass.isPending}
+                          />
+                        </div>
+                      )}
                       <GetKeyLink url={group.url} />
                     </div>
                     <span className="text-xs text-muted-foreground tabular-nums">

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -1,10 +1,23 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
 import { PageHeader } from '@/components/page-header'
 import { Markdown } from '@/components/markdown'
+import { Tooltip } from '@/components/tooltip'
+
+/** Subset of the /api/image-models response shape — only the fields consumed by ImageTab.
+ *  Structural typing accepts the full API response (which has ~20 fields). */
+interface ImageModel {
+  slug: string
+  shortName: string
+  authorDisplayName: string
+  outputModalities: string[]
+  providerSlug: string
+}
 
 interface FallbackEntry {
   modelDbId: number
@@ -28,18 +41,44 @@ interface ChatMessage {
   }
 }
 
-export default function PlaygroundPage() {
+interface GeneratedImage {
+  url: string
+  prompt: string
+  model: string
+  latency: number
+  timestamp: number
+  aspectRatio: string
+  imageSize: string
+  /** True while the request is in-flight; the card shows a spinner + elapsed time. */
+  pending?: boolean
+  /** Shown on the pending card when the request fails. */
+  error?: string
+}
+
+type PlaygroundTab = 'chat' | 'image'
+
+// ── Tab switcher ─────────────────────────────────────────────────────────────
+function TabSwitcher({ active, onChange }: { active: PlaygroundTab; onChange: (t: PlaygroundTab) => void }) {
+  const tab = (isActive: boolean) =>
+    `px-3 py-1.5 text-xs rounded-lg transition-colors ${
+      isActive ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+    }`
+  return (
+    <div className="inline-flex gap-1 rounded-xl border p-1">
+      <button className={tab(active === 'chat')} onClick={() => onChange('chat')}>Chat</button>
+      <button className={tab(active === 'image')} onClick={() => onChange('image')}>Image</button>
+    </div>
+  )
+}
+
+// ── Chat tab ─────────────────────────────────────────────────────────────────
+function ChatTab({ keyData }: { keyData?: { apiKey: string } }) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>('auto')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
-
-  const { data: keyData } = useQuery<{ apiKey: string }>({
-    queryKey: ['unified-key'],
-    queryFn: () => apiFetch('/api/settings/api-key'),
-  })
 
   const { data: fallbackEntries = [] } = useQuery<FallbackEntry[]>({
     queryKey: ['fallback'],
@@ -138,116 +177,1176 @@ export default function PlaygroundPage() {
     : availableModels.find(m => m.modelId === selectedModel)?.displayName ?? selectedModel
 
   return (
+    <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0">
+      {/* Model selector + clear */}
+      <div className="flex items-center gap-2 p-3 border-b">
+        <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? 'auto')}>
+          <SelectTrigger className="w-[260px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="auto">Auto (fallback chain)</SelectItem>
+            {availableModels.map(m => (
+              <SelectItem key={m.modelDbId} value={m.modelId}>
+                <span className="flex items-center gap-2">
+                  <span>{m.displayName}</span>
+                  <span className="text-xs text-muted-foreground">{m.platform}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {messages.length > 0 && (
+          <Button variant="outline" size="sm" onClick={handleClear}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        {messages.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-center">
+            <div className="space-y-2 max-w-sm">
+              <p className="text-base font-medium">Send a message to get started.</p>
+              <p className="text-sm text-muted-foreground">
+                Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {messages.map((msg, i) => (
+              <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                    msg.role === 'user'
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted'
+                  }`}
+                >
+                  {msg.role === 'assistant' ? (
+                    <Markdown>{msg.content}</Markdown>
+                  ) : (
+                    <div className="whitespace-pre-wrap">{msg.content}</div>
+                  )}
+                  {msg.meta && (
+                    <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
+                      {msg.meta.platform && <span>{msg.meta.platform}</span>}
+                      {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
+                      {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
+                      {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
+                        <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+            {loading && (
+              <div className="flex justify-start">
+                <div className="bg-muted rounded-2xl px-4 py-3">
+                  <div className="flex gap-1">
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+                    <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+                  </div>
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="border-t bg-background/50 p-3">
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a message… (⏎ to send, ⇧⏎ for newline)"
+            rows={1}
+            className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
+            style={{ height: 'auto', overflow: 'hidden' }}
+            onInput={e => autoResizeTextarea(e.target as HTMLTextAreaElement)}
+          />
+          <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
+            {loading ? 'Sending…' : 'Send'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Image tab ────────────────────────────────────────────────────────────────
+const ASPECT_RATIOS = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'] as const
+const IMAGE_SIZES = ['0.5K', '1K', '2K', '4K'] as const
+
+/** Auto-resize a textarea to fit its content, up to maxHeight px. */
+function autoResizeTextarea(el: HTMLTextAreaElement, maxHeight = 160) {
+  el.style.height = 'auto'
+  el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px'
+}
+
+function ImageTab({ keyData }: { keyData?: { apiKey: string } }) {
+  const [prompt, setPrompt] = useState('')
+  const [, setTick] = useState(0)
+  const [selectedModel, setSelectedModel] = useState<string>('')
+  const [aspectRatio, setAspectRatio] = useState<string>('1:1')
+  const [imageSize, setImageSize] = useState<string>('1K')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  // Recraft
+  const [style, setStyle] = useState('')
+  const [strength, setStrength] = useState('')
+  const [rgbColors, setRgbColors] = useState('')
+  const [backgroundRgbColor, setBackgroundRgbColor] = useState('')
+  // Sourceful
+  const [scoringPrompt, setScoringPrompt] = useState('')
+  const [backgroundMode, setBackgroundMode] = useState('original')
+  const [backgroundHexColor, setBackgroundHexColor] = useState('')
+  const [rgbConfigError, setRgbConfigError] = useState<string | null>(null)
+  // Complex typed params (previously lumped in a generic JSON textarea)
+  const [textLayout, setTextLayout] = useState('')
+  const [fontInputs, setFontInputs] = useState('')
+  const [superResRefs, setSuperResRefs] = useState('')
+  const [scoringRubric, setScoringRubric] = useState('')
+  // Raw JSON bidirectional view
+  const [isRawJsonMode, setIsRawJsonMode] = useState(false)
+  const [rawJsonText, setRawJsonText] = useState('')
+  const [rawJsonError, setRawJsonError] = useState<string | null>(null)
+  const [history, setHistory] = useState<GeneratedImage[]>([])
+  // Input image for image-to-image generation
+  const [inputImage, setInputImage] = useState<string | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [lightbox, setLightbox] = useState<number | null>(null)
+  const [zoomLabel, setZoomLabel] = useState<string | null>(null)
+  const zoomLabelTimeout = useRef<ReturnType<typeof setTimeout>>(null)
+  const [zoomScale, setZoomScale] = useState(1)
+  const [panOffset, setPanOffset] = useState({ x: 0, y: 0 })
+  const [isPanning, setIsPanning] = useState(false)
+  const panStart = useRef({ x: 0, y: 0 })
+  const didDrag = useRef(false)
+  const imageWrapperRef = useRef<HTMLDivElement>(null)
+  // Ref for latest zoom scale so keyboard handler sees fresh value.
+  const zoomScaleRef = useRef(zoomScale)
+  zoomScaleRef.current = zoomScale
+  const [expandedPrompts, setExpandedPrompts] = useState<Set<number>>(new Set())
+  const [recentlyCompleted, setRecentlyCompleted] = useState<Set<number>>(new Set())
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const abortControllers = useRef<Map<number, AbortController>>(new Map())
+
+  const { data: imageModels = [] } = useQuery<ImageModel[]>({
+    queryKey: ['image-models'],
+    queryFn: () => apiFetch('/api/image-models'),
+    staleTime: 10 * 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (imageModels.length > 0 && !selectedModel) {
+      setSelectedModel(imageModels[0].slug)
+    }
+    // eslint-disable-next-line -- only run when models load
+  }, [imageModels.length])
+
+  // Clear recently-completed highlight after the animation duration.
+  useEffect(() => {
+    if (recentlyCompleted.size === 0) return
+    const timeout = setTimeout(() => setRecentlyCompleted(new Set()), 1500)
+    return () => clearTimeout(timeout)
+  }, [recentlyCompleted])
+  const completed = history.filter(img => !img.pending && !img.error)
+  // Reset zoom/pan when navigating to a different image, and show hints briefly.
+  useEffect(() => {
+    setZoomScale(1)
+    setPanOffset({ x: 0, y: 0 })
+    setZoomLabel(null)
+    if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+  }, [lightbox])
+  useEffect(() => {
+    if (lightbox === null) return
+    // Lock body scroll while lightbox is open.
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightbox(null)
+      else if (e.key === 'ArrowLeft' && lightbox > 0) setLightbox(lightbox - 1)
+      else if (e.key === 'ArrowRight' && lightbox < completed.length - 1) setLightbox(lightbox + 1)
+      else if (e.key === '+' || e.key === '=') {
+        e.preventDefault()
+        const next = Math.min(5, zoomScaleRef.current + 0.25)
+        setZoomScale(next)
+        setZoomLabel(`${Math.round(next * 100)}%`)
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      } else if (e.key === '-') {
+        e.preventDefault()
+        const next = Math.max(1, zoomScaleRef.current - 0.25)
+        if (next === 1) setPanOffset({ x: 0, y: 0 })
+        setZoomScale(next)
+        setZoomLabel(`${Math.round(next * 100)}%`)
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      } else if (e.key === '0') {
+        e.preventDefault()
+        setZoomScale(1)
+        setPanOffset({ x: 0, y: 0 })
+        setZoomLabel('Fit')
+        if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+        zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = ''
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [lightbox, completed.length])
+
+  // Abort all in-flight requests on unmount.
+  useEffect(() => () => {
+    abortControllers.current.forEach(c => c.abort())
+    if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+  }, [])
+  useEffect(() => {
+    if (!history.some(img => img.pending)) {
+      // No more pending requests — clean up expanded prompt state too.
+      if (expandedPrompts.size > 0) setExpandedPrompts(new Set())
+      return
+    }
+    const id = setInterval(() => setTick(t => t + 1), 1000)
+    return () => clearInterval(id)
+  }, [history])
+
+  // ── Input image handlers ──────────────────────────────────────────
+  const readFileAsDataUrl = (file: File) => {
+    const reader = new FileReader()
+    reader.onload = () => setInputImage(reader.result as string)
+    reader.onerror = () => setInputImage(null)
+    reader.readAsDataURL(file)
+  }
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault()
+        readFileAsDataUrl(item.getAsFile()!)
+        return
+      }
+    }
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(false)
+    const file = e.dataTransfer?.files?.[0]
+    if (file?.type.startsWith('image/')) readFileAsDataUrl(file)
+  }
+
+  const handleGenerate = async () => {
+    const text = prompt.trim()
+    if (!text || !selectedModel) return
+
+    const startTime = Date.now()
+    const model = selectedModel
+    const thisInputImage = inputImage // snapshot for this request
+    const thisAspectRatio = aspectRatio
+    const thisImageSize = imageSize
+
+    // Push a pending placeholder immediately so the grid shows a spinner.
+    const pendingEntry: GeneratedImage = {
+      url: '',
+      prompt: text,
+      model,
+      latency: 0,
+      timestamp: startTime,
+      aspectRatio: thisAspectRatio,
+      imageSize: thisImageSize,
+      pending: true,
+    }
+    setHistory(prev => [pendingEntry, ...prev].slice(0, 50))
+    setPrompt('')
+    setTimeout(() => inputRef.current?.focus(), 0)
+
+    const controller = new AbortController()
+    abortControllers.current.set(startTime, controller)
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (keyData?.apiKey) headers['Authorization'] = `Bearer ${keyData.apiKey}`
+
+      const body: any = {
+        model,
+        messages: [{
+          role: 'user',
+          content: thisInputImage
+            ? [
+                { type: 'image_url', image_url: { url: thisInputImage } },
+                { type: 'text', text },
+              ]
+            : text,
+        }],
+        modalities: activeModel?.outputModalities?.includes('text') ? ['image', 'text'] : ['image'],
+      }
+
+      if (aspectRatio !== '1:1' || imageSize !== '1K') {
+        body.image_config = { aspect_ratio: aspectRatio, image_size: imageSize }
+      }
+
+      // ── Advanced image_config (Recraft / Sourceful / extra JSON) ────
+      const imageConfig: Record<string, unknown> = body.image_config ? { ...body.image_config } : {}
+
+      // Always include aspect_ratio + image_size when any advanced option is set
+      const provider = activeModel?.providerSlug?.toLowerCase() ?? ''
+      const advancedConfig = isRawJsonMode ? (() => { try { return JSON.parse(rawJsonText) ?? {} } catch { return {} } })() : computedImageConfig
+      // Only include provider-specific fields when the provider matches
+      const filteredAdvanced: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(advancedConfig)) {
+        if (v == null || v === '') continue
+        // Recraft-specific: style, strength, rgb_colors, background_rgb_color, text_layout
+        if (['style', 'strength', 'rgb_colors', 'background_rgb_color', 'text_layout'].includes(k)) {
+          if (provider === 'recraft') filteredAdvanced[k] = v
+        // Sourceful-specific: scoring_prompt, scoring_rubric, font_inputs, super_resolution_references, background_mode, background_hex_color
+        } else if (['scoring_prompt', 'scoring_rubric', 'font_inputs', 'super_resolution_references', 'background_mode', 'background_hex_color'].includes(k)) {
+          if (provider === 'sourceful') filteredAdvanced[k] = v
+        } else {
+          filteredAdvanced[k] = v
+        }
+      }
+      const hasAdvanced = Object.keys(filteredAdvanced).length > 0
+      if (hasAdvanced && !imageConfig.aspect_ratio) {
+        imageConfig.aspect_ratio = aspectRatio
+        imageConfig.image_size = imageSize
+      }
+      Object.assign(imageConfig, filteredAdvanced)
+
+      if (Object.keys(imageConfig).length > 0) {
+        body.image_config = imageConfig
+      }
+
+      const base = import.meta.env.BASE_URL.replace(/\/$/, '')
+
+      // ── Non-streaming path ───────────────────────────────────────────
+      const res = await fetch(`${base}/v1/chat/completions`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+
+      const latency = Date.now() - startTime
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: { message: `HTTP ${res.status}` } }))
+        const errMsg = err.error?.message ?? `HTTP ${res.status}`
+        abortControllers.current.delete(startTime)
+        setHistory(prev => prev.map(img =>
+          img.timestamp === startTime ? { ...img, pending: false, error: errMsg } : img
+        ))
+        return
+      }
+
+      abortControllers.current.delete(startTime)
+      const data = await res.json()
+      const message = data.choices?.[0]?.message
+      const images = message?.images ?? []
+
+      if (images.length === 0) {
+        // Some models return base64 in content instead of images array
+        const content = message?.content ?? ''
+        if (content.startsWith('data:image')) {
+          setHistory(prev => prev.map(img =>
+            img.timestamp === startTime ? { ...img, url: content, latency, pending: false } : img
+          ))
+          setRecentlyCompleted(prev => new Set(prev).add(startTime))
+        } else {
+          setHistory(prev => prev.map(img =>
+            img.timestamp === startTime ? { ...img, pending: false, error: 'No image returned. The model may have returned text instead.' } : img
+          ))
+        }
+        return
+      }
+
+      // Replace the pending placeholder with the first image,
+      // then push additional images as new entries.
+      let replaced = false
+      for (const img of images) {
+        const url = img.image_url?.url ?? img.url // fallback for providers omitting the image_url wrapper
+        if (!url) continue
+        if (!replaced) {
+          setHistory(prev => prev.map(e =>
+            e.timestamp === startTime ? { ...e, url, latency, pending: false } : e
+          ))
+          setRecentlyCompleted(prev => new Set(prev).add(startTime))
+          replaced = true
+        } else {
+          const ts = Date.now()
+          setHistory(prev => [{ url, prompt: text, model, latency, timestamp: ts, aspectRatio: thisAspectRatio, imageSize: thisImageSize }, ...prev].slice(0, 50))
+          setRecentlyCompleted(prev => new Set(prev).add(ts))
+        }
+      }
+    } catch (err: any) {
+      abortControllers.current.delete(startTime)
+      if (err.name === 'AbortError') {
+        // Remove the pending placeholder entirely — nothing to show.
+        setHistory(prev => prev.filter(img => img.timestamp !== startTime))
+      } else {
+        setHistory(prev => prev.map(img =>
+          img.timestamp === startTime ? { ...img, pending: false, error: err.message ?? 'Unknown error' } : img
+        ))
+      }
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleGenerate()
+    }
+  }
+
+  // ── Computed image_config from individual fields ─────────────────────
+  const computedImageConfig = useMemo(() => {
+    const config: Record<string, unknown> = {}
+    if (style.trim()) config.style = style.trim()
+    const s = parseFloat(strength)
+    if (strength.trim() && !isNaN(s) && s >= 0 && s <= 1) config.strength = s
+    if (rgbColors.trim()) {
+      try {
+        const parsed = JSON.parse(`[${rgbColors}]`)
+        if (Array.isArray(parsed) && parsed.every((c: unknown) => Array.isArray(c) && c.length === 3 && c.every((v: unknown) => typeof v === 'number'))) {
+          config.rgb_colors = parsed
+        }
+      } catch { /* ignore */ }
+    }
+    if (backgroundRgbColor.trim()) {
+      try {
+        const parsed = JSON.parse(`[${backgroundRgbColor}]`)
+        if (Array.isArray(parsed) && parsed.length === 3 && parsed.every((v: unknown) => typeof v === 'number')) {
+          config.background_rgb_color = parsed
+        }
+      } catch { /* ignore */ }
+    }
+    if (scoringPrompt.trim()) config.scoring_prompt = scoringPrompt.trim()
+    const effectiveMode = backgroundHexColor.trim() && backgroundMode === 'original' ? 'solid' : backgroundMode
+    if (effectiveMode !== 'original' || backgroundHexColor.trim()) {
+      config.background_mode = effectiveMode
+      if (effectiveMode === 'solid' && backgroundHexColor.trim()) config.background_hex_color = backgroundHexColor.trim()
+    }
+    try { if (textLayout.trim()) config.text_layout = JSON.parse(textLayout) } catch { /* ignore */ }
+    try { if (fontInputs.trim()) config.font_inputs = JSON.parse(fontInputs) } catch { /* ignore */ }
+    try { if (scoringRubric.trim()) config.scoring_rubric = JSON.parse(scoringRubric) } catch { /* ignore */ }
+    const refs = superResRefs.split('\n').map(l => l.trim()).filter(Boolean)
+    if (refs.length > 0) config.super_resolution_references = refs
+    return config
+  }, [style, strength, rgbColors, backgroundRgbColor, scoringPrompt, backgroundMode, backgroundHexColor, textLayout, fontInputs, scoringRubric, superResRefs])
+
+  // ── Raw JSON blur handler (bidirectional sync: JSON → fields) ──────
+  const handleRawJsonBlur = () => {
+    try {
+      const parsed = JSON.parse(rawJsonText)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setRawJsonError('Expected a JSON object, not an array')
+        return
+      }
+      setRawJsonError(null)
+      setStyle(parsed.style ?? '')
+      setStrength(parsed.strength != null ? String(parsed.strength) : '')
+      setRgbColors(Array.isArray(parsed.rgb_colors) ? parsed.rgb_colors.map((c: unknown) => Array.isArray(c) ? `[${(c as number[]).join(',')}]` : '').filter(Boolean).join(', ') : '')
+      setBackgroundRgbColor(Array.isArray(parsed.background_rgb_color) ? JSON.stringify(parsed.background_rgb_color).replace(/[\[\]\s]/g, '') : '')
+      setScoringPrompt(parsed.scoring_prompt ?? '')
+      setBackgroundMode(['original', 'transparent', 'solid'].includes(parsed.background_mode) ? parsed.background_mode : 'original')
+      setBackgroundHexColor(parsed.background_hex_color ?? '')
+      setTextLayout(parsed.text_layout != null ? JSON.stringify(parsed.text_layout, null, 2) : '')
+      setFontInputs(parsed.font_inputs != null ? JSON.stringify(parsed.font_inputs, null, 2) : '')
+      setScoringRubric(parsed.scoring_rubric != null ? JSON.stringify(parsed.scoring_rubric, null, 2) : '')
+      setSuperResRefs(Array.isArray(parsed.super_resolution_references) ? parsed.super_resolution_references.join('\n') : '')
+    } catch (err: any) {
+      setRawJsonError(`Invalid JSON: ${err.message}`)
+    }
+  }
+
+  const activeModel = imageModels.find(m => m.slug === selectedModel)
+
+  return (
+    <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0 relative"
+      onPaste={handlePaste}
+      onDragOver={e => {
+        e.preventDefault()
+        if (e.dataTransfer?.types?.includes('Files')) setDragOver(true)
+      }}
+      onDragLeave={e => {
+        if (e.currentTarget === e.target || !e.currentTarget.contains(e.relatedTarget as Node)) {
+          setDragOver(false)
+        }
+      }}
+      onDrop={handleDrop}
+    >
+      {/* Drag overlay — covers the entire card */}
+      {dragOver && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-3xl bg-primary/10 border-2 border-dashed border-primary backdrop-blur-[1px]">
+          <div className="text-center space-y-1">
+            <span className="text-2xl">🖼</span>
+            <p className="text-sm font-medium text-primary">Drop image here</p>
+            <p className="text-xs text-muted-foreground">Use as reference for image-to-image generation</p>
+          </div>
+        </div>
+      )}
+      {/* Controls */}
+      <div className="flex items-center gap-2 p-3 border-b flex-wrap">
+        <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? '')}>
+          <SelectTrigger className="w-[300px]">
+            <SelectValue placeholder="Select an image model…" />
+          </SelectTrigger>
+          <SelectContent>
+            {imageModels.map(m => (
+              <SelectItem key={m.slug} value={m.slug}>
+                <span className="flex items-center gap-2">
+                  <span>{m.shortName}</span>
+                  <span className="text-xs text-muted-foreground">{m.authorDisplayName}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={aspectRatio} onValueChange={(v) => setAspectRatio(v ?? '1:1')}>
+          <SelectTrigger className="w-[100px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ASPECT_RATIOS.map(r => (
+              <SelectItem key={r} value={r}>{r}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={imageSize} onValueChange={(v) => setImageSize(v ?? '1K')}>
+          <SelectTrigger className="w-[90px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {IMAGE_SIZES.map(s => (
+              <SelectItem key={s} value={s}>{s}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <button
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className={`text-xs px-2 py-1 rounded-lg transition-colors ${
+            showAdvanced ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+          }`}
+        >
+          ⚙ Advanced {showAdvanced ? '▾' : '▸'}
+        </button>
+        {history.length > 0 && (
+          <Button variant="outline" size="sm" onClick={() => setHistory([])}>
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Advanced options panel */}
+      {showAdvanced && (
+        <div className="border-b bg-muted/30 p-3 space-y-3 text-xs">
+          {/* Toggle: structured vs raw JSON */}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => {
+                const next = !isRawJsonMode
+                if (next) { setRawJsonText(JSON.stringify(computedImageConfig, null, 2)); setRawJsonError(null) }
+                setIsRawJsonMode(next)
+              }}
+              className={`text-xs px-2 py-0.5 rounded-lg transition-colors ${
+                isRawJsonMode ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+              }`}
+            >
+              {'{ } Raw JSON'}
+            </button>
+          </div>
+
+          {isRawJsonMode ? (
+            /* ── Raw JSON view ───────────────────────────────── */
+            <div className="space-y-1">
+              <Textarea
+                value={rawJsonText}
+                onChange={e => { setRawJsonText(e.target.value); setRawJsonError(null) }}
+                onBlur={handleRawJsonBlur}
+                placeholder="{ &quot;style&quot;: &quot;Photorealism&quot;, ... }"
+                className="min-h-[120px] text-xs font-mono"
+              />
+              {rawJsonError && (
+                <p className="text-[10px] text-red-500">{rawJsonError}</p>
+              )}
+            </div>
+          ) : (
+            /* ── Structured inputs ──────────────────────────── */
+            (() => {
+              const provider = activeModel?.providerSlug?.toLowerCase() ?? ''
+              return (
+                <>
+                  {/* ── Recraft ──────────────────────────── */}
+                  {provider === 'recraft' && (
+                    <div className="space-y-2">
+                      <p className="font-medium text-muted-foreground uppercase tracking-wide">Recraft options</p>
+                      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Style</span>
+                          <Input value={style} onChange={e => setStyle(e.target.value)} placeholder="e.g. Photorealism" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Strength (0–1)</span>
+                          <Input value={strength} onChange={e => setStrength(e.target.value)} placeholder="0.2" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">RGB colors</span>
+                          <Input
+                            value={rgbColors}
+                            onChange={e => { setRgbColors(e.target.value); setRgbConfigError(null) }}
+                            onBlur={() => {
+                              if (!rgbColors.trim()) { setRgbConfigError(null); return }
+                              try {
+                                const parsed = JSON.parse(`[${rgbColors}]`)
+                                if (!Array.isArray(parsed) || !parsed.every((c: unknown) => Array.isArray(c) && c.length === 3 && c.every((v: unknown) => typeof v === 'number'))) {
+                                  setRgbConfigError('Expected: [r,g,b], [r,g,b]')
+                                } else { setRgbConfigError(null) }
+                              } catch { setRgbConfigError('Invalid format') }
+                            }}
+                            placeholder="[255,0,0], [0,128,0]"
+                            className="h-7 text-xs"
+                          />
+                          {rgbConfigError && <p className="text-[10px] text-red-500">{rgbConfigError}</p>}
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">BG RGB color</span>
+                          <Input value={backgroundRgbColor} onChange={e => setBackgroundRgbColor(e.target.value)} placeholder="0,0,255" className="h-7 text-xs" />
+                        </label>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">text_layout (JSON)</span>
+                          <Textarea value={textLayout} onChange={e => setTextLayout(e.target.value)} placeholder='[{"text": "Hello", "bbox": [[0.3,0.45],[0.6,0.45],[0.6,0.55],[0.3,0.55]]}]' className="min-h-[40px] text-xs font-mono" />
+                        </label>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* ── Sourceful ────────────────────────── */}
+                  {provider === 'sourceful' && (
+                    <div className="space-y-2">
+                      <p className="font-medium text-muted-foreground uppercase tracking-wide">Sourceful options</p>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Scoring prompt</span>
+                          <Input value={scoringPrompt} onChange={e => setScoringPrompt(e.target.value)} placeholder="Prefer realistic materials…" className="h-7 text-xs" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">Background mode</span>
+                          <Select value={backgroundMode} onValueChange={(v) => setBackgroundMode(v ?? 'original')}>
+                            <SelectTrigger className="h-7 text-xs"><SelectValue /></SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="original">Original</SelectItem>
+                              <SelectItem value="transparent">Transparent</SelectItem>
+                              <SelectItem value="solid">Solid color</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </label>
+                        {backgroundMode === 'solid' && (
+                          <label className="space-y-1">
+                            <span className="text-muted-foreground">BG hex color</span>
+                            <Input value={backgroundHexColor} onChange={e => setBackgroundHexColor(e.target.value)} placeholder="#f6f1e8" className="h-7 text-xs" />
+                          </label>
+                        )}
+                      </div>
+                      <div className="space-y-1">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">font_inputs (JSON)</span>
+                          <Textarea value={fontInputs} onChange={e => setFontInputs(e.target.value)} placeholder='[{"font_url": "https://...", "text": "Hello"}]' className="min-h-[40px] text-xs font-mono" />
+                        </label>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">super_resolution_references</span>
+                          <Textarea value={superResRefs} onChange={e => setSuperResRefs(e.target.value)} placeholder="https://example.com/ref1.jpg&#10;https://example.com/ref2.jpg" className="min-h-[44px] text-xs font-mono" />
+                        </label>
+                        <label className="space-y-1">
+                          <span className="text-muted-foreground">scoring_rubric (JSON)</span>
+                          <Textarea value={scoringRubric} onChange={e => setScoringRubric(e.target.value)} placeholder='[{"key": "lighting", "label": "Lighting", "description": "...", "weight": 1}]' className="min-h-[44px] text-xs font-mono" />
+                        </label>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )
+            })()
+          )}
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-6">
+        {history.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-center">
+            <div className="space-y-2 max-w-sm">
+              <p className="text-base font-medium">Describe an image to generate.</p>
+              <p className="text-sm text-muted-foreground">
+                {activeModel
+                  ? <>Using <span className="text-foreground">{activeModel.shortName}</span>.</>
+                  : 'Select a model above.'}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {history.map((img, i) => (
+              img.pending ? (
+<div key={img.timestamp} className="rounded-2xl border bg-muted/50 aspect-square flex flex-col items-center justify-center relative group p-4">
+                  {/* Cancel button */}
+                  <button
+                    onClick={e => { e.stopPropagation(); abortControllers.current.get(img.timestamp)?.abort() }}
+                    className="absolute top-2 right-2 w-7 h-7 rounded-full bg-muted-foreground/20 hover:bg-red-500/80 text-muted-foreground hover:text-white text-sm flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100 z-10"
+                    aria-label="Cancel generation"
+                    title="Cancel generation"
+                  >
+                    ×
+                  </button>
+                  {/* Spinner + status */}
+                  <div className="flex flex-col items-center gap-1.5">
+                    <div className="flex gap-1 justify-center">
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+                      <span className="size-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+                    </div>
+                    <p className="text-xs text-muted-foreground">Generating…</p>
+                    <p className="text-[10px] text-muted-foreground/50 tabular-nums">{Math.floor((Date.now() - img.timestamp) / 1000)}s elapsed</p>
+                  </div>
+                  {/* Prompt + model — collapsible */}
+                  <div className="mt-auto w-full pt-3 border-t border-border/30">
+                    <p
+                      onClick={e => {
+                        e.stopPropagation()
+                        setExpandedPrompts(prev => {
+                          const next = new Set(prev)
+                          if (next.has(img.timestamp)) next.delete(img.timestamp)
+                          else next.add(img.timestamp)
+                          return next
+                        })
+                      }}
+                      className={`text-[11px] text-muted-foreground/70 leading-relaxed cursor-pointer transition-colors hover:text-muted-foreground ${
+                        expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                      }`}
+                      title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                    >
+                      {img.prompt}
+                    </p>
+                    <p className="text-[10px] text-muted-foreground/40 mt-1 tabular-nums">{img.model.split('/').pop()}</p>
+                  </div>
+                </div>
+              ) : img.error ? (
+<div key={img.timestamp} className="rounded-2xl border border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950 aspect-square flex items-center justify-center relative group">
+                  {/* Dismiss button */}
+                  <button
+                    onClick={e => { e.stopPropagation(); setHistory(prev => prev.filter(h => h.timestamp !== img.timestamp)) }}
+                    className="absolute top-2 right-2 w-6 h-6 rounded-full bg-red-200/60 hover:bg-red-400/80 dark:bg-red-800/60 dark:hover:bg-red-700/80 text-red-700 dark:text-red-300 hover:text-white text-sm flex items-center justify-center transition-colors opacity-0 group-hover:opacity-100"
+                    aria-label="Dismiss error"
+                    title="Dismiss"
+                  >
+                    ×
+                  </button>
+                  <div className="text-center space-y-3 p-4">
+                    <div className="space-y-1">
+                      <p className="text-xs text-red-700 dark:text-red-400">{img.error}</p>
+                      <p className="text-[11px] text-muted-foreground line-clamp-2">{img.prompt}</p>
+                      <p className="text-[10px] text-muted-foreground/40">{img.model.split('/').pop()}</p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="text-xs h-7"
+                      onClick={() => {
+                        setHistory(prev => prev.filter(h => h.timestamp !== img.timestamp))
+                        setPrompt(img.prompt)
+                        setSelectedModel(img.model)
+                        setTimeout(() => inputRef.current?.focus(), 0)
+                      }}
+                    >
+                      ↻ Retry
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+              <div key={img.timestamp} className={`rounded-2xl border overflow-hidden bg-card cursor-pointer transition-shadow ${
+                  recentlyCompleted.has(img.timestamp) ? 'ring-2 ring-emerald-400/60 shadow-lg shadow-emerald-400/20' : ''
+                }`} onClick={() => {
+                // Find this image's index in the completed list for lightbox navigation.
+                const idx = completed.findIndex(c => c.timestamp === img.timestamp)
+                if (idx !== -1) setLightbox(idx)
+              }}>
+                <div className="aspect-square relative group">
+                  <img
+                    src={img.url}
+                    alt={img.prompt}
+                    className="w-full h-full object-contain bg-black/5"
+                  />
+                  <a
+                    href={img.url}
+                    download={`image-${i}.png`}
+                    className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <Button variant="secondary" size="sm" className="text-xs h-7">
+                      ↓ Download
+                    </Button>
+                  </a>
+                </div>
+<div className="p-3 space-y-1">
+<div className="flex items-start gap-1.5">
+                    <p
+                      onClick={e => {
+                        e.stopPropagation()
+                        setExpandedPrompts(prev => {
+                          const next = new Set(prev)
+                          if (next.has(img.timestamp)) next.delete(img.timestamp)
+                          else next.add(img.timestamp)
+                          return next
+                        })
+                      }}
+                      className={`text-xs text-muted-foreground flex-1 cursor-pointer transition-colors hover:text-foreground ${
+                        expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                      }`}
+                      title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                    >
+                      {img.prompt}
+                    </p>
+<Tooltip text="Copy prompt">
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          navigator.clipboard.writeText(img.prompt)
+                          const btn = e.currentTarget
+                          btn.textContent = '✓'
+                          setTimeout(() => { btn.textContent = '📋' }, 1200)
+                        }}
+                        className="shrink-0 text-[11px] text-muted-foreground/40 hover:text-muted-foreground transition-colors leading-relaxed"
+                        aria-label="Copy prompt"
+                      >
+                        📋
+                      </button>
+                    </Tooltip>
+                  </div>
+<div className="flex items-center gap-2 text-[10px] text-muted-foreground/60 tabular-nums">
+                    <span>{img.model.split('/').pop()}</span>
+                    <span>· {img.latency} ms</span>
+                    <span>· {img.aspectRatio}</span>
+                    <span>· {img.imageSize}</span>
+<Tooltip text="Use these settings">
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          setAspectRatio(img.aspectRatio)
+                          setImageSize(img.imageSize)
+                        }}
+                        className="text-[10px] text-muted-foreground/30 hover:text-muted-foreground transition-colors cursor-pointer"
+                        aria-label="Use these settings"
+                      >
+                        ⚙
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+              </div>
+            )))}
+          </div>
+        )}
+      </div>
+
+      {/* Input area */}
+      <div className="border-t bg-background/50 p-3">
+        {/* Input image preview */}
+        {inputImage && (
+          <div className="mb-2 flex items-start gap-2">
+            <div className="relative rounded-lg overflow-hidden border w-16 h-16 shrink-0">
+              <img src={inputImage} alt="Input" className="w-full h-full object-cover" />
+              <button
+                onClick={() => setInputImage(null)}
+                className="absolute top-0 right-0 w-4 h-4 bg-foreground/70 text-background rounded-bl text-[10px] leading-none flex items-center justify-center hover:bg-foreground"
+                title="Remove input image"
+              >
+                ×
+              </button>
+            </div>
+            <p className="text-[11px] text-muted-foreground">Input image — this will be used as a reference for image-to-image generation.</p>
+          </div>
+        )}
+        <div className="flex gap-2 items-end">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={e => { const f = e.target.files?.[0]; if (f) readFileAsDataUrl(f) }}
+          />
+          <Tooltip text="Upload an input image for image-to-image generation. You can also paste an image or drag & drop one onto the text area.">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 px-2.5 text-xs shrink-0"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              +
+            </Button>
+          </Tooltip>
+          <textarea
+            ref={inputRef}
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={inputImage ? 'Describe how to transform the image…' : 'Describe the image you want to generate…'}
+            rows={1}
+            className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
+            style={{ height: 'auto', overflow: 'hidden' }}
+            onInput={e => autoResizeTextarea(e.target as HTMLTextAreaElement)}
+          />
+          <Button onClick={handleGenerate} disabled={!prompt.trim() || !selectedModel} size="default">
+            Generate
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Lightbox ───────────────────────────────────────────────────── */}
+      {lightbox !== null && (() => {
+        const img = completed[lightbox]
+        if (!img) return null
+        return (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm"
+          onClick={() => setLightbox(null)}
+        >
+          {/* Close button */}
+          <button
+            onClick={() => setLightbox(null)}
+            className="absolute top-4 right-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+            aria-label="Close lightbox"
+          >
+            ×
+          </button>
+
+          {/* Keyboard hints */}
+          <div className="absolute top-4 left-1/2 -translate-x-1/2 z-10 flex items-center gap-3 rounded-xl bg-black/50 backdrop-blur px-4 py-2 text-white/70 text-[11px] pointer-events-none">
+            <span><kbd className="text-white/90">Esc</kbd> close</span>
+            <span><kbd className="text-white/90">←</kbd> <kbd className="text-white/90">→</kbd> navigate</span>
+            <span><kbd className="text-white/90">Click</kbd> zoom</span>
+            <span><kbd className="text-white/90">Scroll</kbd> zoom</span>
+            <span><kbd className="text-white/90">+</kbd> <kbd className="text-white/90">−</kbd> <kbd className="text-white/90">0</kbd> zoom</span>
+            <span><kbd className="text-white/90">Drag</kbd> pan</span>
+          </div>
+
+          {/* Previous arrow */}
+          {lightbox > 0 && (
+            <button
+              onClick={e => { e.stopPropagation(); setLightbox(lightbox - 1) }}
+              className="absolute left-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+              aria-label="Previous image"
+            >
+              ‹
+            </button>
+          )}
+
+          {/* Next arrow */}
+          {lightbox < completed.length - 1 && (
+            <button
+              onClick={e => { e.stopPropagation(); setLightbox(lightbox + 1) }}
+              className="absolute right-4 z-10 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white text-xl flex items-center justify-center transition-colors"
+              aria-label="Next image"
+            >
+              ›
+            </button>
+          )}
+
+          {/* Image */}
+          <div
+            ref={imageWrapperRef}
+            className="overflow-hidden rounded-xl"
+            onWheel={e => {
+              e.stopPropagation()
+              const delta = e.deltaY > 0 ? -0.25 : 0.25
+              const next = Math.min(5, Math.max(1, zoomScale + delta))
+              // Zoom toward cursor position.
+              if (next === 1) {
+                setPanOffset({ x: 0, y: 0 })
+              } else {
+                const rect = imageWrapperRef.current?.getBoundingClientRect()
+                if (rect) {
+                  const dx = e.clientX - rect.left - rect.width / 2
+                  const dy = e.clientY - rect.top - rect.height / 2
+                  const ratio = next / zoomScale
+                  setPanOffset({
+                    x: dx - (dx - panOffset.x) * ratio,
+                    y: dy - (dy - panOffset.y) * ratio,
+                  })
+                }
+              }
+              setZoomScale(next)
+              setZoomLabel(`${Math.round(next * 100)}%`)
+              if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+              zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+            }}
+          >
+          {/* Zoom level indicator */}
+          {zoomLabel && (
+            <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 rounded-xl bg-black/60 backdrop-blur px-3 py-1.5 text-white text-sm font-medium tabular-nums pointer-events-none">
+              {zoomLabel}
+            </div>
+          )}
+            <img
+              src={img.url}
+              alt={img.prompt}
+              draggable={false}
+              className={`max-w-[90vw] max-h-[85vh] rounded-xl select-none ${
+                isPanning ? '' : 'transition-transform duration-200'
+              } ${
+                zoomScale > 1 ? 'cursor-grab' : 'cursor-zoom-in'
+              } ${isPanning ? 'cursor-grabbing' : ''}`}
+              style={{
+                objectFit: zoomScale > 1 ? 'none' : 'contain',
+                transform: `scale(${zoomScale}) translate(${panOffset.x / zoomScale}px, ${panOffset.y / zoomScale}px)`,
+                transformOrigin: 'center center',
+              }}
+              onClick={e => {
+                e.stopPropagation()
+                // Don't toggle zoom if the user was dragging.
+                if (didDrag.current) {
+                  didDrag.current = false
+                  return
+                }
+                if (zoomScale > 1) {
+                  setZoomScale(1)
+                  setPanOffset({ x: 0, y: 0 })
+                  setZoomLabel('Fit')
+                } else {
+                  setZoomScale(2)
+                  setZoomLabel('200%')
+                }
+                if (zoomLabelTimeout.current) clearTimeout(zoomLabelTimeout.current)
+                zoomLabelTimeout.current = setTimeout(() => setZoomLabel(null), 1500)
+              }}
+              onMouseDown={e => {
+                if (zoomScale <= 1) return
+                e.preventDefault()
+                didDrag.current = false
+                setIsPanning(true)
+                panStart.current = { x: e.clientX - panOffset.x, y: e.clientY - panOffset.y }
+              }}
+              onMouseMove={e => {
+                if (!isPanning) return
+                didDrag.current = true
+                setPanOffset({
+                  x: e.clientX - panStart.current.x,
+                  y: e.clientY - panStart.current.y,
+                })
+              }}
+              onMouseUp={() => setIsPanning(false)}
+              onMouseLeave={() => setIsPanning(false)}
+            />
+          </div>
+
+          {/* Info footer */}
+          <div
+            className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-4 rounded-xl bg-black/60 backdrop-blur px-4 py-2.5 text-white text-xs"
+            onClick={e => e.stopPropagation()}
+          >
+<div className="max-w-sm">
+              {/* Prompt — expand/collapse + copy */}
+              <div className="flex items-start gap-1.5">
+                <p
+                  onClick={() => {
+                    setExpandedPrompts(prev => {
+                      const next = new Set(prev)
+                      if (next.has(img.timestamp)) next.delete(img.timestamp)
+                      else next.add(img.timestamp)
+                      return next
+                    })
+                  }}
+                  className={`text-xs leading-relaxed cursor-pointer transition-colors hover:text-white/90 ${
+                    expandedPrompts.has(img.timestamp) ? '' : 'line-clamp-2'
+                  }`}
+                  title={expandedPrompts.has(img.timestamp) ? 'Click to collapse' : 'Click to expand'}
+                >
+                  {img.prompt}
+                </p>
+<Tooltip text="Copy prompt">
+                  <button
+                    onClick={e => {
+                      e.stopPropagation()
+                      navigator.clipboard.writeText(img.prompt)
+                      const btn = e.currentTarget
+                      btn.textContent = '✓'
+                      setTimeout(() => { btn.textContent = '📋' }, 1200)
+                    }}
+                    className="shrink-0 text-[10px] text-white/30 hover:text-white/80 transition-colors leading-relaxed"
+                    aria-label="Copy prompt"
+                  >
+                    📋
+                  </button>
+                </Tooltip>
+              </div>
+              {/* Metadata + settings */}
+              <div className="flex items-center gap-2 mt-0.5">
+                <p className="text-white/50 tabular-nums text-[11px]">
+                  {img.model.split('/').pop()} · {img.latency} ms · {img.aspectRatio} · {img.imageSize}
+                </p>
+<Tooltip text="Use these settings">
+                  <button
+                    onClick={() => {
+                      setAspectRatio(img.aspectRatio)
+                      setImageSize(img.imageSize)
+                    }}
+                    className="text-[11px] text-white/20 hover:text-white/70 transition-colors cursor-pointer"
+                    aria-label="Use these settings"
+                  >
+                    ⚙
+                  </button>
+                </Tooltip>
+              </div>
+            </div>
+            <span className="text-white/30">{lightbox + 1} / {completed.length}</span>
+            <a
+              href={img.url}
+              download={`image-${img.timestamp}.png`}
+              className="ml-2"
+            >
+              <Button variant="secondary" size="sm" className="text-xs h-7">
+                ↓ Download
+              </Button>
+            </a>
+          </div>
+        </div>
+      )})()}
+    </div>
+  )
+}
+
+// ── Main page ────────────────────────────────────────────────────────────────
+export default function PlaygroundPage() {
+  const [tab, setTab] = useState<PlaygroundTab>('chat')
+
+  const { data: keyData } = useQuery<{ apiKey: string }>({
+    queryKey: ['unified-key'],
+    queryFn: () => apiFetch('/api/settings/api-key'),
+  })
+
+  return (
     <div className="flex flex-col h-[calc(100vh-8rem)]">
       <PageHeader
         title="Playground"
-        description="Send a chat completion through the router and see which provider serves it."
-        actions={
-          <>
-            <Select value={selectedModel} onValueChange={(v) => setSelectedModel(v ?? 'auto')}>
-              <SelectTrigger className="w-[260px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="auto">Auto (fallback chain)</SelectItem>
-                {availableModels.map(m => (
-                  <SelectItem key={m.modelDbId} value={m.modelId}>
-                    <span className="flex items-center gap-2">
-                      <span>{m.displayName}</span>
-                      <span className="text-xs text-muted-foreground">{m.platform}</span>
-                    </span>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {messages.length > 0 && (
-              <Button variant="outline" size="sm" onClick={handleClear}>
-                Clear
-              </Button>
-            )}
-          </>
-        }
+        description={tab === 'chat'
+          ? 'Send a chat completion through the router and see which provider serves it.'
+          : 'Generate images with free text-to-image models via OpenRouter.'}
+        actions={<TabSwitcher active={tab} onChange={setTab} />}
       />
-
-      <div className="flex-1 flex flex-col rounded-3xl border bg-card overflow-hidden min-h-0">
-        <div className="flex-1 overflow-y-auto p-6 space-y-4">
-          {messages.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-center">
-              <div className="space-y-2 max-w-sm">
-                <p className="text-base font-medium">Send a message to get started.</p>
-                <p className="text-sm text-muted-foreground">
-                  Using <span className="text-foreground">{activeModelLabel}</span>. Switch models in the selector above.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <>
-              {messages.map((msg, i) => (
-                <div key={i} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                  <div
-                    className={`max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
-                      msg.role === 'user'
-                        ? 'bg-primary text-primary-foreground'
-                        : 'bg-muted'
-                    }`}
-                  >
-                    {msg.role === 'assistant' ? (
-                      <Markdown>{msg.content}</Markdown>
-                    ) : (
-                      <div className="whitespace-pre-wrap">{msg.content}</div>
-                    )}
-                    {msg.meta && (
-                      <div className="flex items-center gap-2 mt-2 flex-wrap text-[11px] opacity-70 tabular-nums">
-                        {msg.meta.platform && <span>{msg.meta.platform}</span>}
-                        {msg.meta.model && <span className="font-mono">· {msg.meta.model}</span>}
-                        {msg.meta.latency != null && <span>· {msg.meta.latency} ms</span>}
-                        {msg.meta.fallbackAttempts != null && msg.meta.fallbackAttempts > 0 && (
-                          <span>· {msg.meta.fallbackAttempts} fallback{msg.meta.fallbackAttempts > 1 ? 's' : ''}</span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ))}
-              {loading && (
-                <div className="flex justify-start">
-                  <div className="bg-muted rounded-2xl px-4 py-3">
-                    <div className="flex gap-1">
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
-                      <span className="size-1.5 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
-                    </div>
-                  </div>
-                </div>
-              )}
-              <div ref={messagesEndRef} />
-            </>
-          )}
-        </div>
-
-        <div className="border-t bg-background/50 p-3">
-          <div className="flex gap-2 items-end">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={e => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Type a message… (⏎ to send, ⇧⏎ for newline)"
-              rows={1}
-              className="flex-1 resize-none rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[40px] max-h-[160px]"
-              style={{ height: 'auto', overflow: 'hidden' }}
-              onInput={e => {
-                const el = e.target as HTMLTextAreaElement
-                el.style.height = 'auto'
-                el.style.height = Math.min(el.scrollHeight, 160) + 'px'
-              }}
-            />
-            <Button onClick={handleSend} disabled={loading || !input.trim()} size="default">
-              {loading ? 'Sending…' : 'Send'}
-            </Button>
-          </div>
-        </div>
-      </div>
+      {tab === 'chat' ? <ChatTab keyData={keyData} /> : <ImageTab keyData={keyData} />}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,7 +1238,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1255,7 +1254,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1272,7 +1270,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1289,7 +1286,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1306,7 +1302,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1323,7 +1318,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1340,7 +1334,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1357,7 +1350,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1374,7 +1366,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1391,7 +1382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1408,7 +1398,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1425,7 +1414,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1442,7 +1430,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1459,7 +1446,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1476,7 +1462,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1493,7 +1478,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1510,7 +1494,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1527,7 +1510,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1544,7 +1526,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,7 +1542,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1578,7 +1558,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1595,7 +1574,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1612,7 +1590,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1629,7 +1606,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1646,7 +1622,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1663,7 +1638,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10619,6 +10593,53 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.0.0.tgz",
+      "integrity": "sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11247,6 +11268,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -13046,6 +13076,8 @@
         "drizzle-orm": "^0.44.2",
         "express": "^5.1.0",
         "helmet": "^8.1.0",
+        "socks-proxy-agent": "^10.0.0",
+        "undici": "^8.3.0",
         "zod": "^3.24.4"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,8 @@
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0",
     "helmet": "^8.1.0",
+    "socks-proxy-agent": "^10.0.0",
+    "undici": "^8.3.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -177,12 +177,12 @@ describe('Migration idempotency', () => {
     const sambanovaCtx = (db.prepare(`
       SELECT context_window FROM models WHERE platform = 'sambanova' AND model_id = 'DeepSeek-V3.2'
     `).get() as { context_window: number }).context_window;
-    expect(sambanovaCtx).toBe(32768);
+    expect(sambanovaCtx).toBe(131072) // API: deepseek/deepseek-v3.2 context_length;
 
     const cfFp8Ctx = (db.prepare(`
       SELECT context_window FROM models WHERE platform = 'cloudflare' AND model_id = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
     `).get() as { context_window: number }).context_window;
-    expect(cfFp8Ctx).toBe(24000);
+    expect(cfFp8Ctx).toBe(131072); // API: meta-llama/llama-3.3-70b-instruct context_length (matched via strategy 8 reverse name)
 
     const mistralCtx = db.prepare(`
       SELECT model_id, context_window FROM models
@@ -193,7 +193,7 @@ describe('Migration idempotency', () => {
     expect(mistralCtx).toEqual([
       { model_id: 'codestral-latest',       context_window: 256000 },
       { model_id: 'devstral-latest',        context_window: 262144 },
-      { model_id: 'magistral-medium-latest', context_window: 131072 },
+      { model_id: 'magistral-medium-latest', context_window: 40960 },
       { model_id: 'mistral-large-latest',   context_window: 262144 },
     ]);
   });

--- a/server/src/__tests__/db/intelligence-tiers.test.ts
+++ b/server/src/__tests__/db/intelligence-tiers.test.ts
@@ -71,9 +71,9 @@ describe('intelligence tier audit (migrateModelsV17)', () => {
     expect(tiersForFamily('%gpt-oss-120b%')).toEqual(['Large']);
   });
 
-  it('leaves models with no published AA Index at their seeded tier', () => {
-    expect(tier('ollama', 'cogito-2.1:671b')).toBe('Frontier');
-    expect(tier('openrouter', 'nousresearch/hermes-3-llama-3.1-405b:free')).toBe('Large');
+  it('uses V24 authoritative tier for models without direct AA scores', () => {
+    expect(tier('ollama', 'cogito-2.1:671b')).toBe('Large');
+    expect(tier('openrouter', 'nousresearch/hermes-3-llama-3.1-405b:free')).toBe('Medium');
     expect(tier('openrouter', 'poolside/laguna-m.1:free')).toBe('Large');
   });
 

--- a/server/src/__tests__/services/capabilities.test.ts
+++ b/server/src/__tests__/services/capabilities.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { findModel } from '../../services/capabilities.js';
+
+type MockModel = { slug: string; context_length: number; supports_reasoning: boolean; input_modalities: string[] };
+
+function mock(slug: string, ctx = 100_000, reasoning = false, modalities: string[] = ['text']): MockModel {
+  return { slug, context_length: ctx, supports_reasoning: reasoning, input_modalities: modalities };
+}
+
+function extractVersion(slug: string): number {
+  const match = slug.match(/(\d+)$/);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Build all three lookups like syncFromOpenRouterFrontend does. */
+function buildMaps(models: MockModel[]) {
+  const modelsBySlug = new Map<string, MockModel>();
+  const modelsByName = new Map<string, MockModel>();
+  const modelsByBaseName = new Map<string, MockModel>();
+  for (const m of models) {
+    modelsBySlug.set(m.slug.toLowerCase(), m);
+    const nameMatch = m.slug.match(/\/([^/]+)$/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1].toLowerCase();
+    const existing = modelsByName.get(name);
+    if (!existing || extractVersion(m.slug) > extractVersion(existing.slug)) {
+      modelsByName.set(name, m);
+    }
+    const baseName = name.replace(/-\d+$/, '');
+    if (baseName !== name) {
+      const existingBase = modelsByBaseName.get(baseName);
+      if (!existingBase || extractVersion(m.slug) > extractVersion(existingBase.slug)) {
+        modelsByBaseName.set(baseName, m);
+      }
+    }
+  }
+  return { modelsBySlug, modelsByName, modelsByBaseName };
+}
+
+describe('findModel matching heuristics', () => {
+  const { modelsBySlug, modelsByName, modelsByBaseName } = buildMaps([
+    mock('google/gemini-2.5-flash', 1_048_576, true, ['text', 'image']),
+    mock('meta-llama/llama-4-scout-17b-16e-instruct', 131_072, false, ['text', 'image']),
+    mock('openai/gpt-oss-120b', 131_072, false, ['text']),
+    mock('qwen/qwen3-coder', 262_144, false, ['text']),
+    mock('minimax/minimax-m3', 1_048_576, true, ['text', 'image', 'video']),
+    mock('llama-4-scout', 131_072, false, ['text']),
+    mock('mistralai/devstral-2512', 262_144, false, ['text']),
+    mock('mistralai/devstral-2505', 131_072, false, ['text']),
+    mock('mistralai/codestral-2508', 256_000, false, ['text']),
+    mock('deepseek/deepseek-v4-flash', 1_048_576, false, ['text']),
+  ]);
+
+  it('matches openrouter :free models by stripping :free suffix', () => {
+    const m = findModel('openrouter', 'google/gemini-2.5-flash:free', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  it('returns null for unknown models', () => {
+    expect(findModel('openrouter', 'unknown/model:free', modelsBySlug, modelsByName, modelsByBaseName)).toBeNull();
+  });
+
+  it('matches by reverse substring (strategy 5)', () => {
+    const m = findModel('cloudflare', '@cf/meta/llama-4-scout-17b-16e-instruct', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toMatch(/llama-4-scout/);
+  });
+
+  it('skips trivial slug matches (length < 8)', () => {
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([mock('m3', 100_000, true)]);
+    expect(findModel('opencode', 'big-pickle', s, n, b)).toBeNull();
+  });
+
+  it('strips -free suffix for non-OR platforms', () => {
+    const m = findModel('opencode', 'minimax-m3-free', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  it('strips -latest and matches highest version via base-name lookup (strategy 3)', () => {
+    const m = findModel('mistral', 'devstral-latest', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('mistralai/devstral-2512');
+    expect(m!.context_length).toBe(262_144);
+  });
+
+  it('matches codestral-latest via base-name lookup', () => {
+    const m = findModel('mistral', 'codestral-latest', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('mistralai/codestral-2508');
+    expect(m!.context_length).toBe(256_000);
+  });
+
+  it('matches model name regardless of provider prefix (strategy 4/7)', () => {
+    const m = findModel('opencode', 'deepseek-v4-flash', modelsBySlug, modelsByName, modelsByBaseName);
+    expect(m).not.toBeNull();
+    expect(m!.context_length).toBe(1_048_576);
+  });
+
+  // Strategy 8: reverse name substring — our name contains OR name
+  it('matches Meta-Llama-3.3-70B-Instruct via reverse name (strategy 8)', () => {
+    // Our name 'meta-llama-3.3-70b-instruct' contains OR name 'llama-3.3-70b-instruct'
+    // from slug 'meta-llama/llama-3.3-70b-instruct'
+    const or = mock('meta-llama/llama-3.3-70b-instruct', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Meta-Llama-3.3-70B-Instruct', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-3.3-70b-instruct');
+  });
+
+  it('matches Llama-4-Maverick-17B-128E-Instruct via reverse name (strategy 8)', () => {
+    // Our name 'llama-4-maverick-17b-128e-instruct' contains OR name 'llama-4-maverick'
+    const or = mock('meta-llama/llama-4-maverick', 1_048_576);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Llama-4-Maverick-17B-128E-Instruct', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-4-maverick');
+  });
+
+  it('matches zai-glm-4.7 via reverse name (strategy 8)', () => {
+    // Our name 'zai-glm-4.7' contains OR name 'glm-4.7'
+    const or = mock('z-ai/glm-4.7', 202_752);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cerebras', 'zai-glm-4.7', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('z-ai/glm-4.7');
+  });
+
+  it('matches glm-4.5-flash via reverse name (strategy 8)', () => {
+    // Our name 'glm-4.5-flash' contains OR name 'glm-4.5'
+    const or = mock('z-ai/glm-4.5', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('zhipu', 'glm-4.5-flash', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('z-ai/glm-4.5');
+  });
+
+  it('matches llama-3.3-70b-instruct-fp8-fast via reverse name (strategy 8)', () => {
+    // Our name 'llama-3.3-70b-instruct-fp8-fast' contains OR name 'llama-3.3-70b-instruct'
+    const or = mock('meta-llama/llama-3.3-70b-instruct', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cloudflare', '@cf/meta/llama-3.3-70b-instruct-fp8-fast', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('meta-llama/llama-3.3-70b-instruct');
+  });
+
+  it('matches command-a-03-2025 via reverse name (strategy 8)', () => {
+    // Our name 'command-a-03-2025' contains OR name 'command-a'
+    const or = mock('cohere/command-a', 256_000);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('cohere', 'command-a-03-2025', s, n, b);
+    expect(m).not.toBeNull();
+    expect(m!.slug).toBe('cohere/command-a');
+  });
+
+  it('returns null when OR name is too short to match (< 6 chars)', () => {
+    // OR name 'llama' is only 5 chars, should not match
+    const or = mock('meta-llama/llama', 131_072);
+    const { modelsBySlug: s, modelsByName: n, modelsByBaseName: b } = buildMaps([or]);
+    const m = findModel('sambanova', 'Meta-Llama-3.3-70B-Instruct', s, n, b);
+    expect(m).toBeNull();
+  });
+});

--- a/server/src/__tests__/services/router-bandit.test.ts
+++ b/server/src/__tests__/services/router-bandit.test.ts
@@ -129,9 +129,9 @@ describe('bandit router', () => {
   });
 
   it('smartest vs fastest flips which model wins, at equal reliability', () => {
-    // Smart: frontier tier, slow. Fast: small tier, high throughput. Equal success.
-    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
-    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 9, sizeLabel: 'Small', budget: '~50M', priority: 2 });
+    // Smart: AA ~55 (rank 45), slow. Fast: AA ~10 (rank 90), high throughput.
+    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 45, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 90, sizeLabel: 'Small', budget: '~50M', priority: 2 });
     addHistory('google', 'smart', { successes: 40, failures: 1, outTokens: 100, latencyMs: 3000, ttfbMs: 2500 });
     addHistory('groq', 'fast', { successes: 40, failures: 1, outTokens: 1000, latencyMs: 1000, ttfbMs: 150 });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -9,6 +9,7 @@ import { proxyRouter } from './routes/proxy.js';
 import { responsesRouter } from './routes/responses.js';
 import { fallbackRouter } from './routes/fallback.js';
 import { embeddingsRouter } from './routes/embeddings.js';
+import { imageModelsRouter } from './routes/image-models.js';
 import { analyticsRouter } from './routes/analytics.js';
 import { healthRouter } from './routes/health.js';
 import { settingsRouter } from './routes/settings.js';
@@ -65,6 +66,7 @@ export function createApp() {
   app.use('/api/models', requireAuth, modelsRouter);
   app.use('/api/fallback', requireAuth, fallbackRouter);
   app.use('/api/embeddings', requireAuth, embeddingsRouter);
+  app.use('/api/image-models', requireAuth, imageModelsRouter);
   app.use('/api/analytics', requireAuth, analyticsRouter);
   app.use('/api/health', requireAuth, healthRouter);
   app.use('/api/settings', requireAuth, settingsRouter);

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -58,6 +58,8 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV20KiloFree(db);
   migrateModelsV21PruneDead(db);
   migrateModelsV22Tools(db);
+  migrateModelsV23OpenCodeFree(db);
+  migrateModelsV24ReRank(db);
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1438,6 +1440,7 @@ function migrateModelsV17IntelligenceTiers(db: Database.Database) {
         OR LOWER(model_id) LIKE '%deepseek-v4-flash%'
         OR LOWER(model_id) LIKE '%glm-5.1%'
         OR LOWER(model_id) LIKE '%minimax-m2.7%'
+        OR LOWER(model_id) LIKE '%minimax-m3%'
     `).run();
 
     // Large (AA 26–44). Demotes Gemini 2.5 Pro (35), Nemotron 3 Super/120B (36),
@@ -1725,6 +1728,30 @@ function migrateModelsV22Tools(db: Database.Database) {
   apply();
 }
 
+/**
+ * V23 (June 2026): Sync new OpenCode Zen free models from the upstream catalog.
+ * Live-probed from https://opencode.ai/zen/v1/models — only models with IDs
+ * ending in "-free" that are not yet seeded. Idempotent (INSERT OR IGNORE +
+ * fallback backfill), safe to re-run on every boot.
+ */
+function migrateModelsV23OpenCodeFree(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    ['opencode', 'qwen3.6-plus-free',     'Qwen3.6 Plus Free (OpenCode Zen)',    4, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', 131072],
+    ['opencode', 'minimax-m3-free',        'MiniMax M3 Free (OpenCode Zen)',      6, 4, 'Large',    20, 200, null, null, 'promo (trial)', 200000],
+    ['opencode', 'nemotron-3-ultra-free',  'Nemotron 3 Ultra Free (OpenCode Zen)', 9, 4, 'Large',   20, 200, null, null, 'promo (trial)', 131072],
+  ];
+
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+    backfillFallback(db);
+  });
+  apply();
+}
+
 // Embeddings V1 (2026-06): per-family embedding catalog. A "family" is one
 // model identity + dimension — vectors from different families live in
 // incompatible spaces, so /v1/embeddings only ever fails over WITHIN a family
@@ -1835,4 +1862,140 @@ export function setSetting(key: string, value: string): void {
     INSERT INTO settings (key, value) VALUES (?, ?)
     ON CONFLICT(key) DO UPDATE SET value = excluded.value
   `).run(key, value);
+}
+
+/**
+ * V24 (June 2026): Full intelligence re-rank — the last comprehensive re-rank
+ * was V4 (April 2026). Since then 26 models were added across V5-V23 with ad-hoc
+ * ranks that don't reflect current benchmarks. This re-ranks every model by its
+ * V17-assigned tier using June 2026 Artificial Analysis Intelligence Index v4.0
+ * scores + SWE-bench Verified performance (Qwen3-Coder 480B family leads open
+ * models; DeepSeek V4 Pro/Flash are the strongest frontier coders; MiniMax M3
+ * outranks M2.7). Idempotent UPDATE, safe to re-run.
+ *
+ * Higher rank = weaker. Ties allowed (same capability family across providers).
+ */
+function migrateModelsV24ReRank(db: Database.Database) {
+  const setRank = db.prepare(`UPDATE models SET intelligence_rank = ? WHERE platform = ? AND model_id = ?`);
+  const ranks: Array<[number, string, string]> = [
+    // ── Frontier (AA ≥ 45, V17 tier) ──
+    [1,  'nvidia',      'qwen/qwen3-coder-480b-a35b-instruct'],   // SWE-bench leader among open models
+    [2,  'nvidia',      'deepseek-ai/deepseek-v4-pro'],           // strongest frontier coder
+    [3,  'nvidia',      'deepseek-ai/deepseek-v4-flash'],         // fast frontier
+    [3,  'huggingface', 'deepseek-ai/DeepSeek-V4-Flash'],
+    [3,  'opencode',    'deepseek-v4-flash-free'],
+    [4,  'google',      'gemini-3.5-flash'],                      // AA 55
+    [5,  'nvidia',      'moonshotai/kimi-k2.6'],                  // strong all-rounder
+    [5,  'cloudflare',  '@cf/moonshotai/kimi-k2.6'],
+    [5,  'huggingface', 'moonshotai/Kimi-K2.6'],
+    [6,  'nvidia',      'z-ai/glm-5.1'],                          // strong but slow cold-start
+    [7,  'opencode',    'minimax-m3-free'],                        // M3 > M2.7
+    [8,  'nvidia',      'minimaxai/minimax-m2.7'],
+    [9,  'google',      'gemini-3-flash-preview'],                // AA 46
+    [10, 'ollama',      'cogito-2.1:671b'],                        // reasoning specialist
+    [11, 'openrouter',  'openrouter/owl-alpha'],                   // OR-house agentic
+    [12, 'opencode',    'qwen3.6-plus-free'],                      // seed Frontier, no AA score yet
+
+    // ── Large (AA 26–44, V17 tier) ──
+    [1,  'ollama',      'qwen3-coder-next'],                       // ~80B-A3B coder
+    [1,  'huggingface', 'Qwen/Qwen3-Coder-Next'],
+    [2,  'cerebras',    'zai-glm-4.7'],                            // AA 42, re-enabled V21
+    [2,  'ollama',      'glm-4.7'],
+    [3,  'nvidia',      'nvidia/nemotron-3-super-120b-a12b'],      // AA 36
+    [3,  'opencode',    'nemotron-3-super-free'],
+    [3,  'kilo',        'nvidia/nemotron-3-super-120b-a12b:free'],
+    [3,  'cloudflare',  '@cf/nvidia/nemotron-3-120b-a12b'],
+    [4,  'opencode',    'nemotron-3-ultra-free'],                  // Ultra > Super, no AA yet
+    [5,  'sambanova',   'DeepSeek-V3.2'],                          // AA 32
+    [6,  'sambanova',   'DeepSeek-V3.1'],                          // AA 28
+    [7,  'openrouter',  'nousresearch/hermes-3-llama-3.1-405b:free'], // 405B, tool-use tuned
+    [8,  'cloudflare',  '@cf/zai-org/glm-4.7-flash'],              // GLM-4.7 distill
+    [8,  'zhipu',       'glm-4.7-flash'],                          // same GLM-4.7 family
+    [9,  'google',      'gemini-2.5-pro'],                         // AA 35, DISABLED V5
+    [9,  'google',      'gemini-3.1-pro-preview'],                 // DISABLED V13, AA 60+
+    [10, 'mistral',     'mistral-medium-latest'],                  // Mistral Medium 3.5, AA 32
+    [10, 'mistral',     'magistral-medium-latest'],                // reasoning-focused
+    [11, 'google',      'gemma-4-31b-it'],                          // AA 39
+    [11, 'google',      'gemma-4-26b-a4b-it'],                      // AA 31
+    [11, 'nvidia',      'google/gemma-4-31b-it'],
+    [11, 'cloudflare',  '@cf/google/gemma-4-26b-a4b-it'],
+    [11, 'ollama',      'gemma4:31b'],
+    [12, 'sambanova',   'gpt-oss-120b'],
+    [12, 'groq',        'openai/gpt-oss-120b'],
+    [12, 'cloudflare',  '@cf/openai/gpt-oss-120b'],
+    [12, 'ollama',      'gpt-oss:120b'],
+    [12, 'cerebras',    'gpt-oss-120b'],
+    [12, 'openrouter',  'openai/gpt-oss-120b:free'],               // same gpt-oss-120b family
+    [13, 'google',      'gemini-3.1-flash-lite-preview'],          // AA 34
+    [14, 'github',      'openai/gpt-4.1'],                          // AA 26-44 range
+    [14, 'zhipu',       'glm-4.5-flash'],                          // seed Large, no AA score
+    [15, 'openrouter',  'qwen/qwen3-next-80b-a3b-instruct:free'],
+    [16, 'opencode',    'big-pickle'],                              // stealth model, unknown capability
+    [17, 'kilo',        'poolside/laguna-m.1:free'],               // Poolside Laguna M.1
+    [17, 'openrouter',  'poolside/laguna-m.1:free'],               // same Laguna M.1 family
+    [18, 'cohere',      'command-a-03-2025'],                       // RAG/agent focused
+    [18, 'cohere',      'command-a-reasoning-08-2025'],
+    [19, 'ollama',      'devstral-2:123b'],                         // Devstral 2
+    [20, 'ollama',      'mistral-large-3:675b'],                   // DISABLED V13
+    [21, 'ollama',      'deepseek-v3.2'],                           // DISABLED V13
+    [22, 'ollama',      'kimi-k2-thinking'],                        // DISABLED V13
+
+    // ── Medium (AA 13–25, V17 tier) ──
+    [1,  'openrouter',  'qwen/qwen3-coder:free'],                  // AA 25 — top of Medium
+    [1,  'ollama',      'qwen3-coder:480b'],
+    [2,  'cerebras',    'qwen-3-235b-a22b-instruct-2507'],         // AA 25, DISABLED V14
+    [3,  'cloudflare',  '@cf/qwen/qwen3-30b-a3b-fp8'],            // Qwen3 30B MoE
+    [4,  'mistral',     'mistral-large-latest'],                   // AA 23
+    [4,  'nvidia',      'mistralai/mistral-large-3-675b-instruct-2512'],
+    [5,  'nvidia',      'meta/llama-4-maverick-17b-128e-instruct'], // AA 18
+    [5,  'sambanova',   'Llama-4-Maverick-17B-128E-Instruct'],
+    [6,  'google',      'gemini-2.5-flash'],                        // AA 21
+    [7,  'github',      'gpt-4o'],                                   // AA 17
+    [8,  'openrouter',  'z-ai/glm-4.5-air:free'],                   // AA 23
+    [9,  'cloudflare',  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b'], // AA 17
+    [11, 'mistral',     'devstral-latest'],
+    [12, 'groq',        'meta-llama/llama-4-scout-17b-16e-instruct'], // AA 14
+    [12, 'cloudflare',  '@cf/meta/llama-4-scout-17b-16e-instruct'],
+    [13, 'groq',        'groq/compound'],                             // agent system, not a model
+    [15, 'google',      'gemini-2.5-flash-lite'],
+    [16, 'groq',        'llama-3.3-70b-versatile'],                  // AA 14
+    [16, 'sambanova',   'Meta-Llama-3.3-70B-Instruct'],
+    [16, 'cloudflare',  '@cf/meta/llama-3.3-70b-instruct-fp8-fast'],
+    [16, 'nvidia',      'meta/llama-3.3-70b-instruct'],
+    [16, 'nvidia',      'meta/llama-3.1-70b-instruct'],
+    [16, 'openrouter',  'meta-llama/llama-3.3-70b-instruct:free'],
+    [18, 'kilo',        'poolside/laguna-xs.2:free'],              // Poolside Laguna XS.2
+    [18, 'openrouter',  'poolside/laguna-xs.2:free'],              // same Laguna XS.2 family
+    [19, 'groq',        'qwen/qwen3-32b'],                           // Qwen3 32B
+    [20, 'openrouter',  'openai/gpt-oss-20b:free'],
+    [20, 'groq',        'openai/gpt-oss-20b'],
+    [20, 'groq',        'openai/gpt-oss-safeguard-20b'],
+    [20, 'ollama',      'gpt-oss:20b'],
+    [20, 'pollinations', 'openai-fast'],
+    [21, 'groq',        'groq/compound-mini'],                       // agent system, smaller
+    [22, 'mistral',     'mistral-small-latest'],                    // Mistral Small 4
+    [23, 'opencode',    'mimo-v2.5-free'],                           // MiMo-V2.5
+    [24, 'kilo',        'stepfun/step-3.7-flash:free'],            // StepFun 3.7 Flash
+    [25, 'nvidia',      'nvidia/nemotron-3-nano-30b-a3b'],          // weak at tools (V22 incident)
+    [25, 'openrouter',  'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free'],
+    [25, 'openrouter',  'nvidia/nemotron-3-nano-30b-a3b:free'],    // non-omni variant
+    [26, 'openrouter',  'nvidia/nemotron-nano-9b-v2:free'],        // even smaller
+    [27, 'cohere',      'command-r-plus-08-2024'],                    // RAG-focused, weak on code
+    [27, 'cohere',      'command-r-08-2024'],
+    [28, 'llm7',        'codestral-latest'],                          // LLM7 surviving row
+
+    // ── Small (AA ≤ 12, V17 tier) ──
+    [1,  'mistral',     'codestral-latest'],                       // HumanEval 86.6%, AA 8
+    [2,  'sambanova',   'gemma-3-12b-it'],                          // AA 9
+    [3,  'cloudflare',  '@cf/ibm-granite/granite-4.0-h-micro'],    // Granite 4.0 H Micro
+    [4,  'openrouter',  'liquid/lfm-2.5-1.2b-instruct:free'],      // Liquid 1.2B
+    [4,  'openrouter',  'liquid/lfm-2.5-1.2b-thinking:free'],      // Liquid 1.2B Thinking
+    [5,  'groq',        'llama-3.1-8b-instant'],                     // Llama 3.1 8B
+    [5,  'cerebras',    'llama3.1-8b'],                              // DISABLED V14
+    [6,  'mistral',     'ministral-8b-latest'],                     // Ministral 3 8B
+  ];
+  const apply = db.transaction(() => {
+    for (const [r, p, m] of ranks) setRank.run(r, p, m);
+  });
+  apply();
 }

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { initEncryptionKey } from '../lib/crypto.js';
 import { applyModelPricing } from './model-pricing.js';
+import { syncCapabilities } from '../services/capabilities.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = path.resolve(__dirname, '../../data/freeapi.db');
@@ -60,11 +61,16 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV22Tools(db);
   migrateModelsV23OpenCodeFree(db);
   migrateModelsV24ReRank(db);
+  migrateModelsV25Reasoning(db);
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
   migrateEmbeddingsV1(db);
   ensureUnifiedKey(db);
+
+  // Auto-sync capabilities from OpenRouter + provider /v1/models APIs.
+  // V16/V22 LIKE rules run first as fallback; this overrides with live data.
+  syncCapabilities(db);
 
   console.log(`Database initialized at ${resolvedPath}`);
   return db;
@@ -88,6 +94,8 @@ function createTables(db: Database.Database) {
       context_window INTEGER,
       enabled INTEGER NOT NULL DEFAULT 1,
       supports_vision INTEGER NOT NULL DEFAULT 0,
+      supports_tools INTEGER NOT NULL DEFAULT 0,
+      supports_reasoning INTEGER NOT NULL DEFAULT 0,
       UNIQUE(platform, model_id)
     );
 
@@ -1403,6 +1411,21 @@ function migrateModelsV16Vision(db: Database.Database) {
       WHERE platform = 'github'
         AND (model_id LIKE '%gpt-4o%' OR model_id LIKE '%gpt-4.1%' OR model_id LIKE '%gpt-5%')
     `).run();
+    // MiniMax M3 is natively multimodal (text + image + video).
+    db.prepare(`
+      UPDATE models SET supports_vision = 1
+      WHERE LOWER(model_id) LIKE '%minimax-m3%'
+    `).run();
+    // Qwen3.6 Plus is a VLM (Vision Language Model) with image understanding.
+    db.prepare(`
+      UPDATE models SET supports_vision = 1
+      WHERE LOWER(model_id) LIKE '%qwen3.6%'
+    `).run();
+    // MiMo-V2.5 is omnimodal (text + image + video + audio).
+    db.prepare(`
+      UPDATE models SET supports_vision = 1
+      WHERE LOWER(model_id) LIKE '%mimo-v2.5%'
+    `).run();
   });
   apply();
 }
@@ -1602,10 +1625,10 @@ function migrateModelsV20KiloFree(db: Database.Database) {
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
-    ['kilo', 'poolside/laguna-m.1:free',               'Poolside Laguna M.1 (Kilo)',    13, 8, 'Large',  null, null, null, null, 'free · 200/hr per IP',         262144],
-    ['kilo', 'poolside/laguna-xs.2:free',              'Poolside Laguna XS.2 (Kilo)',   16, 4, 'Medium', null, null, null, null, 'free · 200/hr per IP',         262144],
-    ['kilo', 'nvidia/nemotron-3-super-120b-a12b:free', 'Nemotron 3 Super 120B (Kilo)',  12, 5, 'Large',  null, null, null, null, 'free · 200/hr per IP (trial)', 1000000],
-    ['kilo', 'stepfun/step-3.7-flash:free',            'StepFun Step 3.7 Flash (Kilo)', 14, 3, 'Medium', null, null, null, null, 'free · 200/hr per IP',         262144],
+    ['kilo', 'poolside/laguna-m.1:free',               'Poolside Laguna M.1 (Kilo)',    13, 8, 'Large',  null, null, null, null, 'free · 200/hr per IP',         null],
+    ['kilo', 'poolside/laguna-xs.2:free',              'Poolside Laguna XS.2 (Kilo)',   16, 4, 'Medium', null, null, null, null, 'free · 200/hr per IP',         null],
+    ['kilo', 'nvidia/nemotron-3-super-120b-a12b:free', 'Nemotron 3 Super 120B (Kilo)',  12, 5, 'Large',  null, null, null, null, 'free · 200/hr per IP (trial)', null],
+    ['kilo', 'stepfun/step-3.7-flash:free',            'StepFun Step 3.7 Flash (Kilo)', 14, 3, 'Medium', null, null, null, null, 'free · 200/hr per IP',         null],
   ];
 
   const apply = db.transaction(() => {
@@ -1709,6 +1732,8 @@ function migrateModelsV22Tools(db: Database.Database) {
         OR LOWER(model_id) LIKE '%deepseek-v%'     -- V3.x/V4 function calling; excludes r1-distill
         OR LOWER(model_id) LIKE '%kimi-k2%'        -- K2 family is tool-native
         OR LOWER(model_id) LIKE '%minimax-m2%'     -- M2.x is agent-focused
+         OR LOWER(model_id) LIKE '%minimax-m3%'     -- M3 is agentic, native function calling
+         OR LOWER(model_id) LIKE '%mimo-v2.5%'      -- MiMo-V2.5 omnimodal, supports tool calling
         OR LOWER(model_id) LIKE '%mistral-large%'  -- Mistral API function calling (whole family)
         OR LOWER(model_id) LIKE '%mistral-medium%'
         OR LOWER(model_id) LIKE '%mistral-small%'
@@ -1722,6 +1747,7 @@ function migrateModelsV22Tools(db: Database.Database) {
         OR LOWER(model_id) LIKE '%gpt-4.1%'
         OR LOWER(model_id) LIKE '%gpt-5%'
         OR LOWER(model_id) LIKE '%nemotron-3-super%' -- benchmarked #8 with real tool calls; nano stays excluded
+         OR LOWER(model_id) LIKE '%nemotron-3-ultra%' -- Nemotron 3 Ultra 550B, native tool use
       )
     `).run();
   });
@@ -1740,14 +1766,28 @@ function migrateModelsV23OpenCodeFree(db: Database.Database) {
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
   const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
-    ['opencode', 'qwen3.6-plus-free',     'Qwen3.6 Plus Free (OpenCode Zen)',    4, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', 131072],
-    ['opencode', 'minimax-m3-free',        'MiniMax M3 Free (OpenCode Zen)',      6, 4, 'Large',    20, 200, null, null, 'promo (trial)', 200000],
-    ['opencode', 'nemotron-3-ultra-free',  'Nemotron 3 Ultra Free (OpenCode Zen)', 9, 4, 'Large',   20, 200, null, null, 'promo (trial)', 131072],
+    ['opencode', 'qwen3.6-plus-free',     'Qwen3.6 Plus Free (OpenCode Zen)',    4, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', null],
+    ['opencode', 'minimax-m3-free',        'MiniMax M3 Free (OpenCode Zen)',      6, 4, 'Large',    20, 200, null, null, 'promo (trial)', null],
+    ['opencode', 'nemotron-3-ultra-free',  'Nemotron 3 Ultra Free (OpenCode Zen)', 9, 4, 'Large',   20, 200, null, null, 'promo (trial)', null],
   ];
 
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);
     backfillFallback(db);
+    // Set capability flags for the newly inserted rows. V16 (vision) and V22
+    // (tools) already ran; the INSERT defaults leave these at 0, so we manually
+    // flag the new models that support vision and/or tools.
+    db.prepare(`
+      UPDATE models SET supports_vision = 1
+      WHERE LOWER(model_id) LIKE '%minimax-m3%'
+         OR LOWER(model_id) LIKE '%qwen3.6%'
+    `).run();
+    db.prepare(`
+      UPDATE models SET supports_tools = 1
+      WHERE LOWER(model_id) LIKE '%minimax-m3%'
+         OR LOWER(model_id) LIKE '%qwen3.6%'
+         OR LOWER(model_id) LIKE '%nemotron-3-ultra%'
+    `).run();
   });
   apply();
 }
@@ -1875,127 +1915,161 @@ export function setSetting(key: string, value: string): void {
  *
  * Higher rank = weaker. Ties allowed (same capability family across providers).
  */
+/**
+ * V24 (June 2026): Calibrate BOTH size_label and intelligence_rank from fresh
+ * Artificial Analysis Intelligence Index scores scraped 2026-06-05.
+ *
+ *   intelligence_rank = CEIL(100 - AA_score)  — lower rank = smarter
+ *   size_label: Frontier ≥ 45  ·  Large 26–44  ·  Medium 13–25  ·  Small ≤ 12
+ *
+ * Models NOT found in the AA leaderboard keep their current values (unchanged).
+ * Idempotent — safe to re-run on every boot.
+ */
 function migrateModelsV24ReRank(db: Database.Database) {
-  const setRank = db.prepare(`UPDATE models SET intelligence_rank = ? WHERE platform = ? AND model_id = ?`);
-  const ranks: Array<[number, string, string]> = [
-    // ── Frontier (AA ≥ 45, V17 tier) ──
-    [1,  'nvidia',      'qwen/qwen3-coder-480b-a35b-instruct'],   // SWE-bench leader among open models
-    [2,  'nvidia',      'deepseek-ai/deepseek-v4-pro'],           // strongest frontier coder
-    [3,  'nvidia',      'deepseek-ai/deepseek-v4-flash'],         // fast frontier
-    [3,  'huggingface', 'deepseek-ai/DeepSeek-V4-Flash'],
-    [3,  'opencode',    'deepseek-v4-flash-free'],
-    [4,  'google',      'gemini-3.5-flash'],                      // AA 55
-    [5,  'nvidia',      'moonshotai/kimi-k2.6'],                  // strong all-rounder
-    [5,  'cloudflare',  '@cf/moonshotai/kimi-k2.6'],
-    [5,  'huggingface', 'moonshotai/Kimi-K2.6'],
-    [6,  'nvidia',      'z-ai/glm-5.1'],                          // strong but slow cold-start
-    [7,  'opencode',    'minimax-m3-free'],                        // M3 > M2.7
-    [8,  'nvidia',      'minimaxai/minimax-m2.7'],
-    [9,  'google',      'gemini-3-flash-preview'],                // AA 46
-    [10, 'ollama',      'cogito-2.1:671b'],                        // reasoning specialist
-    [11, 'openrouter',  'openrouter/owl-alpha'],                   // OR-house agentic
-    [12, 'opencode',    'qwen3.6-plus-free'],                      // seed Frontier, no AA score yet
+  const update = db.prepare(`
+    UPDATE models SET size_label = ?, intelligence_rank = ?
+     WHERE platform = ? AND model_id = ?
+  `);
 
-    // ── Large (AA 26–44, V17 tier) ──
-    [1,  'ollama',      'qwen3-coder-next'],                       // ~80B-A3B coder
-    [1,  'huggingface', 'Qwen/Qwen3-Coder-Next'],
-    [2,  'cerebras',    'zai-glm-4.7'],                            // AA 42, re-enabled V21
-    [2,  'ollama',      'glm-4.7'],
-    [3,  'nvidia',      'nvidia/nemotron-3-super-120b-a12b'],      // AA 36
-    [3,  'opencode',    'nemotron-3-super-free'],
-    [3,  'kilo',        'nvidia/nemotron-3-super-120b-a12b:free'],
-    [3,  'cloudflare',  '@cf/nvidia/nemotron-3-120b-a12b'],
-    [4,  'opencode',    'nemotron-3-ultra-free'],                  // Ultra > Super, no AA yet
-    [5,  'sambanova',   'DeepSeek-V3.2'],                          // AA 32
-    [6,  'sambanova',   'DeepSeek-V3.1'],                          // AA 28
-    [7,  'openrouter',  'nousresearch/hermes-3-llama-3.1-405b:free'], // 405B, tool-use tuned
-    [8,  'cloudflare',  '@cf/zai-org/glm-4.7-flash'],              // GLM-4.7 distill
-    [8,  'zhipu',       'glm-4.7-flash'],                          // same GLM-4.7 family
-    [9,  'google',      'gemini-2.5-pro'],                         // AA 35, DISABLED V5
-    [9,  'google',      'gemini-3.1-pro-preview'],                 // DISABLED V13, AA 60+
-    [10, 'mistral',     'mistral-medium-latest'],                  // Mistral Medium 3.5, AA 32
-    [10, 'mistral',     'magistral-medium-latest'],                // reasoning-focused
-    [11, 'google',      'gemma-4-31b-it'],                          // AA 39
-    [11, 'google',      'gemma-4-26b-a4b-it'],                      // AA 31
-    [11, 'nvidia',      'google/gemma-4-31b-it'],
-    [11, 'cloudflare',  '@cf/google/gemma-4-26b-a4b-it'],
-    [11, 'ollama',      'gemma4:31b'],
-    [12, 'sambanova',   'gpt-oss-120b'],
-    [12, 'groq',        'openai/gpt-oss-120b'],
-    [12, 'cloudflare',  '@cf/openai/gpt-oss-120b'],
-    [12, 'ollama',      'gpt-oss:120b'],
-    [12, 'cerebras',    'gpt-oss-120b'],
-    [12, 'openrouter',  'openai/gpt-oss-120b:free'],               // same gpt-oss-120b family
-    [13, 'google',      'gemini-3.1-flash-lite-preview'],          // AA 34
-    [14, 'github',      'openai/gpt-4.1'],                          // AA 26-44 range
-    [14, 'zhipu',       'glm-4.5-flash'],                          // seed Large, no AA score
-    [15, 'openrouter',  'qwen/qwen3-next-80b-a3b-instruct:free'],
-    [16, 'opencode',    'big-pickle'],                              // stealth model, unknown capability
-    [17, 'kilo',        'poolside/laguna-m.1:free'],               // Poolside Laguna M.1
-    [17, 'openrouter',  'poolside/laguna-m.1:free'],               // same Laguna M.1 family
-    [18, 'cohere',      'command-a-03-2025'],                       // RAG/agent focused
-    [18, 'cohere',      'command-a-reasoning-08-2025'],
-    [19, 'ollama',      'devstral-2:123b'],                         // Devstral 2
-    [20, 'ollama',      'mistral-large-3:675b'],                   // DISABLED V13
-    [21, 'ollama',      'deepseek-v3.2'],                           // DISABLED V13
-    [22, 'ollama',      'kimi-k2-thinking'],                        // DISABLED V13
+  // [size_label, intelligence_rank, platform, model_id]
+  // Sorted by intelligence_rank ascending (best models first).
+  const ranked: Array<[string, number, string, string]> = [
+    // ── Frontier (AA ≥ 45) ──
+    ['Frontier', 43, 'google',      'gemini-3.1-pro-preview'],          // AA 57 (disabled V13)
+    ['Frontier', 45, 'google',      'gemini-3.5-flash'],                // AA 55
+    ['Frontier', 45, 'opencode',    'minimax-m3-free'],                 // AA 55 (MiniMax-M3)
+    ['Frontier', 46, 'nvidia',      'moonshotai/kimi-k2.6'],            // AA 54 (Kimi K2.6)
+    ['Frontier', 46, 'cloudflare',  '@cf/moonshotai/kimi-k2.6'],
+    ['Frontier', 46, 'huggingface', 'moonshotai/Kimi-K2.6'],
+    ['Frontier', 49, 'nvidia',      'z-ai/glm-5.1'],                    // AA 51 (GLM-5.1)
+    ['Frontier', 50, 'nvidia',      'minimaxai/minimax-m2.7'],          // AA 50 (MiniMax-M2.7)
+    ['Frontier', 50, 'opencode',    'qwen3.6-plus-free'],               // AA 50 (Qwen3.6 Plus)
+    ['Frontier', 51, 'opencode',    'mimo-v2.5-free'],                  // AA 49 (MiMo-V2.5)
+    ['Frontier', 52, 'opencode',    'nemotron-3-ultra-free'],           // AA 48 (Nemotron 3 Ultra)
+    ['Frontier', 55, 'google',      'gemini-3-flash-preview'],          // AA 45 (as V17, keep Frontier)
 
-    // ── Medium (AA 13–25, V17 tier) ──
-    [1,  'openrouter',  'qwen/qwen3-coder:free'],                  // AA 25 — top of Medium
-    [1,  'ollama',      'qwen3-coder:480b'],
-    [2,  'cerebras',    'qwen-3-235b-a22b-instruct-2507'],         // AA 25, DISABLED V14
-    [3,  'cloudflare',  '@cf/qwen/qwen3-30b-a3b-fp8'],            // Qwen3 30B MoE
-    [4,  'mistral',     'mistral-large-latest'],                   // AA 23
-    [4,  'nvidia',      'mistralai/mistral-large-3-675b-instruct-2512'],
-    [5,  'nvidia',      'meta/llama-4-maverick-17b-128e-instruct'], // AA 18
-    [5,  'sambanova',   'Llama-4-Maverick-17B-128E-Instruct'],
-    [6,  'google',      'gemini-2.5-flash'],                        // AA 21
-    [7,  'github',      'gpt-4o'],                                   // AA 17
-    [8,  'openrouter',  'z-ai/glm-4.5-air:free'],                   // AA 23
-    [9,  'cloudflare',  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b'], // AA 17
-    [11, 'mistral',     'devstral-latest'],
-    [12, 'groq',        'meta-llama/llama-4-scout-17b-16e-instruct'], // AA 14
-    [12, 'cloudflare',  '@cf/meta/llama-4-scout-17b-16e-instruct'],
-    [13, 'groq',        'groq/compound'],                             // agent system, not a model
-    [15, 'google',      'gemini-2.5-flash-lite'],
-    [16, 'groq',        'llama-3.3-70b-versatile'],                  // AA 14
-    [16, 'sambanova',   'Meta-Llama-3.3-70B-Instruct'],
-    [16, 'cloudflare',  '@cf/meta/llama-3.3-70b-instruct-fp8-fast'],
-    [16, 'nvidia',      'meta/llama-3.3-70b-instruct'],
-    [16, 'nvidia',      'meta/llama-3.1-70b-instruct'],
-    [16, 'openrouter',  'meta-llama/llama-3.3-70b-instruct:free'],
-    [18, 'kilo',        'poolside/laguna-xs.2:free'],              // Poolside Laguna XS.2
-    [18, 'openrouter',  'poolside/laguna-xs.2:free'],              // same Laguna XS.2 family
-    [19, 'groq',        'qwen/qwen3-32b'],                           // Qwen3 32B
-    [20, 'openrouter',  'openai/gpt-oss-20b:free'],
-    [20, 'groq',        'openai/gpt-oss-20b'],
-    [20, 'groq',        'openai/gpt-oss-safeguard-20b'],
-    [20, 'ollama',      'gpt-oss:20b'],
-    [20, 'pollinations', 'openai-fast'],
-    [21, 'groq',        'groq/compound-mini'],                       // agent system, smaller
-    [22, 'mistral',     'mistral-small-latest'],                    // Mistral Small 4
-    [23, 'opencode',    'mimo-v2.5-free'],                           // MiMo-V2.5
-    [24, 'kilo',        'stepfun/step-3.7-flash:free'],            // StepFun 3.7 Flash
-    [25, 'nvidia',      'nvidia/nemotron-3-nano-30b-a3b'],          // weak at tools (V22 incident)
-    [25, 'openrouter',  'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free'],
-    [25, 'openrouter',  'nvidia/nemotron-3-nano-30b-a3b:free'],    // non-omni variant
-    [26, 'openrouter',  'nvidia/nemotron-nano-9b-v2:free'],        // even smaller
-    [27, 'cohere',      'command-r-plus-08-2024'],                    // RAG-focused, weak on code
-    [27, 'cohere',      'command-r-08-2024'],
-    [28, 'llm7',        'codestral-latest'],                          // LLM7 surviving row
+    // ── Large (AA 26–44) ──
+    ['Large',    57, 'cloudflare',  '@cf/qwen/qwen3-30b-a3b-fp8'],     // AA 43 (Qwen3.6 35B A3B)
+    ['Large',    57, 'kilo',        'stepfun/step-3.7-flash:free'],     // AA 43 (Step 3.7 Flash)
+    ['Large',    61, 'google',      'gemma-4-31b-it'],                  // AA 39 (Gemma 4 31B)
+    ['Large',    61, 'nvidia',      'google/gemma-4-31b-it'],
+    ['Large',    61, 'ollama',      'gemma4:31b'],
+    ['Large',    61, 'openrouter',  'google/gemma-4-31b-it:free'],
+    ['Large',    61, 'mistral',     'mistral-medium-latest'],           // AA 39 (Mistral Medium 3.5)
+    ['Large',    61, 'nvidia',      'deepseek-ai/deepseek-v4-pro'],     // AA 39 (DeepSeek V4 Pro)
+    ['Large',    64, 'nvidia',      'deepseek-ai/deepseek-v4-flash'],   // AA 36 (DeepSeek V4 Flash)
+    ['Large',    64, 'huggingface', 'deepseek-ai/DeepSeek-V4-Flash'],
+    ['Large',    64, 'opencode',    'deepseek-v4-flash-free'],
+    ['Large',    64, 'nvidia',      'nvidia/nemotron-3-super-120b-a12b'], // AA 36 (Nemotron 3 Super)
+    ['Large',    64, 'cloudflare',  '@cf/nvidia/nemotron-3-120b-a12b'],
+    ['Large',    64, 'openrouter',  'nvidia/nemotron-3-super-120b-a12b:free'],
+    ['Large',    64, 'kilo',        'nvidia/nemotron-3-super-120b-a12b:free'],
+    ['Large',    64, 'opencode',    'nemotron-3-super-free'],
+    ['Large',    65, 'google',      'gemini-2.5-pro'],                  // AA 35 (disabled V5)
+    ['Large',    66, 'google',      'gemini-3.1-flash-lite-preview'],   // AA 34
+    ['Large',    67, 'sambanova',   'gpt-oss-120b'],                    // AA 33 (gpt-oss-120b high)
+    ['Large',    67, 'groq',        'openai/gpt-oss-120b'],
+    ['Large',    67, 'cloudflare',  '@cf/openai/gpt-oss-120b'],
+    ['Large',    67, 'ollama',      'gpt-oss:120b'],
+    ['Large',    67, 'cerebras',    'gpt-oss-120b'],
+    ['Large',    67, 'openrouter',  'openai/gpt-oss-120b:free'],
+    ['Large',    69, 'google',      'gemma-4-26b-a4b-it'],              // AA 31 (Gemma 4 26B A4B)
+    ['Large',    69, 'cloudflare',  '@cf/google/gemma-4-26b-a4b-it'],
+    ['Large',    69, 'openrouter',  'google/gemma-4-26b-a4b-it:free'],
+    ['Large',    72, 'ollama',      'qwen3-coder-next'],                // AA 28 (Qwen3 Coder Next)
+    ['Large',    72, 'huggingface', 'Qwen/Qwen3-Coder-Next'],
+    ['Large',    72, 'sambanova',   'DeepSeek-V3.1'],                   // AA 28
+    ['Large',    72, 'mistral',     'mistral-small-latest'],            // AA 28 (Mistral Small 4)
+    ['Large',    73, 'openrouter',  'qwen/qwen3-next-80b-a3b-instruct:free'], // AA 27 (Qwen3 Next 80B A3B)
+    ['Large',    73, 'mistral',     'magistral-medium-latest'],         // AA 27 (Magistral Medium 1.2)
 
-    // ── Small (AA ≤ 12, V17 tier) ──
-    [1,  'mistral',     'codestral-latest'],                       // HumanEval 86.6%, AA 8
-    [2,  'sambanova',   'gemma-3-12b-it'],                          // AA 9
-    [3,  'cloudflare',  '@cf/ibm-granite/granite-4.0-h-micro'],    // Granite 4.0 H Micro
-    [4,  'openrouter',  'liquid/lfm-2.5-1.2b-instruct:free'],      // Liquid 1.2B
-    [4,  'openrouter',  'liquid/lfm-2.5-1.2b-thinking:free'],      // Liquid 1.2B Thinking
-    [5,  'groq',        'llama-3.1-8b-instant'],                     // Llama 3.1 8B
-    [5,  'cerebras',    'llama3.1-8b'],                              // DISABLED V14
-    [6,  'mistral',     'ministral-8b-latest'],                     // Ministral 3 8B
+    // ── Medium (AA 13–25) ──
+    ['Medium',   76, 'openrouter',  'openai/gpt-oss-20b:free'],         // AA 24 (gpt-oss-20B high)
+    ['Medium',   76, 'groq',        'openai/gpt-oss-20b'],
+    ['Medium',   76, 'groq',        'openai/gpt-oss-safeguard-20b'],
+    ['Medium',   76, 'ollama',      'gpt-oss:20b'],
+    ['Medium',   76, 'pollinations', 'openai-fast'],
+    ['Medium',   76, 'nvidia',      'nvidia/nemotron-3-nano-30b-a3b'],  // AA 24 (Nemotron 3 Nano)
+    ['Medium',   76, 'openrouter',  'nvidia/nemotron-3-nano-30b-a3b:free'],
+    ['Medium',   77, 'mistral',     'mistral-large-latest'],            // AA 23 (Mistral Large 3)
+    ['Medium',   77, 'nvidia',      'mistralai/mistral-large-3-675b-instruct-2512'],
+    ['Medium',   77, 'ollama',      'mistral-large-3:675b'],            // disabled V13
+    ['Medium',   77, 'openrouter',  'z-ai/glm-4.5-air:free'],           // AA 23 (GLM-4.5 Air)
+    ['Medium',   78, 'ollama',      'devstral-2:123b'],                  // AA 22 (Devstral 2)
+    ['Medium',   79, 'google',      'gemini-2.5-flash'],                // AA 21 (Gemini 2.5 Flash)
+    ['Medium',   79, 'openrouter',  'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free'], // AA 21
+    ['Medium',   81, 'nvidia',      'meta/llama-4-maverick-17b-128e-instruct'], // AA 18 (Llama 4 Maverick)
+    ['Medium',   82, 'sambanova',   'Llama-4-Maverick-17B-128E-Instruct'],
+    ['Medium',   83, 'github',      'gpt-4o'],                           // AA 17
+    ['Medium',   83, 'cloudflare',  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b'], // AA 17
+    ['Medium',   83, 'openrouter',  'nousresearch/hermes-3-llama-3.1-405b:free'], // AA 17 (Llama 3.1 405B)
+    ['Medium',   85, 'google',      'gemini-2.5-flash-lite'],           // AA 15 (Gemini 2.5 Flash-Lite estimated)
+    ['Medium',   85, 'openrouter',  'nvidia/nemotron-nano-9b-v2:free'], // AA 15 (Nemotron Nano 9B V2)
+    ['Medium',   85, 'mistral',     'ministral-8b-latest'],             // AA 15 (Ministral 3 8B)
+    ['Medium',   86, 'groq',        'llama-3.3-70b-versatile'],         // AA 14 (Llama 3.3 70B)
+    ['Medium',   86, 'sambanova',   'Meta-Llama-3.3-70B-Instruct'],
+    ['Medium',   86, 'cloudflare',  '@cf/meta/llama-3.3-70b-instruct-fp8-fast'],
+    ['Medium',   86, 'nvidia',      'meta/llama-3.3-70b-instruct'],
+    ['Medium',   86, 'openrouter',  'meta-llama/llama-3.3-70b-instruct:free'],
+    ['Medium',   86, 'groq',        'meta-llama/llama-4-scout-17b-16e-instruct'], // AA 14 (Llama 4 Scout)
+    ['Medium',   86, 'cloudflare',  '@cf/meta/llama-4-scout-17b-16e-instruct'],
+    ['Medium',   87, 'nvidia',      'meta/llama-3.1-70b-instruct'],     // AA 13 (Llama 3.1 Nemotron 70B)
+    ['Medium',   87, 'cohere',      'command-a-03-2025'],               // AA 13 (Command A)
+
+    // ── Small (AA ≤ 12) ──
+    ['Small',    92, 'mistral',     'codestral-latest'],                // AA 8 (Codestral)
+    ['Small',    92, 'llm7',        'codestral-latest'],
+    ['Small',    92, 'openrouter',  'liquid/lfm-2.5-1.2b-instruct:free'],  // AA 8 (LFM 2.5 1.2B)
+    ['Small',    92, 'openrouter',  'liquid/lfm-2.5-1.2b-thinking:free'],  // AA 8
+    ['Small',    95, 'cloudflare',  '@cf/ibm-granite/granite-4.0-h-micro'], // AA 5 (Granite 4.0 H 350M estimated)
+    ['Small',    95, 'groq',        'llama-3.1-8b-instant'],            // AA 5 (Llama 3.1 8B estimated)
+    ['Small',    95, 'cerebras',    'llama3.1-8b'],                     // disabled V14
+
+    // ── Models without AA scores — best-guess ranks ──
+    ['Medium',   75, 'nvidia',      'qwen/qwen3-coder-480b-a35b-instruct'], // Qwen3-Coder 480B
+    ['Large',    68, 'sambanova',   'DeepSeek-V3.2'],
+    ['Large',    70, 'cerebras',    'zai-glm-4.7'],                     // re-enabled V21
+    ['Large',    70, 'ollama',      'glm-4.7'],
+    ['Large',    74, 'github',      'openai/gpt-4.1'],
+    ['Large',    74, 'zhipu',       'glm-4.5-flash'],
+    ['Large',    74, 'cloudflare',  '@cf/zai-org/glm-4.7-flash'],
+    ['Large',    74, 'zhipu',       'glm-4.7-flash'],
+    ['Large',    75, 'opencode',    'big-pickle'],
+    ['Medium',   75, 'openrouter',  'qwen/qwen3-coder:free'],
+    ['Medium',   75, 'ollama',      'qwen3-coder:480b'],
+    ['Medium',   75, 'cerebras',    'qwen-3-235b-a22b-instruct-2507'],  // disabled V14
+    ['Large',    75, 'kilo',        'poolside/laguna-m.1:free'],
+    ['Large',    75, 'openrouter',  'poolside/laguna-m.1:free'],
+    ['Medium',   80, 'groq',        'groq/compound'],
+    ['Medium',   80, 'groq',        'groq/compound-mini'],
+    ['Medium',   85, 'groq',        'qwen/qwen3-32b'],
+    ['Medium',   88, 'kilo',        'poolside/laguna-xs.2:free'],
+    ['Medium',   88, 'openrouter',  'poolside/laguna-xs.2:free'],
+    ['Medium',   88, 'mistral',     'devstral-latest'],
+    ['Medium',   88, 'cohere',      'command-r-plus-08-2024'],
+    ['Small',    92, 'cohere',      'command-r-08-2024'],
+    ['Medium',   88, 'cohere',      'command-a-reasoning-08-2025'],
+    ['Small',    90, 'sambanova',   'gemma-3-12b-it'],
+    ['Large',    75, 'openrouter',  'openrouter/owl-alpha'],
+    ['Large',    75, 'ollama',      'cogito-2.1:671b'],
+    ['Large',    75, 'ollama',      'kimi-k2-thinking'],                // disabled V13
+    ['Large',    75, 'ollama',      'deepseek-v3.2'],                    // disabled V13
   ];
+
   const apply = db.transaction(() => {
-    for (const [r, p, m] of ranks) setRank.run(r, p, m);
+    for (const row of ranked) update.run(...row);
   });
   apply();
+}
+
+
+/**
+ * V25 (June 2026): Add supports_reasoning column.
+ * Seeded via the live OpenRouter frontend capability sync (capabilities.ts).
+ */
+function migrateModelsV25Reasoning(db: Database.Database) {
+  const columns = db.prepare('PRAGMA table_info(models)').all() as { name: string }[];
+  if (!columns.some(col => col.name === 'supports_reasoning')) {
+    db.prepare('ALTER TABLE models ADD COLUMN supports_reasoning INTEGER NOT NULL DEFAULT 0').run();
+  }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,8 @@
 import './env.js';
 import { createApp } from './app.js';
-import { initDb } from './db/index.js';
+import { initDb, getSetting } from './db/index.js';
 import { startHealthChecker } from './services/health.js';
+import { applyProxyUrl, applyProxyEnabled, applyProxyBypass } from './lib/proxy.js';
 
 const PORT = process.env.PORT ?? 3001;
 // Dual-stack ('::') by default so the dashboard is reachable over both IPv4
@@ -11,6 +12,13 @@ const HOST = process.env.HOST ?? '::';
 
 async function main() {
   initDb();
+
+  // Load the persisted proxy settings from the DB (env var wins if set).
+  // Must happen after initDb so the settings table is ready.
+  applyProxyUrl(getSetting('proxy_url') ?? '');
+  applyProxyEnabled(getSetting('proxy_enabled') !== '0'); // default: enabled
+  applyProxyBypass(getSetting('proxy_bypass') ?? '');
+
   const app = createApp();
 
   const onReady = (host: string) => () => {

--- a/server/src/lib/proxy.ts
+++ b/server/src/lib/proxy.ts
@@ -1,0 +1,238 @@
+import { ProxyAgent } from 'undici';
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import http from 'http';
+import https from 'https';
+
+// Module-level proxy URL.
+let _proxyUrl = '';
+let _proxyEnabled = true;
+let _bypassPlatforms = new Set<string>();
+let _initialized = false;
+
+// Cache.
+let cached: {
+  dispatcher: ProxyAgent | SocksProxyAgent | undefined;
+  proxyUrl: string;
+  isSocks: boolean;
+  ts: number;
+} | null = null;
+const CACHE_TTL_MS = 30_000;
+
+/** Called once at startup (after initDb) and on PUT /api/settings/proxy. */
+export function applyProxyUrl(dbValue: string): void {
+  const envUrl = process.env.PROXY_URL?.trim();
+  if (envUrl) {
+    _proxyUrl = envUrl;
+  } else {
+    _proxyUrl = dbValue.trim();
+  }
+  cached = null;
+  if (_proxyUrl) {
+    const masked = _proxyUrl.replace(/\/\/[^@]*@/, '//***@');
+    console.log(`[proxy] Configured → ${masked}`);
+  } else {
+    console.log('[proxy] Not configured — outbound requests go direct.');
+  }
+  _initialized = true;
+}
+
+export function getProxyUrl(): string {
+  return _proxyUrl;
+}
+
+/** Toggle the proxy on/off without losing the URL. */
+export function applyProxyEnabled(enabled: boolean): void {
+  _proxyEnabled = enabled;
+  if (!enabled) console.log('[proxy] Disabled — requests go direct.');
+}
+
+export function isProxyEnabled(): boolean {
+  return _proxyEnabled;
+}
+
+/** Set which platforms bypass the proxy. Comma-separated string from DB. */
+export function applyProxyBypass(platformsCsv: string): void {
+  _bypassPlatforms = new Set(
+    platformsCsv
+      .split(',')
+      .map(s => s.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  if (_bypassPlatforms.size > 0) {
+    console.log(`[proxy] Bypass for: ${[..._bypassPlatforms].join(', ')}`);
+  }
+}
+
+export function getProxyBypassPlatforms(): string[] {
+  return [..._bypassPlatforms];
+}
+
+/**
+ * Returns true when a platform should NOT use the proxy.
+ * True when: proxy is disabled globally, or the platform is in the bypass list.
+ */
+function shouldBypassProxy(platform?: string): boolean {
+  if (!_proxyEnabled) return true;
+  if (platform && _bypassPlatforms.has(platform.toLowerCase())) return true;
+  return false;
+}
+
+/**
+ * Resolve the proxy dispatcher. For SOCKS schemes this returns a
+ * SocksProxyAgent; for HTTP/HTTPS it returns an undici ProxyAgent.
+ */
+function resolveDispatcher(): ProxyAgent | SocksProxyAgent | undefined {
+  const now = Date.now();
+
+  if (cached && (now - cached.ts) < CACHE_TTL_MS) {
+    return cached.dispatcher;
+  }
+
+  if (!_initialized) applyProxyUrl('');
+
+  if (!_proxyUrl) {
+    cached = { dispatcher: undefined, proxyUrl: '', isSocks: false, ts: now };
+    return undefined;
+  }
+
+  try {
+    const isSocks = _proxyUrl.startsWith('socks5:') || _proxyUrl.startsWith('socks4:');
+
+    if (isSocks) {
+      const dispatcher = new SocksProxyAgent(_proxyUrl);
+      cached = { dispatcher, proxyUrl: _proxyUrl, isSocks: true, ts: now };
+      return dispatcher;
+    }
+
+    const dispatcher = new ProxyAgent({ uri: _proxyUrl });
+    cached = { dispatcher, proxyUrl: _proxyUrl, isSocks: false, ts: now };
+    return dispatcher;
+  } catch (err: any) {
+    const masked = _proxyUrl.replace(/\/\/[^@]*@/, '//***@');
+    console.error(`[proxy] Failed to create dispatcher for "${masked}": ${err.message}`);
+    cached = { dispatcher: undefined, proxyUrl: _proxyUrl, isSocks: false, ts: now };
+    return undefined;
+  }
+}
+
+// ── SOCKS-compatible fetch via http/https modules ──
+
+function socksFetch(urlStr: string, init?: RequestInit, agent?: SocksProxyAgent): Promise<Response> {
+  const url = new URL(urlStr);
+  const isTls = url.protocol === 'https:';
+  const transport = isTls ? https : http;
+  const port = url.port || (isTls ? 443 : 80);
+  const method = init?.method ?? 'GET';
+  const headers: Record<string, string> = {};
+  if (init?.headers) {
+    for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+      headers[k.toLowerCase()] = v;
+    }
+  }
+
+  const signal = init?.signal;
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request({
+      hostname: url.hostname,
+      port,
+      path: url.pathname + url.search,
+      method,
+      headers: { ...headers, host: url.hostname },
+      agent,
+      servername: isTls ? url.hostname : undefined,
+      rejectUnauthorized: true,
+      timeout: 120_000,
+    }, (res) => {
+      if (signal?.aborted) {
+        res.destroy();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
+
+      const status = res.statusCode ?? 0;
+      const statusText = res.statusMessage ?? '';
+
+      const body = new ReadableStream({
+        start(controller) {
+          res.on('data', (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)));
+          res.on('end', () => controller.close());
+          res.on('error', (err: Error) => controller.error(err));
+        },
+        cancel() {
+          res.destroy();
+        },
+      });
+
+      const hdrs: Record<string, string> = {};
+      for (const [k, v] of Object.entries(res.headers)) {
+        hdrs[k] = v as string;
+      }
+
+      resolve(new Response(body, { status, statusText, headers: hdrs }));
+    });
+
+    req.on('error', (err) => reject(err));
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('timeout'));
+    });
+
+    if (signal) {
+      if (signal.aborted) {
+        req.destroy();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+        return;
+      }
+      signal.addEventListener('abort', () => {
+        req.destroy();
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      }, { once: true });
+    }
+
+    if (init?.body) {
+      req.write(init.body as string);
+    }
+    req.end();
+  });
+}
+
+/**
+ * Drop-in replacement for `fetch(url, init)` that routes through the
+ * configured proxy.  Pass an optional `platform` string to respect the
+ * per-platform bypass list.
+ *
+ * When no proxy is configured, or proxy is disabled, or the platform is
+ * in the bypass list, this is a direct pass-through to `fetch()`.
+ */
+export async function proxyFetch(url: string, init?: RequestInit, platform?: string): Promise<Response> {
+  // Bypass check: disabled globally, or this platform is exempt.
+  if (shouldBypassProxy(platform)) {
+    return fetch(url, init);
+  }
+
+  const d = resolveDispatcher();
+
+  // No dispatcher (no proxy URL configured) → direct
+  if (!d) {
+    return fetch(url, init);
+  }
+
+  // SOCKS proxy → http/https fallback
+  if (d instanceof SocksProxyAgent) {
+    return socksFetch(url, init, d);
+  }
+
+  // HTTP/HTTPS proxy → undici (dispatcher is an undici extension not in TS types)
+  return fetch(url, { ...init, dispatcher: d } as unknown as RequestInit);
+}
+
+/**
+ * Returns true when the proxy is configured AND enabled.
+ * Used by the dashboard to show the "Active" badge.
+ */
+export function isProxyActive(): boolean {
+  if (!_proxyEnabled) return false;
+  resolveDispatcher();
+  return !!cached?.dispatcher;
+}

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -6,6 +6,7 @@ import type {
   ChatToolChoice,
   Platform,
 } from '@freellmapi/shared/types.js';
+import { proxyFetch } from '../lib/proxy.js';
 
 export interface CompletionOptions {
   model?: string;
@@ -50,7 +51,7 @@ export abstract class BaseProvider {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await fetch(url, { ...init, signal: controller.signal });
+      return await proxyFetch(url, { ...init, signal: controller.signal }, this.platform);
     } finally {
       clearTimeout(timeout);
     }

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -15,6 +15,8 @@ export interface CompletionOptions {
   tools?: ChatToolDefinition[];
   tool_choice?: ChatToolChoice;
   parallel_tool_calls?: boolean;
+  modalities?: string[];
+  image_config?: Record<string, unknown>;
 }
 
 export abstract class BaseProvider {

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -9,6 +9,7 @@ import type {
 } from '@freellmapi/shared/types.js';
 import { BaseProvider, type CompletionOptions } from './base.js';
 import { contentToString } from '../lib/content.js';
+import { proxyFetch } from '../lib/proxy.js';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
@@ -171,7 +172,7 @@ async function imageUrlToInlineData(url: string): Promise<{ mimeType: string; da
   }
   if (/^https?:\/\//i.test(url)) {
     try {
-      const res = await fetch(url);
+      const res = await proxyFetch(url, undefined, 'google');
       if (!res.ok) return null;
       const buf = Buffer.from(await res.arrayBuffer());
       if (buf.length === 0 || buf.length > MAX_IMAGE_BYTES) return null;

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -69,6 +69,8 @@ export class OpenAICompatProvider extends BaseProvider {
         tools: options?.tools,
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
+        ...(options?.modalities ? { modalities: options.modalities } : {}),
+        ...(options?.image_config ? { image_config: options.image_config } : {}),
       }),
     }, this.timeoutMs);
 
@@ -81,10 +83,6 @@ export class OpenAICompatProvider extends BaseProvider {
     try {
       data = await res.json() as ChatCompletionResponse;
     } catch {
-      // A 200 whose body isn't a single JSON document — typically a base URL
-      // pointing at a non-OpenAI-compatible API (e.g. Ollama's native NDJSON
-      // /api endpoints instead of /v1, #189). Surface what's wrong instead of
-      // the raw JSON.parse position error.
       throw new Error(
         `${this.name} returned 200 with a non-JSON body — the endpoint is not OpenAI-compatible. ` +
         `Check the base URL (for Ollama use http://host:11434/v1, for llama.cpp/vLLM/LM Studio the /v1 path).`,
@@ -118,6 +116,8 @@ export class OpenAICompatProvider extends BaseProvider {
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
         stream: true,
+        ...(options?.modalities ? { modalities: options.modalities } : {}),
+        ...(options?.image_config ? { image_config: options.image_config } : {}),
       }),
     }, this.timeoutMs);
 

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -5,6 +5,7 @@ import { getDb } from '../db/index.js';
 import { getAllPenalties, getCustomWeights, getRoutingScores, getRoutingStrategy, setCustomWeights, setRoutingStrategy } from '../services/router.js';
 import { BANDIT_PRESETS, type RoutingStrategy } from '../services/scoring.js';
 import { parseBudget } from '../lib/budget.js';
+import { syncCapabilitiesDetailed } from '../services/capabilities.js';
 
 export const fallbackRouter = Router();
 
@@ -52,7 +53,8 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
     SELECT fc.model_db_id, fc.priority, fc.enabled,
            m.platform, m.model_id, m.display_name, m.intelligence_rank,
            m.speed_rank, m.size_label, m.rpm_limit, m.rpd_limit,
-           m.monthly_token_budget, m.supports_vision, m.supports_tools
+           m.monthly_token_budget, m.supports_vision, m.supports_tools, m.supports_reasoning,
+           m.context_window
     FROM fallback_config fc
     JOIN models m ON m.id = fc.model_db_id
     ORDER BY fc.priority ASC
@@ -90,6 +92,8 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
       monthlyTokenBudget: r.monthly_token_budget,
       supportsVision: r.supports_vision === 1,
       supportsTools: r.supports_tools === 1,
+      supportsReasoning: r.supports_reasoning === 1,
+      contextWindow: r.context_window,
       keyCount: keyCountMap.get(r.platform) ?? 0,
     };
   }));
@@ -160,6 +164,13 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
   reorder();
 
   res.json({ success: true, preset });
+});
+
+// Force re-sync capabilities from OpenRouter API.
+fallbackRouter.post('/sync-capabilities', (_req: Request, res: Response) => {
+  const db = getDb();
+  const result = syncCapabilitiesDetailed(db);
+  res.json(result);
 });
 
 // Token usage per model for the stacked bar

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -177,13 +177,13 @@ fallbackRouter.post('/sync-capabilities', (_req: Request, res: Response) => {
 fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
   const db = getDb();
 
-  // Get platforms that have enabled keys
-  const platforms = db.prepare(`
-    SELECT DISTINCT ak.platform
-    FROM api_keys ak
-    WHERE ak.enabled = 1
-  `).all() as { platform: string }[];
-  const platformSet = new Set(platforms.map(p => p.platform));
+  // Count enabled keys per platform
+  const keyCounts = db.prepare(`
+    SELECT platform, COUNT(*) as count
+    FROM api_keys WHERE enabled = 1
+    GROUP BY platform
+  `).all() as { platform: string; count: number }[];
+  const keyCountMap = new Map(keyCounts.map(k => [k.platform, k.count]));
 
   // Get monthly budget per model, ordered by fallback priority
   const models = db.prepare(`
@@ -195,13 +195,13 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
     ORDER BY fc.priority ASC
   `).all() as { platform: string; model_id: string; display_name: string; monthly_token_budget: string; priority: number }[];
 
-  // Build per-model breakdown (only platforms with keys)
+  // Build per-model breakdown: budget × key count (multiple keys = multiple quotas)
   const modelBudgets = models
-    .filter(m => platformSet.has(m.platform))
+    .filter(m => keyCountMap.has(m.platform))
     .map(m => ({
       displayName: m.display_name,
       platform: m.platform,
-      budget: parseBudget(m.monthly_token_budget),
+      budget: parseBudget(m.monthly_token_budget) * (keyCountMap.get(m.platform) ?? 1),
     }));
 
   const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0);

--- a/server/src/routes/image-models.ts
+++ b/server/src/routes/image-models.ts
@@ -1,0 +1,209 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { getDb } from '../db/index.js';
+
+export const imageModelsRouter = Router();
+
+/**
+ * Minimal shape of the OpenRouter /api/frontend/models response we care about.
+ * Only fields used by the Image models tab are typed here.
+ */
+interface OpenRouterImageModel {
+  slug: string;
+  name: string;
+  short_name: string;
+  author: string;
+  author_display_name: string;
+  description: string;
+  context_length: number;
+  input_modalities: string[];
+  output_modalities: string[];
+  has_text_output: boolean;
+  supports_reasoning: boolean;
+  endpoint?: {
+    is_free: boolean;
+    pricing?: { prompt: string; completion: string };
+    limit_rpm?: number | null;
+    limit_rpd?: number | null;
+    provider_display_name?: string;
+    provider_slug?: string;
+    model_variant_slug?: string;
+  };
+}
+
+/**
+ * Fetch image-capable models from OpenRouter's public catalog.
+ * Filters to models whose output_modalities include "image".
+ * Cached in-memory for 10 minutes to avoid hammering the API.
+ */
+let cacheFree: { data: ImageModel[]; ts: number } | null = null;
+let cacheAll: { data: ImageModel[]; ts: number } | null = null;
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+/** Check whether an image model slug is known to be free.
+ *  Used by the proxy passthrough path to reject paid image models —
+ *  image generation never bills the user's OpenRouter credits.
+ *  Matches against both the display slug (model_variant_slug) and the
+ *  raw OpenRouter slug to handle both client-visible and API forms. (#image-gen) */
+export async function isFreeImageModel(slug: string): Promise<boolean> {
+  const now = Date.now();
+  if (!cacheFree || now - cacheFree.ts >= CACHE_TTL_MS) {
+    try {
+      await refreshCacheFree();
+    } catch (err: any) {
+      console.warn('[ImageModels] isFreeImageModel: failed to refresh cache, rejecting conservatively:', err?.message ?? err);
+      return false;
+    }
+  }
+  return cacheFree!.data.some(m => m.slug === slug || m.rawSlug === slug);
+}
+
+async function refreshCacheFree(): Promise<ImageModel[]> {
+  const resp = await fetch('https://openrouter.ai/api/frontend/models', {
+    headers: { 'Accept': 'application/json' },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) throw new Error(`OpenRouter returned ${resp.status}`);
+
+  const body = (await resp.json()) as { data?: OpenRouterImageModel[] };
+  const all: OpenRouterImageModel[] = Array.isArray(body) ? body : (body.data ?? []);
+
+  const free = all.filter(m => {
+    if (!m.output_modalities?.includes('image') || m.output_modalities.length === 0) return false;
+    return m.endpoint?.is_free === true;
+  });
+
+  const db = getDb();
+  const keyPlatforms = new Set(
+    (db.prepare(
+      "SELECT DISTINCT platform FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown')",
+    ).all() as { platform: string }[]).map(r => r.platform),
+  );
+
+  const data = free.map(m => ({
+    slug: m.endpoint?.model_variant_slug ?? m.slug,
+    // For isFreeImageModel broad matching: the raw OpenRouter slug
+    // so clients sending either form still match.
+    rawSlug: m.slug,
+    name: m.name,
+    shortName: m.short_name,
+    author: m.author,
+    authorDisplayName: m.author_display_name ?? m.author ?? m.short_name.split(':')[0] ?? m.slug.split('/')[0],
+    description: m.description ?? '',
+    contextLength: m.context_length ?? 0,
+    inputModalities: m.input_modalities ?? [],
+    outputModalities: m.output_modalities ?? [],
+    supportsReasoning: m.supports_reasoning ?? false,
+    isFree: true,
+    pricing: m.endpoint?.pricing ?? null,
+    rpmLimit: m.endpoint?.limit_rpm ?? null,
+    rpdLimit: m.endpoint?.limit_rpd ?? null,
+    providerDisplayName: m.endpoint?.provider_display_name ?? m.author ?? 'Unknown',
+    providerSlug: m.endpoint?.provider_slug ?? m.author ?? 'unknown',
+    hasKey: keyPlatforms.has('openrouter'),
+  }));
+
+  cacheFree = { data, ts: Date.now() };
+  return data;
+}
+
+interface ImageModel {
+  slug: string;
+  /** Raw OpenRouter slug (before model_variant_slug substitution).
+   *  Used by isFreeImageModel for broad matching against either form. */
+  rawSlug?: string;
+  name: string;
+  shortName: string;
+  author: string;
+  authorDisplayName: string;
+  description: string;
+  contextLength: number;
+  inputModalities: string[];
+  outputModalities: string[];
+  supportsReasoning: boolean;
+  isFree: boolean;
+  pricing: { prompt: string; completion: string } | null;
+  rpmLimit: number | null;
+  rpdLimit: number | null;
+  providerDisplayName: string;
+  providerSlug: string;
+  /** Whether we have a key for OpenRouter in the local DB.
+   *  All image models currently route through OpenRouter exclusively;
+   *  if a non-OpenRouter image model is ever added, this must become
+   *  per-model (keyed on providerSlug, not a single platform check). */
+  hasKey: boolean;
+}
+
+imageModelsRouter.get('/', async (req: Request, res: Response) => {
+  try {
+    const now = Date.now();
+    // ?free_only=0 includes paid models (requires user's own OpenRouter key)
+    const freeOnly = req.query.free_only !== '0';
+
+    if (freeOnly) {
+      // Reuse the shared free-only cache (also used by isFreeImageModel).
+      if (!cacheFree || now - cacheFree.ts >= CACHE_TTL_MS) {
+        await refreshCacheFree();
+      }
+      res.json(cacheFree!.data);
+      return;
+    }
+
+    // Paid-model list — separate cache, fetched on demand.
+    if (cacheAll && now - cacheAll.ts < CACHE_TTL_MS) {
+      res.json(cacheAll.data);
+      return;
+    }
+
+    const resp = await fetch('https://openrouter.ai/api/frontend/models', {
+      headers: { 'Accept': 'application/json' },
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!resp.ok) {
+      res.status(502).json({ error: { message: `OpenRouter API returned ${resp.status}` } });
+      return;
+    }
+
+    const body = (await resp.json()) as { data?: OpenRouterImageModel[] };
+    const all: OpenRouterImageModel[] = Array.isArray(body) ? body : (body.data ?? []);
+
+    const imageModels = all.filter(m => {
+      if (!m.output_modalities?.includes('image') || m.output_modalities.length === 0) return false;
+      return true;
+    });
+
+    const db = getDb();
+    const keyPlatforms = new Set(
+      (db.prepare(
+        "SELECT DISTINCT platform FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown')",
+      ).all() as { platform: string }[]).map(r => r.platform),
+    );
+
+    const result: ImageModel[] = imageModels.map(m => ({
+      slug: m.endpoint?.model_variant_slug ?? m.slug,
+      name: m.name,
+      shortName: m.short_name,
+      author: m.author,
+      authorDisplayName: m.author_display_name ?? m.author ?? m.short_name.split(':')[0] ?? m.slug.split('/')[0],
+      description: m.description ?? '',
+      contextLength: m.context_length ?? 0,
+      inputModalities: m.input_modalities ?? [],
+      outputModalities: m.output_modalities ?? [],
+      supportsReasoning: m.supports_reasoning ?? false,
+      isFree: m.endpoint?.is_free ?? false,
+      pricing: m.endpoint?.pricing ?? null,
+      rpmLimit: m.endpoint?.limit_rpm ?? null,
+      rpdLimit: m.endpoint?.limit_rpd ?? null,
+      providerDisplayName: m.endpoint?.provider_display_name ?? m.author ?? 'Unknown',
+      providerSlug: m.endpoint?.provider_slug ?? m.author ?? 'unknown',
+      hasKey: keyPlatforms.has('openrouter'),
+    }));
+
+    cacheAll = { data: result, ts: now };
+    res.json(result);
+  } catch (err: any) {
+    console.error('[ImageModels] Failed to fetch from OpenRouter:', err?.message ?? err);
+    res.status(502).json({ error: { message: 'Failed to fetch image models from OpenRouter' } });
+  }
+});

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -285,6 +285,7 @@ export function isRetryableError(err: any): boolean {
     || msg.includes('quota') || msg.includes('resource_exhausted')
     || msg.includes('aborted') || msg.includes('timeout') || msg.includes('etimedout')
     || msg.includes('econnrefused') || msg.includes('econnreset')
+    || msg.includes('fetch failed')    // undici transport error (proxy down, DNS, TLS, etc.)
     || msg.includes('503') || msg.includes('unavailable')
     || msg.includes('500') || msg.includes('internal server error')
     // 413: this model's payload limit is too small for the request, but another

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -4,12 +4,15 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type { ChatMessage, ModelListRow } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
+import { getProvider } from '../providers/index.js';
 import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { runEmbeddings, EmbeddingsError } from '../services/embeddings.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
 import { contentToString, messageHasImage, normalizeOutboundContent } from '../lib/content.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
+import { isFreeImageModel } from './image-models.js';
+import { decrypt } from '../lib/crypto.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 import { rescueInlineToolCalls, startsWithDialectMarker, couldBecomeDialectMarker, containsDialectMarker } from '../lib/tool-call-rescue.js';
 
@@ -221,6 +224,11 @@ const userMessageSchema = z.object({
 // them verbatim. We accept them too and coerce empty/null content to "" before
 // forwarding (see message build below) rather than 400-ing a payload OpenAI
 // would take. (#165)
+//
+// images: echoed assistant turns from image-generation responses may carry
+// the generated images array. zod strips unknown keys by default — declaring
+// the field (even as z.any()) prevents data loss when clients replay history
+// containing "images" on assistant messages. (#image-gen)
 const assistantMessageSchema = z.object({
   role: z.literal('assistant'),
   content: z.union([contentSchema, z.null()]).optional(),
@@ -229,6 +237,7 @@ const assistantMessageSchema = z.object({
   // no-tool assistant turns — aionrs (AionUI's engine) writes it into every
   // session-resumed assistant echo. Treated as absent. (#200)
   tool_calls: z.array(toolCallSchema).nullable().optional(),
+  images: z.array(z.any()).optional(),
 });
 
 // Tool results may arrive with null/missing content (a tool that returned
@@ -295,6 +304,9 @@ const chatCompletionSchema = z.object({
   tools: z.array(toolDefinitionSchema).nullable().optional(),
   tool_choice: toolChoiceSchema.nullable().optional(),
   parallel_tool_calls: z.boolean().nullable().optional(),
+  // Image generation fields — forwarded to OpenRouter as-is when present.
+  modalities: z.array(z.string()).nullable().optional(),
+  image_config: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
 export function isRetryableError(err: any): boolean {
@@ -428,7 +440,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     return;
   }
 
-  const { model: requestedModel, temperature, top_p, stream } = parsed.data;
+  const { model: requestedModel, temperature, top_p, stream, modalities, image_config } = parsed.data;
   // Agent-tolerant knob normalization (#200): max_tokens <= 0 means "no
   // limit" in several clients → unset; tool_choice 'any' is OpenAI's
   // 'required'; tool definitions get their 'function' type re-defaulted.
@@ -485,6 +497,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             thought_signature: tc.thought_signature,
           };
         }) } : {}),
+        // Preserve echoed images from image-generation history so clients
+        // that replay full conversation context (including generated images)
+        // don't lose data when forwarding to upstream providers. (#image-gen)
+        ...((m as any).images?.length ? { images: (m as any).images } : {}),
       };
     }
 
@@ -534,6 +550,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // or surfacing the generic "all models exhausted" error (#118, #125). Add a
   // rough per-image token cost so budget routing isn't skewed by content the
   // heuristic above (text-only) can't see.
+  // Image generation requests bypass catalog validation — route directly
+  // to OpenRouter which hosts the image models. (#image-gen)
+  const isImageRequest = Array.isArray(modalities) && modalities.includes('image');
+
   const hasImage = messageHasImage(messages);
   if (hasImage && !hasEnabledVisionModel()) {
     res.status(422).json({
@@ -578,6 +598,23 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // different model would be surprising to OpenAI-compatible clients.
   // Sticky-session is the fallback when no `model` field was sent at all.
   let preferredModel: number | undefined;
+  // Image generation passthrough: when the requested model is an image model
+  // not in our catalog, route directly to OpenRouter. Local models that happen
+  // to accept modalities: ["image"] are NOT hijacked — they go through normal routing.
+  // When model is 'auto' or omitted but modalities includes "image", reject with
+  // a clear message: image generation needs an explicit model (our catalog has
+  // no image models, and 'auto' can't route to OpenRouter without a model id). (#image-gen)
+  let isImagePassthrough = false;
+  if (isImageRequest && (isAutoModel(requestedModel) || !requestedModel)) {
+    res.status(400).json({
+      error: {
+        message: 'Image generation requires a specific model. Use one of the image models listed on the Models > Images page, or call GET /api/image-models for the available list.',
+        type: 'invalid_request_error',
+        code: 'image_model_required',
+      },
+    });
+    return;
+  }
   if (isAutoModel(requestedModel)) {
     // Explicit "auto" → behave exactly like an omitted model field.
     preferredModel = getStickyModel(messages, sessionIdHeader);
@@ -586,6 +623,34 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     const enabled = db.prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1').get(requestedModel) as { id: number } | undefined;
     if (enabled) {
       preferredModel = enabled.id;
+    } else if (isImageRequest) {
+      // Image generation models (e.g. sourceful/riverflow-v2.5-pro) are not
+      // in the local catalog — they live exclusively on OpenRouter. Only
+      // passthrough when the model is genuinely absent from our catalog.
+      // Enforce free-only: image generation never bills the user's OpenRouter
+      // credits. (#image-gen)
+      if (!(await isFreeImageModel(requestedModel))) {
+        res.status(400).json({
+          error: {
+            message: `Image generation is restricted to free models. '${requestedModel}' is either paid or not in the free catalog. Use one of the free models from the Models > Images page.`,
+            type: 'invalid_request_error',
+            code: 'image_model_not_free',
+          },
+        });
+        return;
+      }
+      const orKey = db.prepare("SELECT id FROM api_keys WHERE platform = 'openrouter' AND enabled = 1 AND status IN ('healthy', 'unknown') LIMIT 1").get() as { id: number } | undefined;
+      if (!orKey) {
+        res.status(400).json({
+          error: {
+            message: `Image model '${requestedModel}' requires an OpenRouter API key. Add one on the Keys page.`,
+            type: 'invalid_request_error',
+            code: 'no_openrouter_key',
+          },
+        });
+        return;
+      }
+      isImagePassthrough = true;
     } else {
       const disabled = db.prepare('SELECT id FROM models WHERE model_id = ?').get(requestedModel) as { id: number } | undefined;
       const reason = disabled ? 'is disabled' : 'is not in the catalog';
@@ -613,24 +678,67 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     let route: RouteResult;
-    try {
-      route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage, wantsTools);
-    } catch (err: any) {
-      // No more models available
-      if (lastError) {
-        const safeLastError = sanitizeProviderErrorMessage(lastError.message);
-        res.status(429).json({
-          error: {
-            message: `All models rate-limited. Last error: ${safeLastError}`,
-            type: 'rate_limit_error',
-          },
-        });
-      } else {
-        res.status(err.status ?? 503).json({
-          error: { message: err.message, type: 'routing_error' },
-        });
+    // Image generation passthrough: bypass the normal routing chain and
+    // directly route to OpenRouter with the requested model slug. Image
+    // models don't exist in the local catalog, so routeRequest would
+    // either skip them or route to the wrong provider. Keys are iterated
+    // with skipKeys support so a dead OR key fails over to the next one. (#image-gen)
+    if (isImagePassthrough) {
+      const provider = getProvider('openrouter');
+      if (!provider) {
+        res.status(500).json({ error: { message: 'OpenRouter provider not configured', type: 'server_error' } });
+        return;
       }
-      return;
+      const db = getDb();
+      // Iterate OR keys in id order, skipping previously-failed ones.
+      const allKeyRows = db.prepare(
+        "SELECT id, encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'openrouter' AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id"
+      ).all() as { id: number; encrypted_key: string; iv: string; auth_tag: string }[];
+      const keyRow = allKeyRows.find(k => !skipKeys.has(`openrouter:${requestedModel!}:${k.id}`));
+      if (!keyRow) {
+        if (lastError) {
+          const safeLastError = sanitizeProviderErrorMessage(lastError.message);
+          res.status(429).json({
+            error: { message: `All OpenRouter keys exhausted for image model '${requestedModel}'. Last error: ${safeLastError}`, type: 'rate_limit_error' },
+          });
+        } else {
+          res.status(400).json({
+            error: { message: `Image model '${requestedModel}' requires an OpenRouter API key. Add one on the Keys page.`, type: 'invalid_request_error', code: 'no_openrouter_key' },
+          });
+        }
+        return;
+      }
+      route = {
+        provider,
+        modelId: requestedModel!,
+        modelDbId: 0,
+        apiKey: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
+        keyId: keyRow.id,
+        platform: 'openrouter',
+        displayName: `OpenRouter (${requestedModel!})`,
+        rpdLimit: null,
+        tpdLimit: null,
+      };
+    } else {
+      try {
+        route = routeRequest(estimatedTotal, skipKeys.size > 0 ? skipKeys : undefined, preferredModel, hasImage, wantsTools);
+      } catch (err: any) {
+        // No more models available
+        if (lastError) {
+          const safeLastError = sanitizeProviderErrorMessage(lastError.message);
+          res.status(429).json({
+            error: {
+              message: `All models rate-limited. Last error: ${safeLastError}`,
+              type: 'rate_limit_error',
+            },
+          });
+        } else {
+          res.status(err.status ?? 503).json({
+            error: { message: err.message, type: 'routing_error' },
+          });
+        }
+        return;
+      }
     }
 
     recordRequest(route.platform, route.modelId, route.keyId);
@@ -692,7 +800,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         try {
           const gen = route.provider.streamChatCompletion(
             route.apiKey, messages, route.modelId,
-            { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls },
+            { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls, modalities: modalities ?? undefined, image_config: image_config ?? undefined },
           );
 
           for await (const chunk of gen) {
@@ -806,8 +914,11 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             }
           }
 
+          // Image generation streams may produce no text and no tool_calls —
+          // images arrive in delta.images via real SSE streaming. Skip the
+          // empty-completion check for image requests. (#image-gen)
           const hasText = headerSent || heldText.trim().length > 0;
-          if (!hasText && completedCalls.length === 0) {
+          if (!hasText && completedCalls.length === 0 && !isImageRequest) {
             // Nothing usable came out — same failover semantics as the
             // non-stream empty-completion path. Headers can't have been sent
             // (header flush requires payload), so the client never notices.
@@ -835,7 +946,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.end();
 
           recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
-          recordSuccess(route.modelDbId);
+          if (route.modelDbId > 0) recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader);
           logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, ttfbMs, pinnedModelId);
           return;
@@ -859,19 +970,22 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       } else {
         const result = await route.provider.chatCompletion(
           route.apiKey, messages, route.modelId,
-          { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls },
+          { temperature, max_tokens, top_p, tools, tool_choice, parallel_tool_calls, modalities: modalities ?? undefined, image_config: image_config ?? undefined },
         );
 
         // Empty completion (no text, no tool calls) → fail over rather than
         // return a transport-level "success" the caller can't act on. Mirrors
-        // the zero-chunk streaming case above.
+        // the zero-chunk streaming case above. Image generation responses carry
+        // images on the message instead of text — skip the empty check. (#image-gen)
         const respMsg = result.choices?.[0]?.message;
         const respText = contentToString(respMsg?.content ?? '');
-        if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0) {
+        const respImages = respMsg?.images;
+        const hasImages = Array.isArray(respImages) && respImages.length > 0;
+        if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0 && !hasImages) {
           logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', null, pinnedModelId);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
-          recordRateLimitHit(route.modelDbId);
+          if (route.modelDbId > 0) recordRateLimitHit(route.modelDbId);
           lastError = new Error(`empty completion from ${route.displayName}`);
           continue;
         }
@@ -902,7 +1016,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
         const totalTokens = result.usage?.total_tokens ?? 0;
         recordTokens(route.platform, route.modelId, route.keyId, totalTokens);
-        recordSuccess(route.modelDbId);
+        if (route.modelDbId > 0) recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
 
         res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
@@ -950,7 +1064,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
                 tpd: route.tpdLimit,
               }),
         );
-        recordRateLimitHit(route.modelDbId);
+        if (route.modelDbId > 0) recordRateLimitHit(route.modelDbId);
         lastError = err;
         console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
         continue;

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { getUnifiedApiKey, regenerateUnifiedKey } from '../db/index.js';
+import { getUnifiedApiKey, regenerateUnifiedKey, getSetting, setSetting } from '../db/index.js';
+import { applyProxyUrl, applyProxyEnabled, applyProxyBypass, isProxyActive, getProxyUrl, isProxyEnabled, getProxyBypassPlatforms } from '../lib/proxy.js';
 
 export const settingsRouter = Router();
 
@@ -13,4 +14,68 @@ settingsRouter.get('/api-key', (_req: Request, res: Response) => {
 settingsRouter.post('/api-key/regenerate', (_req: Request, res: Response) => {
   const newKey = regenerateUnifiedKey();
   res.json({ apiKey: newKey });
+});
+
+// Get the proxy settings
+settingsRouter.get('/proxy', (_req: Request, res: Response) => {
+  res.json({
+    proxyUrl: getProxyUrl(),
+    enabled: isProxyEnabled(),
+    bypassPlatforms: getProxyBypassPlatforms(),
+    active: isProxyActive(),
+  });
+});
+
+// Set the proxy settings. Accepts partial updates: proxyUrl, enabled, bypassPlatforms.
+settingsRouter.put('/proxy', (req: Request, res: Response) => {
+  const { proxyUrl, enabled, bypassPlatforms } = req.body as {
+    proxyUrl?: string;
+    enabled?: boolean;
+    bypassPlatforms?: string[];
+  };
+
+  // --- proxyUrl ---
+  if (typeof proxyUrl === 'string') {
+    const trimmed = proxyUrl.trim();
+    if (trimmed) {
+      try {
+        const u = new URL(trimmed);
+        if (!['http:', 'https:', 'socks5:', 'socks4:'].includes(u.protocol)) {
+          res.status(400).json({
+            error: { message: 'Proxy URL must use http, https, socks5, or socks4 scheme', type: 'invalid_request_error' },
+          });
+          return;
+        }
+      } catch {
+        res.status(400).json({
+          error: { message: 'Invalid proxy URL — must be a valid URL like socks5://host:port', type: 'invalid_request_error' },
+        });
+        return;
+      }
+      setSetting('proxy_url', trimmed);
+    } else {
+      setSetting('proxy_url', '');
+    }
+    applyProxyUrl(trimmed);
+  }
+
+  // --- enabled ---
+  if (typeof enabled === 'boolean') {
+    setSetting('proxy_enabled', enabled ? '1' : '0');
+    applyProxyEnabled(enabled);
+  }
+
+  // --- bypassPlatforms ---
+  if (Array.isArray(bypassPlatforms)) {
+    const csv = bypassPlatforms.map(s => s.trim()).filter(Boolean).join(',');
+    setSetting('proxy_bypass', csv);
+    applyProxyBypass(csv);
+  }
+
+  res.json({
+    proxyUrl: getProxyUrl(),
+    enabled: isProxyEnabled(),
+    bypassPlatforms: getProxyBypassPlatforms(),
+    active: isProxyActive(),
+  });
 });

--- a/server/src/services/capabilities.ts
+++ b/server/src/services/capabilities.ts
@@ -1,0 +1,388 @@
+import type Database from 'better-sqlite3';
+import { execSync } from 'child_process';
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Sync model capabilities from OpenRouter's public API into the models table.
+ *
+ * This is the AUTHORITATIVE source for model metadata. When a model is found
+ * on OpenRouter, ALL its capability fields are overwritten from the API:
+ *   - context_window  (from context_length)
+ *   - supports_vision (from input_modalities containing "image")
+ *   - supports_reasoning (from supports_reasoning flag)
+ *   - rpm_limit / rpd_limit (from limit_rpm / limit_rpd)
+ *
+ * V16 (vision) and V22 (tools) LIKE rules still run BEFORE this function
+ * as a fallback baseline — but only models NOT found on OpenRouter keep
+ * those hardcoded values.
+ *
+ * The sync runs synchronously at startup (one ~2s HTTP call to a free,
+ * unauthenticated endpoint). Failures are logged but never fatal — the
+ * migration fallbacks ensure models still work if the API is unreachable.
+ */
+export interface SyncResult {
+  updated: number;
+  unmatched: { platform: string; modelId: string; displayName: string }[];
+  total: number;
+  matched: number;
+  /** Number of models enriched from platform-specific specs (post-OpenRouter sync). */
+  platformSynced: number;
+  error?: string;
+}
+
+export function syncCapabilities(db: Database.Database): void {
+  const result = syncCapabilitiesDetailed(db);
+  if (result.error) console.error('[Caps] OpenRouter sync failed, using migration fallbacks:', result.error);
+  else {
+    const parts = [`${result.matched}/${result.total} matched`];
+    if (result.updated > 0) parts.unshift(`updated ${result.updated} models`);
+    if (result.platformSynced > 0) parts.push(`${result.platformSynced} from platform specs`);
+    console.log(`[Caps] OpenRouter sync: ${parts.join(', ')}`);
+  }
+}
+
+/** Detailed sync that returns unmatched models for UI display. */
+export function syncCapabilitiesDetailed(db: Database.Database): SyncResult {
+  try {
+    const result = syncFromOpenRouterFrontend(db);
+    // After OpenRouter sync, enrich remaining unmatched models from platform specs.
+    const platformSynced = syncPlatformSpecs(db, result.unmatched);
+    return { ...result, platformSynced };
+  } catch (err) {
+    return { updated: 0, unmatched: [], total: 0, matched: 0, platformSynced: 0, error: (err as Error).message };
+  }
+}
+
+// ── OpenRouter /api/frontend/models sync ──────────────────────────────────
+
+interface OpenRouterFrontendModel {
+  slug: string;
+  context_length: number;
+  input_modalities: string[];
+  output_modalities: string[];
+  supports_reasoning: boolean;
+  reasoning_config: { effort?: string; return_reasoning?: boolean } | null;
+  limit_rpm: number;
+  limit_rpd: number;
+  hidden: boolean;
+}
+
+interface OpenRouterFrontendResponse {
+  data: OpenRouterFrontendModel[];
+}
+
+/** Internal return from the OpenRouter sync — before platform specs enrichment. */
+interface OpenRouterSyncResult {
+  updated: number;
+  unmatched: { platform: string; modelId: string; displayName: string }[];
+  total: number;
+  matched: number;
+}
+
+/**
+ * Fetch OpenRouter's public frontend model list and apply capability data
+ * to matching entries in our models table. Returns the number of rows updated.
+ *
+ * This endpoint (/api/frontend/models) is free, requires no auth, and returns
+ * rich metadata for 766+ models:
+ * - context_length: accurate context window per model
+ * - supports_reasoning: whether the model supports chain-of-thought
+ * - input_modalities: vision (image), audio, video support
+ * - limit_rpm / limit_rpd: provider rate limits
+ */
+function syncFromOpenRouterFrontend(db: Database.Database): OpenRouterSyncResult {
+  // Use a blocking fetch with timeout — this runs at boot and we need the
+  // data before the server starts accepting requests.
+  const res = fetchSync('https://openrouter.ai/api/frontend/models', 30000);
+
+  const body = res as OpenRouterFrontendResponse;
+  if (!Array.isArray(body.data)) {
+    throw new Error('OpenRouter /api/frontend/models returned unexpected shape');
+  }
+
+  // Build three lookups:
+  // 1. modelsBySlug: normalized slug → model metadata (exact match)
+  // 2. modelsByName: full model name (part after /) → best version
+  // 3. modelsByBaseName: name with trailing version stripped → best version
+  //    E.g. 'codestral-2508' → base 'codestral' → maps to the highest version
+  const modelsBySlug = new Map<string, OpenRouterFrontendModel>();
+  const modelsByName = new Map<string, OpenRouterFrontendModel>();
+  const modelsByBaseName = new Map<string, OpenRouterFrontendModel>();
+  for (const m of body.data) {
+    if (!m.slug) continue;
+    modelsBySlug.set(m.slug.toLowerCase(), m);
+    const nameMatch = m.slug.match(/\/([^/]+)$/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1].toLowerCase();
+    const existing = modelsByName.get(name);
+    if (!existing || extractVersion(m.slug) > extractVersion(existing.slug)) {
+      modelsByName.set(name, m);
+    }
+    // Base name: strip trailing version number (e.g. 'devstral-2512' → 'devstral')
+    const baseName = name.replace(/-\d+$/, '');
+    if (baseName !== name) {
+      const existingBase = modelsByBaseName.get(baseName);
+      if (!existingBase || extractVersion(m.slug) > extractVersion(existingBase.slug)) {
+        modelsByBaseName.set(baseName, m);
+      }
+    }
+  }
+
+  // Walk every enabled model, match against the OR catalog, and OVERWRITE
+  // all fields. The API is authoritative — if a model is found on OpenRouter,
+  // its API values replace any hardcoded migration values.
+  const update = db.prepare(`
+    UPDATE models SET supports_vision = ?, supports_tools = ?, supports_reasoning = ?,
+                      context_window = ?, rpm_limit = ?, rpd_limit = ?
+     WHERE id = ?
+  `);
+
+  let updated = 0;
+  const unmatched: { platform: string; modelId: string; displayName: string }[] = [];
+  let matched = 0;
+  let total = 0;
+  const apply = db.transaction(() => {
+    const rows = db.prepare(
+      'SELECT id, platform, model_id, display_name, supports_tools FROM models WHERE enabled = 1'
+    ).all() as {
+      id: number; platform: string; model_id: string; display_name: string;
+      supports_tools: number;
+    }[];
+
+    total = rows.length;
+
+    for (const row of rows) {
+      const meta = findModel(row.platform, row.model_id, modelsBySlug, modelsByName, modelsByBaseName);
+      if (!meta) {
+        unmatched.push({ platform: row.platform, modelId: row.model_id, displayName: row.display_name });
+        continue;
+      }
+      matched++;
+
+      const newVision = meta.input_modalities.includes('image') ? 1 : 0;
+      const newReasoning = meta.supports_reasoning ? 1 : 0;
+      const newCtx = meta.context_length > 0 ? meta.context_length : null;
+      const current = db.prepare(
+        'SELECT rpm_limit, rpd_limit, supports_vision, supports_reasoning, context_window FROM models WHERE id = ?'
+      ).get(row.id) as { rpm_limit: number | null; rpd_limit: number | null; supports_vision: number; supports_reasoning: number; context_window: number | null };
+      const newRpm = meta.limit_rpm > 0 ? meta.limit_rpm : current.rpm_limit;
+      const newRpd = meta.limit_rpd > 0 ? meta.limit_rpd : current.rpd_limit;
+
+      if (
+        current.supports_vision === newVision &&
+        current.supports_reasoning === newReasoning &&
+        current.context_window === newCtx
+      ) continue;
+
+      update.run(newVision, row.supports_tools, newReasoning, newCtx, newRpm, newRpd, row.id);
+      updated++;
+    }
+  });
+  apply();
+  return { updated, unmatched, total, matched };
+}
+
+/**
+ * Synchronous fetch wrapper for boot-time use. Uses Node's built-in fetch
+ * but wraps it in a blocking pattern via child_process.execSync + curl as
+ * a fallback if the runtime doesn't support sync fetch.
+ */
+function fetchSync(url: string, timeoutMs: number): unknown {
+  // Blocking fetch via curl — runs at boot before the server accepts requests.
+  const stdout = execSync(
+    `curl -s --max-time ${Math.floor(timeoutMs / 1000)} "${url}"`,
+    { encoding: 'utf8', timeout: timeoutMs + 5000, maxBuffer: 50 * 1024 * 1024 }
+  );
+  return JSON.parse(stdout);
+}
+
+/**
+ * Match a (platform, model_id) pair against the OpenRouter frontend catalog.
+ * Suffixes like `:free`, `-free`, and `-latest` are stripped before matching.
+ * Version-aware: when multiple OR slugs share a name, the highest version wins.
+ */
+export function findModel(
+  platform: string,
+  modelId: string,
+  modelsBySlug: Map<string, OpenRouterFrontendModel>,
+  modelsByName: Map<string, OpenRouterFrontendModel>,
+  modelsByBaseName: Map<string, OpenRouterFrontendModel>,
+): OpenRouterFrontendModel | null {
+  // Normalize: strip :free / -free / -latest suffixes.
+  // E.g. 'google/gemini-2.5-flash:free' → 'google/gemini-2.5-flash'
+  //       'minimax-m3-free' → 'minimax-m3'
+  //       'devstral-latest' → 'devstral'
+  const normalized = modelId.replace(/[:-]free$/i, '').replace(/-latest$/i, '').toLowerCase();
+
+  // Strategy 1: direct slug lookup with normalized ID
+  const direct = modelsBySlug.get(normalized);
+  if (direct) return direct;
+
+  // Strategy 2: direct slug lookup with original ID (no suffix stripping)
+  if (normalized !== modelId.toLowerCase()) {
+    const orig = modelsBySlug.get(modelId.toLowerCase());
+    if (orig) return orig;
+  }
+
+  // Strategy 3: base-name lookup (highest version wins)
+  // E.g. 'devstral' → matches 'mistralai/devstral-2512' (highest version)
+  const ourName = extractName(normalized);
+  if (ourName) {
+    const byBase = modelsByBaseName.get(ourName);
+    if (byBase) return byBase;
+  }
+
+  // Strategy 4: exact name lookup (e.g. 'deepseek-v4-flash' matches slug name directly)
+  if (ourName) {
+    const byName = modelsByName.get(ourName);
+    if (byName) return byName;
+  }
+
+  // Strategy 5 (reverse): our normalized model_id contains an OR slug.
+  for (const [slug, meta] of modelsBySlug) {
+    if (slug.length < 8) continue;
+    if (normalized.includes(slug)) return meta;
+  }
+
+  // Strategy 6 (loose): any OR slug contains our normalized model_id.
+  for (const [slug, meta] of modelsBySlug) {
+    if (slug.includes(normalized)) return meta;
+  }
+
+  // Strategy 7: name substring — OR slug's name contains our name.
+  // E.g. our 'deepseek-v4-flash' matches OR's 'deepseek/deepseek-v4-flash'
+  if (ourName && ourName.length >= 8) {
+    for (const [name, meta] of modelsByName) {
+      if (name.length >= 6 && name.includes(ourName)) return meta;
+    }
+  }
+
+  // Strategy 8: reverse name substring — our name contains an OR slug's name.
+  // E.g. our 'meta-llama-3.3-70b-instruct' contains OR's 'llama-3.3-70b-instruct'
+  //      our 'llama-4-maverick-17b-128e-instruct' contains OR's 'llama-4-maverick'
+  //      our 'zai-glm-4.7' contains OR's 'glm-4.7'
+  // Prefer the LONGEST matching OR name (most specific match).
+  if (ourName && ourName.length >= 8) {
+    let best: OpenRouterFrontendModel | null = null;
+    let bestLen = 0;
+    for (const [name, meta] of modelsByName) {
+      if (name.length >= 6 && name.length < ourName.length && ourName.includes(name) && name.length > bestLen) {
+        best = meta;
+        bestLen = name.length;
+      }
+    }
+    if (best) return best;
+  }
+
+  return null;
+}
+
+// ── Platform-specific model specs ───────────────────────────────────────
+
+/**
+ * Static specs for models exclusive to specific platforms (not on OpenRouter).
+ * Sourced from provider documentation:
+ *   - Groq:   https://console.groq.com/docs/models
+ *   - Cerebras: https://inference-docs.cerebras.ai/models/overview
+ *   - SambaNova: https://docs.sambanova.ai/docs/en/models/sambacloud-models
+ *   - Ollama Cloud: https://ollama.com/library (context from provider cards)
+ *   - Pollinations: https://pollinations.ai
+ *   - Cloudflare: https://developers.cloudflare.com/workers-ai/models/
+ *   - OpenCode: https://opencode.ai/zen/v1/models
+ *
+ * Key format: 'platform|model_id'. Values override migration fallbacks for
+ * models that the OpenRouter sync couldn't match. Only fields that differ
+ * from migration defaults need to be specified.
+ */
+const PLATFORM_MODEL_SPECS: Record<string, { context_window?: number; supports_vision?: boolean; supports_reasoning?: boolean; supports_tools?: boolean }> = {
+  // ── Groq ────────────────────────────────────────────────────────────
+  // Source: https://console.groq.com/docs/models
+  'groq|llama-3.3-70b-versatile':   { context_window: 131072, supports_tools: true },
+  'groq|llama-3.1-8b-instant':      { context_window: 131072, supports_tools: true },
+  'groq|groq/compound':             { context_window: 131072, supports_tools: true },
+  'groq|groq/compound-mini':        { context_window: 131072, supports_tools: true },
+
+  // ── Ollama Cloud ────────────────────────────────────────────────────
+  // Source: Ollama Cloud model cards + provider documentation
+  'ollama|cogito-2.1:671b':         { context_window: 131072, supports_tools: true },
+  'ollama|gpt-oss:120b':            { context_window: 131072, supports_tools: true },
+  'ollama|devstral-2:123b':         { context_window: 262144, supports_tools: true },
+  'ollama|gpt-oss:20b':             { context_window: 131072, supports_tools: true },
+  'ollama|gemma4:31b':              { context_window: 262144 },
+
+  // ── Pollinations ────────────────────────────────────────────────────
+  // Source: https://pollinations.ai — single anonymous model (GPT-OSS 20B)
+  'pollinations|openai-fast':       { context_window: 131072 },
+
+  // ── Cloudflare Workers AI ───────────────────────────────────────────
+  // Source: https://developers.cloudflare.com/workers-ai/models/
+  'cloudflare|@cf/nvidia/nemotron-3-120b-a12b': { context_window: 262144, supports_tools: true },
+
+  // ── OpenCode Zen ────────────────────────────────────────────────────
+  // Source: https://opencode.ai/zen/v1/models — stealth/promo models
+  'opencode|big-pickle':            { context_window: 131072 },
+};
+
+/**
+ * Apply platform-specific specs to models that weren't matched by OpenRouter.
+ * Only touches models whose (platform, model_id) has an entry in
+ * PLATFORM_MODEL_SPECS and whose current values differ from the spec.
+ * Returns the number of rows updated.
+ */
+function syncPlatformSpecs(db: Database.Database, unmatched: { platform: string; modelId: string; displayName: string }[]): number {
+  if (unmatched.length === 0) return 0;
+
+  let synced = 0;
+  const update = db.prepare(`
+    UPDATE models SET context_window = ?, supports_vision = ?, supports_reasoning = ?, supports_tools = ?
+     WHERE id = ?
+  `);
+
+  const apply = db.transaction(() => {
+    for (const u of unmatched) {
+      const key = `${u.platform}|${u.modelId}`;
+      const spec = PLATFORM_MODEL_SPECS[key];
+      if (!spec) continue;
+
+      const row = db.prepare(
+        'SELECT id, context_window, supports_vision, supports_reasoning, supports_tools FROM models WHERE platform = ? AND model_id = ?'
+      ).get(u.platform, u.modelId) as {
+        id: number; context_window: number | null;
+        supports_vision: number; supports_reasoning: number; supports_tools: number;
+      } | undefined;
+      if (!row) continue;
+
+      const newCtx = spec.context_window ?? row.context_window;
+      const newVision = spec.supports_vision !== undefined ? (spec.supports_vision ? 1 : 0) : row.supports_vision;
+      const newReasoning = spec.supports_reasoning !== undefined ? (spec.supports_reasoning ? 1 : 0) : row.supports_reasoning;
+      const newTools = spec.supports_tools !== undefined ? (spec.supports_tools ? 1 : 0) : row.supports_tools;
+
+      if (
+        row.context_window === newCtx &&
+        row.supports_vision === newVision &&
+        row.supports_reasoning === newReasoning &&
+        row.supports_tools === newTools
+      ) continue;
+
+      update.run(newCtx, newVision, newReasoning, newTools, row.id);
+      synced++;
+    }
+  });
+  apply();
+  return synced;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/** Extract the trailing version number from a slug (e.g. 'mistralai/devstral-2512' → 2512). */
+function extractVersion(slug: string): number {
+  const match = slug.match(/(\d+)$/);
+  return match ? Number(match[1]) : 0;
+}
+
+/** Extract the model name from a normalized ID or slug (part after the last `/`). */
+function extractName(normalized: string): string | null {
+  const idx = normalized.lastIndexOf('/');
+  return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+}

--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -9,6 +9,7 @@
 // cross-provider redundancy for free.
 import { getDb, getSetting } from '../db/index.js';
 import { decrypt } from '../lib/crypto.js';
+import { proxyFetch } from '../lib/proxy.js';
 
 export interface EmbeddingModelRow {
   id: number;
@@ -91,7 +92,7 @@ async function openAiStyleEmbed(
   inputs: string[],
   extra: Record<string, unknown> = {},
 ): Promise<ProviderCallResult> {
-  const r = await fetch(url, {
+  const r = await proxyFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify({ model: modelId, input: inputs, ...extra }),
@@ -114,15 +115,15 @@ async function openAiStyleEmbed(
 async function callProvider(row: EmbeddingModelRow, key: string, inputs: string[]): Promise<ProviderCallResult> {
   switch (row.platform) {
     case 'google':
-      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', key, row.model_id, inputs);
+      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', key, row.model_id, inputs, {});
     case 'nvidia':
       // NeMo Retriever NIMs require input_type; 'query' is the symmetric-safe
       // choice for a gateway that can't know whether this is index or query time.
       return openAiStyleEmbed('https://integrate.api.nvidia.com/v1/embeddings', key, row.model_id, inputs, { input_type: 'query' });
     case 'openrouter':
-      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', key, row.model_id, inputs);
+      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', key, row.model_id, inputs, {});
     case 'github':
-      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', key, row.model_id, inputs);
+      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', key, row.model_id, inputs, {});
     case 'cloudflare': {
       // Key is stored as "account_id:token".
       const sep = key.indexOf(':');
@@ -131,12 +132,12 @@ async function callProvider(row: EmbeddingModelRow, key: string, inputs: string[
       const token = key.slice(sep + 1);
       return openAiStyleEmbed(
         `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1/embeddings`,
-        token, row.model_id, inputs,
+        token, row.model_id, inputs, {},
       );
     }
     case 'huggingface': {
       // HF serves embeddings as the feature-extraction task, not /v1/embeddings.
-      const r = await fetch(
+      const r = await proxyFetch(
         `https://router.huggingface.co/hf-inference/models/${row.model_id}/pipeline/feature-extraction`,
         {
           method: 'POST',
@@ -151,7 +152,7 @@ async function callProvider(row: EmbeddingModelRow, key: string, inputs: string[
       return { vectors, inputTokens: null };
     }
     case 'cohere': {
-      const r = await fetch('https://api.cohere.com/v2/embed', {
+      const r = await proxyFetch('https://api.cohere.com/v2/embed', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
         body: JSON.stringify({

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -293,14 +293,12 @@ export function refreshStatsCache(db: Database, force = false): void {
   statsCacheTime = Date.now();
 }
 
-// Composite intelligence: size_label is the cross-provider capability tier
-// (issue #135 — intelligence_rank is only meaningful within one provider), so
-// tier dominates and intelligence_rank breaks ties inside a tier.
-const TIER_VALUE: Record<string, number> = { Frontier: 4, Large: 3, Medium: 2, Small: 1 };
-function intelligenceComposite(sizeLabel: string, intelligenceRank: number): number {
-  const tier = TIER_VALUE[sizeLabel] ?? 0;
-  // tier*1000 keeps tiers strictly separated; -rank prefers lower rank in-tier.
-  return tier * 1000 - intelligenceRank;
+// Intelligence: raw AA score (100 - intelligence_rank).
+// intelligence_rank = CEIL(100 - AA_score) from migrateModelsV24ReRank,
+// so this inverts it to recover the actual Artificial Analysis Intelligence
+// Index value (0-100 scale). Higher = smarter.
+function intelligenceComposite(_sizeLabel: string, intelligenceRank: number): number {
+  return 100 - intelligenceRank;
 }
 
 // Per-model axis values + the final score. `sampled` chooses Thompson sampling
@@ -361,8 +359,11 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy): ChainRow[] {
   }
 
   const composites = chain.map(e => intelligenceComposite(e.size_label, e.intelligence_rank));
-  const intelMin = composites.length ? Math.min(...composites) : 0;
-  const intelMax = composites.length ? Math.max(...composites) : 0;
+  // Use fixed [0, 100] range — AA scores are naturally 0-100, so this gives
+  // each model its true intelligence percentile without compressing same-tier
+  // models together (which happened with tier*1000 - rank).
+  const intelMin = 0;
+  const intelMax = 100;
 
   return chain
     .map(e => ({ e, s: scoreChainEntry(e, weights, intelMin, intelMax, true).score }))
@@ -572,8 +573,9 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
   // table still shows a meaningful ranking even with the bandit turned off.
   const weights = weightsFor(strategy) ?? BANDIT_PRESETS.balanced;
   const composites = chain.map(e => intelligenceComposite(e.size_label, e.intelligence_rank));
-  const intelMin = composites.length ? Math.min(...composites) : 0;
-  const intelMax = composites.length ? Math.max(...composites) : 0;
+  // Fixed [0, 100] range — AA scores are naturally 0-100.
+  const intelMin = 0;
+  const intelMax = 100;
 
   const scores: RoutingScore[] = chain.map(entry => {
     const scored = scoreChainEntry(entry, weights, intelMin, intelMax, false);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -138,6 +138,8 @@ export interface ChatMessage {
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatToolCall[];
+  /** Image generation responses carry generated images here (OpenRouter extension). */
+  images?: Array<{ type?: 'image_url'; image_url: { url: string; detail?: string } }>;
 }
 
 export interface ChatCompletionRequest {
@@ -150,6 +152,10 @@ export interface ChatCompletionRequest {
   tools?: ChatToolDefinition[];
   tool_choice?: ChatToolChoice;
   parallel_tool_calls?: boolean;
+  /** Image generation: output modalities (e.g. ["image", "text"]). */
+  modalities?: string[];
+  /** Image generation: model-specific config (aspect_ratio, image_size, etc.). */
+  image_config?: Record<string, unknown>;
 }
 
 export interface ChatCompletionChoice {


### PR DESCRIPTION
## What

Multiplies each model's monthly token budget by the number of enabled API keys for its platform in the `/api/fallback/token-usage` endpoint.

**Before**: a provider with 3 API keys showed the same budget as 1 key.
**After**: budget = per-key quota × key count, correctly reflecting total available capacity.

## Why

Each API key carries its own independent free-tier quota. The dashboard's stacked bar should reflect aggregate available budget, not per-key budget.

## Note

Optimal usage requires a proxy setup — some providers rate-limit by API key + IP, so multiple keys from the same IP may share a single rate-limit pool rather than being truly independent. The multiplication is correct for most providers (Google, OpenRouter, etc.) but the effective multiplier depends on deployment topology.

## Changes

- `server/src/routes/fallback.ts`: `/token-usage` now counts enabled keys per platform via `GROUP BY` and multiplies `parseBudget()` by key count