### PR TITLE
fix(proxy): rescue Groq-style tool_use_failed 400s into structured tool_calls (#264)

### DIFF
--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -325,4 +325,66 @@ describe('OpenAICompatProvider - platform instances', () => {
       expect(result._routed_via?.platform).toBe(p.platform);
     });
   }
+
+  // #264: Groq (and others) reject a model's inline tool-call dialect with a 400
+  // `tool_use_failed`, handing back the raw text in `error.failed_generation`.
+  // We rescue it into structured tool_calls instead of dead-ending the turn.
+  describe('tool_use_failed rescue (#264)', () => {
+    let provider: OpenAICompatProvider;
+    beforeEach(() => {
+      provider = new OpenAICompatProvider({ platform: 'groq', name: 'Groq', baseUrl: 'https://api.groq.com/openai/v1' });
+    });
+    const tools = [{
+      type: 'function' as const,
+      function: { name: 'read', description: 'read a file', parameters: { type: 'object', properties: { file_path: { type: 'string' } }, required: ['file_path'] } },
+    }];
+    const failBody = {
+      error: {
+        message: 'Failed to call a function. Please adjust your prompt. See \'failed_generation\' for more details.',
+        type: 'invalid_request_error',
+        code: 'tool_use_failed',
+        failed_generation: '<function=read={"file_path": "sample.txt"}</function>',
+      },
+    };
+
+    it('non-stream: rescues failed_generation into structured tool_calls', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false, status: 400, statusText: 'Bad Request',
+        json: () => Promise.resolve(failBody),
+      } as any);
+
+      const r = await provider.chatCompletion('key', [{ role: 'user', content: 'read sample.txt' }], 'llama-3.3-70b-versatile', { tools, tool_choice: 'auto' });
+      expect(r.choices[0].finish_reason).toBe('tool_calls');
+      const tc = r.choices[0].message.tool_calls;
+      expect(tc?.length).toBe(1);
+      expect(tc![0].function.name).toBe('read');
+      expect(JSON.parse(tc![0].function.arguments)).toEqual({ file_path: 'sample.txt' });
+    });
+
+    it('stream: yields a synthesized tool_calls turn instead of throwing', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false, status: 400, statusText: 'Bad Request',
+        json: () => Promise.resolve(failBody),
+      } as any);
+
+      const chunks: any[] = [];
+      for await (const c of provider.streamChatCompletion('key', [{ role: 'user', content: 'read sample.txt' }], 'llama-3.3-70b-versatile', { tools, tool_choice: 'auto' })) {
+        chunks.push(c);
+      }
+      const calls = chunks.flatMap(c => c.choices[0].delta.tool_calls ?? []);
+      expect(calls.length).toBe(1);
+      expect(calls[0].function.name).toBe('read');
+      expect(chunks.some(c => c.choices[0].finish_reason === 'tool_calls')).toBe(true);
+    });
+
+    it('still throws when there is no failed_generation to rescue', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+        ok: false, status: 400, statusText: 'Bad Request',
+        json: () => Promise.resolve({ error: { message: 'bad request', code: 'invalid_request' } }),
+      } as any);
+      await expect(
+        provider.chatCompletion('key', [{ role: 'user', content: 'hi' }], 'm', { tools }),
+      ).rejects.toThrow(/API error 400/);
+    });
+  });
 });

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -2,9 +2,12 @@ import type {
   ChatMessage,
   ChatCompletionResponse,
   ChatCompletionChunk,
+  ChatToolCall,
   Platform,
 } from '@freellmapi/shared/types.js';
 import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
+import { rescueInlineToolCalls } from '../lib/tool-call-rescue.js';
+import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 
 /**
  * Generic provider for platforms that use an OpenAI-compatible API.
@@ -55,6 +58,31 @@ export class OpenAICompatProvider extends BaseProvider {
     return options?.parallel_tool_calls;
   }
 
+  /** Some providers (Groq especially) reject a model's tool call with a 400
+   * `tool_use_failed` when the model emitted it as inline DIALECT TEXT
+   * (`<function=NAME{...}</function>`, Hermes/Qwen XML, etc.) that the provider's
+   * own parser couldn't convert — but they hand back the raw text in
+   * `error.failed_generation`. Weaker tool models (e.g. groq llama-3.3-70b) hit
+   * this constantly, dead-ending an agent's whole turn even though the call is
+   * perfectly recoverable. Reuse the same inline-dialect rescue the proxy already
+   * applies to streamed text: parse `failed_generation` into structured
+   * tool_calls so the turn succeeds instead of failing over (or exhausting the
+   * chain when every enabled tool model behaves the same way). See issue #264. */
+  private rescueFailedGeneration(errBody: unknown, options?: CompletionOptions): ChatToolCall[] | null {
+    const failed = (errBody as { error?: { failed_generation?: unknown } })?.error?.failed_generation;
+    if (typeof failed !== 'string' || failed.length === 0) return null;
+    const toolNames = new Set((options?.tools ?? []).map(t => t.function.name));
+    if (toolNames.size === 0) return null;
+    const rescue = rescueInlineToolCalls(failed, toolNames);
+    if (!rescue.detected || !rescue.calls?.length) return null;
+    const schemas = toolSchemaMap(options?.tools);
+    return rescue.calls.map((c, i) => ({
+      id: `call_rescued_${i + 1}`,
+      type: 'function' as const,
+      function: { name: c.name, arguments: repairToolArguments(c.arguments, schemas.get(c.name)) },
+    }));
+  }
+
   /** Keyless providers (Kilo's anonymous free tier) must send NO Authorization
    * header — a stored sentinel like `Bearer no-key` could be treated as an
    * invalid key. Everyone else sends the bearer as usual. */
@@ -89,6 +117,20 @@ export class OpenAICompatProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
+      const rescued = this.rescueFailedGeneration(err, options);
+      if (rescued) {
+        console.log(`[${this.name}] Rescued ${rescued.length} inline tool call(s) from a ${res.status} tool_use_failed (#264)`);
+        const out: ChatCompletionResponse = {
+          id: `chatcmpl-rescued-${Date.now()}`,
+          object: 'chat.completion',
+          created: Math.floor(Date.now() / 1000),
+          model: modelId,
+          choices: [{ index: 0, message: { role: 'assistant', content: null as unknown as string, tool_calls: rescued }, finish_reason: 'tool_calls' }],
+          usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        };
+        out._routed_via = { platform: this.platform, model: modelId };
+        return out;
+      }
       throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 
@@ -138,6 +180,15 @@ export class OpenAICompatProvider extends BaseProvider {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
+      const rescued = this.rescueFailedGeneration(err, options);
+      if (rescued) {
+        console.log(`[${this.name}] Rescued ${rescued.length} inline tool call(s) from a ${res.status} tool_use_failed (stream, #264)`);
+        const base = { id: `chatcmpl-rescued-${Date.now()}`, object: 'chat.completion.chunk' as const, created: Math.floor(Date.now() / 1000), model: modelId };
+        yield { ...base, choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }] };
+        yield { ...base, choices: [{ index: 0, delta: { tool_calls: rescued.map((c, i) => ({ index: i, ...c })) as unknown as ChatToolCall[] }, finish_reason: null }] };
+        yield { ...base, choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] };
+        return;
+      }
       throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
     }
 


### PR DESCRIPTION
Fixes #264.

## Root cause (reproduced)
I set up OpenClaw → captured its real outbound payload (22 tools) → replayed it through each provider via FreeLLMAPI's own transform:
- **Gemini** accepts all 22 tools (returns `tool_calls`). Not the culprit.
- **Groq `llama-3.3-70b-versatile`** returns **HTTP 400 `tool_use_failed`** — the model emitted its tool call as inline **dialect text**:
  ```
  failed_generation: <function=read={"file_path": "sample.txt"}</function>
  ```
  Groq's own parser couldn't convert it, so it 400s. `gpt-oss-120b` works on both Groq and Cerebras — this is a weaker-model behavior.

That 400 is retryable, so the router fails over — but when an agent's enabled chain is mostly such models, every attempt 400s identically and the chain exhausts, which the agent reports as `FailoverError: provider rejected the request schema or tool payload`.

## Fix
FreeLLMAPI already rescues this exact inline dialect from streamed *text* (`rescueInlineToolCalls`). This extends the same rescue to the **400 `failed_generation`** case in `openai-compat.ts`: when a non-2xx response carries `error.failed_generation`, parse it into structured `tool_calls` (with argument repair) and synthesize a normal `tool_calls` turn instead of throwing — covering both the non-stream and stream paths. No `failed_generation` → throws exactly as before.

This turns a dead-end 400 into a working tool call on the *first* model, so agents no longer burn the whole chain.

## Verification
- **Live**: replayed against Groq `llama-3.3-70b-versatile` with the captured payload — non-stream rescue recovered the `read` call (`finish_reason: tool_calls`).
- **Unit**: added tests for non-stream rescue, stream rescue (synthesized chunks), and the no-`failed_generation` passthrough (still throws). Full suite 462 pass; `tsc` clean.