### PR TITLE
fix(export-catalog): keep --stdout output pure JSON

### DIFF
--- a/server/src/scripts/export-catalog.ts
+++ b/server/src/scripts/export-catalog.ts
@@ -65,6 +65,10 @@ function main() {
   const tier = (arg('tier') as 'live' | 'monthly' | undefined) ?? 'live';
   const version = arg('version') ?? dateVersion();
 
+  // In --stdout mode stdout must carry ONLY the JSON document; incidental
+  // logs (e.g. initDb's "Database initialized at ...") go to stderr instead.
+  if (flag('stdout')) console.log = console.error;
+
   initDb(dbPath);
   const db = getDb();
 


### PR DESCRIPTION
In --stdout mode incidental console.log lines (initDb's path banner) landed ahead of the JSON document and corrupted piped exports. Route them to stderr. The ops push script also defends against this independently.