### PR TITLE
fix: rate ledger drift, token double-count, penalty decay, error

### DIFF
--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { initDb, getDb } from '../../db/index.js';
 import { encrypt } from '../../lib/crypto.js';
-import { routeRequest, setRoutingStrategy } from '../../services/router.js';
+import {
+  getAllPenalties,
+  recordRateLimitHit,
+  routeRequest,
+  setRoutingStrategy,
+} from '../../services/router.js';
 
 describe('Router', () => {
   beforeAll(() => {
@@ -21,6 +26,10 @@ describe('Router', () => {
     for (let i = 0; i < models.length; i++) {
       update.run(i + 1, models[i].id);
     }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should throw when no keys are configured', () => {
@@ -157,5 +166,20 @@ describe('Router', () => {
     expect(result.platform).toBe('groq');
     expect(result.apiKey).toBe('test-groq-key');
     expect(corruptKey.status).toBe('error');
+  });
+
+  it('applies elapsed decay before adding a new 429 penalty', () => {
+    vi.useFakeTimers();
+    const modelDbId = 987654321;
+
+    recordRateLimitHit(modelDbId);
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    recordRateLimitHit(modelDbId);
+
+    expect(getAllPenalties()).toContainEqual({
+      modelDbId,
+      count: 2,
+      penalty: 3,
+    });
   });
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -29,13 +29,14 @@ function isAutoModel(modelId: string | undefined): boolean {
 // length and per-character timing, which a network attacker could in principle
 // use to recover the key one byte at a time.
 export function timingSafeStringEqual(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  // Compare against a same-length buffer regardless of input length so the
-  // comparison itself runs in constant time; the explicit length check at the
-  // end is what actually decides equality when lengths differ.
-  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
-  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
+  // Use HMAC to produce fixed-length digests so timingSafeEqual always
+  // receives same-length buffers regardless of input length. This eliminates
+  // both the per-character timing leak and the length-branch timing leak that
+  // the Buffer.alloc-on-mismatch approach had.
+  const key = Buffer.alloc(32);
+  const a = crypto.createHmac('sha256', key).update(provided).digest();
+  const b = crypto.createHmac('sha256', key).update(expected).digest();
+  return crypto.timingSafeEqual(a, b);
 }
 
 // Extract the unified API key from an incoming request. Accepts both the
@@ -644,8 +645,6 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       return;
     }
 
-    recordRequest(route.platform, route.modelId, route.keyId);
-
     try {
       if (stream) {
         // — Stream turn-integrity (#231 audit) —
@@ -775,7 +774,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const probe = heldText.trimStart();
             if (startsWithDialectMarker(probe)) {
               mode = 'dialect';
-            } else if (!couldBecomeDialectMarker(probe) || heldText.length > 256) {
+            } else if (!couldBecomeDialectMarker(probe) || probe.length > 256) {
               mode = 'passthrough';
               flushHeaders();
               writeChunk(mkChunk({ content: heldText }, null));
@@ -828,7 +827,6 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           flushHeaders();
           if (heldText.length > 0) {
             writeChunk(mkChunk({ content: heldText }, null));
-            totalOutputTokens += Math.ceil(heldText.length / 4);
           }
           if (completedCalls.length > 0) {
             writeChunk(mkChunk({ tool_calls: completedCalls.map((c, i) => ({ index: i, ...c })) }, null));
@@ -845,6 +843,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.write('data: [DONE]\n\n');
           res.end();
 
+          recordRequest(route.platform, route.modelId, route.keyId);
           recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
           recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -912,6 +911,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         }
 
         const totalTokens = result.usage?.total_tokens ?? 0;
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, totalTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -24,6 +24,7 @@ import {
   setStickyModel,
   logRequest,
 } from './proxy.js';
+import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
 export const responsesRouter = Router();
 
@@ -359,7 +360,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
     } catch (err: any) {
       const status = lastError ? 429 : (err.status ?? 503);
       const message = lastError
-        ? `All models rate-limited. Last error: ${lastError.message}`
+        ? `All models rate-limited. Last error: ${sanitizeProviderErrorMessage(lastError.message)}`
         : err.message;
       const type = lastError ? 'rate_limit_error' : 'routing_error';
       if (streamStarted) {
@@ -370,8 +371,6 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       }
       return;
     }
-
-    recordRequest(route.platform, route.modelId, route.keyId);
 
     try {
       if (stream) {
@@ -586,6 +585,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         sse('response.completed', { response: finalResponse });
         res.end();
 
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -630,6 +630,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           continue;
         }
 
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, result.usage?.total_tokens ?? 0);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -647,7 +648,8 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       }
     } catch (err: any) {
       const latency = Date.now() - start;
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, err.message);
+      const safeError = sanitizeProviderErrorMessage(err.message);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
 
       // Mid-stream failures can't be retried (bytes already sent) — close cleanly.
       if (stream && streamStarted) {
@@ -669,7 +671,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         continue;
       }
 
-      res.status(502).json({ error: { message: `Provider error (${route.displayName}): ${err.message}`, type: 'provider_error' } });
+      res.status(502).json({ error: { message: `Provider error (${route.displayName}): ${safeError}`, type: 'provider_error' } });
       return;
     }
   }

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -79,6 +79,8 @@ export function recordRateLimitHit(modelDbId: number) {
   const existing = rateLimitPenalties.get(modelDbId);
   const now = Date.now();
   if (existing) {
+    const decaySteps = Math.floor((now - existing.lastHit) / DECAY_INTERVAL_MS);
+    existing.penalty = Math.max(0, existing.penalty - decaySteps * DECAY_AMOUNT);
     existing.count++;
     existing.lastHit = now;
     existing.penalty = Math.min(existing.penalty + PENALTY_PER_429, MAX_PENALTY);
@@ -102,25 +104,22 @@ export function recordSuccess(modelDbId: number) {
 
 /**
  * Get the current penalty for a model (with time-based decay).
+ * Pure read — does not mutate the entry; decay is applied lazily only when
+ * recording a new hit (recordRateLimitHit) so the clock isn't reset on every
+ * routing call.
  */
 function getPenalty(modelDbId: number): number {
   const entry = rateLimitPenalties.get(modelDbId);
   if (!entry) return 0;
 
-  // Apply time-based decay
-  const now = Date.now();
-  const elapsed = now - entry.lastHit;
+  const elapsed = Date.now() - entry.lastHit;
   const decaySteps = Math.floor(elapsed / DECAY_INTERVAL_MS);
-  if (decaySteps > 0) {
-    entry.penalty = Math.max(0, entry.penalty - (decaySteps * DECAY_AMOUNT));
-    entry.lastHit = now; // reset so we don't double-decay
-    if (entry.penalty === 0) {
-      rateLimitPenalties.delete(modelDbId);
-      return 0;
-    }
+  const decayed = Math.max(0, entry.penalty - decaySteps * DECAY_AMOUNT);
+  if (decayed === 0) {
+    rateLimitPenalties.delete(modelDbId);
+    return 0;
   }
-
-  return entry.penalty;
+  return decayed;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces several important improvements across the router service, proxy, and response handling logic. The main changes include a more secure implementation for timing-safe string comparison, more accurate and efficient rate limit penalty decay, improved error message sanitization, and adjustments to request logging to ensure accuracy in streaming scenarios.

**Security and correctness improvements:**

* Replaced the previous `timingSafeStringEqual` implementation with an HMAC-based approach to ensure constant-time comparison regardless of input length, eliminating potential timing attacks. (`server/src/routes/proxy.ts` [server/src/routes/proxy.tsL32-R39](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4L32-R39))

**Rate limit penalty management:**

* Updated the rate limit penalty logic to apply elapsed time decay only when a new rate limit hit is recorded, rather than on every read, preventing clock resets and ensuring penalties decay as intended. (`server/src/services/router.ts` [[1]](diffhunk://#diff-7419ca2927de0e8232257b149c27d80959f2eab78348bab7f6ed77462cd305b8R82-R83) [[2]](diffhunk://#diff-7419ca2927de0e8232257b149c27d80959f2eab78348bab7f6ed77462cd305b8R107-R122)
* Added a new test to verify that penalty decay is correctly applied before adding a new penalty. (`server/src/__tests__/services/router.test.ts` [server/src/__tests__/services/router.test.tsR170-R184](diffhunk://#diff-12da778e93707dcbb6aedeed5c57416ca903c9a968c3cb4f1886aea71cbf0deaR170-R184))

**Error handling and sanitization:**

* Introduced `sanitizeProviderErrorMessage` to redact sensitive provider error messages before they are sent in responses or logged, improving security and privacy. (`server/src/routes/responses.ts` [[1]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffR27) [[2]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffL362-R363) [[3]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffL650-R652) [[4]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffL672-R674)

**Request logging and accounting:**

* Moved `recordRequest` calls to occur only after a successful response or stream is completed, ensuring that only successful completions are logged, which prevents inaccurate request counts in the event of early failures. (`server/src/routes/proxy.ts` [[1]](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4L647-L648) [[2]](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4R846) [[3]](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4R914); `server/src/routes/responses.ts` [[4]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffL374-L375) [[5]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffR588) [[6]](diffhunk://#diff-c5a037b06d65f03161f1ffd8bfbbc51736188404ddd1451632e2ccbdad7f39ffR633)

**Miscellaneous fixes:**

* Fixed a bug where the length check for switching stream modes used the wrong variable, ensuring correct behavior for dialect marker detection. (`server/src/routes/proxy.ts` [server/src/routes/proxy.tsL778-R777](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4L778-R777))
* Removed redundant output token counting in a streaming response handler. (`server/src/routes/proxy.ts` [server/src/routes/proxy.tsL831](diffhunk://#diff-186b4b92d674424ecc3eeb86de71909229a663380d8d9092903e97e8a211d3e4L831))