### PR TITLE
fix(playground): explain empty model list when no keys configured (#269)

### DIFF
--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -158,6 +158,13 @@ export default function PlaygroundPage() {
                     </span>
                   </SelectItem>
                 ))}
+                {availableModels.length === 0 && (
+                  // Models only appear once a platform has an enabled key. Without
+                  // one, the list is just "Auto" and looks broken — say why. (#269)
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                    No models yet. Add an API key on the Keys page to populate this list.
+                  </div>
+                )}
               </SelectContent>
             </Select>
             {messages.length > 0 && (


### PR DESCRIPTION
Addresses #269.

## Root cause
The Playground model selector filters to models whose platform has an enabled key:

```ts
const availableModels = fallbackEntries.filter(e => e.keyCount > 0 && e.enabled)
```

With no keys added yet, every entry filters out and the dropdown shows only "Auto (fallback chain)", which looks like a broken/empty list. The catalog itself is seeded fine; nothing is wrong with the data.

## Fix
Add an inline empty-state hint in the selector when `availableModels.length === 0`, telling the user to add an API key on the Keys page. Small, targeted UX fix; no behavior change to routing.

If a reporter has keys configured and still sees nothing, that would point at a seed/migration problem and we'd follow up separately, but the common case (fresh install, no keys) is now self-explanatory.

Client build clean.