### PR TITLE
fix(desktop): open external links in the system browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/immanuelsavio"><img src="https://images.weserv.nl/?url=github.com/immanuelsavio.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@immanuelsavio" /></a>
 <a href="https://github.com/Slyker"><img src="https://images.weserv.nl/?url=github.com/Slyker.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Slyker" /></a>
 <a href="https://github.com/wells1013"><img src="https://images.weserv.nl/?url=github.com/wells1013.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@wells1013" /></a>
+<a href="https://github.com/evgkrsk"><img src="https://images.weserv.nl/?url=github.com/evgkrsk.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@evgkrsk" /></a>
 <a href="https://github.com/aaronjmars"><img src="https://images.weserv.nl/?url=github.com/aaronjmars.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@aaronjmars" /></a>
 <a href="https://github.com/Robs87"><img src="https://images.weserv.nl/?url=github.com/Robs87.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Robs87" /></a>
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, dialog, ipcMain, clipboard, nativeTheme } from 'electron';
+import { app, dialog, ipcMain, clipboard, nativeTheme, shell } from 'electron';
 import { startServer, ensureSessionToken, getUnifiedApiKey } from './server.mjs';
 import { loadConfig, saveConfig } from './config.js';
 import { buildTray } from './tray.js';
@@ -37,6 +37,33 @@ if (!app.requestSingleInstanceLock()) {
 
   // The app lives in the tray; closing the dashboard window must not quit.
   app.on('window-all-closed', () => {});
+
+  // Every window is a view onto the local dashboard, so anything that isn't
+  // the local server belongs in the system browser. Without a window-open
+  // handler, target="_blank" links (e.g. "Get API key" on the Keys page)
+  // spawn a bare child window that inherits our preload and renders blank
+  // (#304) — deny the window and hand the URL to the OS instead. Only
+  // http(s) ever reaches openExternal.
+  const isExternal = (url: string) => {
+    try {
+      const u = new URL(url);
+      return (u.protocol === 'http:' || u.protocol === 'https:') && u.hostname !== '127.0.0.1';
+    } catch {
+      return false;
+    }
+  };
+  app.on('web-contents-created', (_event, contents) => {
+    contents.setWindowOpenHandler(({ url }) => {
+      if (isExternal(url)) shell.openExternal(url);
+      return { action: 'deny' };
+    });
+    contents.on('will-navigate', (event, url) => {
+      if (isExternal(url)) {
+        event.preventDefault();
+        shell.openExternal(url);
+      }
+    });
+  });
 
   // ── popover IPC ──────────────────────────────────────────────────────────
   ipcMain.handle('freeapi:snapshot', () => {


### PR DESCRIPTION
Fixes #304.

## Problem
Clicking any "Get API key" link on the desktop app's Keys page opened a blank Electron window instead of the provider's key page. The dashboard and popover windows were created without a `setWindowOpenHandler`, so `target="_blank"` links fell through to Electron's default: a bare child `BrowserWindow` that inherits the dashboard preload (which expects a `--freeapi-token` argument) and renders blank. The Stripe billing-portal `window.open` on the Premium page hit the same path.

## Fix
An app-wide `web-contents-created` hook in `desktop/src/main.ts`:
- `setWindowOpenHandler` denies every child window and passes external `http(s)` URLs to `shell.openExternal`, so they open in the system default browser.
- a `will-navigate` guard prevents plain links from navigating any window away from the local dashboard, routing those to the browser too.
- only `http:`/`https:` URLs ever reach `openExternal`.

## Verification
Ran the dev app with CDP, navigated to `/keys`, and clicked a real "Get API key" link: no new Electron window target appeared (previously one did), and a local-listener probe confirmed the URL was opened by the system default browser (Chrome UA, not Electron's bundled Chromium).

Thanks @evgkrsk for the report.