### PR TITLE
fix(google): correct validateKey error taxonomy so good keys aren't auto-disabled (#268)

### DIFF
--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -89,6 +89,44 @@ describe('GoogleProvider', () => {
     expect(await provider.validateKey('invalid-key')).toBe(false);
   });
 
+  // #268: Google reports a bad key as HTTP 400 INVALID_ARGUMENT / API_KEY_INVALID,
+  // not 401/403. A confirmed-bad key must return false (→ auto-disable counter).
+  it('validateKey returns false for a genuinely invalid key (HTTP 400 API_KEY_INVALID)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({
+        error: {
+          code: 400,
+          message: 'API key not valid. Please pass a valid API key.',
+          status: 'INVALID_ARGUMENT',
+          details: [{ '@type': 'type.googleapis.com/google.rpc.ErrorInfo', reason: 'API_KEY_INVALID' }],
+        },
+      }),
+    } as any);
+    expect(await provider.validateKey('bad-key')).toBe(false);
+  });
+
+  // #268: a permission/region/restriction 403 (e.g. API not enabled on the project,
+  // or an IP/API-key restriction on the proxy host) must NOT auto-disable a key that
+  // may still work for generateContent elsewhere — validateKey throws so health.ts
+  // records status='error' instead of incrementing the disable counter.
+  it('validateKey throws (does not return false) on a permission/region 403', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({
+        error: {
+          code: 403,
+          message: 'Generative Language API has not been used in project before or it is disabled.',
+          status: 'PERMISSION_DENIED',
+          details: [{ '@type': 'type.googleapis.com/google.rpc.ErrorInfo', reason: 'SERVICE_DISABLED' }],
+        },
+      }),
+    } as any);
+    await expect(provider.validateKey('region-blocked-key')).rejects.toThrow(/inconclusive/i);
+  });
+
   it('should translate system messages to systemInstruction', async () => {
     let capturedBody: any;
     vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -573,12 +573,48 @@ export class GoogleProvider extends BaseProvider {
 
   async validateKey(apiKey: string): Promise<boolean> {
     // Transport errors propagate — health.ts marks status='error' without
-    // counting toward auto-disable. Only confirmed 401/403 disables a key.
+    // counting toward auto-disable.
     const res = await this.fetchWithTimeout(
       `${API_BASE}/models?key=${apiKey}`,
       { method: 'GET' },
       10000,
     );
-    return res.status !== 401 && res.status !== 403;
+    if (res.ok) return true;
+
+    // Google's error taxonomy is NOT the usual 401/403-means-bad-key (#268):
+    //   - bad/expired key            → HTTP 400 INVALID_ARGUMENT / reason API_KEY_INVALID
+    //   - API not enabled on project → HTTP 403 PERMISSION_DENIED / reason SERVICE_DISABLED
+    //   - IP / referrer / API-key restriction, or empty key → HTTP 403 PERMISSION_DENIED
+    //   - unsupported region         → HTTP 400 FAILED_PRECONDITION ("User location is not supported")
+    // The old check (`status !== 401 && status !== 403`) had this exactly
+    // backwards: it marked a genuinely-bad 400 key as HEALTHY, and auto-disabled
+    // a perfectly good key that merely hit a permission/region/restriction 403 on
+    // the host running the proxy (the key still works for generateContent from
+    // another network). So only a CONFIRMED bad credential returns false (which
+    // counts toward auto-disable); every other non-2xx is inconclusive and throws
+    // so health.ts records status='error' WITHOUT disabling a usable key.
+    type GoogleErrorBody = { error?: { message?: unknown; status?: unknown; details?: unknown } };
+    let body: GoogleErrorBody | null = null;
+    try { body = (await res.json()) as GoogleErrorBody; } catch { /* non-JSON error body */ }
+    const err = body?.error;
+    const details = Array.isArray(err?.details) ? err!.details as Array<{ reason?: unknown }> : [];
+    const reason = details.find(d => typeof d?.reason === 'string')?.reason as string | undefined;
+    const message = typeof err?.message === 'string' ? err.message : '';
+    const gStatus = typeof err?.status === 'string' ? err.status : undefined;
+
+    const badCredentials =
+      res.status === 401 ||
+      reason === 'API_KEY_INVALID' ||
+      /API key not valid|API key expired|API_KEY_INVALID/i.test(message);
+    if (badCredentials) {
+      console.warn(`[Google] validateKey: key rejected as invalid (HTTP ${res.status}${reason ? ` ${reason}` : ''})`);
+      return false;
+    }
+
+    console.warn(
+      `[Google] validateKey: inconclusive HTTP ${res.status} (${gStatus ?? 'UNKNOWN'}${reason ? `/${reason}` : ''}): ${message.slice(0, 200)} ` +
+      `— treating as 'error', not auto-disabling (the key may be valid but blocked by region/permission/restriction on this host).`,
+    );
+    throw new Error(`Google key validation inconclusive (HTTP ${res.status}${gStatus ? ` ${gStatus}` : ''})`);
   }
 }


### PR DESCRIPTION
Fixes #268.

## Root cause
Reproduced against the live Gemini API. Google's status codes are **not** the conventional 401/403-means-bad-key:

| Situation | HTTP | status / reason |
|---|---|---|
| Valid key | 200 | — |
| Bad/expired key | **400** | `INVALID_ARGUMENT` / `API_KEY_INVALID` |
| API not enabled on project | 403 | `PERMISSION_DENIED` / `SERVICE_DISABLED` |
| IP / referrer / API-key restriction, empty key | 403 | `PERMISSION_DENIED` |
| Unsupported region | **400** | `FAILED_PRECONDITION` ("User location is not supported") |

`validateKey` used `return res.status !== 401 && res.status !== 403`, which is backwards for Google:
1. A genuinely **invalid 400 key** was reported **healthy** — bad Google keys never got disabled.
2. A **permission/region/restriction 403** (specific to the host running the proxy) was reported **invalid** → auto-disabled after 3 checks, even though the key works fine for `generateContent` from another network.

That's the exact reported symptom: a key that works via direct `curl` from the reporter's laptop gets auto-disabled on their Docker host, and requests silently fall over to Groq.

## Fix
`validateKey` now interprets the real taxonomy:
- **200** → valid.
- **Confirmed bad credential** (HTTP 401, or `API_KEY_INVALID` reason / "API key not valid" message) → `false` (still counts toward auto-disable — so *actually-bad* keys now get disabled, which they didn't before).
- **Any other non-2xx** (permission / region / quota / config) → **throws**, logging the exact upstream status + reason. `health.ts` records `status='error'` and does **not** auto-disable a usable key.

This directly implements the "log the exact upstream status" diagnostic step and stops the destructive auto-disable.

## Tests
Added coverage for the 400-invalid-key (→ false) and 403-permission-denied (→ throws) paths. Full server suite green; `tsc` clean.