### PR TITLE
fix: multiply monthly token budget by key count, with proxy toggle

### DIFF
--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -194,6 +194,7 @@ interface TokenUsageData {
   totalBudget: number
   totalUsed: number
   models: { displayName: string; platform: string; budget: number }[]
+  proxy: boolean
 }
 
 const platformColors: Record<string, string> = {
@@ -233,7 +234,7 @@ function AxisBar({ value, color }: { value: number | undefined; color: string })
 // Legend rows visible while collapsed (~6 rows: 6 × 16px line + 5 × 6px gap).
 const LEGEND_COLLAPSED_PX = 126
 
-function TokenUsageBar({ data }: { data: TokenUsageData }) {
+function TokenUsageBar({ data, proxyMode, onProxyToggle }: { data: TokenUsageData; proxyMode: boolean; onProxyToggle: (v: boolean) => void }) {
   const { totalBudget, totalUsed, models } = data
   const remaining = Math.max(0, totalBudget - totalUsed)
   const remainingPct = totalBudget > 0 ? Math.round((remaining / totalBudget) * 100) : 0
@@ -264,7 +265,15 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
   return (
     <section className="rounded-3xl border bg-card p-5">
       <div className="flex items-baseline justify-between mb-3">
-        <h2 className="text-sm font-medium">Monthly token budget</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-medium">Monthly token budget</h2>
+          <label className="inline-flex items-center gap-1.5 cursor-pointer select-none">
+            <Switch checked={proxyMode} onCheckedChange={onProxyToggle} />
+            <span className="text-[11px] text-muted-foreground">
+              {proxyMode ? 'Per key · multi-IP' : 'Per provider'}
+            </span>
+          </label>
+        </div>
         <span className="text-xs text-muted-foreground tabular-nums">
           <span className="text-foreground font-medium">{formatTokens(remaining)}</span> remaining
           <span className="mx-1.5">·</span>
@@ -431,9 +440,11 @@ export default function FallbackPage() {
     queryFn: () => apiFetch('/api/fallback'),
   })
 
+  const [proxyMode, setProxyMode] = useState(false)
+
   const { data: tokenUsage } = useQuery<TokenUsageData>({
-    queryKey: ['fallback', 'token-usage'],
-    queryFn: () => apiFetch('/api/fallback/token-usage'),
+    queryKey: ['fallback', 'token-usage', proxyMode],
+    queryFn: () => apiFetch(`/api/fallback/token-usage?proxy=${proxyMode}`),
   })
 
   const { data: routing } = useQuery<RoutingData>({
@@ -544,7 +555,7 @@ export default function FallbackPage() {
 
       <div className="space-y-6">
         {/* Monthly token budget — moved to the top */}
-        {tokenUsage && tokenUsage.totalBudget > 0 && <TokenUsageBar data={tokenUsage} />}
+        {tokenUsage && tokenUsage.totalBudget > 0 && <TokenUsageBar data={tokenUsage} proxyMode={proxyMode} onProxyToggle={setProxyMode} />}
 
         {/* Strategy selector */}
         <section className="rounded-3xl border bg-card p-5">

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -162,11 +162,15 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
   res.json({ success: true, preset });
 });
 
-// Token usage per model for the stacked bar
-fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
+// Token usage per model for the stacked bar.
+// ?proxy=true  → multiply per-model budget by key count (multi-IP deployment).
+// ?proxy=false → use raw per-key budget (single-IP / no proxy), default.
+fallbackRouter.get('/token-usage', (req: Request, res: Response) => {
   const db = getDb();
+  const proxy = req.query.proxy === 'true';
 
-  // Count enabled keys per platform — multiple keys carry independent quotas
+  // Count enabled keys per platform — always fetch so we can filter out
+  // platforms with zero keys; only multiply when in proxy mode.
   const keyCounts = db.prepare(`
     SELECT platform, COUNT(*) as count
     FROM api_keys WHERE enabled = 1
@@ -184,15 +188,16 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
     ORDER BY fc.priority ASC
   `).all() as { platform: string; model_id: string; display_name: string; monthly_token_budget: string; priority: number }[];
 
-  // Build per-model breakdown: budget × key count (multiple keys = multiple quotas).
-  // Optimal when keys are used behind separate IPs (some providers rate-limit
-  // by IP + key, so a single IP may share a pool regardless of key count).
+  // Build per-model breakdown: only platforms with keys; multiply by key count
+  // when in proxy mode (multi-IP = truly independent quotas).
   const modelBudgets = models
     .filter(m => keyCountMap.has(m.platform))
     .map(m => ({
       displayName: m.display_name,
       platform: m.platform,
-      budget: parseBudget(m.monthly_token_budget) * (keyCountMap.get(m.platform) ?? 1),
+      budget: proxy
+        ? parseBudget(m.monthly_token_budget) * (keyCountMap.get(m.platform) ?? 1)
+        : parseBudget(m.monthly_token_budget),
     }));
 
   const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0);
@@ -210,5 +215,6 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
     totalBudget,
     totalUsed: usage.total_used,
     models: modelBudgets,
+    proxy, // let the client know which mode was used
   });
 });

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -166,13 +166,13 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
 fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
   const db = getDb();
 
-  // Get platforms that have enabled keys
-  const platforms = db.prepare(`
-    SELECT DISTINCT ak.platform
-    FROM api_keys ak
-    WHERE ak.enabled = 1
-  `).all() as { platform: string }[];
-  const platformSet = new Set(platforms.map(p => p.platform));
+  // Count enabled keys per platform — multiple keys carry independent quotas
+  const keyCounts = db.prepare(`
+    SELECT platform, COUNT(*) as count
+    FROM api_keys WHERE enabled = 1
+    GROUP BY platform
+  `).all() as { platform: string; count: number }[];
+  const keyCountMap = new Map(keyCounts.map(k => [k.platform, k.count]));
 
   // Get monthly budget per model, ordered by fallback priority
   const models = db.prepare(`
@@ -184,13 +184,15 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
     ORDER BY fc.priority ASC
   `).all() as { platform: string; model_id: string; display_name: string; monthly_token_budget: string; priority: number }[];
 
-  // Build per-model breakdown (only platforms with keys)
+  // Build per-model breakdown: budget × key count (multiple keys = multiple quotas).
+  // Optimal when keys are used behind separate IPs (some providers rate-limit
+  // by IP + key, so a single IP may share a pool regardless of key count).
   const modelBudgets = models
-    .filter(m => platformSet.has(m.platform))
+    .filter(m => keyCountMap.has(m.platform))
     .map(m => ({
       displayName: m.display_name,
       platform: m.platform,
-      budget: parseBudget(m.monthly_token_budget),
+      budget: parseBudget(m.monthly_token_budget) * (keyCountMap.get(m.platform) ?? 1),
     }));
 
   const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0);


### PR DESCRIPTION
## What

Adds a proxy-aware monthly token budget calculation with a UI toggle.

### Backend

`/api/fallback/token-usage` now accepts `?proxy=true` or `?proxy=false` (default):
- **`?proxy=false`** (default): raw per-key budget — platforms with multiple keys still show the single-key quota. Correct for single-IP deployments where providers pool rate limits.
- **`?proxy=true`**: multiplies each model's budget by the number of enabled API keys for its platform. Correct for multi-IP proxy setups where each key gets its own independent rate-limit pool.

Both modes filter out platforms with zero enabled keys. The response includes a `proxy` boolean.

### Frontend

A toggle switch is added to the "Monthly token budget" bar. It passes `?proxy=true/false` to the API and react-query refetches on toggle. The label reads "Per key · multi-IP" when active, "Per provider" when off.

## Why

Each API key carries its own independent free-tier quota — but only when deployed behind separate IPs (via a proxy). Without a proxy, providers may pool rate limits by IP, making multiple keys on the same IP count as one. This PR exposes both views so users can choose based on their deployment.

## Changes

- `server/src/routes/fallback.ts`: `/token-usage` accepts `?proxy` query param, multiplies by key count when `true`
- `client/src/pages/FallbackPage.tsx`: proxy mode toggle in the TokenUsageBar with react-query refetch