### PR TITLE
feat(models): /v1/models returns full catalog with per-model availability (#287)

### DIFF
--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -86,6 +86,55 @@ describe('Virtual "auto" model', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  // #242: default returns the whole catalog, each entry annotated with whether
+  // it's currently usable (connected) and, if not, why.
+  it('returns the whole catalog by default, each tagged with availability (#242)', async () => {
+    const { status, body } = await request(app, 'GET', '/v1/models', undefined, authHeaders());
+    expect(status).toBe(200);
+    expect(body.data[0]).toMatchObject({ id: 'auto', available: true, unavailable_reason: null });
+
+    const models = body.data.filter((m: any) => m.id !== 'auto');
+    expect(models.length).toBeGreaterThan(0);
+    for (const m of models) {
+      expect(typeof m.available).toBe('boolean');
+      if (m.available) expect(m.unavailable_reason).toBeNull();
+      else expect(['no_key', 'disabled']).toContain(m.unavailable_reason);
+    }
+    // Only a groq key is seeded: a groq model is available; a non-groq model is
+    // listed but unavailable for lack of a key.
+    expect(models.some((m: any) => m.owned_by === 'groq' && m.available)).toBe(true);
+    expect(models.some((m: any) => m.owned_by !== 'groq' && !m.available && m.unavailable_reason === 'no_key')).toBe(true);
+  });
+
+  it('?available=true narrows to only connected models (#242)', async () => {
+    const filtered = await request(app, 'GET', '/v1/models?available=true', undefined, authHeaders());
+    expect(filtered.status).toBe(200);
+    const filteredModels = filtered.body.data.filter((m: any) => m.id !== 'auto');
+    expect(filteredModels.length).toBeGreaterThan(0);
+    expect(filteredModels.every((m: any) => m.available === true)).toBe(true);
+
+    // The unfiltered list is strictly larger — the keyless models reappear.
+    const all = await request(app, 'GET', '/v1/models', undefined, authHeaders());
+    const allModels = all.body.data.filter((m: any) => m.id !== 'auto');
+    expect(allModels.length).toBeGreaterThan(filteredModels.length);
+  });
+
+  it('marks a disabled model with unavailable_reason "disabled" (#242)', async () => {
+    const db = getDb();
+    const row = db.prepare("SELECT model_id FROM models WHERE platform='groq' AND enabled=1 LIMIT 1").get() as { model_id: string } | undefined;
+    expect(row).toBeDefined();
+    db.prepare('UPDATE models SET enabled=0 WHERE model_id=?').run(row!.model_id);
+    try {
+      const { body } = await request(app, 'GET', '/v1/models', undefined, authHeaders());
+      const entry = body.data.find((m: any) => m.id === row!.model_id);
+      expect(entry).toBeDefined();
+      expect(entry.available).toBe(false);
+      expect(entry.unavailable_reason).toBe('disabled');
+    } finally {
+      db.prepare('UPDATE models SET enabled=1 WHERE model_id=?').run(row!.model_id);
+    }
+  });
+
   it('treats model:"auto" as auto-route instead of a 400', async () => {
     const origFetch = global.fetch;
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -126,27 +126,40 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
     return;
   }
 
+  // By default we return the WHOLE catalog (one row per model id), each tagged
+  // with whether it is currently usable, so a client can see everything and know
+  // what's connected vs. disabled/keyless (#242). `?available=true` (alias
+  // `?connected=true`) narrows the list to only models that can serve a request
+  // right now — the previous default behavior. `available` is computed as
+  // "enabled AND an enabled key can serve it"; dedup prefers an available
+  // instance of a model id over a disabled/keyless one.
+  const availableExpr = `
+    (CASE WHEN m.enabled = 1 AND EXISTS (
+        SELECT 1 FROM api_keys k
+        WHERE k.platform = m.platform
+          AND k.enabled = 1
+          AND (m.key_id IS NULL OR k.id = m.key_id)
+      ) THEN 1 ELSE 0 END)`;
   const db = getDb();
   const models = db.prepare(`
-    SELECT platform, model_id, display_name, context_window
+    SELECT platform, model_id, display_name, context_window, enabled, available, intelligence_rank, id
     FROM (
-      SELECT platform, model_id, display_name, context_window, intelligence_rank, id,
+      SELECT m.platform, m.model_id, m.display_name, m.context_window, m.intelligence_rank, m.id,
+             m.enabled AS enabled,
+             ${availableExpr} AS available,
              ROW_NUMBER() OVER (
-               PARTITION BY model_id
-               ORDER BY intelligence_rank ASC, id ASC
+               PARTITION BY m.model_id
+               ORDER BY ${availableExpr} DESC, m.intelligence_rank ASC, m.id ASC
              ) AS rn
       FROM models m
-      WHERE m.enabled = 1
-        AND EXISTS (
-          SELECT 1 FROM api_keys k
-          WHERE k.platform = m.platform
-            AND k.enabled = 1
-            AND (m.key_id IS NULL OR k.id = m.key_id)
-        )
     )
     WHERE rn = 1
-    ORDER BY intelligence_rank ASC, id ASC
+    ORDER BY available DESC, enabled DESC, intelligence_rank ASC, id ASC
   `).all() as ModelListRow[];
+
+  const q = String(req.query.available ?? req.query.connected ?? '').toLowerCase();
+  const onlyAvailable = q === '1' || q === 'true' || q === 'yes';
+  const listed = onlyAvailable ? models.filter(m => m.available === 1) : models;
 
   res.json({
     object: 'list',
@@ -158,14 +171,19 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
         owned_by: 'freellmapi',
         name: 'Auto (router picks the best available model)',
         context_window: null,
+        available: true,
+        unavailable_reason: null,
       },
-      ...models.map(m => ({
+      ...listed.map(m => ({
         id: m.model_id,
         object: 'model',
         created: 0,
         owned_by: m.platform,
         name: m.display_name,
         context_window: m.context_window,
+        // Non-standard but additive: OpenAI clients ignore unknown fields.
+        available: m.available === 1,
+        unavailable_reason: m.available === 1 ? null : (m.enabled === 1 ? 'no_key' : 'disabled'),
       })),
     ],
   });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -74,6 +74,10 @@ export interface ModelListRow {
   model_id: string;
   display_name: string;
   context_window: number | null;
+  // 1 when the catalog row is enabled. 1 when an enabled key can serve it
+  // (enabled AND a matching enabled api_key exists). SQLite returns 0/1.
+  enabled: number;
+  available: number;
 }
 
 export type KeyStatus = 'healthy' | 'rate_limited' | 'invalid' | 'error' | 'unknown';


### PR DESCRIPTION
Closes #287. Follows up #242.

## What
`GET /v1/models` now returns the **whole catalog** by default (one entry per model id), each annotated with whether it's usable — instead of silently hiding everything that isn't connected.

Per entry (additive — OpenAI clients ignore unknown fields):
- `available`: boolean — enabled AND a matching enabled key exists.
- `unavailable_reason`: `null` | `"no_key"` | `"disabled"`.

Opt-in filter:
- `?available=true` (alias `?connected=true`) → only connected models (the previous default behavior).

Dedup prefers an available instance of a model id over a disabled/keyless one; the `auto` virtual model is always `available: true`.

## Tests
Added 3 cases to `proxy-auto-model.test.ts`: default annotations (groq available, non-groq `no_key`), `?available=true` narrowing, and a disabled model surfacing `unavailable_reason: "disabled"`. Full suite green (459); `tsc` clean.