### PR TITLE
docs: credit @aaronjmars and @Robs87 in Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/immanuelsavio"><img src="https://images.weserv.nl/?url=github.com/immanuelsavio.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@immanuelsavio" /></a>
 <a href="https://github.com/Slyker"><img src="https://images.weserv.nl/?url=github.com/Slyker.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Slyker" /></a>
 <a href="https://github.com/wells1013"><img src="https://images.weserv.nl/?url=github.com/wells1013.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@wells1013" /></a>
+<a href="https://github.com/aaronjmars"><img src="https://images.weserv.nl/?url=github.com/aaronjmars.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@aaronjmars" /></a>
+<a href="https://github.com/Robs87"><img src="https://images.weserv.nl/?url=github.com/Robs87.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Robs87" /></a>
 
 ## Terms of Service review
 


### PR DESCRIPTION
Credits the two new contributors from this round of merges:
- **@aaronjmars** — #284 (security: pin AES-256-GCM auth tag length to 16 bytes on decrypt)
- **@Robs87** — #245 (remove unsafe `as any` casts in the router)

@itsfuad (#294), @danscMax (#260), and @barbotkonv (#288) were already in the list.