### PR TITLE
filter v1 models by connected providers

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -114,7 +114,8 @@ export function setStickyModel(messages: ChatMessage[], modelDbId: number, sessi
   }
 }
 
-// OpenAI-compatible /models endpoint (used by Hermes for metadata)
+// OpenAI-compatible /models endpoint (used by Hermes for metadata) 
+// shows API models which is linked by the user
 proxyRouter.get('/models', (req: Request, res: Response) => {
   const token = extractApiToken(req);
   const unifiedKey = getUnifiedApiKey();
@@ -132,8 +133,14 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
                PARTITION BY model_id
                ORDER BY intelligence_rank ASC, id ASC
              ) AS rn
-      FROM models
-      WHERE enabled = 1
+      FROM models m
+      WHERE m.enabled = 1
+        AND EXISTS (
+          SELECT 1 FROM api_keys k
+          WHERE k.platform = m.platform
+            AND k.enabled = 1
+            AND (m.key_id IS NULL OR k.id = m.key_id)
+        )
     )
     WHERE rn = 1
     ORDER BY intelligence_rank ASC, id ASC
@@ -161,6 +168,7 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
     ],
   });
 });
+
 
 const MAX_RETRIES = 20;
 


### PR DESCRIPTION
### Summary
This PR updates the `/v1/models` endpoint query to only return models for which at least one active, enabled API key exists in the database. 

### Why
Currently, the endpoint lists every single model in the global catalog, regardless of whether a user has actually added credentials for that provider. This causes downstream clients to see models that the proxy router can never successfully route to. 

Filtering the list by connected providers aligns the API behavior with the existing dashboard logic (such as the budget bar).

### Changes
- Modified the SQLite prepared statement in `server/src/routes/proxy.ts` to include an `EXISTS` clause tracking active `api_keys` matching the model's platform/key configuration.