### PR TITLE
fix(google): cache Gemini thoughtSignature for multi-turn tool calls

### DIFF
--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -12,6 +12,41 @@ import { contentToString } from '../lib/content.js';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
+// Gemini 3 REQUIRES the `thoughtSignature` that accompanied a function call to
+// be echoed back whenever that call appears in conversation history, or it
+// rejects the request with 400 "Function call is missing a thought_sig". But
+// OpenAI-format clients (the API surface we expose) have no field to carry a
+// provider-specific signature, so it's dropped on the round-trip and every
+// multi-turn tool conversation through Gemini fails. To bridge this without a
+// schema change, cache each signature we emit keyed by tool-call id and
+// re-attach it when the same call comes back without one. Strictly additive: a
+// cache miss yields exactly the previous behavior (the request may 400 and fail
+// over, as before). Bounded with a TTL so it can't grow unbounded.
+const THOUGHT_SIG_TTL_MS = 30 * 60 * 1000; // 30 min — longer than any single tool loop
+const THOUGHT_SIG_MAX = 5000;
+const thoughtSigCache = new Map<string, { sig: string; exp: number }>();
+
+function rememberThoughtSig(callId: string | undefined, sig: string | undefined): void {
+  if (!callId || !sig) return;
+  // Cheap eviction: when full, drop the oldest insertion (Map preserves order).
+  if (thoughtSigCache.size >= THOUGHT_SIG_MAX) {
+    const oldest = thoughtSigCache.keys().next().value;
+    if (oldest !== undefined) thoughtSigCache.delete(oldest);
+  }
+  thoughtSigCache.set(callId, { sig, exp: Date.now() + THOUGHT_SIG_TTL_MS });
+}
+
+function recallThoughtSig(callId: string | undefined): string | undefined {
+  if (!callId) return undefined;
+  const hit = thoughtSigCache.get(callId);
+  if (!hit) return undefined;
+  if (hit.exp < Date.now()) {
+    thoughtSigCache.delete(callId);
+    return undefined;
+  }
+  return hit.sig;
+}
+
 interface GeminiPart {
   text?: string;
   inlineData?: {
@@ -235,8 +270,12 @@ async function toGeminiContents(messages: ChatMessage[]) {
         }
 
         for (const call of m.tool_calls ?? []) {
+          // Prefer a signature the client preserved; otherwise recover the one
+          // we cached when this call was first produced (OpenAI-format clients
+          // drop the field, so this is the common path for Gemini multi-turn).
+          const sig = call.thought_signature ?? recallThoughtSig(call.id);
           parts.push({
-            thoughtSignature: call.thought_signature,
+            thoughtSignature: sig,
             functionCall: {
               id: call.id,
               name: call.function.name,
@@ -295,6 +334,10 @@ function extractToolCalls(parts: GeminiPart[] | undefined): ChatToolCall[] {
     if (!part.functionCall?.name) continue;
 
     const id = part.functionCall.id ?? `call_${Date.now()}_${fallbackIndex++}`;
+    // Cache the signature keyed by the id we hand the client, so when the client
+    // echoes this call back (without the signature, as OpenAI format requires)
+    // we can re-attach it and Gemini accepts the history.
+    rememberThoughtSig(id, part.thoughtSignature);
     calls.push({
       id,
       type: 'function',


### PR DESCRIPTION
## Problem
Gemini 3 rejects any request whose history contains a function call without the `thoughtSignature` that originally accompanied it — `400 "Function call is missing a thought_sig"`. OpenAI-format clients have no field to carry a provider-specific signature, so it's dropped between turns and **every multi-turn tool conversation through a Gemini model fails**, silently removing the whole Gemini family from the tool-calling fallback chain.

## Fix
Cache each `thoughtSignature` we emit, keyed by the tool-call id returned to the client, and re-attach it when the same call comes back without one.

- **Strictly additive**: a cache miss yields exactly the prior behavior (request may 400 and fail over).
- Bounded map (5000 entries) with a 30-minute TTL.
- Both streaming and non-streaming extract paths populate the cache.

## Test
- `tsc --noEmit` clean
- Full suite: 417/417 pass