### PR TITLE
fix: pass actual ttfbMs on mid-stream error and add missing 403 model-skip in Responses API

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -953,7 +953,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), null, pinnedModelId);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), ttfbMs, pinnedModelId);
             return;
           }
           // Headers never sent — bubble to the outer retry handler, which

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -18,6 +18,7 @@ import {
   isRetryableError,
   isPaymentRequiredError,
   isModelNotFoundError,
+  isModelAccessForbiddenError,
   timingSafeStringEqual,
   extractApiToken,
   getStickyModel,
@@ -661,7 +662,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       if (isRetryableError(err)) {
         // Model-level 404: rule out the whole model for this request — its
         // other keys would 404 the same way. (PR #111, credits @barbotkonv.)
-        if (isModelNotFoundError(err)) skipModels.add(route.modelDbId);
+        if (isModelNotFoundError(err) || isModelAccessForbiddenError(err)) skipModels.add(route.modelDbId);
         skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
         setCooldown(route.platform, route.modelId, route.keyId, isPaymentRequiredError(err)
           ? PAYMENT_REQUIRED_COOLDOWN_MS


### PR DESCRIPTION
Two small fixes found while auditing the streaming and retry paths.
### 1. Lost TTFB metric on mid-stream errors (`proxy.ts`)
When a streaming error occurred **after** headers were already sent to the
client (mid-stream provider failure), the error log entry passed `null` for
`ttfbMs` — even though the TTFB had already been measured by `flushHeaders()`.
This silently dropped the time-to-first-byte metric from analytics for every
stream that started but failed mid-way.
**Fix:** Pass the captured `ttfbMs` variable instead of `null`.
### 2. Missing 403 model-skip in Responses API (`responses.ts`)
**Why this matters:**
The `/v1/responses` endpoint is the primary path used by **Codex CLI** — a
popular agentic coding tool that speaks the OpenAI Responses API. When
`isModelAccessForbiddenError` was introduced to the proxy handler to skip
entire models on 403 (#256, closed), the fix was only applied to the
`/chat/completions` retry loop. The Responses API handler was missed.
In practice, with a **single key per platform**, both paths behave the same
because `routeRequest` naturally moves past the cooldowned key to the next
model. The gap only surfaces when a platform has **multiple keys** and a
model is tier-restricted across all of them — e.g., two GitHub tokens trying
`gpt-4o` on the free tier. Without this fix, the Responses API wastes N
retries (one per key) on a model that can never succeed, while
`/chat/completions` skips it immediately on the first 403.
**Fix:** Added `isModelAccessForbiddenError` to the model-skip condition
in the Responses API retry loop, matching parity with `proxy.ts` (line 1054).
This is a **correctness alignment** fix — the two retry loops should behave
identically. The change is trivial (one line + one import) and risk-free.
## Testing
- All 462 existing tests pass (1 pre-existing unrelated proxy-test failure
  requires an actual HTTP proxy to be configured).
- Changes are purely additive and `isModelAccessForbiddenError` is already
  exported from `proxy.ts`.