### PR TITLE
fix(routing): custom strategy crashes the Fallback page

### DIFF
--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -100,11 +100,15 @@ function CustomWeightsPopover({ saved, onSave, saving }: {
   const [values, setValues] = useState<RoutingWeights>(() => fromSaved(saved))
   const [dirty, setDirty] = useState(false)
 
-  function fromSaved(w: RoutingWeights): RoutingWeights {
+  // Defensive: an older/partial server response (or a future field rename) could
+  // leave `saved` undefined; never let that white-screen the whole page (there's
+  // no error boundary above us). Fall back to an even split.
+  function fromSaved(w?: RoutingWeights): RoutingWeights {
+    const safe = w ?? { reliability: 1 / 3, speed: 1 / 3, intelligence: 1 / 3 }
     return {
-      reliability: Math.round(w.reliability * 100),
-      speed: Math.round(w.speed * 100),
-      intelligence: Math.round(w.intelligence * 100),
+      reliability: Math.round(safe.reliability * 100),
+      speed: Math.round(safe.speed * 100),
+      intelligence: Math.round(safe.intelligence * 100),
     }
   }
 

--- a/server/src/__tests__/routes/fallback.test.ts
+++ b/server/src/__tests__/routes/fallback.test.ts
@@ -57,6 +57,48 @@ describe('Fallback API', () => {
     expect(first).toHaveProperty('intelligenceRank');
   });
 
+  // Regression: GET /routing must always carry customWeights, even before the
+  // user has saved any — the dashboard's custom-weight sliders dereference it
+  // and a missing field white-screened the Fallback page.
+  it('GET /api/fallback/routing always includes customWeights', async () => {
+    const { status, body } = await request(app, 'GET', '/api/fallback/routing');
+    expect(status).toBe(200);
+    expect(body).toHaveProperty('strategy');
+    expect(body).toHaveProperty('customWeights');
+    for (const axis of ['reliability', 'speed', 'intelligence']) {
+      expect(typeof body.customWeights[axis]).toBe('number');
+    }
+  });
+
+  it('PUT /api/fallback/routing accepts the custom strategy with weights and persists them', async () => {
+    const put = await request(app, 'PUT', '/api/fallback/routing', {
+      strategy: 'custom',
+      weights: { reliability: 50, speed: 30, intelligence: 20 },
+    });
+    expect(put.status).toBe(200);
+    expect(put.body.strategy).toBe('custom');
+
+    // Weights are renormalized to sum 1 and echoed back on the next GET.
+    const { body } = await request(app, 'GET', '/api/fallback/routing');
+    expect(body.strategy).toBe('custom');
+    const w = body.customWeights;
+    expect(w.reliability + w.speed + w.intelligence).toBeCloseTo(1, 5);
+    expect(w.reliability).toBeCloseTo(0.5, 5);
+    expect(w.speed).toBeCloseTo(0.3, 5);
+
+    // Restore a neutral preset so later tests start clean.
+    await request(app, 'PUT', '/api/fallback/routing', { strategy: 'balanced' });
+  });
+
+  it('PUT /api/fallback/routing rejects all-zero custom weights', async () => {
+    const { status } = await request(app, 'PUT', '/api/fallback/routing', {
+      strategy: 'custom',
+      weights: { reliability: 0, speed: 0, intelligence: 0 },
+    });
+    expect(status).toBe(400);
+    await request(app, 'PUT', '/api/fallback/routing', { strategy: 'balanced' });
+  });
+
   it('PUT /api/fallback updates order', async () => {
     const { body: original } = await request(app, 'GET', '/api/fallback');
 

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -7,7 +7,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
-import { getAllPenalties, getRoutingScores, getRoutingStrategy, setRoutingStrategy } from '../services/router.js';
+import { getAllPenalties, getRoutingScores, getRoutingStrategy, setRoutingStrategy, setCustomWeights } from '../services/router.js';
 import { BANDIT_PRESETS, type RoutingStrategy } from '../services/scoring.js';
 import { parseBudget } from '../lib/budget.js';
 
@@ -21,16 +21,34 @@ fallbackRouter.get('/routing', (_req: Request, res: Response) => {
 });
 
 const routingSchema = z.object({
-  strategy: z.enum(['priority', 'balanced', 'smartest', 'fastest', 'reliable']),
+  strategy: z.enum(['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom']),
+  // Only meaningful with strategy 'custom': the user's weight vector. Any
+  // non-negative vector is accepted; setCustomWeights renormalizes to sum 1.
+  weights: z.object({
+    reliability: z.number().nonnegative(),
+    speed: z.number().nonnegative(),
+    intelligence: z.number().nonnegative(),
+  }).optional(),
 });
 
 // PUT /routing → switch strategy. Presets are just weight vectors over the three
-// axes; 'priority' falls back to the legacy manual chain order.
+// axes; 'priority' falls back to the legacy manual chain order; 'custom' uses
+// the user's saved weights (optionally updated in the same request).
 fallbackRouter.put('/routing', (req: Request, res: Response) => {
   const parsed = routingSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
     return;
+  }
+  // Persist the weights before flipping the strategy so the new mode reads the
+  // intended vector immediately. setCustomWeights throws on an all-zero vector.
+  if (parsed.data.weights) {
+    try {
+      setCustomWeights(parsed.data.weights);
+    } catch (err: any) {
+      res.status(400).json({ error: { message: err?.message ?? 'Invalid custom weights' } });
+      return;
+    }
   }
   setRoutingStrategy(parsed.data.strategy as RoutingStrategy);
   res.json({ strategy: getRoutingStrategy(), presets: BANDIT_PRESETS });

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -708,7 +708,7 @@ export interface RoutingScore {
   totalRequests: number; // decay-weighted observations
 }
 
-export function getRoutingScores(): { strategy: RoutingStrategy; weights: RoutingWeights | null; scores: RoutingScore[] } {
+export function getRoutingScores(): { strategy: RoutingStrategy; weights: RoutingWeights | null; customWeights: RoutingWeights; scores: RoutingScore[] } {
   const db = getDb();
   const strategy = getRoutingStrategy();
   refreshStatsCache(db);
@@ -750,7 +750,11 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
     };
   }).sort((a, b) => b.score - a.score);
 
-  return { strategy, weights: weightsFor(strategy), scores };
+  // customWeights is always present (the saved vector, or the balanced default)
+  // so the dashboard's custom-weight sliders can render even before the user
+  // has saved their own — distinct from `weights`, which is null in priority
+  // mode and the active preset otherwise.
+  return { strategy, weights: weightsFor(strategy), customWeights: getCustomWeights(), scores };
 }
 
 // Whether at least one vision-capable model is enabled in the fallback chain.


### PR DESCRIPTION
## Problem
With the routing strategy set to `custom`, the Fallback page white-screened:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'reliability')
  at fromSaved (FallbackPage.tsx:105)  ← CustomWeightsPopover
```
`GET /api/fallback/routing` (`getRoutingScores`) never returned `customWeights`, but the client typed it non-null (`RoutingData.customWeights`) and passed it straight into `CustomWeightsPopover`, which dereferences `saved.reliability`. There's no error boundary above the page, so the whole view went blank.

The custom strategy was also only half-wired over HTTP: `PUT /routing` rejected `strategy: 'custom'` and ignored a `weights` body, even though the router engine (`getCustomWeights` / `setCustomWeights` / `weightsFor('custom')`) fully supported it.

## Fix
- **server GET** — always include `customWeights` (the saved vector, or the balanced default) alongside `weights`.
- **server PUT** — accept `strategy: 'custom'` and an optional `weights` object; persist via `setCustomWeights` (renormalized to sum 1) before flipping strategy. All-zero weights → 400.
- **client** — `fromSaved` tolerates an undefined vector (falls back to an even split), so a partial/older response can never white-screen the page again.

## Tests
Adds route coverage: GET always carries `customWeights`; PUT `custom`+`weights` persists and renormalizes; all-zero is rejected. Full `fallback` suite (10 tests) passes under `vitest --pool=forks`.

## Verification
Verified live against the running dev server through the same Vite proxy the browser uses: `GET` returns `customWeights` (HTTP 200, strategy `custom`), `PUT custom`+weights persists renormalized to sum 1, all-zero → 400. User confirmed the page renders.