### PR TITLE
feat(api): advertise context window on /v1/models (#282)

### DIFF
--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -135,6 +135,33 @@ describe('Virtual "auto" model', () => {
     }
   });
 
+  // #282: clients read a model's context window from /v1/models; advertise it
+  // under both `context_window` and the OpenRouter-convention `context_length`,
+  // and give "auto" the largest window among connected models so clients don't
+  // fall back to a conservative ~16k default and truncate long inputs.
+  it('advertises context_length and a non-null auto context window (#282)', async () => {
+    const { status, body } = await request(app, 'GET', '/v1/models', undefined, authHeaders());
+    expect(status).toBe(200);
+
+    const auto = body.data.find((m: any) => m.id === 'auto');
+    expect(auto.context_window).toBe(auto.context_length);
+    expect(typeof auto.context_window).toBe('number');
+    expect(auto.context_window).toBeGreaterThan(0);
+
+    // Every real model mirrors context_window into context_length.
+    const connected = body.data.filter((m: any) => m.id !== 'auto' && m.available);
+    expect(connected.length).toBeGreaterThan(0);
+    for (const m of connected) {
+      expect(m.context_length).toBe(m.context_window);
+    }
+
+    // Auto's advertised ceiling is the max window among connected models.
+    const maxConnected = Math.max(
+      ...connected.filter((m: any) => m.context_window != null).map((m: any) => m.context_window),
+    );
+    expect(auto.context_window).toBe(maxConnected);
+  });
+
   it('treats model:"auto" as auto-route instead of a 400', async () => {
     const origFetch = global.fetch;
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -153,6 +153,20 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
   const onlyAvailable = q === '1' || q === 'true' || q === 'yes';
   const listed = onlyAvailable ? models.filter(m => m.available === 1) : models;
 
+  // "auto" routes to whichever model fits, so its honest ceiling is the largest
+  // context window among models that can serve a request right now. Advertising
+  // null here makes OpenAI-compatible clients (opencode, Continue) fall back to
+  // their own conservative default — commonly ~16k — and truncate long inputs
+  // before they ever reach us (#282). Computed over currently-available models
+  // (not the query-filtered `listed`) so the ceiling is honest even on the
+  // default unfiltered list; null only when nothing is connected.
+  const availableContextWindows = models
+    .filter(m => m.available === 1 && m.context_window != null)
+    .map(m => m.context_window as number);
+  const autoContextWindow = availableContextWindows.length > 0
+    ? Math.max(...availableContextWindows)
+    : null;
+
   res.json({
     object: 'list',
     data: [
@@ -162,7 +176,11 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
         created: 0,
         owned_by: 'freellmapi',
         name: 'Auto (router picks the best available model)',
-        context_window: null,
+        context_window: autoContextWindow,
+        // `context_length` is OpenRouter's field name and the one most
+        // OpenAI-compatible clients read; emit both so whichever a client
+        // looks for is populated. Additive — clients ignore unknown fields.
+        context_length: autoContextWindow,
         available: true,
         unavailable_reason: null,
       },
@@ -173,6 +191,7 @@ proxyRouter.get('/models', (req: Request, res: Response) => {
         owned_by: m.platform,
         name: m.display_name,
         context_window: m.context_window,
+        context_length: m.context_window,
         // Non-standard but additive: OpenAI clients ignore unknown fields.
         available: m.available === 1,
         unavailable_reason: m.available === 1 ? null : (m.enabled === 1 ? 'no_key' : 'disabled'),


### PR DESCRIPTION
Fixes #282.

## Problem
A user reported their context window was "stuck at 16k" on large files. Investigation showed it isn't a FreeLLMAPI cap — there is no 16k value anywhere in the catalog (seeded windows go 8k → 24k/32k → 128k+), and the router already skips any model whose `context_window` can't hold the request (`router.ts:592`).

The 16k comes from the **client**. OpenAI-compatible tools (opencode, Continue) read a model's context window from `/v1/models`; for custom providers they don't get it from models.dev, so when the field they look for is missing they fall back to a conservative default (commonly ~16k/32k) and truncate long inputs *before the request reaches us*. Our `/v1/models` advertised `context_length` nowhere, and `auto` — the default model everyone uses — reported `context_window: null`.

## Fix (additive, no schema change)
- Emit `context_length` (OpenRouter's field name, the one most clients read) alongside the existing `context_window` on every entry.
- Give `auto` a real ceiling: the largest context window among models that can serve a request right now, instead of `null`. Computed over currently-available models so the number is honest even on the default unfiltered list; `null` only when nothing is connected.

## Test
Added a case asserting `auto` advertises a non-null window equal to the max among connected models, and that every real model mirrors `context_window` into `context_length`. Full `proxy-auto-model` suite passes under `vitest --pool=forks` (CI config).

## Note for affected clients
opencode ignores a custom provider's `/v1/models` limits entirely and needs `limit.context` set in its own config; a short troubleshooting doc for that will follow separately. This PR fixes every client that *does* read the endpoint.