### PR TITLE
fix(security): pin AES-256-GCM authTag length to 16 bytes on decrypt

### DIFF
--- a/server/src/__tests__/lib/crypto.test.ts
+++ b/server/src/__tests__/lib/crypto.test.ts
@@ -28,6 +28,14 @@ describe('Crypto', () => {
     expect(() => decrypt(encrypted, iv, 'a'.repeat(32))).toThrow();
   });
 
+  it('should reject truncated auth tags (< 16 bytes) to block forgery brute-force', () => {
+    const { encrypted, iv, authTag } = encrypt('test-key');
+    for (const truncatedBytes of [4, 8, 12, 13, 14, 15]) {
+      const truncated = authTag.slice(0, truncatedBytes * 2);
+      expect(() => decrypt(encrypted, iv, truncated)).toThrow();
+    }
+  });
+
   describe('maskKey', () => {
     it('should mask long keys', () => {
       expect(maskKey('gsk_test1234567890abcdef')).toBe('gsk_...cdef');

--- a/server/src/lib/crypto.ts
+++ b/server/src/lib/crypto.ts
@@ -98,9 +98,15 @@ export function encrypt(text: string): { encrypted: string; iv: string; authTag:
   };
 }
 
+// AUTH_TAG_BYTES pins the GCM tag length to 16 bytes. Without this option Node
+// will accept any tag of length 4–16 bytes (RFC 5116 §3.2), which lets anyone
+// who can rewrite a row in `api_keys` swap in a 4-byte tag and start brute-
+// forcing forgeries at 2^32 attempts. Pinning closes that truncation path.
+const AUTH_TAG_BYTES = 16;
+
 export function decrypt(encrypted: string, iv: string, authTag: string): string {
   const key = getEncryptionKey();
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, 'hex'));
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, 'hex'), { authTagLength: AUTH_TAG_BYTES });
   decipher.setAuthTag(Buffer.from(authTag, 'hex'));
 
   let decrypted = decipher.update(encrypted, 'hex', 'utf8');


### PR DESCRIPTION
## Summary
The decrypt path uses `crypto.createDecipheriv('aes-256-gcm', key, iv)` without the `authTagLength` option. Per Node and [RFC 5116 §3.2](https://datatracker.ietf.org/doc/html/rfc5116#section-3.2), GCM in this mode accepts any auth tag of length 4–16 bytes. Encryption already emits 16-byte tags (`cipher.getAuthTag()`), but the decrypter accepts truncated ones, so a tampered `api_keys` row holding a 4-byte tag is brute-forceable at `2^32` attempts instead of `2^128`.

This is the same hardening the [Node docs explicitly recommend](https://nodejs.org/api/crypto.html#class-cipher) ("if no _authTagLength_ option is provided… any value from 4 to 16 bytes is permitted") and that the README's "Encrypted key storage — API keys are encrypted with AES-256-GCM before hitting SQLite" claim implicitly relies on.

## Impact
The proxy stores upstream provider API keys (Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, Cohere, Cloudflare, etc.) in `api_keys` encrypted under the operator's `ENCRYPTION_KEY`. Anyone with write access to that SQLite row — operator-side compromise, malicious backup restore, a future SQL-injection or `/keys` route bug — can swap a 4-byte tag in and brute-force a successful decryption with `~4 × 10^9` forgery attempts. With `authTagLength: 16` pinned, the same attack needs `~3.4 × 10^38` attempts (i.e. it stops being a practical threat).

No remote-only exploit chain — the threat model is rewrite-the-DB, not crash-the-/v1-endpoint. So this is a defense-in-depth gap, not a 0-day. The fix is one line; shipping it costs nothing.

## Location
`server/src/lib/crypto.ts:103` — the `decrypt()` call to `createDecipheriv`.

## Fix
Add the `{ authTagLength: 16 }` option to `createDecipheriv`:

```ts
const AUTH_TAG_BYTES = 16;
const decipher = crypto.createDecipheriv(ALGORITHM, key, Buffer.from(iv, 'hex'), { authTagLength: AUTH_TAG_BYTES });
```

`encrypt()` already emits full 16-byte tags via `cipher.getAuthTag()`, so every existing row in `api_keys` continues to decrypt without re-encryption.

## Detected by
Aeon + semgrep (`p/security-audit → javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length`)
- Severity: medium
- CWE-310 — Cryptographic issues (incomplete integrity verification on AES-GCM tag length).

## Verification
`npm run test -w server` passes — **45 files, 445 tests** (up from 444; the existing wrong-tag test still passes, the new test `should reject truncated auth tags (< 16 bytes) to block forgery brute-force` covers 4/8/12/13/14/15-byte truncations).

```
Test Files  45 passed (45)
     Tests  445 passed (445)
  Duration  20.72s
```

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Close this if you'd rather fix it differently — the one-line authTagLength pin is the minimal patch; happy to revisit shape if you'd prefer it on `encrypt()` too.