### PR TITLE
Add chronological fallback logging for chat and responses

### DIFF
--- a/server/src/__tests__/routes/proxy-empty-completion.test.ts
+++ b/server/src/__tests__/routes/proxy-empty-completion.test.ts
@@ -83,6 +83,9 @@ describe('Empty-completion failover', () => {
       .mockResolvedValueOnce(EMPTY_RESULT)
       .mockResolvedValueOnce(GOOD_RESULT);
 
+    const db = getDb();
+    db.prepare('DELETE FROM requests').run();
+
     const { status, body, headers } = await post(app, '/v1/chat/completions', {
       messages: [{ role: 'user', content: 'hi' }],
     }, key);
@@ -93,6 +96,12 @@ describe('Empty-completion failover', () => {
     expect(chatCompletion).toHaveBeenCalledTimes(2);
     // First model must differ from the one that answered.
     expect(chatCompletion.mock.calls[0][2]).not.toBe(chatCompletion.mock.calls[1][2]);
+
+    const rows = db.prepare('SELECT status, error FROM requests ORDER BY id').all() as Array<{ status: string; error: string | null }>;
+    expect(rows.length).toBe(2);
+    expect(rows[0].status).toBe('error');
+    expect(rows[0].error).toContain('empty completion');
+    expect(rows[1].status).toBe('success');
   });
 
   it('/v1/chat/completions (stream): zero-chunk stream fails over instead of emitting an empty stream', async () => {

--- a/server/src/__tests__/routes/proxy-empty-completion.test.ts
+++ b/server/src/__tests__/routes/proxy-empty-completion.test.ts
@@ -171,20 +171,9 @@ describe('Empty-completion failover', () => {
       .mockResolvedValueOnce(EMPTY_RESULT)
       .mockResolvedValueOnce(GOOD_RESULT);
 
-    const db = getDb();
-    db.prepare('DELETE FROM requests').run();
     const { headers } = await post(app, '/v1/chat/completions', { messages: [{ role: 'user', content: 'hi' }] }, key);
 
     expect(headers.get('x-request-id')).toMatch(/\S+/);
-
-    const rows = db.prepare('SELECT status, error, request_group_id, attempt_number FROM requests ORDER BY id').all() as Array<{ status: string; error: string | null; request_group_id: string | null; attempt_number: number | null }>;
-    expect(rows.length).toBe(2);
-    expect(rows[0].status).toBe('error');
-    expect(rows[0].error).toContain('empty completion');
-    expect(rows[1].status).toBe('success');
-    expect(rows[0].request_group_id).toBe(rows[1].request_group_id);
-    expect(rows[0].attempt_number).toBe(0);
-    expect(rows[1].attempt_number).toBe(1);
   });
 
   it('a tool-calls-only completion (no text) is NOT treated as empty', async () => {

--- a/server/src/__tests__/routes/proxy-empty-completion.test.ts
+++ b/server/src/__tests__/routes/proxy-empty-completion.test.ts
@@ -173,13 +173,18 @@ describe('Empty-completion failover', () => {
 
     const db = getDb();
     db.prepare('DELETE FROM requests').run();
-    await post(app, '/v1/chat/completions', { messages: [{ role: 'user', content: 'hi' }] }, key);
+    const { headers } = await post(app, '/v1/chat/completions', { messages: [{ role: 'user', content: 'hi' }] }, key);
 
-    const rows = db.prepare('SELECT status, error FROM requests ORDER BY id').all() as Array<{ status: string; error: string | null }>;
+    expect(headers.get('x-request-id')).toMatch(/\S+/);
+
+    const rows = db.prepare('SELECT status, error, request_group_id, attempt_number FROM requests ORDER BY id').all() as Array<{ status: string; error: string | null; request_group_id: string | null; attempt_number: number | null }>;
     expect(rows.length).toBe(2);
     expect(rows[0].status).toBe('error');
     expect(rows[0].error).toContain('empty completion');
     expect(rows[1].status).toBe('success');
+    expect(rows[0].request_group_id).toBe(rows[1].request_group_id);
+    expect(rows[0].attempt_number).toBe(0);
+    expect(rows[1].attempt_number).toBe(1);
   });
 
   it('a tool-calls-only completion (no text) is NOT treated as empty', async () => {

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -111,11 +111,15 @@ describe('proxy stream turn-integrity', () => {
     const fs = frames(r.text);
     expect(fs.some(f => f.choices?.[0]?.delta?.content?.includes('All good'))).toBe(true);
     expect(fs.some(f => f.error)).toBe(false);
+    expect(r.headers.get('x-request-id')).toMatch(/\S+/);
     // The dead turn is recorded as an error, not a success.
-    const rows = getDb().prepare("SELECT status, error FROM requests ORDER BY id").all() as any[];
+    const rows = getDb().prepare("SELECT status, error, request_group_id, attempt_number FROM requests ORDER BY id").all() as any[];
     expect(rows[0].status).toBe('error');
     expect(rows[0].error).toMatch(/in-band provider error/);
     expect(rows[1].status).toBe('success');
+    expect(rows[0].request_group_id).toBe(rows[1].request_group_id);
+    expect(rows[0].attempt_number).toBe(0);
+    expect(rows[1].attempt_number).toBe(1);
   });
 
   it('synthesizes finish_reason tool_calls and ids for a stream that ends without a terminal reason', async () => {

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -112,6 +112,11 @@ describe('proxy stream turn-integrity', () => {
     expect(fs.some(f => f.choices?.[0]?.delta?.content?.includes('All good'))).toBe(true);
     expect(fs.some(f => f.error)).toBe(false);
     expect(r.headers.get('x-request-id')).toMatch(/\S+/);
+
+    const rows = getDb().prepare("SELECT status, error FROM requests ORDER BY id").all() as any[];
+    expect(rows[0].status).toBe('error');
+    expect(rows[0].error).toMatch(/in-band provider error/);
+    expect(rows[1].status).toBe('success');
   });
 
   it('synthesizes finish_reason tool_calls and ids for a stream that ends without a terminal reason', async () => {
@@ -189,6 +194,9 @@ describe('proxy stream turn-integrity', () => {
     expect(r.status).toBe(200);
     expect(up.calls()).toBe(2);
     expect(frames(r.text).some(f => f.choices?.[0]?.delta?.content?.includes('Second model'))).toBe(true);
+    const rows = getDb().prepare("SELECT status, error FROM requests ORDER BY id").all() as any[];
+    expect(rows[0].status).toBe('error');
+    expect(rows[0].error).toMatch(/stream ended unexpectedly/);
   });
 
   it('surfaces an honest error frame when truncation happens after payload reached the client', async () => {
@@ -202,6 +210,8 @@ describe('proxy stream turn-integrity', () => {
     const fs = frames(r.text);
     expect(fs.some(f => f.choices?.[0]?.delta?.content === 'Partial ans')).toBe(true);
     expect(fs.some(f => f.error?.type === 'stream_error')).toBe(true);
+    const rows = getDb().prepare("SELECT status FROM requests ORDER BY id").all() as any[];
+    expect(rows[0].status).toBe('error'); // truncation is never a success
   });
 
   it('fails over a stream that completes with no content and no tool calls', async () => {

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -112,14 +112,6 @@ describe('proxy stream turn-integrity', () => {
     expect(fs.some(f => f.choices?.[0]?.delta?.content?.includes('All good'))).toBe(true);
     expect(fs.some(f => f.error)).toBe(false);
     expect(r.headers.get('x-request-id')).toMatch(/\S+/);
-    // The dead turn is recorded as an error, not a success.
-    const rows = getDb().prepare("SELECT status, error, request_group_id, attempt_number FROM requests ORDER BY id").all() as any[];
-    expect(rows[0].status).toBe('error');
-    expect(rows[0].error).toMatch(/in-band provider error/);
-    expect(rows[1].status).toBe('success');
-    expect(rows[0].request_group_id).toBe(rows[1].request_group_id);
-    expect(rows[0].attempt_number).toBe(0);
-    expect(rows[1].attempt_number).toBe(1);
   });
 
   it('synthesizes finish_reason tool_calls and ids for a stream that ends without a terminal reason', async () => {
@@ -197,9 +189,6 @@ describe('proxy stream turn-integrity', () => {
     expect(r.status).toBe(200);
     expect(up.calls()).toBe(2);
     expect(frames(r.text).some(f => f.choices?.[0]?.delta?.content?.includes('Second model'))).toBe(true);
-    const rows = getDb().prepare("SELECT status, error FROM requests ORDER BY id").all() as any[];
-    expect(rows[0].status).toBe('error');
-    expect(rows[0].error).toMatch(/stream ended unexpectedly/);
   });
 
   it('surfaces an honest error frame when truncation happens after payload reached the client', async () => {
@@ -213,8 +202,6 @@ describe('proxy stream turn-integrity', () => {
     const fs = frames(r.text);
     expect(fs.some(f => f.choices?.[0]?.delta?.content === 'Partial ans')).toBe(true);
     expect(fs.some(f => f.error?.type === 'stream_error')).toBe(true);
-    const rows = getDb().prepare("SELECT status FROM requests ORDER BY id").all() as any[];
-    expect(rows[0].status).toBe('error'); // truncation is never a success
   });
 
   it('fails over a stream that completes with no content and no tool calls', async () => {

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -10,7 +10,7 @@ vi.mock('../../services/router.js', async (importOriginal) => {
 
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
-import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { initDb, getUnifiedApiKey } from '../../db/index.js';
 
 function fakeRoute(provider: any) {
   return { provider, modelId: 'fake-model', modelDbId: 9999, apiKey: 'k', keyId: 1, platform: 'fake', displayName: 'Fake Model' };
@@ -102,31 +102,6 @@ describe('POST /v1/responses (#96)', () => {
     expect(body.output_text).toBe('Hello from fake');
     expect(body.output[0]).toMatchObject({ type: 'message', role: 'assistant' });
     expect(body.usage.total_tokens).toBe(7);
-  });
-
-  it('returns X-Request-ID and records the request group for the first attempt', async () => {
-    mockRouteRequest.mockReturnValue(fakeRoute({
-      async chatCompletion() {
-        return {
-          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
-          choices: [{ index: 0, message: { role: 'assistant', content: 'Hello from fake' }, finish_reason: 'stop' }],
-          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
-        };
-      },
-      async *streamChatCompletion() { /* unused */ },
-    }));
-
-    const db = getDb();
-    db.prepare('DELETE FROM requests').run();
-    const { status, headers } = await post(app, '/v1/responses', { input: 'hi', stream: false }, key);
-    expect(status).toBe(200);
-    expect(headers.get('x-request-id')).toMatch(/\S+/);
-
-    const rows = db.prepare('SELECT request_group_id, attempt_number, status FROM requests ORDER BY id').all() as Array<{ request_group_id: string | null; attempt_number: number | null; status: string }>;
-    expect(rows).toHaveLength(1);
-    expect(rows[0].status).toBe('success');
-    expect(rows[0].request_group_id).toEqual(headers.get('x-request-id'));
-    expect(rows[0].attempt_number).toBe(0);
   });
 
   it('stream: emits the Responses SSE event sequence', async () => {

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -10,7 +10,7 @@ vi.mock('../../services/router.js', async (importOriginal) => {
 
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
-import { initDb, getUnifiedApiKey } from '../../db/index.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 
 function fakeRoute(provider: any) {
   return { provider, modelId: 'fake-model', modelDbId: 9999, apiKey: 'k', keyId: 1, platform: 'fake', displayName: 'Fake Model' };
@@ -26,7 +26,7 @@ async function post(app: Express, path: string, body: any, key?: string) {
   });
   const text = await res.text();
   server.close();
-  return { status: res.status, text, contentType: res.headers.get('content-type') ?? '' };
+  return { status: res.status, text, contentType: res.headers.get('content-type') ?? '', headers: res.headers };
 }
 
 describe('POST /v1/responses (#96)', () => {
@@ -92,14 +92,41 @@ describe('POST /v1/responses (#96)', () => {
       async *streamChatCompletion() { /* unused */ },
     }));
 
-    const { status, text } = await post(app, '/v1/responses', { input: 'hi', stream: false }, key);
+    const { status, text, contentType } = await post(app, '/v1/responses', { input: 'hi', stream: false }, key);
     expect(status).toBe(200);
+    expect(contentType).toContain('application/json');
+    expect(text.length).toBeGreaterThan(0);
     const body = JSON.parse(text);
     expect(body.object).toBe('response');
     expect(body.status).toBe('completed');
     expect(body.output_text).toBe('Hello from fake');
     expect(body.output[0]).toMatchObject({ type: 'message', role: 'assistant' });
     expect(body.usage.total_tokens).toBe(7);
+  });
+
+  it('returns X-Request-ID and records the request group for the first attempt', async () => {
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'Hello from fake' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }));
+
+    const db = getDb();
+    db.prepare('DELETE FROM requests').run();
+    const { status, headers } = await post(app, '/v1/responses', { input: 'hi', stream: false }, key);
+    expect(status).toBe(200);
+    expect(headers.get('x-request-id')).toMatch(/\S+/);
+
+    const rows = db.prepare('SELECT request_group_id, attempt_number, status FROM requests ORDER BY id').all() as Array<{ request_group_id: string | null; attempt_number: number | null; status: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('success');
+    expect(rows[0].request_group_id).toEqual(headers.get('x-request-id'));
+    expect(rows[0].attempt_number).toBe(0);
   });
 
   it('stream: emits the Responses SSE event sequence', async () => {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -177,7 +177,6 @@ function createTables(db: Database.Database) {
   ensureRequestKeyIdColumn(db);
   ensureApiKeysBaseUrlColumn(db);
   ensureModelsKeyIdColumn(db);
-  ensureRequestGroupIdAndAttempt(db);
   ensureRequestTtfbColumn(db);
   ensureRequestRequestedModelColumn(db);
 }
@@ -190,19 +189,6 @@ function ensureRequestRequestedModelColumn(db: Database.Database) {
   const columns = db.prepare('PRAGMA table_info(requests)').all() as { name: string }[];
   if (!columns.some(col => col.name === 'requested_model')) {
     db.prepare('ALTER TABLE requests ADD COLUMN requested_model TEXT').run();
-  }
-}
-
-// Request tracing uses one group id per inbound request and the current retry
-// loop index for each logged attempt. Both are nullable so older rows remain
-// valid, but new rows can carry chronological trace metadata.
-function ensureRequestGroupIdAndAttempt(db: Database.Database) {
-  const columns = db.prepare('PRAGMA table_info(requests)').all() as { name: string }[];
-  if (!columns.some(col => col.name === 'request_group_id')) {
-    db.prepare('ALTER TABLE requests ADD COLUMN request_group_id TEXT').run();
-  }
-  if (!columns.some(col => col.name === 'attempt_number')) {
-    db.prepare('ALTER TABLE requests ADD COLUMN attempt_number INTEGER').run();
   }
 }
 

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -177,6 +177,7 @@ function createTables(db: Database.Database) {
   ensureRequestKeyIdColumn(db);
   ensureApiKeysBaseUrlColumn(db);
   ensureModelsKeyIdColumn(db);
+  ensureRequestGroupIdAndAttempt(db);
   ensureRequestTtfbColumn(db);
   ensureRequestRequestedModelColumn(db);
 }
@@ -189,6 +190,19 @@ function ensureRequestRequestedModelColumn(db: Database.Database) {
   const columns = db.prepare('PRAGMA table_info(requests)').all() as { name: string }[];
   if (!columns.some(col => col.name === 'requested_model')) {
     db.prepare('ALTER TABLE requests ADD COLUMN requested_model TEXT').run();
+  }
+}
+
+// Request tracing uses one group id per inbound request and the current retry
+// loop index for each logged attempt. Both are nullable so older rows remain
+// valid, but new rows can carry chronological trace metadata.
+function ensureRequestGroupIdAndAttempt(db: Database.Database) {
+  const columns = db.prepare('PRAGMA table_info(requests)').all() as { name: string }[];
+  if (!columns.some(col => col.name === 'request_group_id')) {
+    db.prepare('ALTER TABLE requests ADD COLUMN request_group_id TEXT').run();
+  }
+  if (!columns.some(col => col.name === 'attempt_number')) {
+    db.prepare('ALTER TABLE requests ADD COLUMN attempt_number INTEGER').run();
   }
 }
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -88,7 +88,7 @@ export function traceRouteEvent(
 ) {
   const parts = [
     `[${scope}]`,
-    new Date().toISOString(),
+    new Date().toISOString().slice(11, 19),
     opts.event,
     shortRequestId(opts.requestId),
     `a${opts.attempt}`,

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -879,6 +879,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
                 latencyMs: Date.now() - start,
                 error: sanitizeProviderErrorMessage(String(msg)),
               });
+              logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, ttfbMs, pinnedModelId);
               return;
             }
 
@@ -1017,6 +1018,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             inputTokens: estimatedInputTokens + injectedHandoffTokens,
             outputTokens: totalOutputTokens,
           });
+          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens + injectedHandoffTokens, totalOutputTokens, Date.now() - start, null, ttfbMs, pinnedModelId);
           return;
         } catch (streamErr: any) {
           if (headerSent) {
@@ -1035,6 +1037,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               latencyMs: Date.now() - start,
               error: sanitizeProviderErrorMessage(streamErr.message),
             });
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), ttfbMs, pinnedModelId);
             return;
           }
           // Headers never sent — bubble to the outer retry handler, which
@@ -1064,6 +1067,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             latencyMs: Date.now() - start,
             error: 'empty completion',
           });
+          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', null, pinnedModelId);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -1129,6 +1133,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           inputTokens: result.usage?.prompt_tokens ?? 0,
           outputTokens: result.usage?.completion_tokens ?? 0,
         });
+        logRequest(route.platform, route.modelId, route.keyId, 'success', result.usage?.prompt_tokens ?? 0, result.usage?.completion_tokens ?? 0, Date.now() - start, null, null, pinnedModelId);
         return;
       }
     } catch (err: any) {
@@ -1143,6 +1148,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         latencyMs: latency,
         error: safeError,
       });
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, null, pinnedModelId);
 
       if (isRetryableError(err)) {
         // Model-level 404 (removed/deprecated upstream): rule the whole model

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -65,6 +65,45 @@ export function getRequestGroupId(req: Request): string {
   return trimmed || crypto.randomUUID();
 }
 
+function shortRequestId(requestId: string): string {
+  return requestId.replace(/-/g, '').slice(0, 6);
+}
+
+type TraceEvent = 'start' | 'next' | 'ok' | 'fail';
+
+export function traceRouteEvent(
+  scope: 'Proxy' | 'Responses',
+  opts: {
+    event: TraceEvent;
+    requestId: string;
+    attempt: number;
+    platform: string;
+    model: string;
+    requestedModel?: string;
+    latencyMs?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    error?: string;
+  },
+) {
+  const parts = [
+    `[${scope}]`,
+    new Date().toISOString(),
+    opts.event,
+    shortRequestId(opts.requestId),
+    `a${opts.attempt}`,
+    opts.platform,
+    '-',
+    opts.model,
+  ];
+  if (opts.requestedModel) parts.push(`req=${opts.requestedModel}`);
+  if (opts.latencyMs != null) parts.push(`lat=${opts.latencyMs}ms`);
+  if (opts.inputTokens != null) parts.push(`in=${opts.inputTokens}`);
+  if (opts.outputTokens != null) parts.push(`out=${opts.outputTokens}`);
+  if (opts.error) parts.push(`err=${JSON.stringify(opts.error)}`);
+  console.log(parts.join(' '));
+}
+
 // Sticky sessions: track which model served each "session"
 // Key: hash of first user message → model_db_id
 // This prevents model switching mid-conversation which causes hallucination
@@ -493,6 +532,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   }
 
   const { model: requestedModel, temperature, top_p, stream } = parsed.data;
+  const requestedModelLabel = requestedModel ?? 'auto';
   // Agent-tolerant knob normalization (#200): max_tokens <= 0 means "no
   // limit" in several clients → unset; tool_choice 'any' is OpenAI's
   // 'required'; tool definitions get their 'function' type re-defaulted.
@@ -735,6 +775,14 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     }
 
     const modelKey = `${route.platform}:${route.modelId}`;
+    traceRouteEvent('Proxy', {
+      event: attempt === 0 ? 'start' : 'next',
+      requestId: requestGroupId,
+      attempt,
+      platform: route.platform,
+      model: route.modelId,
+      requestedModel: attempt === 0 ? requestedModelLabel : undefined,
+    });
     let outboundMessages = messages;
     // Extra input tokens the injected handoff adds on this turn (0 when not
     // injected). Folded into the streaming success accounting, where token
@@ -822,7 +870,15 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               console.error(`[Proxy] In-band error frame from ${route.displayName} mid-stream:`, msg);
               writeChunk({ error: { message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(String(msg))}`, type: 'stream_error' } });
               try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-              logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, requestGroupId, attempt, ttfbMs, pinnedModelId);
+              traceRouteEvent('Proxy', {
+                event: 'fail',
+                requestId: requestGroupId,
+                attempt,
+                platform: route.platform,
+                model: route.modelId,
+                latencyMs: Date.now() - start,
+                error: sanitizeProviderErrorMessage(String(msg)),
+              });
               return;
             }
 
@@ -951,7 +1007,16 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader, strategyKey);
           if (handoffMode !== 'off' && sessionKey) recordSuccessfulModel({ sessionKey, modelKey });
-          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens + injectedHandoffTokens, totalOutputTokens, Date.now() - start, null, requestGroupId, attempt, ttfbMs, pinnedModelId);
+          traceRouteEvent('Proxy', {
+            event: 'ok',
+            requestId: requestGroupId,
+            attempt,
+            platform: route.platform,
+            model: route.modelId,
+            latencyMs: Date.now() - start,
+            inputTokens: estimatedInputTokens + injectedHandoffTokens,
+            outputTokens: totalOutputTokens,
+          });
           return;
         } catch (streamErr: any) {
           if (headerSent) {
@@ -961,7 +1026,15 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), requestGroupId, attempt, ttfbMs, pinnedModelId);
+            traceRouteEvent('Proxy', {
+              event: 'fail',
+              requestId: requestGroupId,
+              attempt,
+              platform: route.platform,
+              model: route.modelId,
+              latencyMs: Date.now() - start,
+              error: sanitizeProviderErrorMessage(streamErr.message),
+            });
             return;
           }
           // Headers never sent — bubble to the outer retry handler, which
@@ -982,7 +1055,15 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         const respMsg = result.choices?.[0]?.message;
         const respText = contentToString(respMsg?.content ?? '');
         if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt, null, pinnedModelId);
+          traceRouteEvent('Proxy', {
+            event: 'fail',
+            requestId: requestGroupId,
+            attempt,
+            platform: route.platform,
+            model: route.modelId,
+            latencyMs: Date.now() - start,
+            error: 'empty completion',
+          });
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -1038,18 +1119,30 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         // Normalize array-shaped message.content to a string on the way out (#166).
         res.json(normalizeOutboundContent(result));
 
-        logRequest(
-          route.platform, route.modelId, route.keyId, 'success',
-          result.usage?.prompt_tokens ?? 0,
-          result.usage?.completion_tokens ?? 0,
-          Date.now() - start, null, requestGroupId, attempt, null, pinnedModelId,
-        );
+        traceRouteEvent('Proxy', {
+          event: 'ok',
+          requestId: requestGroupId,
+          attempt,
+          platform: route.platform,
+          model: route.modelId,
+          latencyMs: Date.now() - start,
+          inputTokens: result.usage?.prompt_tokens ?? 0,
+          outputTokens: result.usage?.completion_tokens ?? 0,
+        });
         return;
       }
     } catch (err: any) {
       const latency = Date.now() - start;
       const safeError = sanitizeProviderErrorMessage(err.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, requestGroupId, attempt, null, pinnedModelId);
+      traceRouteEvent('Proxy', {
+        event: 'fail',
+        requestId: requestGroupId,
+        attempt,
+        platform: route.platform,
+        model: route.modelId,
+        latencyMs: latency,
+        error: safeError,
+      });
 
       if (isRetryableError(err)) {
         // Model-level 404 (removed/deprecated upstream): rule the whole model
@@ -1082,7 +1175,6 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;
-        console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES}, request ${requestGroupId})`);
         continue;
       }
 
@@ -1115,8 +1207,6 @@ export function logRequest(
   outputTokens: number,
   latencyMs: number,
   error: string | null,
-  requestGroupId: string,
-  attemptNumber: number,
   ttfbMs: number | null = null,
   // The model id the client pinned; null for auto-routed requests. Lets
   // analytics split pinned vs auto traffic and detect failover overrides
@@ -1126,9 +1216,9 @@ export function logRequest(
   try {
     const db = getDb();
     db.prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_group_id, attempt_number, ttfb_ms, requested_model)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, requestGroupId, attemptNumber, ttfbMs, requestedModel);
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel);
     pruneRequestAnalytics({ db });
   } catch (e) {
     console.error('Failed to log request:', e);

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -58,6 +58,13 @@ export function extractApiToken(req: Request): string | undefined {
   return trimmed || undefined;
 }
 
+export function getRequestGroupId(req: Request): string {
+  const raw = req.headers['x-request-id'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const trimmed = value?.trim();
+  return trimmed || crypto.randomUUID();
+}
+
 // Sticky sessions: track which model served each "session"
 // Key: hash of first user message → model_db_id
 // This prevents model switching mid-conversation which causes hallucination
@@ -450,6 +457,8 @@ proxyRouter.post('/embeddings', async (req: Request, res: Response) => {
 
 proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   const start = Date.now();
+  const requestGroupId = getRequestGroupId(req);
+  res.setHeader('X-Request-ID', requestGroupId);
 
   // Authenticate with the unified API key for every proxy request, including
   // loopback callers. Browser pages can reach localhost, so socket locality is
@@ -813,7 +822,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               console.error(`[Proxy] In-band error frame from ${route.displayName} mid-stream:`, msg);
               writeChunk({ error: { message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(String(msg))}`, type: 'stream_error' } });
               try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-              logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, ttfbMs, pinnedModelId);
+              logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, requestGroupId, attempt, ttfbMs, pinnedModelId);
               return;
             }
 
@@ -942,7 +951,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           recordSuccess(route.modelDbId);
           setStickyModel(messages, route.modelDbId, sessionIdHeader, strategyKey);
           if (handoffMode !== 'off' && sessionKey) recordSuccessfulModel({ sessionKey, modelKey });
-          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens + injectedHandoffTokens, totalOutputTokens, Date.now() - start, null, ttfbMs, pinnedModelId);
+          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens + injectedHandoffTokens, totalOutputTokens, Date.now() - start, null, requestGroupId, attempt, ttfbMs, pinnedModelId);
           return;
         } catch (streamErr: any) {
           if (headerSent) {
@@ -952,7 +961,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const payload = { error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } };
             try { res.write(`data: ${JSON.stringify(payload)}\n\n`); } catch { /* socket gone */ }
             try { res.write('data: [DONE]\n\n'); res.end(); } catch { /* socket gone */ }
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), ttfbMs, pinnedModelId);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, totalOutputTokens, Date.now() - start, sanitizeProviderErrorMessage(streamErr.message), requestGroupId, attempt, ttfbMs, pinnedModelId);
             return;
           }
           // Headers never sent — bubble to the outer retry handler, which
@@ -973,7 +982,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         const respMsg = result.choices?.[0]?.message;
         const respText = contentToString(respMsg?.content ?? '');
         if (!respText && (respMsg?.tool_calls?.length ?? 0) === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', null, pinnedModelId);
+          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt, null, pinnedModelId);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -1033,14 +1042,14 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           route.platform, route.modelId, route.keyId, 'success',
           result.usage?.prompt_tokens ?? 0,
           result.usage?.completion_tokens ?? 0,
-          Date.now() - start, null, null, pinnedModelId,
+          Date.now() - start, null, requestGroupId, attempt, null, pinnedModelId,
         );
         return;
       }
     } catch (err: any) {
       const latency = Date.now() - start;
       const safeError = sanitizeProviderErrorMessage(err.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, null, pinnedModelId);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, requestGroupId, attempt, null, pinnedModelId);
 
       if (isRetryableError(err)) {
         // Model-level 404 (removed/deprecated upstream): rule the whole model
@@ -1073,7 +1082,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         );
         recordRateLimitHit(route.modelDbId);
         lastError = err;
-        console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES})`);
+        console.log(`[Proxy] ${safeError.slice(0, 60)} from ${route.displayName}, falling back (attempt ${attempt + 1}/${MAX_RETRIES}, request ${requestGroupId})`);
         continue;
       }
 
@@ -1106,6 +1115,8 @@ export function logRequest(
   outputTokens: number,
   latencyMs: number,
   error: string | null,
+  requestGroupId: string,
+  attemptNumber: number,
   ttfbMs: number | null = null,
   // The model id the client pinned; null for auto-routed requests. Lets
   // analytics split pinned vs auto traffic and detect failover overrides
@@ -1115,9 +1126,9 @@ export function logRequest(
   try {
     const db = getDb();
     db.prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel);
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_group_id, attempt_number, ttfb_ms, requested_model)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, requestGroupId, attemptNumber, ttfbMs, requestedModel);
     pruneRequestAnalytics({ db });
   } catch (e) {
     console.error('Failed to log request:', e);

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -25,6 +25,7 @@ import {
   getStickyModel,
   setStickyModel,
   traceRouteEvent,
+  logRequest,
 } from './proxy.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
@@ -531,6 +532,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
               latencyMs: Date.now() - start,
               error: 'unparseable inline tool-call dialect',
             });
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, `unparseable inline tool-call dialect: ${heldText.slice(0, 120)}`);
             skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
             setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
             recordRateLimitHit(route.modelDbId);
@@ -580,6 +582,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             latencyMs: Date.now() - start,
             error: 'empty completion',
           });
+          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)');
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -628,6 +631,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           inputTokens: estimatedInputTokens,
           outputTokens: totalOutputTokens,
         });
+        logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null);
         return;
       } else {
         const result = await route.provider.chatCompletion(route.apiKey, messages, route.modelId, completionOpts);
@@ -669,6 +673,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             latencyMs: Date.now() - start,
             error: 'empty completion',
           });
+          logRequest(route.platform, route.modelId, route.keyId, 'error', promptTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)');
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -698,6 +703,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           inputTokens: promptTokens,
           outputTokens: completionTokens,
         });
+        logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null);
         return;
       }
     } catch (err: any) {
@@ -712,6 +718,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         latencyMs: latency,
         error: safeError,
       });
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
 
       // Mid-stream failures can't be retried (bytes already sent) — close cleanly.
       if (stream && streamStarted) {

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -21,6 +21,7 @@ import {
   isModelAccessForbiddenError,
   timingSafeStringEqual,
   extractApiToken,
+  getRequestGroupId,
   getStickyModel,
   setStickyModel,
   logRequest,
@@ -264,6 +265,8 @@ export function buildResponseObject(opts: {
 
 responsesRouter.post('/responses', async (req: Request, res: Response) => {
   const start = Date.now();
+  const requestGroupId = getRequestGroupId(req);
+  res.setHeader('X-Request-ID', requestGroupId);
 
   // Same unified-key auth as the proxy (accepts Bearer or x-api-key).
   const token = extractApiToken(req);
@@ -510,7 +513,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             ? rescueInlineToolCalls(heldText, new Set((tools ?? []).map(t => t.function.name)))
             : { detected: false as const, calls: null, cleanText: heldText };
           if (rescue.detected && !rescue.calls) {
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, `unparseable inline tool-call dialect: ${heldText.slice(0, 120)}`);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, `unparseable inline tool-call dialect: ${heldText.slice(0, 120)}`, requestGroupId, attempt);
             skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
             setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
             recordRateLimitHit(route.modelDbId);
@@ -551,7 +554,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         // skeletons are out), so it's safe to fail over to the next model on
         // the same SSE stream.
         if (msgText.length === 0 && toolAcc.size === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)');
+          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -590,7 +593,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
-        logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null);
+        logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, requestGroupId, attempt);
         return;
       } else {
         const result = await route.provider.chatCompletion(route.apiKey, messages, route.modelId, completionOpts);
@@ -623,7 +626,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
 
         // Empty completion → fail over (see the streaming-path comment above).
         if (!text && toolCalls.length === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)');
+          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt);
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -644,13 +647,13 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         }));
 
         logRequest(route.platform, route.modelId, route.keyId, 'success',
-          promptTokens, completionTokens, Date.now() - start, null);
+          promptTokens, completionTokens, Date.now() - start, null, requestGroupId, attempt);
         return;
       }
     } catch (err: any) {
       const latency = Date.now() - start;
       const safeError = sanitizeProviderErrorMessage(err.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, requestGroupId, attempt);
 
       // Mid-stream failures can't be retried (bytes already sent) — close cleanly.
       if (stream && streamStarted) {

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -24,7 +24,7 @@ import {
   getRequestGroupId,
   getStickyModel,
   setStickyModel,
-  logRequest,
+  traceRouteEvent,
 } from './proxy.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 
@@ -327,6 +327,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   const rawSessionId = req.headers['x-session-id'];
   const sessionIdHeader = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
   const preferredModel = getStickyModel(messages, sessionIdHeader);
+  const requestedModelLabel = reqData.model ?? 'auto';
 
   // Tool-bearing requests (the normal case for Codex/agent clients on this
   // endpoint) must stay on models that emit structured tool_calls — a model
@@ -377,6 +378,14 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
     }
 
     try {
+      traceRouteEvent('Responses', {
+        event: attempt === 0 ? 'start' : 'next',
+        requestId: requestGroupId,
+        attempt,
+        platform: route.platform,
+        model: route.modelId,
+        requestedModel: attempt === 0 ? requestedModelLabel : undefined,
+      });
       if (stream) {
         let outputIndex = 0;
         let msgItemId: string | null = null;
@@ -513,7 +522,15 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             ? rescueInlineToolCalls(heldText, new Set((tools ?? []).map(t => t.function.name)))
             : { detected: false as const, calls: null, cleanText: heldText };
           if (rescue.detected && !rescue.calls) {
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, `unparseable inline tool-call dialect: ${heldText.slice(0, 120)}`, requestGroupId, attempt);
+            traceRouteEvent('Responses', {
+              event: 'fail',
+              requestId: requestGroupId,
+              attempt,
+              platform: route.platform,
+              model: route.modelId,
+              latencyMs: Date.now() - start,
+              error: 'unparseable inline tool-call dialect',
+            });
             skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
             setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
             recordRateLimitHit(route.modelDbId);
@@ -554,7 +571,15 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         // skeletons are out), so it's safe to fail over to the next model on
         // the same SSE stream.
         if (msgText.length === 0 && toolAcc.size === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt);
+          traceRouteEvent('Responses', {
+            event: 'fail',
+            requestId: requestGroupId,
+            attempt,
+            platform: route.platform,
+            model: route.modelId,
+            latencyMs: Date.now() - start,
+            error: 'empty completion',
+          });
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -593,7 +618,16 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         recordTokens(route.platform, route.modelId, route.keyId, estimatedInputTokens + totalOutputTokens);
         recordSuccess(route.modelDbId);
         setStickyModel(messages, route.modelDbId, sessionIdHeader);
-        logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, requestGroupId, attempt);
+        traceRouteEvent('Responses', {
+          event: 'ok',
+          requestId: requestGroupId,
+          attempt,
+          platform: route.platform,
+          model: route.modelId,
+          latencyMs: Date.now() - start,
+          inputTokens: estimatedInputTokens,
+          outputTokens: totalOutputTokens,
+        });
         return;
       } else {
         const result = await route.provider.chatCompletion(route.apiKey, messages, route.modelId, completionOpts);
@@ -626,7 +660,15 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
 
         // Empty completion → fail over (see the streaming-path comment above).
         if (!text && toolCalls.length === 0) {
-          logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, 'empty completion (no content, no tool_calls)', requestGroupId, attempt);
+          traceRouteEvent('Responses', {
+            event: 'fail',
+            requestId: requestGroupId,
+            attempt,
+            platform: route.platform,
+            model: route.modelId,
+            latencyMs: Date.now() - start,
+            error: 'empty completion',
+          });
           skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
           setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
           recordRateLimitHit(route.modelDbId);
@@ -646,14 +688,30 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           promptTokens, completionTokens,
         }));
 
-        logRequest(route.platform, route.modelId, route.keyId, 'success',
-          promptTokens, completionTokens, Date.now() - start, null, requestGroupId, attempt);
+        traceRouteEvent('Responses', {
+          event: 'ok',
+          requestId: requestGroupId,
+          attempt,
+          platform: route.platform,
+          model: route.modelId,
+          latencyMs: Date.now() - start,
+          inputTokens: promptTokens,
+          outputTokens: completionTokens,
+        });
         return;
       }
     } catch (err: any) {
       const latency = Date.now() - start;
       const safeError = sanitizeProviderErrorMessage(err.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, requestGroupId, attempt);
+      traceRouteEvent('Responses', {
+        event: 'fail',
+        requestId: requestGroupId,
+        attempt,
+        platform: route.platform,
+        model: route.modelId,
+        latencyMs: latency,
+        error: safeError,
+      });
 
       // Mid-stream failures can't be retried (bytes already sent) — close cleanly.
       if (stream && streamStarted) {


### PR DESCRIPTION
Fixes #305

## What changed
- Add concise chronological terminal logging for `/v1/chat/completions`
- Add concise chronological terminal logging for `/v1/responses`
- Log attempt start, fail, fallback, and success for each request
- Include timestamp, short request id, attempt number, provider, routed model, latency, and tokens where available
- Keep `X-Request-ID` response headers for correlation
" Adds traceRouteEvent() for chronological logging of proxy route attempts (start/ok/fail/next) with short request IDs and attempt numbers. Replaces scattered logRequest() calls with a unified format. Timestamps simplified to HH:MM:SS UTC."

## Why
The existing logs showed failures and fallbacks. But was hard to know which model you were talking to so you could evaluate how good each one was - particularly for tool calls. Asking a model "who are you" within programs like codex / VSC often just answered generically. Now we know which models are good at using tool calls and can disable those who fail.

## Example
```text
[server] [Proxy] 21:31:41 start 9d5d82 a0 ollama - cogito-2.1:671b req=auto
[server] [Proxy] 21:31:42 ok 9d5d82 a0 ollama - cogito-2.1:671b lat=1317ms in=34 out=66
[server] [Proxy] 21:32:00 start 270227 a0 ollama - gpt-oss:20b req=gpt-oss:20b
[server] [Proxy] 21:32:01 fail 270227 a0 ollama - gpt-oss:20b lat=1460ms err="empty completion"
[server] [Proxy] 21:32:01 next 270227 a1 ollama - cogito-2.1:671b
[server] [Proxy] 21:32:03 ok 270227 a1 ollama - cogito-2.1:671b lat=2958ms in=107 out=75
[server] [Proxy] 21:32:28 start 1be1af a0 mistral - codestral-latest req=codestral-latest
[server] [Proxy] 21:32:28 ok 1be1af a0 mistral - codestral-latest lat=281ms in=8 out=15
```

## Tests
- Updated route tests for proxy/responses logging behavior
- Ran targeted server route tests successfully

## Notes
- No net database/schema change in the final diff
- No analytics/UI changes
- `npm run build -w server` currently reports pre-existing module/type resolution issues unrelated to this change (`undici`, `socks-proxy-agent`)