### PR TITLE
fix(catalog): retire dead OpenCode Zen free models (nemotron-3-super-free, minimax-m3-free)

### DIFF
--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -258,7 +258,9 @@ describe('Migration idempotency', () => {
        ORDER BY model_id
     `).all() as { model_id: string; enabled: number; supports_tools: number }[];
     expect(zen.map(r => [r.model_id, r.enabled, r.supports_tools])).toEqual([
-      ['minimax-m3-free',       1, 1],
+      // minimax-m3-free was seeded enabled here in V24, then retired in V25 when
+      // its free promo ended (now enabled=0). nemotron-3-ultra-free is still live.
+      ['minimax-m3-free',       0, 1],
       ['nemotron-3-ultra-free', 1, 1],
     ]);
 
@@ -268,6 +270,21 @@ describe('Migration idempotency', () => {
       SELECT enabled FROM models WHERE platform = 'nvidia' AND model_id = 'google/gemma-4-31b-it'
     `).get() as { enabled: number };
     expect(gemma.enabled).toBe(0);
+  });
+
+  it('V25: dead OpenCode Zen free promos (nemotron-3-super-free, minimax-m3-free) are disabled', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const dead = db.prepare(`
+      SELECT model_id, enabled FROM models
+       WHERE platform = 'opencode' AND model_id IN ('nemotron-3-super-free', 'minimax-m3-free')
+       ORDER BY model_id
+    `).all() as { model_id: string; enabled: number }[];
+    expect(dead.map(r => [r.model_id, r.enabled])).toEqual([
+      ['minimax-m3-free',       0],
+      ['nemotron-3-super-free', 0],
+    ]);
   });
 
   it('all enabled catalog platforms have a registered provider', async () => {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -31,6 +31,7 @@ export function migrateDbSchema(db: Database.Database) {
   migrateModelsV22Tools(db);
   migrateModelsV23FreeTierAudit(db);
   migrateModelsV24ZenRefresh(db);
+  migrateModelsV25ZenDeadPromos(db);
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1830,6 +1831,34 @@ function migrateModelsV24ZenRefresh(db: Database.Database) {
       UPDATE models SET enabled = 0
        WHERE platform = 'nvidia' AND model_id = 'google/gemma-4-31b-it'
     `).run();
+  });
+  apply();
+}
+
+/**
+ * V25 (2026-06-09): retire two OpenCode Zen free models that went dead.
+ * Observed on the production proxy — together they accounted for ~55% of a
+ * day's error rows, each 401ing on every route attempt (a 401 is non-retryable,
+ * so when one was picked first it hard-failed the request, not just logged):
+ *   - nemotron-3-super-free → `401: Model nemotron-3-super-free is not supported`.
+ *     V24 kept it enabled with "prune if it starts billing or 402s"; Zen has now
+ *     removed it outright.
+ *   - minimax-m3-free → `401: Free promotion has ended for MiniMax M3 Free`.
+ *     Added in V24 while its promo was live; the promo has since lapsed (same
+ *     fate qwen3.6-plus-free hit). These are server-side, account-independent
+ *     verdicts — dead for everyone, not a per-key issue.
+ * Disabled, not removed (row kept so fallback history survives and a future
+ * promo can re-enable). Idempotent: re-asserted each boot like the V13/V24
+ * disables.
+ */
+function migrateModelsV25ZenDeadPromos(db: Database.Database) {
+  const disable = db.prepare(`UPDATE models SET enabled = 0 WHERE platform = ? AND model_id = ?`);
+  const disables: Array<[string, string]> = [
+    ['opencode', 'nemotron-3-super-free'],
+    ['opencode', 'minimax-m3-free'],
+  ];
+  const apply = db.transaction(() => {
+    for (const [p, m] of disables) disable.run(p, m);
   });
   apply();
 }


### PR DESCRIPTION
Two OpenCode Zen free models went dead and were still enabled in the catalog, 401ing on every route attempt. On the production proxy they accounted for ~55% of a day's error rows, and since a 401 is non-retryable, when one was picked first it hard-failed the request rather than just logging a failover hop.

- **nemotron-3-super-free** -> `401: Model nemotron-3-super-free is not supported` (Zen removed it; V24 had kept it on a watchlist with "prune if it starts billing or 402s")
- **minimax-m3-free** -> `401: Free promotion has ended for MiniMax M3 Free` (added in V24 while its promo was live; now lapsed, same fate as qwen3.6-plus-free)

Both are server-side, account-independent verdicts (dead for everyone, not a per-key issue), so migration **V25** disables them. Rows kept (not removed) so fallback history survives and a future promo can re-enable. Idempotent, re-asserted each boot like the V13/V24 disables. Full suite green (402 tests).