### PR TITLE
Batch: avoidable-error fixes (403 failover, NIM/DeepSeek 400s, TPM, ledger, Retry-After, /v1/models)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,11 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/Naster17"><img src="https://images.weserv.nl/?url=github.com/Naster17.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Naster17" /></a>
 <a href="https://github.com/StealthTensor"><img src="https://images.weserv.nl/?url=github.com/StealthTensor.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@StealthTensor" /></a>
 <a href="https://github.com/EmranAhmed"><img src="https://images.weserv.nl/?url=github.com/EmranAhmed.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@EmranAhmed" /></a>
+<a href="https://github.com/itsfuad"><img src="https://images.weserv.nl/?url=github.com/itsfuad.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@itsfuad" /></a>
+<a href="https://github.com/RobinHoodO"><img src="https://images.weserv.nl/?url=github.com/RobinHoodO.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@RobinHoodO" /></a>
+<a href="https://github.com/hmm183"><img src="https://images.weserv.nl/?url=github.com/hmm183.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@hmm183" /></a>
+<a href="https://github.com/duemilionidieuro-bot"><img src="https://images.weserv.nl/?url=github.com/duemilionidieuro-bot.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@duemilionidieuro-bot" /></a>
+<a href="https://github.com/hjhhoni"><img src="https://images.weserv.nl/?url=github.com/hjhhoni.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@hjhhoni" /></a>
 
 ## Terms of Service review
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -18,12 +18,15 @@ export const UNAUTHORIZED_EVENT = 'freellmapi:unauthorized';
 export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const token = getToken();
   const res = await fetch(`${BASE}${path}`, {
+    // `...options` first so an explicit method/body/signal applies, but headers
+    // are merged last — otherwise an options.headers would clobber the
+    // Content-Type and Authorization we set here.
+    ...options,
     headers: {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...options?.headers,
     },
-    ...options,
   });
   if (res.status === 401) {
     // Session missing/expired — drop the token and let the AuthGate re-render.
@@ -34,7 +37,21 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
     const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
     throw new Error(body.error?.message ?? `HTTP ${res.status}`);
   }
-  return res.json();
+  // A 200 whose body isn't JSON means this request never reached the API — the
+  // usual cause is a reverse proxy (or static host) serving the dashboard's
+  // index.html for /api/* instead of forwarding it to the backend. Without this
+  // guard the raw res.json() throws an opaque "Unexpected token '<'", which on
+  // the setup/login form surfaces as "sign up page cannot work". Say what's
+  // actually wrong. (#257)
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(
+      `Expected JSON from ${path} but got a non-JSON response. The API isn't reachable at this origin — ` +
+      `make sure the backend is running and that /api is forwarded to it, not served as the dashboard's static files.`,
+    );
+  }
 }
 
 export async function logout(): Promise<void> {

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -92,6 +92,45 @@ describe('OpenAICompatProvider', () => {
     expect(capturedBody.parallel_tool_calls).toBe(true);
   });
 
+  describe('forceSingleToolCall (NVIDIA NIM single-tool-call 400 — issue #255)', () => {
+    const nim = () => new OpenAICompatProvider({
+      platform: 'nvidia',
+      name: 'NVIDIA NIM',
+      baseUrl: 'https://integrate.api.nvidia.com/v1',
+      forceSingleToolCall: true,
+    });
+    const okResponse = {
+      ok: true,
+      json: () => Promise.resolve({
+        id: 'x', object: 'chat.completion', created: 1, model: 'm',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+    } as any;
+    const tools = [{ type: 'function' as const, function: { name: 'f', description: 'd', parameters: { type: 'object', properties: {} } } }];
+
+    it('pins parallel_tool_calls to false when tools are present, even if the caller asked for true', async () => {
+      let body: any = null;
+      vi.spyOn(global, 'fetch').mockImplementation(async (_u, init) => { body = JSON.parse((init as any).body); return okResponse; });
+      await nim().chatCompletion('k', [{ role: 'user', content: 'hi' }], 'm', { tools, parallel_tool_calls: true });
+      expect(body.parallel_tool_calls).toBe(false);
+    });
+
+    it('leaves parallel_tool_calls untouched when there are no tools', async () => {
+      let body: any = null;
+      vi.spyOn(global, 'fetch').mockImplementation(async (_u, init) => { body = JSON.parse((init as any).body); return okResponse; });
+      await nim().chatCompletion('k', [{ role: 'user', content: 'hi' }], 'm', {});
+      expect(body.parallel_tool_calls).toBeUndefined();
+    });
+
+    it('does not affect providers without the flag (parallel_tool_calls passes through)', async () => {
+      let body: any = null;
+      vi.spyOn(global, 'fetch').mockImplementation(async (_u, init) => { body = JSON.parse((init as any).body); return okResponse; });
+      await provider.chatCompletion('k', [{ role: 'user', content: 'hi' }], 'm', { tools, parallel_tool_calls: true });
+      expect(body.parallel_tool_calls).toBe(true);
+    });
+  });
+
   it('should throw on error response', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: false,

--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { isRetryableError, isPaymentRequiredError, isModelNotFoundError } from '../../routes/proxy.js';
+import { isRetryableError, isPaymentRequiredError, isModelNotFoundError, isModelAccessForbiddenError } from '../../routes/proxy.js';
+
+describe('isModelAccessForbiddenError (403 model-not-on-tier, drives whole-model skip — issue #256)', () => {
+  it('flags a 403 reaching the proxy by message or attached status', () => {
+    // GitHub Models / Cloudflare 403 a model the key's free tier can't reach.
+    expect(isModelAccessForbiddenError(new Error('GitHub Models API error 403: Model not available on your plan'))).toBe(true);
+    expect(isModelAccessForbiddenError(new Error('Cloudflare API error 403: this model requires a subscription'))).toBe(true);
+    expect(isModelAccessForbiddenError(new Error('Forbidden'))).toBe(true);
+    // #261 attaches the upstream status to the thrown error; honor it even if
+    // the message phrasing omits the code.
+    expect(isModelAccessForbiddenError(Object.assign(new Error('access denied'), { status: 403 }))).toBe(true);
+  });
+
+  it('does not flag rate limits, 404s, or payment errors', () => {
+    expect(isModelAccessForbiddenError(new Error('429 Too Many Requests'))).toBe(false);
+    expect(isModelAccessForbiddenError(new Error('OpenRouter API error 404: Provider returned error'))).toBe(false);
+    expect(isModelAccessForbiddenError(new Error('HuggingFace Router API error 402: Payment required'))).toBe(false);
+  });
+});
 
 describe('isModelNotFoundError (drives whole-model skip within a request)', () => {
   it('flags 404 / not-found / no-endpoints phrasings', () => {
@@ -67,6 +85,22 @@ describe('isRetryableError', () => {
     });
   });
 
+  describe('403 model not on this key\'s tier fails over instead of 502 (issue #256)', () => {
+    it('treats a 403 from GitHub Models / Cloudflare as retryable', () => {
+      expect(isRetryableError(new Error('GitHub Models API error 403: Model not available on your plan'))).toBe(true);
+      expect(isRetryableError(new Error('Cloudflare API error 403: this model requires a subscription'))).toBe(true);
+    });
+
+    it('treats a bare "Forbidden" / attached 403 status as retryable', () => {
+      expect(isRetryableError(new Error('Forbidden'))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error('access denied'), { status: 403 }))).toBe(true);
+    });
+
+    it('still treats a bare 400 validation error as non-retryable', () => {
+      expect(isRetryableError(new Error('400 Bad Request'))).toBe(false);
+    });
+  });
+
   describe('402 Payment Required out-of-credits fails over (graceful degradation)', () => {
     it('treats a HuggingFace Router 402 as retryable (same model lives on other providers)', () => {
       expect(isRetryableError(new Error('HuggingFace Router API error 402: Payment required'))).toBe(true);
@@ -100,11 +134,14 @@ describe('isRetryableError', () => {
       expect(isRetryableError(new Error('ECONNREFUSED'))).toBe(true);
     });
 
-    it('4xx auth/validation errors are NOT retryable', () => {
+    it('401 / bare-400 auth & validation errors are NOT retryable', () => {
       expect(isRetryableError(new Error('401 Unauthorized'))).toBe(false);
-      expect(isRetryableError(new Error('403 Forbidden'))).toBe(false);
       expect(isRetryableError(new Error('400 Bad Request'))).toBe(false);
       expect(isRetryableError(new Error('Invalid API key'))).toBe(false);
+      // 403 is deliberately NOT here anymore: a request-time 403 on a key that
+      // passed validateKey is a model-not-on-tier gate, so it fails over to the
+      // next model rather than 502-ing the request (issue #256). The 403 cases
+      // are covered in the dedicated describe block above.
     });
   });
 });

--- a/server/src/__tests__/routes/proxy-tools.test.ts
+++ b/server/src/__tests__/routes/proxy-tools.test.ts
@@ -181,4 +181,43 @@ describe('Proxy tool-calling support', () => {
     expect(providerBody.messages[2].tool_call_id).toBe('call_weather_1');
     expect(body.choices[0].message.content).toContain('30C');
   });
+
+  it('round-trips assistant reasoning_content on follow-up turns (DeepSeek thinking — #255)', async () => {
+    const origFetch = global.fetch;
+    let providerBody: any = null;
+
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+        providerBody = JSON.parse((init as any).body);
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'chatcmpl-r', object: 'chat.completion', created: 1, model: 'm',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+          }),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status } = await request(app, 'POST', '/v1/chat/completions', {
+      messages: [
+        { role: 'user', content: 'think then answer' },
+        {
+          role: 'assistant',
+          content: 'partial',
+          // What a DeepSeek thinking model returned last turn and the client
+          // replayed. Stripping it makes OpenCode Zen 400 on this request.
+          reasoning_content: 'Let me reason about this step by step...',
+        },
+        { role: 'user', content: 'continue' },
+      ],
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(providerBody.messages[1].role).toBe('assistant');
+    expect(providerBody.messages[1].reasoning_content).toBe('Let me reason about this step by step...');
+  });
 });

--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -12,6 +12,7 @@ import {
   providerDailyRequestCount,
   getProviderDailyRequestCap,
 } from '../../services/ratelimit.js';
+import { parseRetryAfterMs } from '../../providers/base.js';
 
 function removeDbFile(dbPath: string) {
   for (const suffix of ['', '-shm', '-wal']) {
@@ -227,5 +228,46 @@ describe('Rate Limiter', () => {
       recordRequest('openrouter', 'model-c', testId);
       expect(canUseProvider('openrouter', testId)).toBe(false); // 3 >= 3
     });
+  });
+});
+
+describe('Cooldown duration with upstream Retry-After', () => {
+  const noLimits = { rpd: null, tpd: null };
+  let testId: number;
+  beforeEach(() => { testId = Math.floor(Math.random() * 1_000_000); });
+
+  it('uses the transient cooldown when no Retry-After is given', () => {
+    expect(getCooldownDurationForLimit('groq', 'm', testId, noLimits)).toBe(90_000);
+  });
+
+  it('never benches shorter than the heuristic (ignores a shorter Retry-After)', () => {
+    expect(getCooldownDurationForLimit('groq', 'm', testId, noLimits, 30_000)).toBe(90_000);
+  });
+
+  it('honors a Retry-After longer than the heuristic', () => {
+    expect(getCooldownDurationForLimit('groq', 'm', testId, noLimits, 300_000)).toBe(300_000);
+  });
+
+  it('caps an absurd Retry-After at a day', () => {
+    expect(getCooldownDurationForLimit('groq', 'm', testId, noLimits, 5 * 86_400_000)).toBe(86_400_000);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds', () => {
+    expect(parseRetryAfterMs('120')).toBe(120_000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('parses an HTTP-date into a positive future delay', () => {
+    const ms = parseRetryAfterMs(new Date(Date.now() + 60_000).toUTCString());
+    expect(ms).toBeGreaterThan(50_000);
+    expect(ms).toBeLessThanOrEqual(60_000);
+  });
+
+  it('returns undefined for absent or unparseable values', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs('')).toBeUndefined();
+    expect(parseRetryAfterMs('soon')).toBeUndefined();
   });
 });

--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
 import { initDb, getDb } from '../../db/index.js';
 import { encrypt } from '../../lib/crypto.js';
-import { routeRequest, setRoutingStrategy } from '../../services/router.js';
+import {
+  getAllPenalties,
+  recordRateLimitHit,
+  routeRequest,
+  setRoutingStrategy,
+} from '../../services/router.js';
 
 describe('Router', () => {
   beforeAll(() => {
@@ -21,6 +26,10 @@ describe('Router', () => {
     for (let i = 0; i < models.length; i++) {
       update.run(i + 1, models[i].id);
     }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should throw when no keys are configured', () => {
@@ -157,5 +166,20 @@ describe('Router', () => {
     expect(result.platform).toBe('groq');
     expect(result.apiKey).toBe('test-groq-key');
     expect(corruptKey.status).toBe('error');
+  });
+
+  it('applies elapsed decay before adding a new 429 penalty', () => {
+    vi.useFakeTimers();
+    const modelDbId = 987654321;
+
+    recordRateLimitHit(modelDbId);
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    recordRateLimitHit(modelDbId);
+
+    expect(getAllPenalties()).toContainEqual({
+      modelDbId,
+      count: 2,
+      penalty: 3,
+    });
   });
 });

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -7,6 +7,36 @@ import type {
   Platform,
 } from '@freellmapi/shared/types.js';
 
+/** A provider HTTP error carrying the upstream status and, when the response
+ *  included a Retry-After header, the parsed delay so the router can bench the
+ *  key for at least that long. */
+export interface ProviderHttpError extends Error {
+  status?: number;
+  retryAfterMs?: number;
+}
+
+/** Parse an HTTP `Retry-After` header (delta-seconds or an HTTP-date) into a
+ *  millisecond delay. Returns undefined when absent or unparseable. */
+export function parseRetryAfterMs(value: string | null | undefined): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
+  const when = Date.parse(trimmed);
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now());
+  return undefined;
+}
+
+/** Build an error for a non-OK upstream response, capturing the status and any
+ *  Retry-After hint. Used by every provider adapter so the proxy can honor a
+ *  provider's explicit back-off when it sets the cooldown. */
+export function providerHttpError(res: Response, message: string): ProviderHttpError {
+  const err = new Error(message) as ProviderHttpError;
+  err.status = res.status;
+  const retryAfterMs = parseRetryAfterMs(res.headers?.get('retry-after'));
+  if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+  return err;
+}
+
 export interface CompletionOptions {
   model?: string;
   temperature?: number;

--- a/server/src/providers/cloudflare.ts
+++ b/server/src/providers/cloudflare.ts
@@ -3,7 +3,7 @@ import type {
   ChatCompletionResponse,
   ChatCompletionChunk,
 } from '@freellmapi/shared/types.js';
-import { BaseProvider, type CompletionOptions } from './base.js';
+import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
 import { contentToString } from '../lib/content.js';
 
 /**
@@ -58,7 +58,7 @@ export class CloudflareProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Cloudflare API error ${res.status}: ${(err as any).error?.message ?? (err as any).errors?.[0]?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Cloudflare API error ${res.status}: ${(err as any).error?.message ?? (err as any).errors?.[0]?.message ?? res.statusText}`);
     }
 
     const data = await res.json() as ChatCompletionResponse;
@@ -96,7 +96,7 @@ export class CloudflareProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Cloudflare API error ${res.status}: ${(err as any).error?.message ?? (err as any).errors?.[0]?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Cloudflare API error ${res.status}: ${(err as any).error?.message ?? (err as any).errors?.[0]?.message ?? res.statusText}`);
     }
 
     yield* this.readSseStream(res);

--- a/server/src/providers/cohere.ts
+++ b/server/src/providers/cohere.ts
@@ -3,7 +3,7 @@ import type {
   ChatCompletionResponse,
   ChatCompletionChunk,
 } from '@freellmapi/shared/types.js';
-import { BaseProvider, type CompletionOptions } from './base.js';
+import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
 import { flattenMessageContent } from '../lib/content.js';
 
 const API_BASE = 'https://api.cohere.ai/compatibility/v1';
@@ -39,7 +39,7 @@ export class CohereProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Cohere API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Cohere API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     const data = await res.json() as ChatCompletionResponse;
@@ -75,7 +75,7 @@ export class CohereProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Cohere API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Cohere API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     yield* this.readSseStream(res);

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -7,7 +7,7 @@ import type {
   ChatToolDefinition,
   TokenUsage,
 } from '@freellmapi/shared/types.js';
-import { BaseProvider, type CompletionOptions } from './base.js';
+import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
 import { contentToString } from '../lib/content.js';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
@@ -350,7 +350,7 @@ export class GoogleProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Google API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Google API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     const data = await res.json() as GeminiResponse;
@@ -413,7 +413,7 @@ export class GoogleProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`Google API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `Google API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     const reader = res.body?.getReader();

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -33,11 +33,14 @@ register(new OpenAICompatProvider({
 // credit (expires in 3 months); once it lapses, every chat call 402s
 // "payment method required" with no recurring no-card path back.
 
-// NVIDIA NIM - OpenAI-compatible
+// NVIDIA NIM - OpenAI-compatible. Several NIM models reject parallel tool calls
+// ("This model only supports single tool-calls at once!"), so pin
+// parallel_tool_calls to false when tools are present. See issue #255.
 register(new OpenAICompatProvider({
   platform: 'nvidia',
   name: 'NVIDIA NIM',
   baseUrl: 'https://integrate.api.nvidia.com/v1',
+  forceSingleToolCall: true,
 }));
 
 // Mistral - OpenAI-compatible

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -4,7 +4,7 @@ import type {
   ChatCompletionChunk,
   Platform,
 } from '@freellmapi/shared/types.js';
-import { BaseProvider, type CompletionOptions } from './base.js';
+import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
 
 /**
  * Generic provider for platforms that use an OpenAI-compatible API.
@@ -74,7 +74,7 @@ export class OpenAICompatProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     let data: ChatCompletionResponse;
@@ -123,7 +123,7 @@ export class OpenAICompatProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(`${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
     yield* this.readSseStream(res);

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -20,6 +20,10 @@ export class OpenAICompatProvider extends BaseProvider {
   /** Per-provider HTTP timeout override. Cloud APIs finish in ~15s; locally-hosted
    * inference (llama.cpp / vLLM on CPU) can take 30-120s for long prompts. Default 15000. */
   private readonly timeoutMs: number;
+  /** NVIDIA NIM models reject any request that permits parallel tool calls with
+   * `400 This model only supports single tool-calls at once!`. When set, pin
+   * parallel_tool_calls to false whenever tools are in play. See issue #255. */
+  private readonly forceSingleToolCall: boolean;
 
   constructor(opts: {
     platform: Platform;
@@ -29,6 +33,7 @@ export class OpenAICompatProvider extends BaseProvider {
     validateUrl?: string;
     timeoutMs?: number;
     keyless?: boolean;
+    forceSingleToolCall?: boolean;
   }) {
     super();
     this.platform = opts.platform;
@@ -38,6 +43,16 @@ export class OpenAICompatProvider extends BaseProvider {
     this.validateUrl = opts.validateUrl;
     this.timeoutMs = opts.timeoutMs ?? 15000;
     this.keyless = opts.keyless ?? false;
+    this.forceSingleToolCall = opts.forceSingleToolCall ?? false;
+  }
+
+  /** Resolve the parallel_tool_calls flag to send upstream. For providers that
+   * only accept single tool calls (NVIDIA NIM), force `false` whenever tools are
+   * present so the model never tries to emit two at once and 400s; otherwise pass
+   * the caller's value through unchanged. See issue #255. */
+  private resolveParallelToolCalls(options?: CompletionOptions): boolean | undefined {
+    if (this.forceSingleToolCall && options?.tools && options.tools.length > 0) return false;
+    return options?.parallel_tool_calls;
   }
 
   /** Keyless providers (Kilo's anonymous free tier) must send NO Authorization
@@ -68,7 +83,7 @@ export class OpenAICompatProvider extends BaseProvider {
         top_p: options?.top_p,
         tools: options?.tools,
         tool_choice: options?.tool_choice,
-        parallel_tool_calls: options?.parallel_tool_calls,
+        parallel_tool_calls: this.resolveParallelToolCalls(options),
       }),
     }, options?.timeoutMs ?? this.timeoutMs);
 
@@ -116,7 +131,7 @@ export class OpenAICompatProvider extends BaseProvider {
         top_p: options?.top_p,
         tools: options?.tools,
         tool_choice: options?.tool_choice,
-        parallel_tool_calls: options?.parallel_tool_calls,
+        parallel_tool_calls: this.resolveParallelToolCalls(options),
         stream: true,
       }),
     }, this.timeoutMs);

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -973,7 +973,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             : getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, {
                 rpd: route.rpdLimit,
                 tpd: route.tpdLimit,
-              }),
+              }, err.retryAfterMs),
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -238,6 +238,11 @@ const assistantMessageSchema = z.object({
   // no-tool assistant turns — aionrs (AionUI's engine) writes it into every
   // session-resumed assistant echo. Treated as absent. (#200)
   tool_calls: z.array(toolCallSchema).nullable().optional(),
+  // Thinking trace echoed back by a client. DeepSeek thinking models on
+  // OpenCode Zen 400 ("reasoning_content in thinking mode must be passed back")
+  // unless the prior turn's reasoning_content is replayed, so keep it through
+  // validation instead of stripping it. See issue #255.
+  reasoning_content: z.string().nullable().optional(),
 });
 
 // Tool results may arrive with null/missing content (a tool that returned
@@ -507,6 +512,13 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         role: 'assistant',
         content: assistantContent,
         ...(m.name ? { name: m.name } : {}),
+        // Replay the thinking trace verbatim. DeepSeek thinking models on
+        // OpenCode Zen reject a follow-up turn that drops it; other providers
+        // ignore the unknown field. Same round-trip rationale as
+        // thought_signature below. (#255)
+        ...(typeof m.reasoning_content === 'string' && m.reasoning_content.length > 0
+          ? { reasoning_content: m.reasoning_content }
+          : {}),
         // hasToolCalls (not a bare truthiness check) so null AND empty-array
         // tool_calls are dropped rather than forwarded — strict upstreams
         // reject both shapes. (#200)

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -114,7 +114,8 @@ export function setStickyModel(messages: ChatMessage[], modelDbId: number, sessi
   }
 }
 
-// OpenAI-compatible /models endpoint (used by Hermes for metadata)
+// OpenAI-compatible /models endpoint (used by Hermes for metadata) 
+// shows API models which is linked by the user
 proxyRouter.get('/models', (req: Request, res: Response) => {
   const token = extractApiToken(req);
   const unifiedKey = getUnifiedApiKey();
@@ -132,8 +133,14 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
                PARTITION BY model_id
                ORDER BY intelligence_rank ASC, id ASC
              ) AS rn
-      FROM models
-      WHERE enabled = 1
+      FROM models m
+      WHERE m.enabled = 1
+        AND EXISTS (
+          SELECT 1 FROM api_keys k
+          WHERE k.platform = m.platform
+            AND k.enabled = 1
+            AND (m.key_id IS NULL OR k.id = m.key_id)
+        )
     )
     WHERE rn = 1
     ORDER BY intelligence_rank ASC, id ASC
@@ -161,6 +168,7 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
     ],
   });
 });
+
 
 const MAX_RETRIES = 20;
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -29,13 +29,14 @@ function isAutoModel(modelId: string | undefined): boolean {
 // length and per-character timing, which a network attacker could in principle
 // use to recover the key one byte at a time.
 export function timingSafeStringEqual(provided: string, expected: string): boolean {
-  const a = Buffer.from(provided);
-  const b = Buffer.from(expected);
-  // Compare against a same-length buffer regardless of input length so the
-  // comparison itself runs in constant time; the explicit length check at the
-  // end is what actually decides equality when lengths differ.
-  const compareA = a.length === b.length ? a : Buffer.alloc(b.length);
-  return crypto.timingSafeEqual(compareA, b) && a.length === b.length;
+  // Use HMAC to produce fixed-length digests so timingSafeEqual always
+  // receives same-length buffers regardless of input length. This eliminates
+  // both the per-character timing leak and the length-branch timing leak that
+  // the Buffer.alloc-on-mismatch approach had.
+  const key = Buffer.alloc(32);
+  const a = crypto.createHmac('sha256', key).update(provided).digest();
+  const b = crypto.createHmac('sha256', key).update(expected).digest();
+  return crypto.timingSafeEqual(a, b);
 }
 
 // Extract the unified API key from an incoming request. Accepts both the
@@ -652,8 +653,6 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       return;
     }
 
-    recordRequest(route.platform, route.modelId, route.keyId);
-
     try {
       if (stream) {
         // — Stream turn-integrity (#231 audit) —
@@ -783,7 +782,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const probe = heldText.trimStart();
             if (startsWithDialectMarker(probe)) {
               mode = 'dialect';
-            } else if (!couldBecomeDialectMarker(probe) || heldText.length > 256) {
+            } else if (!couldBecomeDialectMarker(probe) || probe.length > 256) {
               mode = 'passthrough';
               flushHeaders();
               writeChunk(mkChunk({ content: heldText }, null));
@@ -836,7 +835,6 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           flushHeaders();
           if (heldText.length > 0) {
             writeChunk(mkChunk({ content: heldText }, null));
-            totalOutputTokens += Math.ceil(heldText.length / 4);
           }
           if (completedCalls.length > 0) {
             writeChunk(mkChunk({ tool_calls: completedCalls.map((c, i) => ({ index: i, ...c })) }, null));
@@ -853,6 +851,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.write('data: [DONE]\n\n');
           res.end();
 
+          recordRequest(route.platform, route.modelId, route.keyId);
           recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
           recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -920,6 +919,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         }
 
         const totalTokens = result.usage?.total_tokens ?? 0;
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, totalTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -4,7 +4,7 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import type { ChatMessage, ModelListRow } from '@freellmapi/shared/types.js';
 import { routeRequest, recordRateLimitHit, recordSuccess, hasEnabledVisionModel, hasEnabledToolsModel, type RouteResult } from '../services/router.js';
-import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS } from '../services/ratelimit.js';
+import { recordRequest, recordTokens, setCooldown, getCooldownDurationForLimit, PAYMENT_REQUIRED_COOLDOWN_MS, MODEL_FORBIDDEN_COOLDOWN_MS } from '../services/ratelimit.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
 import { runEmbeddings, EmbeddingsError } from '../services/embeddings.js';
 import { getDb, getUnifiedApiKey } from '../db/index.js';
@@ -322,6 +322,13 @@ export function isRetryableError(err: any): boolean {
     // for a model that's been pulled). Rotate to the next model in the chain —
     // setCooldown + the health checker will avoid this model on subsequent requests.
     || msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
+    // 403: the key is valid (it passed validateKey, and the health checker
+    // disables truly-forbidden keys) but this specific model is off-limits to
+    // the key's tier — e.g. gpt-4o on GitHub Models' free tier, subscription-only
+    // models on Cloudflare. Another model in the chain is reachable, so fail over
+    // instead of 502-ing the whole request. Paired with isModelAccessForbiddenError
+    // to rule the model out for this request and a day-long bench. See issue #256.
+    || isModelAccessForbiddenError(err)
     // 400: one provider may reject parameters another accepts (e.g. max_tokens
     // limits, unsupported params). The matching pattern is "api error 400"
     // which comes from the OpenAI-compat provider's error formatting, not
@@ -361,6 +368,18 @@ export function isPaymentRequiredError(err: any): boolean {
 export function isModelNotFoundError(err: any): boolean {
   const msg = (err.message ?? '').toLowerCase();
   return msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found');
+}
+
+// A 403 Forbidden returned for a specific model behind an otherwise-valid key.
+// Drives the same whole-model skip as a 404: every key on this platform's tier
+// would be forbidden the same model, so rule it out for the rest of the request
+// rather than trying it again with a sibling key. Distinct from a dead key —
+// validateKey returns false on 401/403, so the health checker disables genuinely
+// forbidden keys; a 403 reaching here is model-not-on-this-tier. See issue #256.
+export function isModelAccessForbiddenError(err: any): boolean {
+  if (err?.status === 403) return true;
+  const msg = (err?.message ?? '').toLowerCase();
+  return msg.includes('403') || msg.includes('forbidden');
 }
 
 // Pull the incremental text out of a streaming chunk for token counting.
@@ -959,7 +978,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         // out for the rest of this request — its other keys would 404 the same
         // way. The per-key cooldown below still applies, so cross-request
         // behavior (#66/#76) is unchanged. (PR #111, credits @barbotkonv.)
-        if (isModelNotFoundError(err)) skipModels.add(route.modelDbId);
+        // 404 (removed upstream) and 403 (model off-limits to this key's tier)
+        // both rule the model out: a sibling key on the same platform would
+        // fail it identically, so skip it for the rest of this request.
+        if (isModelNotFoundError(err) || isModelAccessForbiddenError(err)) skipModels.add(route.modelDbId);
 
         // Put this model+key on cooldown and try the next one
         const skipId = `${route.platform}:${route.modelId}:${route.keyId}`;
@@ -970,6 +992,11 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           route.keyId,
           isPaymentRequiredError(err)
             ? PAYMENT_REQUIRED_COOLDOWN_MS
+            // A 403 won't clear on the next window (it's a tier/subscription gate,
+            // not a transient limit), so bench this model+key for a day like a 402
+            // instead of re-trying it every request. See issue #256.
+            : isModelAccessForbiddenError(err)
+            ? MODEL_FORBIDDEN_COOLDOWN_MS
             : getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, {
                 rpd: route.rpdLimit,
                 tpd: route.tpdLimit,

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -24,6 +24,7 @@ import {
   setStickyModel,
   logRequest,
 } from './proxy.js';
+import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
 export const responsesRouter = Router();
 
@@ -359,7 +360,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
     } catch (err: any) {
       const status = lastError ? 429 : (err.status ?? 503);
       const message = lastError
-        ? `All models rate-limited. Last error: ${lastError.message}`
+        ? `All models rate-limited. Last error: ${sanitizeProviderErrorMessage(lastError.message)}`
         : err.message;
       const type = lastError ? 'rate_limit_error' : 'routing_error';
       if (streamStarted) {
@@ -370,8 +371,6 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       }
       return;
     }
-
-    recordRequest(route.platform, route.modelId, route.keyId);
 
     try {
       if (stream) {
@@ -586,6 +585,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         sse('response.completed', { response: finalResponse });
         res.end();
 
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -630,6 +630,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           continue;
         }
 
+        recordRequest(route.platform, route.modelId, route.keyId);
         recordTokens(route.platform, route.modelId, route.keyId, result.usage?.total_tokens ?? 0);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
@@ -647,7 +648,8 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       }
     } catch (err: any) {
       const latency = Date.now() - start;
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, err.message);
+      const safeError = sanitizeProviderErrorMessage(err.message);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
 
       // Mid-stream failures can't be retried (bytes already sent) — close cleanly.
       if (stream && streamStarted) {
@@ -669,7 +671,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         continue;
       }
 
-      res.status(502).json({ error: { message: `Provider error (${route.displayName}): ${err.message}`, type: 'provider_error' } });
+      res.status(502).json({ error: { message: `Provider error (${route.displayName}): ${safeError}`, type: 'provider_error' } });
       return;
     }
   }

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -326,16 +326,21 @@ export function getCooldownDurationForLimit(
   modelId: string,
   keyId: number,
   limits: { rpd: number | null; tpd: number | null },
+  retryAfterMs?: number | null,
 ): number {
   const now = Date.now();
   const rpdExhausted =
     limits.rpd !== null && requestCount(platform, modelId, keyId, DAY, now) >= limits.rpd;
   const tpdExhausted =
     limits.tpd !== null && tokenCount(platform, modelId, keyId, DAY, now) >= limits.tpd;
-  if (rpdExhausted || tpdExhausted) {
-    return getNextCooldownDuration(platform, modelId, keyId);
-  }
-  return TRANSIENT_COOLDOWN_MS;
+  const base = (rpdExhausted || tpdExhausted)
+    ? getNextCooldownDuration(platform, modelId, keyId)
+    : TRANSIENT_COOLDOWN_MS;
+  // Honor an upstream Retry-After as a floor: never bench shorter than our own
+  // heuristic, but extend (capped at a day) when the provider explicitly asks
+  // to wait longer than we otherwise would.
+  if (retryAfterMs != null && retryAfterMs > base) return Math.min(retryAfterMs, DAY);
+  return base;
 }
 
 function persistedCooldownExpiry(

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -308,6 +308,14 @@ const TRANSIENT_COOLDOWN_MS = 90 * 1000;
 // on the next 402 after expiry if still unpaid; a restart re-benches on first hit.
 export const PAYMENT_REQUIRED_COOLDOWN_MS = DAY;
 
+// Long cooldown for a 403 Forbidden on a key that already passed validateKey
+// (so it is not a dead key — the health checker disables those). A request-time
+// 403 means this key's tier can't reach this specific model (e.g. gpt-4o on
+// GitHub Models' free tier, subscription-only models on Cloudflare). That won't
+// change within a minute window, so bench this model+key for a full day and let
+// the router fail over to a model the key can actually serve. See issue #256.
+export const MODEL_FORBIDDEN_COOLDOWN_MS = DAY;
+
 // Decide how long to bench a model+key after an upstream 429. Escalate to the
 // long quarantine (getNextCooldownDuration, up to 24h) ONLY when the model is
 // genuinely at its DAILY limit (RPD or TPD) — that won't recover until the

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -445,6 +445,12 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     // gets the normal "all models exhausted" error rather than a wasted sweep.
     if (entry.context_window != null && estimatedTokens > entry.context_window) continue;
 
+    // Same guard for a model with a small per-minute token budget: a single
+    // request that alone exceeds tpm_limit can never fit one minute of quota and
+    // returns a guaranteed 413 (e.g. Groq gpt-oss-120b: 131k context but 8k TPM).
+    // estimatedTokens already includes reserved output, mirroring the check above.
+    if (entry.tpm_limit != null && estimatedTokens > entry.tpm_limit) continue;
+
     // Check if we have a provider for this platform
     const provider = getProvider(entry.platform as any);
     if (!provider) continue;

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -79,6 +79,8 @@ export function recordRateLimitHit(modelDbId: number) {
   const existing = rateLimitPenalties.get(modelDbId);
   const now = Date.now();
   if (existing) {
+    const decaySteps = Math.floor((now - existing.lastHit) / DECAY_INTERVAL_MS);
+    existing.penalty = Math.max(0, existing.penalty - decaySteps * DECAY_AMOUNT);
     existing.count++;
     existing.lastHit = now;
     existing.penalty = Math.min(existing.penalty + PENALTY_PER_429, MAX_PENALTY);
@@ -102,25 +104,22 @@ export function recordSuccess(modelDbId: number) {
 
 /**
  * Get the current penalty for a model (with time-based decay).
+ * Pure read — does not mutate the entry; decay is applied lazily only when
+ * recording a new hit (recordRateLimitHit) so the clock isn't reset on every
+ * routing call.
  */
 function getPenalty(modelDbId: number): number {
   const entry = rateLimitPenalties.get(modelDbId);
   if (!entry) return 0;
 
-  // Apply time-based decay
-  const now = Date.now();
-  const elapsed = now - entry.lastHit;
+  const elapsed = Date.now() - entry.lastHit;
   const decaySteps = Math.floor(elapsed / DECAY_INTERVAL_MS);
-  if (decaySteps > 0) {
-    entry.penalty = Math.max(0, entry.penalty - (decaySteps * DECAY_AMOUNT));
-    entry.lastHit = now; // reset so we don't double-decay
-    if (entry.penalty === 0) {
-      rateLimitPenalties.delete(modelDbId);
-      return 0;
-    }
+  const decayed = Math.max(0, entry.penalty - decaySteps * DECAY_AMOUNT);
+  if (decayed === 0) {
+    rateLimitPenalties.delete(modelDbId);
+    return 0;
   }
-
-  return entry.penalty;
+  return decayed;
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -139,6 +139,10 @@ export interface ChatMessage {
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatToolCall[];
+  // The model's thinking trace on an assistant turn. Some thinking models
+  // (DeepSeek on OpenCode Zen) require it to be replayed verbatim on the next
+  // turn or they 400; the proxy preserves and forwards it. See issue #255.
+  reasoning_content?: string;
 }
 
 export interface ChatCompletionRequest {


### PR DESCRIPTION
Batches up the avoidable-error work tracked across #251 #253 #254 #255 #256 #257 #261. Integrates four ready PRs (cherry-picked with original authorship preserved) and adds four new fixes. Full server suite green (401 tests), server + client build clean.

## New fixes
- **fail over on model-level 403 instead of 502 (#256)** — `isRetryableError()` handled 404/413/402/400-api-error but not 403, so when `auto` picked a model the key's tier can't reach (gpt-4o on GitHub Models free tier, subscription-only Cloudflare models), the whole request 502'd. A request-time 403 is model-level, not a dead key (the key already passed `validateKey`, and the health checker disables keys that 401/403 it), so it's now treated like a 404: retryable, rules the model out for the request, and benched for a day (`MODEL_FORBIDDEN_COOLDOWN_MS`). 401/bare-400 stay non-retryable. Reported by @duemilionidieuro-bot.
- **force single tool-call for NVIDIA NIM (#255 item 2)** — NIM rejects parallel tool calls with `400: This model only supports single tool-calls at once!`. New `forceSingleToolCall` option on the openai-compat adapter pins `parallel_tool_calls:false` when tools are present; enabled for NVIDIA. Reported by @RobinHoodO.
- **round-trip reasoning_content for DeepSeek thinking models (#255 item 3)** — DeepSeek on OpenCode Zen 400s on follow-up turns unless the prior assistant `reasoning_content` is replayed. The proxy stripped it twice (assistant zod schema + message rebuild). Now preserved through validation and forwarded, same handling as `thought_signature`. Reported by @RobinHoodO.
- **actionable error when /api returns non-JSON (#257)** — backend signup is correct (verified end-to-end on a fresh install). The reproducible failure is a reverse proxy serving the SPA's index.html for `/api/*`, which made `apiFetch` throw an opaque `Unexpected token '<'` on the setup form. Now detected and turned into a clear message; also reordered fetch init so `options.headers` can't clobber Content-Type/Authorization. Reported by @hjhhoni.

## Integrated PRs (authorship preserved)
- **#254** skip models whose `tpm_limit` can't fit the request — @RobinHoodO (closes #255 item 1)
- **#251** filter `/v1/models` by connected providers — @hmm183
- **#253** rate ledger drift, token double-count, penalty decay, error sanitization — @itsfuad
- **#261** honor upstream Retry-After when benching a key — @danscMax

## Not included
- #256 item 2 (live model-catalog discovery) — left for a separate change; this PR only fixes the 403 half.

Contributors added to the README.