### PR TITLE
feat: rich tooltips on token budget bar segments

### DIFF
--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -274,21 +274,26 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
 
       <div className="flex h-2.5 rounded-full overflow-hidden bg-muted">
         {modelsWithWidth.map((m, i) => (
-          <div
-            key={i}
-            title={`${m.displayName} (${m.platform}): ${formatTokens(m.remainingTokens)} remaining`}
-            style={{
-              width: `${m.widthPct}%`,
-              backgroundColor: platformColors[m.platform] ?? '#94a3b8',
-            }}
-          />
+          <div key={i} style={{ width: `${m.widthPct}%`, height: '100%' }}>
+            <Tooltip
+              className="h-full flex"
+              text={`${m.displayName} · ${m.platform}${m.remainingTokens > 0 ? ` · ${formatTokens(m.remainingTokens)} remaining` : ''}${m.budget > 0 ? ` · ${formatTokens(m.budget)} quota` : ''}`}
+            >
+              <div
+                className="h-full flex-1"
+                style={{
+                  backgroundColor: platformColors[m.platform] ?? '#94a3b8',
+                }}
+              />
+            </Tooltip>
+          </div>
         ))}
         {totalUsed > 0 && (
-          <div
-            title={`Used: ${formatTokens(totalUsed)}`}
-            className="bg-muted-foreground/30"
-            style={{ width: `${usedPct}%` }}
-          />
+          <div style={{ width: `${usedPct}%`, height: '100%' }}>
+            <Tooltip className="h-full flex" text={`Used: ${formatTokens(totalUsed)}`}>
+              <div className="bg-muted-foreground/30 h-full flex-1" />
+            </Tooltip>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## What

Adds rich tooltips to the monthly token budget bar segments. Hovering any colored segment shows:

- **DisplayName**
- **platform**
- **X remaining** tokens (hidden if 0)
- **Y quota** (hidden if 0)

The gray "used" segment shows total consumed tokens.

## Why

The native `title` attribute doesn't render on 10px-high bar segments. The Tooltip component renders via `createPortal` to `document.body`, bypassing `overflow-hidden` clipping. The `className='h-full flex'` override replaces the default `inline-flex`, giving the wrapper span proper block-level sizing so it fills the parent div and mouse events fire correctly.

## Changes

- `client/src/pages/FallbackPage.tsx`: TokenUsageBar segments now wrapped in `<Tooltip className='h-full flex'>`