### PR TITLE
docs: add CONTRIBUTING with AI/LLM contribution policy (#139)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Contributors are very welcome. This project is a local-first aggregator for free LLM API tiers, so most contributions fall into a few buckets: adding a provider, adding an endpoint, improving the router, polishing the dashboard, or fixing bugs. The README has a "Good first PRs" list if you want a starting point.
+
+## Development loop
+
+```bash
+npm install
+npm run dev      # server on :3001, dashboard on :5173, both with HMR
+npm test         # server vitest; also runs client tests if present
+npm run build    # compile server and dashboard
+```
+
+Every PR should:
+
+- Include a test, and keep the existing suite green (`npm test`).
+- Match the `.editorconfig` and tsconfig defaults already in the repo.
+- Stay scoped to one change. Smaller PRs get reviewed and merged faster.
+- Avoid adding paid or card-gated services. This catalog only lists tiers that are genuinely free to start using without a credit card.
+
+## AI and LLM-assisted contributions
+
+LLM-assisted PRs are welcome. A lot of this codebase is itself built that way, so there is no stigma here. The bar is the same as for any other PR: you are responsible for what you submit.
+
+That means:
+
+- **Understand your own diff.** If a reviewer asks why a line is there, you should be able to answer. Do not open a PR you cannot explain.
+- **Test it for real.** Run the code, not just the prompt. Generated tests that do not actually exercise the change, or that pass against a mock of the wrong shape, are worse than no tests.
+- **Keep it scoped.** Tools love to "helpfully" reformat unrelated files, rename things, or rewrite comments. Strip that out before opening the PR so the diff is only the change you intend.
+- **No invented facts.** Provider rate limits, model ids, and endpoints must be verified against the provider, not recalled by a model. A wrong rate limit in the catalog is a bug that ships to everyone.
+- **Disclose nothing special required.** You do not need to label a PR as AI-assisted. We care about the result, not the keystrokes.
+
+PRs that are clearly unreviewed model output (broad unexplained diffs, fabricated limits, tests that do not run) will be asked for changes or closed.
+
+## Reporting issues
+
+Bug reports are most useful with: your version (or commit), the provider involved, and the exact request and response where you can share them. For verification or routing bugs, the server logs around the failing request help a lot.
+
+## Related community work
+
+Some useful fixes and experiments live in community forks and branches. If you are looking for prior art before starting, these are worth a read:
+
+- `fix-loopback-only` — restrict admin API access to localhost to avoid external exposure.
+- `fix-35-admin-security` — optional `ADMIN_PASSWORD` HMAC auth for remote admin API access.
+- `fix-101-markdown` — Markdown rendering in the Playground UI.
+- `fix-119-atomic-ratelimits` — atomic SQLite `BEGIN IMMEDIATE` transactions to fix rate-limit race conditions.
+- `feature-122-auto-routing` — per-request `smart` / `fast` / `cheap` routing strategies.
+
+If you port one of these into a PR, credit the original author in the PR description so they land in the Contributors list.

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ Stacking free tiers has real trade-offs. Be honest with yourself about them:
 
 ## Contributing
 
-Contributors very welcome! Good first PRs:
+Contributors very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev loop, PR expectations, and the policy on AI/LLM-assisted contributions (short version: welcome, same quality bar as any other PR). Good first PRs:
 
 - **Add a provider** — copy `server/src/providers/openai-compat.ts` as a template, wire it into `server/src/providers/index.ts`, seed its models in `server/src/db/index.ts`, add a test in `server/src/__tests__/providers/`.
 - **Add an endpoint** — images, moderations, audio. The provider base class can grow new methods; adapters declare which they support.


### PR DESCRIPTION
Closes #139.

Adds `CONTRIBUTING.md` with:
- Dev loop and PR expectations (test included, suite green, scoped, no paid/card-gated services).
- An explicit **AI/LLM-assisted contributions** policy: welcome, same quality bar as any other PR (understand your diff, test it for real, keep it scoped, no invented provider limits). PRs that are clearly unreviewed model output get changes requested or closed.
- Issue reporting guidance and a "related community work" list pointing at the relevant fork branches as prior art.

Linked from the README Contributing section.