### PR TITLE
Add Agnes AI provider (OpenAI-compatible)

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -54,6 +54,7 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'llm7', label: 'LLM7 (anon ok)', url: 'https://llm7.io' },
   { value: 'huggingface', label: 'HuggingFace Router', url: 'https://huggingface.co/settings/tokens' },
   { value: 'opencode', label: 'OpenCode Zen (free key)', url: 'https://opencode.ai/auth' },
+  { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -184,6 +184,22 @@ register(new OpenAICompatProvider({
   keyless: true,
 }));
 
+// Agnes AI (Sapiens AI) — OpenAI-compatible, backed by LiteLLM + vLLM. Its
+// proprietary Agnes models are currently served at $0/token: live-probed
+// 2026-06-15, the LiteLLM cost headers (x-litellm-response-cost-original) come
+// back 0.0 with no credit drain, so usage is genuinely free rather than a
+// one-time signup-credit grant. The $0 is promotional ("previously $X" /
+// "during this period"), and there is a paid Token/Unlimited subscription
+// underneath, so watch for reversion to paid. ~30 concurrent requests succeed
+// before 429s (no documented RPM/RPD). Free key from platform.agnes-ai.com,
+// no card. Catalog rows live in the catalog (premium → age into free); not
+// shipped as freeapi model migrations.
+register(new OpenAICompatProvider({
+  platform: 'agnes',
+  name: 'Agnes AI',
+  baseUrl: 'https://apihub.agnes-ai.com/v1',
+}));
+
 // Chutes was evaluated for V11 and dropped: probe with a free-tier key
 // returned 402 on every model — "Quota exceeded and account balance is
 // $0.0, please pay with fiat or send tao". The "free" tier requires a

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -14,7 +14,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'custom',
 ] as const;
 
 // `key` is optional so keyless providers (Kilo's anonymous gateway) can be added

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -29,6 +29,10 @@ export type Platform =
   // OVHcloud AI Endpoints — OpenAI-compatible, keyless anonymous tier
   // (2 req/min per IP per model); see migrateModelsV26.
   | 'ovh'
+  // Agnes AI (Sapiens AI) — OpenAI-compatible (LiteLLM + vLLM backend). Serves
+  // its own proprietary Agnes models; the free key comes from
+  // platform.agnes-ai.com (no card).
+  | 'agnes'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
Registers **Agnes AI** (Sapiens AI) as an OpenAI-compatible provider so the proxy can route to its endpoint.

## What this adds (mechanics only)
- `agnes` added to the `Platform` union (`shared/types.ts`)
- `OpenAICompatProvider` registration → `https://apihub.agnes-ai.com/v1` (`server/src/providers/index.ts`)
- `agnes` added to the keys-route allowlist (`server/src/routes/keys.ts`)
- Agnes AI entry on the Keys page provider list, free key from `platform.agnes-ai.com`, no card (`client/src/pages/KeysPage.tsx`)

No catalog model rows are shipped here — Agnes serves its own proprietary models, which are managed in the catalog (added as premium, age into free).

## Verification
- Live probe: requests return 200, OpenAI-compatible (LiteLLM + vLLM backend). Cost headers (`x-litellm-response-cost-original`) report `0.0` with no credit drain → genuinely free per-token, not a one-time credit grant. ~30 concurrent requests succeed before 429s.
- `tsc -b` clean; provider + keys suites pass (77/77) under `vitest --pool=forks`.

## Note
The $0/token is promotional ("previously \$X" / "during this period") with a paid Token/Unlimited subscription underneath — worth monitoring for reversion to paid.