### PR TITLE
V24: Zen roster refresh - Nemotron 3 Ultra + MiniMax M3 free, pause hung NIM gemma

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/LoneRifle"><img src="https://images.weserv.nl/?url=github.com/LoneRifle.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@LoneRifle" /></a>
 <a href="https://github.com/ita333"><img src="https://images.weserv.nl/?url=github.com/ita333.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@ita333" /></a>
 <a href="https://github.com/barbotkonv"><img src="https://images.weserv.nl/?url=github.com/barbotkonv.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@barbotkonv" /></a>
+<a href="https://github.com/Naster17"><img src="https://images.weserv.nl/?url=github.com/Naster17.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Naster17" /></a>
 
 ## Terms of Service review
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -348,7 +348,7 @@
         <div class="provider-card">
           <div class="provider-name"><span class="provider-icon" style="font-size:12px;font-weight:700;color:var(--muted)">OC</span>OpenCode Zen</div>
           <div class="provider-tokens"><span class="num">promo</span><span class="label">rotating free models</span></div>
-          <div class="provider-models">DeepSeek V4 Flash · Nemotron 3 Super · MiMo V2.5 · Big Pickle. Free account key, no card.</div>
+          <div class="provider-models">DeepSeek V4 Flash · Nemotron 3 Ultra · MiniMax M3 · MiMo V2.5 · Big Pickle. Free account key.</div>
         </div>
         <div class="provider-card">
           <div class="provider-name"><span class="provider-icon"><img src="logos/cloudflare.svg" alt="" /></span>Cloudflare Workers AI</div>

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -242,10 +242,32 @@ describe('Migration idempotency', () => {
       ['cognitivecomputations/dolphin-mistral-24b-venice-edition:free', 1, 0, 0],
       ['meta-llama/llama-3.2-3b-instruct:free',                         1, 0, 0],
       ['moonshotai/kimi-k2.6:free',                                     1, 0, 1],
-      ['nvidia/nemotron-3-ultra-550b-a55b:free',                        0, 0, 0], // hangs 180s+; seeded disabled
+      ['nvidia/nemotron-3-ultra-550b-a55b:free',                        0, 0, 1], // hangs 180s+; seeded disabled (tools verified via Zen in V24)
       ['nvidia/nemotron-nano-12b-v2-vl:free',                           1, 1, 1],
       ['glm-4.6v-flash',                                                1, 1, 1],
     ]);
+  });
+
+  it('V24: Zen roster refresh lands and the hung NIM gemma is paused', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const zen = db.prepare(`
+      SELECT model_id, enabled, supports_tools FROM models
+       WHERE platform = 'opencode' AND model_id IN ('nemotron-3-ultra-free', 'minimax-m3-free')
+       ORDER BY model_id
+    `).all() as { model_id: string; enabled: number; supports_tools: number }[];
+    expect(zen.map(r => [r.model_id, r.enabled, r.supports_tools])).toEqual([
+      ['minimax-m3-free',       1, 1],
+      ['nemotron-3-ultra-free', 1, 1],
+    ]);
+
+    // The hung NIM gemma route is paused (row kept, enabled=0, re-asserted
+    // each boot like the V13 disables).
+    const gemma = db.prepare(`
+      SELECT enabled FROM models WHERE platform = 'nvidia' AND model_id = 'google/gemma-4-31b-it'
+    `).get() as { enabled: number };
+    expect(gemma.enabled).toBe(0);
   });
 
   it('all enabled catalog platforms have a registered provider', async () => {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -30,6 +30,7 @@ export function migrateDbSchema(db: Database.Database) {
   migrateModelsV21PruneDead(db);
   migrateModelsV22Tools(db);
   migrateModelsV23FreeTierAudit(db);
+  migrateModelsV24ZenRefresh(db);
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1698,6 +1699,8 @@ function migrateModelsV22Tools(db: Database.Database) {
         OR LOWER(model_id) LIKE '%gpt-5%'
         OR LOWER(model_id) LIKE '%nemotron-3-super%' -- benchmarked #8 with real tool calls; nano stays excluded
         OR LOWER(model_id) LIKE '%nemotron-nano-12b-v2-vl%' -- unlike the 30B nano: live-probed structured tool_calls (V23, 2026-06-07)
+        OR LOWER(model_id) LIKE '%nemotron-3-ultra%' -- structured tool_calls live-verified via Zen's dedicated endpoint (V24, 2026-06-07); covers the disabled OR row too
+        OR LOWER(model_id) LIKE '%minimax-m3%'       -- finish_reason:tool_calls live-verified on Zen (V24)
       )
     `).run();
   });
@@ -1734,8 +1737,9 @@ function migrateModelsV22Tools(db: Database.Database) {
  *   - openrouter nemotron-3-ultra-550b-a55b:free — 1M ctx, currently the
  *     biggest free model anywhere, but generation takes 180s+ even on trivial
  *     prompts (heavily congested), so it's seeded enabled=0. Flip it on when
- *     it serves sanely — and verify tools then (declared by OpenRouter, but
- *     unverifiable while it hangs, so V22 deliberately has no rule for it).
+ *     it serves sanely. (Tools were unverifiable on the OR route while it
+ *     hangs; V24 verified the model family's structured tool_calls via Zen's
+ *     dedicated endpoint and added the V22 rule, so this seed is now 1.)
  *   - openrouter llama-3.2-3b-instruct:free and
  *     dolphin-mistral-24b-venice-edition:free — both heavily contended
  *     (persistent upstream 429s at probe time) but real routes; no tools.
@@ -1767,7 +1771,7 @@ function migrateModelsV23FreeTierAudit(db: Database.Database) {
     `);
     const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null, number, number, number]> = [
       ['openrouter', 'moonshotai/kimi-k2.6:free',                                     'Kimi K2.6 (OR free)',                 3, 9,  'Frontier', 20, 200, null, null, '~6M',  262144,  1, 0, 1],
-      ['openrouter', 'nvidia/nemotron-3-ultra-550b-a55b:free',                        'Nemotron 3 Ultra 550B (free, slow)',  7, 11, 'Frontier', 20, 200, null, null, '~6M',  1000000, 0, 0, 0],
+      ['openrouter', 'nvidia/nemotron-3-ultra-550b-a55b:free',                        'Nemotron 3 Ultra 550B (free, slow)',  7, 11, 'Frontier', 20, 200, null, null, '~6M',  1000000, 0, 0, 1],
       ['openrouter', 'nvidia/nemotron-nano-12b-v2-vl:free',                           'Nemotron Nano 12B VL (free)',        26, 9,  'Medium',   20, 200, null, null, '~6M',  128000,  1, 1, 1],
       ['openrouter', 'meta-llama/llama-3.2-3b-instruct:free',                         'Llama 3.2 3B (free)',                30, 9,  'Small',    20, 200, null, null, '~6M',  131072,  1, 0, 0],
       ['openrouter', 'cognitivecomputations/dolphin-mistral-24b-venice-edition:free', 'Dolphin Mistral 24B Venice (free)',  25, 9,  'Medium',   20, 200, null, null, '~6M',  32768,   1, 0, 0],
@@ -1775,6 +1779,57 @@ function migrateModelsV23FreeTierAudit(db: Database.Database) {
     ];
     for (const a of additions) insert.run(...a);
     backfillFallback(db);
+  });
+  apply();
+}
+
+/**
+ * V24 (June 2026): OpenCode Zen roster refresh + NIM gemma pause. All claims
+ * live-probed 2026-06-07 with a real Zen account key through the gateway.
+ *
+ * Zen's promo roster rotated since V18:
+ *   - ADDED nemotron-3-ultra-free — newly docs-confirmed free, and unlike the
+ *     OpenRouter ultra route (which hangs: 0 tokens in 140s even streaming),
+ *     Zen serves it from a dedicated vLLM endpoint in ~2s WITH structured
+ *     tool_calls. Currently the biggest usable free model anywhere.
+ *   - ADDED minimax-m3-free — requested in #242 (thanks @Naster17). Live
+ *     probe: 2s chat, finish_reason:tool_calls. CAVEAT: not in Zen's docs
+ *     free table (same undocumented status qwen3.6-plus-free had before its
+ *     promo ended), so it may transition without notice — watchlist.
+ *   - qwen3.6-plus-free now errors "Free promotion has ended" — confirms the
+ *     docs-confirmed-only bar; never added, nothing to remove.
+ *   - nemotron-3-super-free DROPPED OUT of Zen's docs free table but still
+ *     serves (routes to the same congested NVIDIA :free upstream as
+ *     OpenRouter, ~15s). Kept enabled; prune if it starts billing or 402s.
+ *   - big-pickle unmasked: responses report model "deepseek-v4-flash".
+ *
+ * Also pauses nvidia/google/gemma-4-31b-it: still listed on NIM's /v1/models
+ * (only gemma-4 there) but every chat probe hangs 90s+ even on tiny prompts —
+ * NIM free-tier serverless capacity starvation (forum 504 reports, May–Jun
+ * 2026) compounded by a known gemma-4-31b dense Flash-Attention prefill
+ * deadlock upstream. Disabled like the V13 disables (re-asserted each boot);
+ * re-enable via a future migration when NIM serves it again. Gemma-4 coverage
+ * remains via google/openrouter/cloudflare rows.
+ *
+ * Idempotent: INSERT OR IGNORE + always-run UPDATEs, safe to re-run.
+ */
+function migrateModelsV24ZenRefresh(db: Database.Database) {
+  const apply = db.transaction(() => {
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, supports_vision, supports_tools)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const additions: Array<[string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null, number, number, number]> = [
+      ['opencode', 'nemotron-3-ultra-free', 'Nemotron 3 Ultra Free (OpenCode Zen)',  7, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', 131072, 1, 0, 1],
+      ['opencode', 'minimax-m3-free',       'MiniMax M3 Free (OpenCode Zen)',        4, 4, 'Frontier', 20, 200, null, null, 'promo (trial)', 131072, 1, 0, 1],
+    ];
+    for (const a of additions) insert.run(...a);
+    backfillFallback(db);
+
+    db.prepare(`
+      UPDATE models SET enabled = 0
+       WHERE platform = 'nvidia' AND model_id = 'google/gemma-4-31b-it'
+    `).run();
   });
   apply();
 }

--- a/server/src/db/model-pricing.ts
+++ b/server/src/db/model-pricing.ts
@@ -131,11 +131,14 @@ export const MODEL_PRICING: PricingRow[] = [
   ['ollama', 'qwen3-coder-next', 0.11, 0.80],
   ['ollama', 'qwen3-coder:480b', 0.22, 1.80],
 
-  // OpenCode Zen (big-pickle is stealth — no equivalent)
+  // OpenCode Zen (big-pickle is stealth — no equivalent; V24 rows priced at
+  // the OpenRouter paid variants, snapshot 2026-06-07)
   ['opencode', 'big-pickle', null, null],
   ['opencode', 'deepseek-v4-flash-free', 0.098, 0.197],
   ['opencode', 'mimo-v2.5-free', 0.14, 0.28],
+  ['opencode', 'minimax-m3-free', 0.30, 1.20],
   ['opencode', 'nemotron-3-super-free', 0.09, 0.45],
+  ['opencode', 'nemotron-3-ultra-free', 0.50, 2.50],
 
   // OpenRouter :free pools (priced at the same model's paid variant)
   // V23 additions snapshot the OpenRouter pricing API on 2026-06-07.

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -15,6 +15,10 @@ export interface CompletionOptions {
   tools?: ChatToolDefinition[];
   tool_choice?: ChatToolChoice;
   parallel_tool_calls?: boolean;
+  /** Per-call HTTP timeout override. Not part of the OpenAI wire format (it is
+   * stripped before the request body is built); used by the probe script so
+   * NVIDIA's 15-60s serverless cold starts don't read as failures. */
+  timeoutMs?: number;
 }
 
 export abstract class BaseProvider {

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -70,7 +70,7 @@ export class OpenAICompatProvider extends BaseProvider {
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
       }),
-    }, this.timeoutMs);
+    }, options?.timeoutMs ?? this.timeoutMs);
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));

--- a/server/src/scripts/test-all-models.ts
+++ b/server/src/scripts/test-all-models.ts
@@ -45,7 +45,9 @@ for (const row of models) {
 
   const start = Date.now();
   try {
-    const res = await provider.chatCompletion(apiKey, [{ role: 'user', content: 'hi' }], row.model_id, { max_tokens: 5 });
+    // 120s: NVIDIA NIM cold starts regularly take 15-60s and frontier reasoning
+    // models longer — at the default 15s they false-flag as broken (V23 audit).
+    const res = await provider.chatCompletion(apiKey, [{ role: 'user', content: 'hi' }], row.model_id, { max_tokens: 5, timeoutMs: 120000 });
     const raw = res.choices?.[0]?.message?.content;
     const reply = typeof raw === 'string' ? raw.slice(0, 40) : '';
     results.push({ row, ok: true, ms: Date.now() - start, reply });


### PR DESCRIPTION
## Summary
- Add `nemotron-3-ultra-free` (OpenCode Zen): newly docs-confirmed free. Zen serves the 550B from a dedicated vLLM endpoint in ~2s with structured tool_calls, while the OpenRouter ultra route still hangs (0 tokens in 140s, streaming included). Currently the biggest usable free model anywhere.
- Add `minimax-m3-free` (OpenCode Zen): requested in #242 - thanks @Naster17! Live probe: 2s chat, `finish_reason: tool_calls`. Caveat documented: it is not in Zen's docs free table (same undocumented status `qwen3.6-plus-free` had before its promo ended), so it is on the watchlist.
- `qwen3.6-plus-free` confirmed dead ("Free promotion has ended" error) - validates the docs-confirmed-only bar from V18.
- `nemotron-3-super-free` dropped out of Zen's docs free table but still serves (~15s via the congested NVIDIA `:free` upstream); kept enabled with a watch note.
- Pause `nvidia/google/gemma-4-31b-it` (enabled=0): still listed on NIM's `/v1/models` but every probe hangs 90s+ even on tiny prompts (NIM serverless capacity starvation + the known gemma-4-31b dense Flash-Attention prefill deadlock). Gemma-4 coverage remains via google/openrouter/cloudflare rows.
- Probe script reliability: `CompletionOptions.timeoutMs` per-call override (honored by the OpenAI-compat provider), `test-all-models` now probes at 120s so NVIDIA cold starts stop false-flagging as broken.
- V22 tools rules: `%nemotron-3-ultra%` (verified via Zen) and `%minimax-m3%`; the disabled OR ultra row's seed flips to tools=1 accordingly.
- Pricing rows for both additions from the OpenRouter paid variants (snapshot 2026-06-07); README Contributors gains @Naster17; docs Zen card refreshed.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 384/384 server tests pass, including a new V24 test (Zen rows + flags, gemma paused) and the updated V23 expectation
- [x] Migration applied to the real pre-V24 dev DB: 108 -> 110 models, flags and pricing verified
- [x] All 7 Zen free-ish IDs live-probed with a real account key (chat + tools + timing)