### PR TITLE
fix(proxy): lazy-load undici + pin ^6 so CI/Node 20 doesn't crash on import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,6 +1238,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1254,6 +1255,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1270,6 +1272,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1286,6 +1289,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1302,6 +1306,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1318,6 +1323,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1334,6 +1340,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1350,6 +1357,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1366,6 +1374,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1382,6 +1391,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1398,6 +1408,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1414,6 +1425,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1430,6 +1442,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1446,6 +1459,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1462,6 +1476,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1478,6 +1493,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1494,6 +1510,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1510,6 +1527,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1526,6 +1544,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1542,6 +1561,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1558,6 +1578,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1574,6 +1595,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1590,6 +1612,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1606,6 +1629,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1622,6 +1646,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1638,6 +1663,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11270,15 +11296,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -13077,7 +13094,7 @@
         "express": "^5.1.0",
         "helmet": "^8.1.0",
         "socks-proxy-agent": "^10.0.0",
-        "undici": "^8.3.0",
+        "undici": "^6.21.0",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -13113,6 +13130,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "server/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "server/node_modules/undici-types": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "express": "^5.1.0",
     "helmet": "^8.1.0",
     "socks-proxy-agent": "^10.0.0",
-    "undici": "^8.3.0",
+    "undici": "^6.21.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/server/src/lib/proxy.ts
+++ b/server/src/lib/proxy.ts
@@ -1,7 +1,25 @@
-import { ProxyAgent } from 'undici';
-import { SocksProxyAgent } from 'socks-proxy-agent';
 import http from 'http';
 import https from 'https';
+
+// undici (ProxyAgent) and socks-proxy-agent are lazy-loaded on first proxy use
+// ONLY. Importing undici at module top-level eagerly runs its web/cache init,
+// which throws on some Node 20.x builds ("webidl.util.markAsUncloneable is not
+// a function"). Since this module is imported by every provider via base.ts, a
+// top-level undici import crashed the entire app/test suite even when no proxy
+// was configured. Lazy-loading keeps the proxy feature genuinely zero-cost and
+// zero-risk for the common no-proxy case.
+type Ctor<T> = new (...args: any[]) => T;
+let _proxyAgentCtor: Ctor<unknown> | null = null;
+let _socksAgentCtor: Ctor<unknown> | null = null;
+
+async function loadHttpProxyAgent(): Promise<Ctor<unknown>> {
+  if (!_proxyAgentCtor) _proxyAgentCtor = (await import('undici')).ProxyAgent as unknown as Ctor<unknown>;
+  return _proxyAgentCtor;
+}
+async function loadSocksAgent(): Promise<Ctor<unknown>> {
+  if (!_socksAgentCtor) _socksAgentCtor = (await import('socks-proxy-agent')).SocksProxyAgent as unknown as Ctor<unknown>;
+  return _socksAgentCtor;
+}
 
 // Module-level proxy URL.
 let _proxyUrl = '';
@@ -11,7 +29,7 @@ let _initialized = false;
 
 // Cache.
 let cached: {
-  dispatcher: ProxyAgent | SocksProxyAgent | undefined;
+  dispatcher: unknown | undefined;
   proxyUrl: string;
   isSocks: boolean;
   ts: number;
@@ -81,11 +99,11 @@ function shouldBypassProxy(platform?: string): boolean {
  * Resolve the proxy dispatcher. For SOCKS schemes this returns a
  * SocksProxyAgent; for HTTP/HTTPS it returns an undici ProxyAgent.
  */
-function resolveDispatcher(): ProxyAgent | SocksProxyAgent | undefined {
+async function resolveDispatcher(): Promise<{ dispatcher: unknown; isSocks: boolean } | undefined> {
   const now = Date.now();
 
   if (cached && (now - cached.ts) < CACHE_TTL_MS) {
-    return cached.dispatcher;
+    return cached.dispatcher ? { dispatcher: cached.dispatcher, isSocks: cached.isSocks } : undefined;
   }
 
   if (!_initialized) applyProxyUrl('');
@@ -99,14 +117,16 @@ function resolveDispatcher(): ProxyAgent | SocksProxyAgent | undefined {
     const isSocks = _proxyUrl.startsWith('socks5:') || _proxyUrl.startsWith('socks4:');
 
     if (isSocks) {
-      const dispatcher = new SocksProxyAgent(_proxyUrl);
+      const SocksAgent = await loadSocksAgent();
+      const dispatcher = new SocksAgent(_proxyUrl);
       cached = { dispatcher, proxyUrl: _proxyUrl, isSocks: true, ts: now };
-      return dispatcher;
+      return { dispatcher, isSocks: true };
     }
 
-    const dispatcher = new ProxyAgent({ uri: _proxyUrl });
+    const ProxyAgentCtor = await loadHttpProxyAgent();
+    const dispatcher = new ProxyAgentCtor({ uri: _proxyUrl });
     cached = { dispatcher, proxyUrl: _proxyUrl, isSocks: false, ts: now };
-    return dispatcher;
+    return { dispatcher, isSocks: false };
   } catch (err: any) {
     const masked = _proxyUrl.replace(/\/\/[^@]*@/, '//***@');
     console.error(`[proxy] Failed to create dispatcher for "${masked}": ${err.message}`);
@@ -117,7 +137,7 @@ function resolveDispatcher(): ProxyAgent | SocksProxyAgent | undefined {
 
 // ── SOCKS-compatible fetch via http/https modules ──
 
-function socksFetch(urlStr: string, init?: RequestInit, agent?: SocksProxyAgent): Promise<Response> {
+function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Promise<Response> {
   const url = new URL(urlStr);
   const isTls = url.protocol === 'https:';
   const transport = isTls ? https : http;
@@ -211,28 +231,29 @@ export async function proxyFetch(url: string, init?: RequestInit, platform?: str
     return fetch(url, init);
   }
 
-  const d = resolveDispatcher();
+  const resolved = await resolveDispatcher();
 
-  // No dispatcher (no proxy URL configured) → direct
-  if (!d) {
+  // No dispatcher (no proxy URL configured, or it failed to build) → direct
+  if (!resolved) {
     return fetch(url, init);
   }
 
   // SOCKS proxy → http/https fallback
-  if (d instanceof SocksProxyAgent) {
-    return socksFetch(url, init, d);
+  if (resolved.isSocks) {
+    return socksFetch(url, init, resolved.dispatcher as http.Agent);
   }
 
   // HTTP/HTTPS proxy → undici (dispatcher is an undici extension not in TS types)
-  return fetch(url, { ...init, dispatcher: d } as unknown as RequestInit);
+  return fetch(url, { ...init, dispatcher: resolved.dispatcher } as unknown as RequestInit);
 }
 
 /**
- * Returns true when the proxy is configured AND enabled.
- * Used by the dashboard to show the "Active" badge.
+ * Returns true when the proxy is configured AND enabled. Used by the dashboard
+ * to show the "Active" badge. Intentionally does NOT construct a dispatcher (so
+ * it never triggers the lazy undici import) — "configured + enabled" is exactly
+ * what the badge means.
  */
 export function isProxyActive(): boolean {
-  if (!_proxyEnabled) return false;
-  resolveDispatcher();
-  return !!cached?.dispatcher;
+  if (!_initialized) applyProxyUrl('');
+  return _proxyEnabled && !!_proxyUrl;
 }


### PR DESCRIPTION
## Why CI is red
CI (Node 20) went red starting at #286. Root cause:

\`\`\`
TypeError: webidl.util.markAsUncloneable is not a function
  ❯ new CacheStorage  node_modules/undici/index.js:179
  ❯ src/lib/proxy.ts (top-level import) → base.ts → providers/index.js → src/app.ts
\`\`\`

\`lib/proxy.ts\` imported \`undici\` at module top-level. \`undici@8\`'s index eagerly initializes its web/cache layer, which throws on Node 20.x builds. Since \`lib/proxy.ts\` is imported by every provider through \`base.ts\`, that crash brought down **36 of 46 test suites** in CI — while passing locally on Node 24.

## Fix
1. **Lazy-load** `undici` (ProxyAgent) and `socks-proxy-agent` via dynamic `import()` inside `resolveDispatcher()`, only when a proxy is actually configured. The no-proxy path — all tests, all default installs — never imports either lib now. `isProxyActive()` no longer constructs a dispatcher either.
2. **Pin `undici` to `^6`** (→ 6.26.0). v6 has broad Node 18/20 support, no `markAsUncloneable` crash, aligns with Node 20's bundled undici, and works as a global-`fetch` `dispatcher`.

Net effect: the proxy feature is genuinely zero-cost/zero-risk when unused, and works on Node 20 when used.

## Verification
`npm test` (459 pass) and `npm run build` both green under the exact CI command (`vitest run --pool=forks --fileParallelism=false`). The 10 proxy routing tests still pass.