### PR TITLE
V23 free-tier audit: drop SambaNova + Chutes, add 6 live-verified free models

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **One OpenAI-compatible endpoint. Sixteen free LLM providers. ~1.7B tokens per month.**
 
-Aggregate the free tiers from Google, Groq, Cerebras, SambaNova, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, and LLM7 — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
+Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, and OpenCode Zen — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
 [![CI](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml/badge.svg)](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
@@ -47,7 +47,7 @@ The problem is that stacking them by hand is painful: sixteen different SDKs, si
 <td align="center" width="180"><a href="https://ai.google.dev"><b>Google</b><br/>Gemini 2.5 Flash · 3.x previews</a></td>
 <td align="center" width="180"><a href="https://groq.com"><b>Groq</b><br/>Llama 3.3, Llama 4, GPT-OSS, Qwen3</a></td>
 <td align="center" width="180"><a href="https://cerebras.ai"><b>Cerebras</b><br/>Qwen3 235B</a></td>
-<td align="center" width="180"><a href="https://cloud.sambanova.ai"><b>SambaNova</b><br/>DeepSeek V3.x · Llama 4 · Gemma 3</a></td>
+<td align="center" width="180"><a href="https://opencode.ai/zen"><b>OpenCode Zen</b><br/>DeepSeek V4 Flash · Nemotron (promo)</a></td>
 </tr>
 <tr>
 <td align="center"><a href="https://mistral.ai"><b>Mistral</b><br/>Large 3 · Medium 3.5 · Codestral · Devstral</a></td>
@@ -293,7 +293,7 @@ print(final.choices[0].message.content)
 
 **Vision / image input**
 
-Send images with the standard OpenAI `image_url` content blocks (base64 `data:` URLs or `http(s)` URLs). When a request contains an image, the router restricts itself to **vision-capable models** and ignores text-only ones. Vision models are tagged with a **Vision** badge on the Fallback Chain page; the current set includes Gemini (2.5 / 3.x), Llama 4 Scout/Maverick (Groq, NVIDIA, SambaNova), and GitHub's GPT-4o / GPT-4.1.
+Send images with the standard OpenAI `image_url` content blocks (base64 `data:` URLs or `http(s)` URLs). When a request contains an image, the router restricts itself to **vision-capable models** and ignores text-only ones. Vision models are tagged with a **Vision** badge on the Fallback Chain page; the current set includes Gemini (2.5 / 3.x), Llama 4 Scout/Maverick (Groq, NVIDIA), GLM-4.6V Flash (Z.ai), Nemotron Nano 12B VL (OpenRouter), and GitHub's GPT-4o / GPT-4.1.
 
 ```python
 resp = client.chat.completions.create(
@@ -311,7 +311,7 @@ print(resp.choices[0].message.content)
 
 If no vision-capable model is enabled in your Fallback Chain, an image request returns a clear `422` (`code: "no_vision_model"`) rather than silently dropping the image. (Image input on `/v1/responses` isn't supported yet — use `/v1/chat/completions`.)
 
-Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, SambaNova, Mistral, OpenRouter, GitHub Models, HuggingFace, Cloudflare, Cohere compat) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
+Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, Mistral, OpenRouter, GitHub Models, HuggingFace, Cloudflare, Cohere compat) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
 
 Every response carries an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
 
@@ -474,7 +474,6 @@ A self-hosted, single-user, personal-use setup was re-reviewed against each prov
 | Cerebras | ✅ Likely OK | Permitted; explicitly forbids selling/transferring API keys. |
 | Mistral | ✅ Likely OK | APIs allowed for personal/internal business use. |
 | OpenRouter | ✅ Likely OK | April 2026 ToS sharpens the no-resale / no-competing-service clause; private single-user proxy still fine. |
-| SambaNova | ⚠️ Ambiguous | EULA §1.5(c) blocks resale and "service bureau" use; single-user with no third-party access is fine. |
 | Cloudflare Workers AI | ⚠️ Ambiguous | No anti-proxy clause; covered by general Self-Serve Subscription Agreement. |
 | NVIDIA NIM | ⚠️ Caution | Trial ToS §1.2 / §1.4: *"evaluation only, not production."* Disabled in default catalog. |
 | GitHub Models | ⚠️ Caution | Free tier explicitly scoped to *"experimentation"* and *"prototyping."* |

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -200,7 +200,6 @@ const platformColors: Record<string, string> = {
   google:      '#4285f4',
   groq:        '#f55036',
   cerebras:    '#8b5cf6',
-  sambanova:   '#14b8a6',
   nvidia:      '#76b900',
   mistral:     '#f59e0b',
   openrouter:  '#ec4899',

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -37,7 +37,6 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'google', label: 'Google AI Studio', url: 'https://aistudio.google.com/apikey' },
   { value: 'groq', label: 'Groq', url: 'https://console.groq.com/keys' },
   { value: 'cerebras', label: 'Cerebras', url: 'https://cloud.cerebras.ai' },
-  { value: 'sambanova', label: 'SambaNova', url: 'https://cloud.sambanova.ai' },
   { value: 'nvidia', label: 'NVIDIA NIM', url: 'https://build.nvidia.com/settings/api-keys' },
   { value: 'mistral', label: 'Mistral', url: 'https://console.mistral.ai/api-keys/' },
   { value: 'openrouter', label: 'OpenRouter', url: 'https://openrouter.ai/keys' },

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>FreeLLMAPI — One key. 1.7 billion free LLM tokens. Every month.</title>
-<meta name="description" content="A self-hosted, OpenAI-compatible proxy that routes across 16 free-tier LLM providers — Gemini, OpenRouter, Cerebras, Groq, Mistral, GitHub Models, SambaNova, Cohere, Cloudflare, Z.ai, NVIDIA, HuggingFace, Ollama, Kilo, Pollinations, LLM7 — plus any custom OpenAI-compatible endpoint. ~1.7B free tokens / month, 100+ models." />
+<meta name="description" content="A self-hosted, OpenAI-compatible proxy that routes across 16 free-tier LLM providers — Gemini, OpenRouter, Cerebras, Groq, Mistral, GitHub Models, OpenCode Zen, Cohere, Cloudflare, Z.ai, NVIDIA, HuggingFace, Ollama, Kilo, Pollinations, LLM7 — plus any custom OpenAI-compatible endpoint. ~1.7B free tokens / month, 100+ models." />
 <meta name="theme-color" content="#0a0a0a" />
 <link rel="canonical" href="https://tashfeenahmed.github.io/freellmapi/" />
 
@@ -346,9 +346,9 @@
           <div class="provider-models">GPT-4.1 · GPT-4o. <b>50 RPD</b> on the free Copilot tier. Higher caps with paid Copilot.</div>
         </div>
         <div class="provider-card">
-          <div class="provider-name"><span class="provider-icon"><img src="logos/sambanova.jpg" alt="" /></span>SambaNova</div>
-          <div class="provider-tokens"><span class="num">~3M</span><span class="unit">/mo</span><span class="label">shared</span></div>
-          <div class="provider-models">DeepSeek V3.1/V3.2 · Llama 4 Maverick · Llama 3.3 70B · Gemma 3 12B · GPT-OSS 120B.</div>
+          <div class="provider-name"><span class="provider-icon" style="font-size:12px;font-weight:700;color:var(--muted)">OC</span>OpenCode Zen</div>
+          <div class="provider-tokens"><span class="num">promo</span><span class="label">rotating free models</span></div>
+          <div class="provider-models">DeepSeek V4 Flash · Nemotron 3 Super · MiMo V2.5 · Big Pickle. Free account key, no card.</div>
         </div>
         <div class="provider-card">
           <div class="provider-name"><span class="provider-icon"><img src="logos/cloudflare.svg" alt="" /></span>Cloudflare Workers AI</div>

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -174,11 +174,6 @@ describe('Migration idempotency', () => {
     `).get() as { rpm_limit: number; rpd_limit: number; tpm_limit: number; tpd_limit: number };
     expect(cerebrasLimits).toEqual({ rpm_limit: 5, rpd_limit: 2400, tpm_limit: 30000, tpd_limit: 1000000 });
 
-    const sambanovaCtx = (db.prepare(`
-      SELECT context_window FROM models WHERE platform = 'sambanova' AND model_id = 'DeepSeek-V3.2'
-    `).get() as { context_window: number }).context_window;
-    expect(sambanovaCtx).toBe(32768);
-
     const cfFp8Ctx = (db.prepare(`
       SELECT context_window FROM models WHERE platform = 'cloudflare' AND model_id = '@cf/meta/llama-3.3-70b-instruct-fp8-fast'
     `).get() as { context_window: number }).context_window;
@@ -213,6 +208,43 @@ describe('Migration idempotency', () => {
       { model_id: 'gpt-oss-120b',                    enabled: 1 },
       { model_id: 'llama3.1-8b',                     enabled: 0 },
       { model_id: 'qwen-3-235b-a22b-instruct-2507',  enabled: 0 },
+    ]);
+  });
+
+  it('V23: sambanova/chutes are gone; live-verified free additions are present with the right flags', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    // Platform drops — no model, fallback, or key rows survive.
+    const deadRows = db.prepare(
+      `SELECT COUNT(*) AS n FROM models WHERE platform IN ('sambanova', 'chutes')`
+    ).get() as { n: number };
+    expect(deadRows.n).toBe(0);
+    const deadKeys = db.prepare(
+      `SELECT COUNT(*) AS n FROM api_keys WHERE platform IN ('sambanova', 'chutes')`
+    ).get() as { n: number };
+    expect(deadKeys.n).toBe(0);
+
+    // Additions, with the flags the live probe verified (vision/tools come
+    // from the V16/V22 rules, so they must hold on a fresh seed too).
+    const added = db.prepare(`
+      SELECT platform, model_id, enabled, supports_vision, supports_tools FROM models
+       WHERE (platform = 'openrouter' AND model_id IN (
+               'moonshotai/kimi-k2.6:free',
+               'nvidia/nemotron-3-ultra-550b-a55b:free',
+               'nvidia/nemotron-nano-12b-v2-vl:free',
+               'meta-llama/llama-3.2-3b-instruct:free',
+               'cognitivecomputations/dolphin-mistral-24b-venice-edition:free'))
+          OR (platform = 'zhipu' AND model_id = 'glm-4.6v-flash')
+       ORDER BY platform, model_id
+    `).all() as { model_id: string; enabled: number; supports_vision: number; supports_tools: number }[];
+    expect(added.map(r => [r.model_id, r.enabled, r.supports_vision, r.supports_tools])).toEqual([
+      ['cognitivecomputations/dolphin-mistral-24b-venice-edition:free', 1, 0, 0],
+      ['meta-llama/llama-3.2-3b-instruct:free',                         1, 0, 0],
+      ['moonshotai/kimi-k2.6:free',                                     1, 0, 1],
+      ['nvidia/nemotron-3-ultra-550b-a55b:free',                        0, 0, 0], // hangs 180s+; seeded disabled
+      ['nvidia/nemotron-nano-12b-v2-vl:free',                           1, 1, 1],
+      ['glm-4.6v-flash',                                                1, 1, 1],
     ]);
   });
 

--- a/server/src/__tests__/db/intelligence-tiers.test.ts
+++ b/server/src/__tests__/db/intelligence-tiers.test.ts
@@ -54,7 +54,7 @@ describe('intelligence tier audit (migrateModelsV17)', () => {
   });
 
   it('demotes weak models to Small', () => {
-    expect(tier('sambanova', 'gemma-3-12b-it')).toBe('Small');     // AA 9
+    expect(tier('groq', 'llama-3.1-8b-instant')).toBe('Small');    // AA ~10 (sambanova gemma-3-12b row dropped in V23)
     expect(tier('mistral', 'codestral-latest')).toBe('Small');     // AA 8
     expect(tier('cohere', 'command-r-08-2024')).toBe('Small');     // legacy
   });

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -256,7 +256,6 @@ describe('OpenAICompatProvider - platform instances', () => {
   const platforms = [
     { platform: 'groq',       name: 'Groq',          baseUrl: 'https://api.groq.com/openai/v1' },
     { platform: 'cerebras',   name: 'Cerebras',      baseUrl: 'https://api.cerebras.ai/v1' },
-    { platform: 'sambanova',  name: 'SambaNova',     baseUrl: 'https://api.sambanova.ai/v1' },
     { platform: 'nvidia',     name: 'NVIDIA NIM',    baseUrl: 'https://integrate.api.nvidia.com/v1' },
     { platform: 'mistral',    name: 'Mistral',       baseUrl: 'https://api.mistral.ai/v1' },
     { platform: 'openrouter', name: 'OpenRouter',    baseUrl: 'https://openrouter.ai/api/v1' },

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -54,7 +54,7 @@ function mockUpstream(script: Array<{ body: string; status?: number }>) {
     const urlStr = typeof url === 'string' ? url : url.toString();
     // Only intercept provider upstreams; the test's own localhost request
     // and anything else goes through.
-    if (!/api\.groq\.com|openrouter\.ai|api\.cohere|generativelanguage|integrate\.api\.nvidia|api\.cerebras|api\.mistral|router\.huggingface|api\.sambanova|llm\.chutes|api\.cloudflare|models\.github|open\.bigmodel|api\.llm7|api\.kilo|text\.pollinations|ollama\.com|opencode\.ai/.test(urlStr)) {
+    if (!/api\.groq\.com|openrouter\.ai|api\.cohere|generativelanguage|integrate\.api\.nvidia|api\.cerebras|api\.mistral|router\.huggingface|api\.cloudflare|models\.github|open\.bigmodel|api\.llm7|api\.kilo|text\.pollinations|ollama\.com|opencode\.ai/.test(urlStr)) {
       return origFetch(url as any, init);
     }
     const reqBody = JSON.parse(String((init as RequestInit).body));

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -58,6 +58,7 @@ export function initDb(dbPath?: string): Database.Database {
   migrateModelsV20KiloFree(db);
   migrateModelsV21PruneDead(db);
   migrateModelsV22Tools(db);
+  migrateModelsV23FreeTierAudit(db);
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1401,6 +1402,14 @@ function migrateModelsV16Vision(db: Database.Database) {
       WHERE platform = 'github'
         AND (model_id LIKE '%gpt-4o%' OR model_id LIKE '%gpt-4.1%' OR model_id LIKE '%gpt-5%')
     `).run();
+    // V23 vision additions, both live-probed 2026-06-07 (answered a color
+    // question about an inline data-URL PNG): Zhipu's free GLM-4.6V Flash and
+    // NVIDIA's Nemotron Nano 12B v2 VL (via OpenRouter).
+    db.prepare(`
+      UPDATE models SET supports_vision = 1
+      WHERE LOWER(model_id) LIKE '%glm-4.6v%'
+         OR LOWER(model_id) LIKE '%nemotron-nano-12b-v2-vl%'
+    `).run();
   });
   apply();
 }
@@ -1698,7 +1707,8 @@ function migrateModelsV22Tools(db: Database.Database) {
       WHERE (
            LOWER(model_id) LIKE '%gpt-oss%'        -- groq/OR/cerebras/CF/sambanova/ollama; incl. safeguard (tool-tuned)
         OR ((LOWER(model_id) LIKE '%llama-3%' OR LOWER(model_id) LIKE '%llama-4%')
-            AND LOWER(model_id) NOT LIKE '%hermes%') -- Llama 3.x/4 native tools; hermes-3-llama emits text tool calls
+            AND LOWER(model_id) NOT LIKE '%hermes%'   -- hermes-3-llama emits text tool calls
+            AND LOWER(model_id) NOT LIKE '%llama-3.2%') -- 3B route declares no tool support (V23)
         OR LOWER(model_id) LIKE '%gemini-%'        -- every Gemini; gemma intentionally NOT matched
         OR LOWER(model_id) LIKE '%glm-%'           -- GLM 4.5+/5.x are agentic-tuned (zai/zhipu/CF/ollama)
         OR LOWER(model_id) LIKE '%qwen3%'
@@ -1719,8 +1729,84 @@ function migrateModelsV22Tools(db: Database.Database) {
         OR LOWER(model_id) LIKE '%gpt-4.1%'
         OR LOWER(model_id) LIKE '%gpt-5%'
         OR LOWER(model_id) LIKE '%nemotron-3-super%' -- benchmarked #8 with real tool calls; nano stays excluded
+        OR LOWER(model_id) LIKE '%nemotron-nano-12b-v2-vl%' -- unlike the 30B nano: live-probed structured tool_calls (V23, 2026-06-07)
       )
     `).run();
+  });
+  apply();
+}
+
+/**
+ * V23 (June 2026): recurring-free audit — drop SambaNova + Chutes, add
+ * live-verified free models (all probed 2026-06-07 with production keys).
+ *
+ * Removed platforms (models, fallback rows, AND key rows; earlier migrations
+ * re-insert the model rows on every boot, so this later DELETE is what keeps
+ * them out — same pattern as V21):
+ *   - sambanova: free tier is gone for good. The always-free tier was retired
+ *     in early 2025 ("We do not have any current plans to maintain the free
+ *     tier in any state" — staff, community.sambanova.ai/t/847) in favor of a
+ *     one-time $5 trial credit that expires in 3 months. Once it lapses with
+ *     no card on file, every chat call 402s "payment method required" — live
+ *     probe confirmed on all 6 models, while /v1/models still 200s (billing
+ *     gate, not a key problem). No recurring no-card path remains.
+ *   - chutes: never a registered provider — rows were hand-added during the
+ *     V11 evaluation. The Early Access free plan (200 req/day) fully retired
+ *     2026-03-15 (chutes.ai/news/community-announcement-february); PAYG and
+ *     paid subs only now, so V11's drop verdict is permanent.
+ *
+ * Added:
+ *   - openrouter kimi-k2.6:free — chat probed 200; tools flagged via the V22
+ *     %kimi-k2% family rule (the tool probe itself only hit upstream 429s —
+ *     it's a popular new route — but K2 is tool-native everywhere we run it).
+ *   - openrouter nemotron-nano-12b-v2-vl:free — structured tool_calls AND
+ *     vision both live-verified; V16/V22 rules added.
+ *   - zhipu glm-4.6v-flash — listed "Free" on Z.AI pricing; 200 with our
+ *     existing bigmodel.cn key; structured tool_calls + vision verified.
+ *   - openrouter nemotron-3-ultra-550b-a55b:free — 1M ctx, currently the
+ *     biggest free model anywhere, but generation takes 180s+ even on trivial
+ *     prompts (heavily congested), so it's seeded enabled=0. Flip it on when
+ *     it serves sanely — and verify tools then (declared by OpenRouter, but
+ *     unverifiable while it hangs, so V22 deliberately has no rule for it).
+ *   - openrouter llama-3.2-3b-instruct:free and
+ *     dolphin-mistral-24b-venice-edition:free — both heavily contended
+ *     (persistent upstream 429s at probe time) but real routes; no tools.
+ *   - NOT added: nvidia/nemotron-3.5-content-safety:free — it's a safety
+ *     classifier, not a chat model: probe returned content:null with a "User
+ *     Safety: safe/unsafe" verdict in reasoning, which would surface as empty
+ *     responses whenever the fallback chain landed on it.
+ *
+ * Idempotent: DELETEs re-run harmlessly; INSERT OR IGNORE means the ultra
+ * row's enabled=0 is seed-only, so a dashboard re-enable sticks across boots.
+ * vision/tools seeds match the V16/V22 rules (which re-assert next boot);
+ * tiers match V17's bands.
+ */
+function migrateModelsV23FreeTierAudit(db: Database.Database) {
+  const apply = db.transaction(() => {
+    for (const platform of ['sambanova', 'chutes']) {
+      db.prepare(`
+        DELETE FROM fallback_config WHERE model_db_id IN (
+          SELECT id FROM models WHERE platform = ?
+        )
+      `).run(platform);
+      db.prepare('DELETE FROM models WHERE platform = ?').run(platform);
+      db.prepare('DELETE FROM api_keys WHERE platform = ?').run(platform);
+    }
+
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, supports_vision, supports_tools)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null, number, number, number]> = [
+      ['openrouter', 'moonshotai/kimi-k2.6:free',                                     'Kimi K2.6 (OR free)',                 3, 9,  'Frontier', 20, 200, null, null, '~6M',  262144,  1, 0, 1],
+      ['openrouter', 'nvidia/nemotron-3-ultra-550b-a55b:free',                        'Nemotron 3 Ultra 550B (free, slow)',  7, 11, 'Frontier', 20, 200, null, null, '~6M',  1000000, 0, 0, 0],
+      ['openrouter', 'nvidia/nemotron-nano-12b-v2-vl:free',                           'Nemotron Nano 12B VL (free)',        26, 9,  'Medium',   20, 200, null, null, '~6M',  128000,  1, 1, 1],
+      ['openrouter', 'meta-llama/llama-3.2-3b-instruct:free',                         'Llama 3.2 3B (free)',                30, 9,  'Small',    20, 200, null, null, '~6M',  131072,  1, 0, 0],
+      ['openrouter', 'cognitivecomputations/dolphin-mistral-24b-venice-edition:free', 'Dolphin Mistral 24B Venice (free)',  25, 9,  'Medium',   20, 200, null, null, '~6M',  32768,   1, 0, 0],
+      ['zhipu',      'glm-4.6v-flash',                                                'GLM-4.6V Flash',                     21, 4,  'Large',    null, null, null, null, '~30M', 131072,  1, 1, 1],
+    ];
+    for (const a of additions) insert.run(...a);
+    backfillFallback(db);
   });
   apply();
 }

--- a/server/src/db/model-pricing.ts
+++ b/server/src/db/model-pricing.ts
@@ -138,8 +138,14 @@ export const MODEL_PRICING: PricingRow[] = [
   ['opencode', 'nemotron-3-super-free', 0.09, 0.45],
 
   // OpenRouter :free pools (priced at the same model's paid variant)
+  // V23 additions snapshot the OpenRouter pricing API on 2026-06-07.
+  ['openrouter', 'cognitivecomputations/dolphin-mistral-24b-venice-edition:free', null, null], // free-only route
   ['openrouter', 'google/gemma-4-26b-a4b-it:free', 0.06, 0.33],
   ['openrouter', 'google/gemma-4-31b-it:free', 0.12, 0.37],
+  ['openrouter', 'meta-llama/llama-3.2-3b-instruct:free', 0.05, 0.34],
+  ['openrouter', 'moonshotai/kimi-k2.6:free', 0.684, 3.42],
+  ['openrouter', 'nvidia/nemotron-3-ultra-550b-a55b:free', 0.50, 2.50],
+  ['openrouter', 'nvidia/nemotron-nano-12b-v2-vl:free', null, null], // no paid variant listed
   // LFM 2.5 1.2B has no paid listing; tiny-model estimate
   ['openrouter', 'liquid/lfm-2.5-1.2b-instruct:free', 0.01, 0.04],
   ['openrouter', 'liquid/lfm-2.5-1.2b-thinking:free', 0.01, 0.04],
@@ -164,16 +170,12 @@ export const MODEL_PRICING: PricingRow[] = [
   // Pollinations (serves gpt-oss-20b)
   ['pollinations', 'openai-fast', 0.029, 0.14],
 
-  // SambaNova
-  ['sambanova', 'DeepSeek-V3.1', 0.21, 0.79],
-  ['sambanova', 'DeepSeek-V3.2', 0.229, 0.343],
-  ['sambanova', 'Llama-4-Maverick-17B-128E-Instruct', 0.15, 0.60],
-  ['sambanova', 'Meta-Llama-3.3-70B-Instruct', 0.10, 0.32],
-  ['sambanova', 'gemma-3-12b-it', 0.04, 0.13],
-  ['sambanova', 'gpt-oss-120b', 0.039, 0.18],
+  // SambaNova rows were removed in V23 (platform dropped — free tier retired).
 
-  // Zhipu (4.5-flash estimated at the 4.7-flash rate — no paid 4.5-flash)
+  // Zhipu (4.5-flash estimated at the 4.7-flash rate — no paid 4.5-flash;
+  // 4.6v-flash priced at OpenRouter's paid z-ai/glm-4.6v)
   ['zhipu', 'glm-4.5-flash', 0.06, 0.40],
+  ['zhipu', 'glm-4.6v-flash', 0.30, 0.90],
   ['zhipu', 'glm-4.7-flash', 0.06, 0.40],
 ];
 

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -28,12 +28,10 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.cerebras.ai/v1',
 }));
 
-// SambaNova - OpenAI-compatible
-register(new OpenAICompatProvider({
-  platform: 'sambanova',
-  name: 'SambaNova',
-  baseUrl: 'https://api.sambanova.ai/v1',
-}));
+// SambaNova was dropped in V23 (June 2026): the free tier is permanently gone.
+// The always-free tier was retired in early 2025 for a one-time $5 trial
+// credit (expires in 3 months); once it lapses, every chat call 402s
+// "payment method required" with no recurring no-card path back.
 
 // NVIDIA NIM - OpenAI-compatible
 register(new OpenAICompatProvider({

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -8,7 +8,7 @@ import { BaseProvider, type CompletionOptions } from './base.js';
 
 /**
  * Generic provider for platforms that use an OpenAI-compatible API.
- * Covers: Groq, Cerebras, SambaNova, NVIDIA NIM, Mistral, OpenRouter,
+ * Covers: Groq, Cerebras, NVIDIA NIM, Mistral, OpenRouter,
  * GitHub Models, Fireworks AI.
  */
 export class OpenAICompatProvider extends BaseProvider {

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -10,8 +10,9 @@ export const keysRouter = Router();
 // Active providers — must match providers/index.ts registrations + shared/types.ts Platform.
 // Moonshot and MiniMax direct integrations were dropped in V4. HuggingFace
 // was dropped in V4 and re-added in V13 via the router.huggingface.co route.
+// SambaNova was dropped in V23 (free tier permanently retired).
 const PLATFORMS = [
-  'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral',
+  'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'custom',
 ] as const;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,11 +5,12 @@
 // Moonshot and MiniMax direct integrations were dropped in migrateModelsV4
 // (see server/src/db/index.ts). HuggingFace was dropped in V4 and re-added
 // in V13 via the router.huggingface.co Inference Providers meta-router.
+// SambaNova was dropped in V23 (free tier permanently retired — 402
+// "payment method required" once the one-time $5 trial credit lapses).
 export type Platform =
   | 'google'
   | 'groq'
   | 'cerebras'
-  | 'sambanova'
   | 'nvidia'
   | 'mistral'
   | 'openrouter'


### PR DESCRIPTION
## Summary
- Drop the SambaNova platform entirely: the free tier is permanently gone (one-time $5 trial credit since early 2025; 402 "payment method required" once it lapses, live-probed on all 6 models while /v1/models still answers 200 - billing gate, not a key problem)
- Purge the orphan Chutes rows (Early Access free plan fully retired 2026-03-15, making the V11 drop verdict permanent)
- Add 6 free models, every claim live-probed through production keys on 2026-06-07:
  - `moonshotai/kimi-k2.6:free` (OpenRouter, Frontier, tools, 262K ctx)
  - `nvidia/nemotron-nano-12b-v2-vl:free` (OpenRouter, vision + structured tool_calls verified)
  - `glm-4.6v-flash` (Zhipu, free vision model, tools + vision verified)
  - `nvidia/nemotron-3-ultra-550b-a55b:free` (1M ctx, seeded disabled - hangs 180s+ while congested)
  - `meta-llama/llama-3.2-3b-instruct:free`, `dolphin-mistral-24b-venice-edition:free` (no-tools)
- Deliberately NOT added: `nvidia/nemotron-3.5-content-safety:free` - it is a safety classifier that returns `content:null` for normal chat and would surface as empty responses in the fallback chain
- V16 vision + V22 tools rules extended for the new models; V22 llama rule gains a llama-3.2 exclusion
- Pricing table refreshed from the OpenRouter pricing API; README/docs swap SambaNova's provider-grid slot for OpenCode Zen (in the catalog since V18, missing from docs)

## Test plan
- [x] `tsc --noEmit` clean
- [x] 378/378 server tests pass, including a new V23 idempotency test (drops, additions, flags)
- [x] Migration applied to a real pre-V23 dev DB: 112 -> 108 models, zero fallback orphans
- [x] Idempotent across boots; V16/V22 rules re-assert the same flags
- [x] Live boot: /v1/models serves the 5 enabled additions, hides the disabled ultra, no sambanova