### PR TITLE
feat(router): skip models whose tpm_limit can't fit the request

### DIFF
--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -445,6 +445,12 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     // gets the normal "all models exhausted" error rather than a wasted sweep.
     if (entry.context_window != null && estimatedTokens > entry.context_window) continue;
 
+    // Same guard for a model with a small per-minute token budget: a single
+    // request that alone exceeds tpm_limit can never fit one minute of quota and
+    // returns a guaranteed 413 (e.g. Groq gpt-oss-120b: 131k context but 8k TPM).
+    // estimatedTokens already includes reserved output, mirroring the check above.
+    if (entry.tpm_limit != null && estimatedTokens > entry.tpm_limit) continue;
+
     // Check if we have a provider for this platform
     const provider = getProvider(entry.platform as any);
     if (!provider) continue;


### PR DESCRIPTION
## Problem
The failover router already skips a model whose `context_window` can't hold the request (`router.ts`, the `estimatedTokens > entry.context_window` guard). But it doesn't apply the same logic to the **per-minute token budget**. A model with a large context but a small TPM is still selected for an oversized prompt and returns a guaranteed 413.

Observed in production (single proxy, 2026-06):
```
Groq API error 413: Request too large for model `openai/gpt-oss-120b` ... tokens per minute (TPM): Limit 8000, Requested 20449
```
Groq `gpt-oss-120b` has a 131k context but only an 8k TPM, so a 20k-token prompt clears the context guard and then 413s.

## Fix
One condition mirroring the existing context-window guard:
```ts
if (entry.tpm_limit != null && estimatedTokens > entry.tpm_limit) continue;
```
`tpm_limit` is already loaded onto the routable entry and typed `number | null`, and `estimatedTokens` already includes reserved output — so this is a fast-path skip identical in shape to the context check. A request that alone exceeds a model's per-minute token budget can never succeed within one window, so skipping turns the wasted attempt into a clean failover hop. Only enforced when `tpm_limit` is known; otherwise behaviour is unchanged.

## Notes
Minimal and behaviour-preserving when `tpm_limit` is null (the common case). A companion issue documents two related per-adapter 400s separately.
