### PR TITLE
docs: document missing env vars; fix dev-key and setup steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ ENCRYPTION_KEY=your-64-char-hex-key-here
 # Server port (default: 3001)
 PORT=3001
 
+# Network interface the server listens on. Default '::' (dual-stack IPv4+IPv6);
+# hosts with IPv6 disabled fall back to IPv4 automatically. Set 0.0.0.0 for
+# IPv4-only or 127.0.0.1 to restrict to localhost. (Different from HOST_BIND
+# below, which only affects Docker port publishing.)
+# HOST=::
+
 # Docker only: which host interface the container's port is published on.
 # Defaults to 127.0.0.1, so the dashboard/API is reachable only from the
 # machine running Docker. To open it to other devices on your LAN (e.g. a
@@ -15,6 +21,11 @@ PORT=3001
 # Max /v1 proxy requests per minute per client IP (default: 120). Set to 0
 # to disable proxy rate limiting.
 # PROXY_RATE_LIMIT_RPM=120
+
+# Per-provider daily request cap, named PROVIDER_DAILY_REQUEST_CAP_<PLATFORM>
+# (platform name upper-cased). Overrides the built-in default for that provider;
+# set to 0 to disable the cap. Example — cap OpenRouter at 50 requests/day:
+# PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50
 
 # Custom-provider URL policy. Cloud metadata and link-local addresses
 # (169.254.169.254, metadata.google.internal, fe80::/10, ...) are ALWAYS
@@ -56,3 +67,12 @@ REQUEST_ANALYTICS_MAX_ROWS=100000
 # Vite dev dashboard. Only set this if you serve the dashboard from a
 # different host than the API (e.g. http://my-server.local).
 # DASHBOARD_ORIGINS=http://my-server.local,http://192.168.1.50
+
+# --- Advanced / embedding ---------------------------------------------------
+# Path to a prebuilt client `dist` directory to serve. Defaults to the bundled
+# client build; set this only if you build the dashboard separately.
+# CLIENT_DIST=/path/to/client/dist
+
+# Explicit path to the .env file to load. Useful for embedders (e.g. the
+# desktop app, where the code runs from inside a bundle). Defaults to ./.env.
+# FREEAPI_ENV_PATH=/path/to/.env

--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ npm run dev
 git clone https://github.com/tashfeenahmed/freellmapi.git
 cd freellmapi
 npm install
-Copy-Item .env.example .env
 $ENCRYPTION_KEY = node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 "ENCRYPTION_KEY=$ENCRYPTION_KEY`nPORT=3001" | Out-File -Encoding utf8 .env
 npm run dev

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Your fresh install ships with the free catalog snapshot (82 models today) and ke
 git clone https://github.com/tashfeenahmed/freellmapi.git
 cd freellmapi
 npm install
-cp .env.example .env
 ENCRYPTION_KEY="$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')"
 printf "ENCRYPTION_KEY=%s\nPORT=3001\n" "$ENCRYPTION_KEY" > .env
 npm run dev
@@ -203,8 +202,8 @@ npm run dev
 ```
 
 `ENCRYPTION_KEY` is required for startup. The server only falls back to a
-database-stored development key when `DEV_MODE=true` and `NODE_ENV` is not
-`production`; do not use that fallback with real provider keys.
+database-stored development key when `NODE_ENV` is not `production`; do not use
+that fallback with real provider keys.
 
 Request analytics are retained for 90 days or 100000 request rows by default,
 whichever limit prunes first. Set `REQUEST_ANALYTICS_RETENTION_DAYS=0` or


### PR DESCRIPTION
## What
- **`.env.example`**: document four environment variables that the server reads but were undocumented — `HOST` (listen interface), `CLIENT_DIST` (serve a prebuilt UI), `FREEAPI_ENV_PATH` (embedder `.env` path), and `PROVIDER_DAILY_REQUEST_CAP_<PLATFORM>` (per-provider daily cap).
- **README**: the dev-key fallback is gated on `NODE_ENV !== 'production'` only (`crypto.ts` `isDevFallbackAllowed`), not `DEV_MODE` — corrected the sentence. Also dropped the redundant `cp .env.example .env` that the following `printf … > .env` immediately overwrites.

Docs only — no code changes.
