### PR TITLE
feat: image generation via Pollinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRoute
 - [Desktop app](#desktop-app)
 - [Premium (live catalog)](#premium-live-catalog)
 - [Using the API](#using-the-api)
+- [Image Generation](#image-generation)
 - [Screenshots](#screenshots)
 - [How it works](#how-it-works)
 - [Context Handoff](#context-handoff)
@@ -87,6 +88,7 @@ Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cp
 - **Responses API** — `POST /v1/responses` (the wire format current Codex CLI versions require) is implemented as a translating shim over the same router, with full streaming events and tool calls.
 - **Streaming and non-streaming** — Server-Sent Events for `stream: true`, JSON response otherwise. Every provider adapter implements both.
 - **Tool calling** — OpenAI-style `tools` / `tool_choice` requests are passed through, and assistant `tool_calls` + `tool` role follow-up messages round-trip across providers.
+- **Image generation** — `POST /v1/images/generations` via Pollinations (keyless, anonymous tier). Returns `url` or `b64_json` per the OpenAI spec. `n>1` is rejected — see [Image Generation](#image-generation).
 - **Embeddings** — `/v1/embeddings` with family-based routing: failover only ever happens between providers serving the *same* model (vectors from different models are incompatible), never across models. See [Embeddings](#embeddings).
 - **Automatic fallover** — If the chosen provider returns a 429, 5xx, or times out, the router skips it, puts the key on a short cooldown, and retries on the next model in your fallback chain (up to 20 attempts).
 - **Per-key rate tracking** — RPM, RPD, TPM, and TPD counters per `(platform, model, key)` so the router always picks a key that's under its caps.
@@ -104,7 +106,6 @@ Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cp
 
 The scope is deliberately narrow. If a feature isn't on this list and isn't below, assume it isn't there yet.
 
-- **Image generation** (`/v1/images/*`)
 - **Audio / speech** (`/v1/audio/*`)
 - **Legacy completions** (`/v1/completions`) — only the chat endpoint is implemented
 - **Moderation** (`/v1/moderations`)
@@ -367,7 +368,28 @@ Works with `stream=True` as well — you'll get `delta.tool_calls` chunks follow
 
 Every response carries an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
 
-### Embeddings
+## Image Generation
+
+`/v1/images/generations` is OpenAI-compatible and routes to the [Pollinations](https://pollinations.ai) image API (keyless, anonymous tier, no credit card). The only model on the anonymous `/models` list as of 2026-06-16 is `sana` — that is the default when no model is specified.
+
+```bash
+curl http://localhost:3001/v1/images/generations \
+  -H "Authorization: Bearer $FREELLMAPI_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "a red panda coding on a laptop, watercolor",
+    "size": "1024x1024",
+    "response_format": "url"
+  }'
+```
+
+Notes on the upstream:
+
+- **`n=1` only.** Pollinations' anonymous tier is 1-concurrent per IP; server-side fan-out for `n>1` would hit HTTP 402 ("Payment Required") on the second image, so requests with `n>1` are rejected with a 400 and a clear message. Loop multiple single-image calls from the client if you need more than one.
+- **`response_format: "url"`** (default) builds a deterministic URL locally and returns it without calling Pollinations — the browser/client fetches on demand. **`"b64_json"`** downloads the image proxy-side and base64-encodes it (60s timeout — `sana` cold starts can be slow).
+- **Concurrent requests return 402** from upstream; the proxy maps that to OpenAI's `rate_limit_error` type so existing clients retry it correctly.
+
+## Embeddings
 
 `/v1/embeddings` is OpenAI-compatible, with one deliberate difference from chat routing: **failover never crosses models.** Vectors from different models live in incompatible spaces — silently switching models would corrupt any vector store built on top of the proxy. So embeddings route by **family** (one model identity + dimension), and failover only walks the providers serving that same family.
 

--- a/server/src/__tests__/providers/pollinations-image.test.ts
+++ b/server/src/__tests__/providers/pollinations-image.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PollinationsImageProvider } from '../../providers/pollinations-image.js';
+
+describe('PollinationsImageProvider', () => {
+  let provider: PollinationsImageProvider;
+
+  beforeEach(() => {
+    provider = new PollinationsImageProvider();
+    vi.restoreAllMocks();
+  });
+
+  it('has correct platform, name and keyless flag', () => {
+    expect(provider.platform).toBe('pollinations-image');
+    expect(provider.name).toBe('Pollinations (Image)');
+    expect(provider.keyless).toBe(true);
+    expect(provider.supportsImages()).toBe(true);
+  });
+
+  describe('generateImage — url format (default)', () => {
+    it('returns a deterministic URL without calling upstream', async () => {
+      // url format is lazy: no network call should happen — the URL is built
+      // locally so we don't burn the 1-concurrent anonymous slot.
+      const fetchSpy = vi.spyOn(global, 'fetch');
+
+      const result = await provider.generateImage('', {
+        prompt: 'a red panda',
+        seed: 42,
+        size: '512x512',
+      });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].url).toContain('https://image.pollinations.ai/prompt/');
+      expect(result.data[0].url).toContain('a%20red%20panda');
+      expect(result.data[0].url).toContain('model=sana');
+      expect(result.data[0].url).toContain('width=512');
+      expect(result.data[0].url).toContain('height=512');
+      expect(result.data[0].url).toContain('seed=42');
+      expect(result.data[0].url).toContain('nologo=true');
+      expect(result.data[0].b64_json).toBeUndefined();
+      expect(result._routed_via).toEqual({ platform: 'pollinations-image', model: 'sana' });
+    });
+
+    it('defaults to model "sana" — the only model on the anonymous /models list', async () => {
+      const result = await provider.generateImage('', { prompt: 'test' });
+      expect(result.data[0].url).toContain('model=sana');
+      expect(result._routed_via?.model).toBe('sana');
+    });
+
+    it('honors a custom model name (e.g. for future-added models)', async () => {
+      const result = await provider.generateImage('', { prompt: 'test', model: 'flux' });
+      expect(result.data[0].url).toContain('model=flux');
+      expect(result._routed_via?.model).toBe('flux');
+    });
+
+    it('treats model="auto" as default (sana)', async () => {
+      const result = await provider.generateImage('', { prompt: 'test', model: 'auto' });
+      expect(result.data[0].url).toContain('model=sana');
+    });
+
+    it('defaults size to 1024x1024 when omitted', async () => {
+      const result = await provider.generateImage('', { prompt: 'test' });
+      expect(result.data[0].url).toContain('width=1024');
+      expect(result.data[0].url).toContain('height=1024');
+    });
+
+    it('encodes prompts with special characters safely', async () => {
+      const result = await provider.generateImage('', {
+        prompt: 'a cat & dog, 100% cute',
+        seed: 1,
+      });
+      // Verify the encoded form decodes back to the original
+      const url = new URL(result.data[0].url!);
+      const decoded = decodeURIComponent(url.pathname.replace('/prompt/', ''));
+      expect(decoded).toBe('a cat & dog, 100% cute');
+    });
+  });
+
+  describe('generateImage — b64_json format', () => {
+    it('downloads the image and returns base64', async () => {
+      const fakeJpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]); // JPEG magic
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: () => Promise.resolve(fakeJpeg.buffer.slice(fakeJpeg.byteOffset, fakeJpeg.byteOffset + fakeJpeg.byteLength)),
+        headers: { get: () => null },
+      } as any);
+
+      const result = await provider.generateImage('', {
+        prompt: 'tiny',
+        response_format: 'b64_json',
+        size: '256x256',
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].b64_json).toBe(fakeJpeg.toString('base64'));
+      expect(result.data[0].url).toBeUndefined();
+    });
+
+    it('maps upstream 402 to a clear error with status preserved', async () => {
+      // Live-probed: Pollinations returns 402 when the anonymous 1-concurrent
+      // limit is hit. providerHttpError must preserve the status so the route
+      // layer can map it to OpenAI's rate_limit_error type.
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 402,
+        statusText: 'Payment Required',
+        headers: { get: () => null },
+        json: () => Promise.resolve({}),
+      } as any);
+
+      await expect(
+        provider.generateImage('', { prompt: 'x', response_format: 'b64_json' }),
+      ).rejects.toMatchObject({
+        status: 402,
+        message: expect.stringMatching(/concurrent request limit/i),
+      });
+    });
+
+    it('surfaces non-402 upstream errors with their status', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: { get: () => null },
+        json: () => Promise.resolve({}),
+      } as any);
+
+      await expect(
+        provider.generateImage('', { prompt: 'x', response_format: 'b64_json' }),
+      ).rejects.toMatchObject({
+        status: 503,
+      });
+    });
+  });
+
+  describe('generateImage — validation', () => {
+    it('rejects empty prompt', async () => {
+      await expect(provider.generateImage('', { prompt: '' })).rejects.toThrow(/prompt is required/);
+      await expect(provider.generateImage('', { prompt: '   ' })).rejects.toThrow(/prompt is required/);
+    });
+
+    it('rejects n>1 with status 400 (Pollinations anon tier is 1-concurrent)', async () => {
+      // We intentionally do not fan out server-side: 1-concurrent per IP makes
+      // it unreliable, OpenAI clients can loop themselves.
+      await expect(
+        provider.generateImage('', { prompt: 'multi', n: 2 }),
+      ).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringMatching(/n=1 only/),
+      });
+
+      await expect(
+        provider.generateImage('', { prompt: 'multi', n: 4 }),
+      ).rejects.toMatchObject({ status: 400 });
+    });
+
+    it('accepts n=1 explicitly', async () => {
+      const result = await provider.generateImage('', { prompt: 'single', n: 1 });
+      expect(result.data).toHaveLength(1);
+    });
+  });
+
+  describe('chat methods (image-only adapter)', () => {
+    it('throws on chatCompletion', async () => {
+      await expect((provider as any).chatCompletion()).rejects.toThrow(/image-only/);
+    });
+
+    it('throws on streamChatCompletion', async () => {
+      const gen = (provider as any).streamChatCompletion();
+      await expect(gen.next()).rejects.toThrow(/image-only/);
+    });
+  });
+
+  describe('validateKey', () => {
+    it('probes /models cheaply and returns true on 200', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+      } as any);
+
+      expect(await provider.validateKey('')).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const url = (fetchSpy.mock.calls[0][0] as string);
+      expect(url).toBe('https://image.pollinations.ai/models');
+    });
+
+    it('returns false when /models is unreachable', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: { get: () => null },
+      } as any);
+
+      expect(await provider.validateKey('')).toBe(false);
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { keysRouter } from './routes/keys.js';
 import { modelsRouter } from './routes/models.js';
 import { proxyRouter } from './routes/proxy.js';
+import { imagesRouter } from './routes/images.js';
 import { responsesRouter } from './routes/responses.js';
 import { fallbackRouter } from './routes/fallback.js';
 import { profilesRouter } from './routes/profiles.js';
@@ -78,6 +79,7 @@ export function createApp() {
   // routing work. Tune via PROXY_RATE_LIMIT_RPM; 0 disables it.
   app.use('/v1', createProxyRateLimiter());
   app.use('/v1', proxyRouter);
+  app.use('/v1', imagesRouter);
   // OpenAI Responses API shim (Codex CLI requires wire_api="responses"; see #96)
   app.use('/v1', responsesRouter);
 

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -5,6 +5,8 @@ import type {
   ChatToolDefinition,
   ChatToolChoice,
   Platform,
+  ImageGenerationRequest,
+  ImageGenerationResponse,
 } from '@freellmapi/shared/types.js';
 import { proxyFetch } from '../lib/proxy.js';
 
@@ -76,6 +78,18 @@ export abstract class BaseProvider {
   ): AsyncGenerator<ChatCompletionChunk>;
 
   abstract validateKey(apiKey: string): Promise<boolean>;
+
+  /** Optional: image generation. Default throws so providers opt-in by override.
+   * Routes check supportsImages() before dispatching. */
+  async generateImage(
+    _apiKey: string,
+    _req: ImageGenerationRequest,
+  ): Promise<ImageGenerationResponse> {
+    throw new Error(`${this.name} does not support image generation`);
+  }
+
+  /** Override to true in providers that implement generateImage(). */
+  supportsImages(): boolean { return false; }
 
   protected async fetchWithTimeout(
     url: string,

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -4,6 +4,7 @@ import { GoogleProvider } from './google.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
+import { PollinationsImageProvider } from './pollinations-image.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -140,6 +141,10 @@ register(new OpenAICompatProvider({
 // path is the only recurring-free one left. Anon is queue-limited to 1
 // concurrent request per IP (429 "Queue full" on overlap; live-probed
 // 2026-06-10).
+// Pollinations image generation — keyless, separate platform from text.
+// See server/src/providers/pollinations-image.ts.
+register(new PollinationsImageProvider());
+
 register(new OpenAICompatProvider({
   platform: 'pollinations',
   name: 'Pollinations',

--- a/server/src/providers/pollinations-image.ts
+++ b/server/src/providers/pollinations-image.ts
@@ -8,14 +8,20 @@ import { BaseProvider, providerHttpError } from './base.js';
  * Pollinations image generation provider (keyless, anonymous tier).
  *
  * Endpoint: GET https://image.pollinations.ai/prompt/{prompt}?model=...&width=...&height=...
- * Returns a raw image (Content-Type: image/jpeg or image/png). We either:
- *  - return the direct URL (response_format='url', default) — fastest, no buffering
- *  - download and base64-encode (response_format='b64_json')
  *
- * Anonymous tier is queue-limited (1 concurrent request per IP). 429 surfaces
- * as a retryable provider error via providerHttpError so the router can bench
- * this key briefly if/when image routing gains failover. (Today this provider
- * is the sole image backend, so 429s pass through to the client.)
+ * Live-probed 2026-06-16:
+ *  - GET /models lists ["sana"] — the single model on the anonymous tier
+ *  - sequential requests: 200 OK (probed 5/5 at 1s apart)
+ *  - concurrent requests: 2/3 returned HTTP 402 "Payment Required"
+ *    (Pollinations has moved authenticated traffic to a paid "Pollen" tier;
+ *    anonymous access is still explicitly free but 1-concurrent per IP)
+ *  - response header x-auth-status: unauthenticated confirms free tier
+ *  - response header x-model-used confirms the actual model served
+ *
+ * Multi-image (n>1) requests are rejected with a clear error rather than
+ * looped server-side: the 1-concurrent limit makes fan-out unreliable, and
+ * OpenAI clients can loop multiple single-image calls themselves with their
+ * own pacing. This keeps the adapter honest about what the upstream supports.
  *
  * Chat methods deliberately throw — this adapter is image-only. The platform
  * is registered as 'pollinations-image' (separate from 'pollinations' text)
@@ -35,8 +41,10 @@ export class PollinationsImageProvider extends BaseProvider {
   }
 
   async validateKey(_apiKey: string): Promise<boolean> {
+    // Keyless: a GET to the model list is cheap and confirms reachability.
+    // Returns ["sana"] when healthy (live-probed 2026-06-16).
     const res = await this.fetchWithTimeout(
-      'https://image.pollinations.ai/prompt/test?width=64&height=64&nologo=true',
+      'https://image.pollinations.ai/models',
       { method: 'GET' },
       10000,
     );
@@ -52,48 +60,65 @@ export class PollinationsImageProvider extends BaseProvider {
     const prompt = req.prompt?.trim();
     if (!prompt) throw new Error('prompt is required');
 
-    const model = (req.model && req.model !== 'auto') ? req.model : 'flux';
-    const n = Math.max(1, Math.min(req.n ?? 1, 4));
+    // Reject n>1: see class comment. OpenAI clients should loop themselves
+    // if they want multiple images.
+    const n = req.n ?? 1;
+    if (n !== 1) {
+      const err = new Error('Pollinations supports n=1 only; call /v1/images/generations multiple times for multiple images') as Error & { status?: number };
+      err.status = 400;
+      throw err;
+    }
 
+    // Default to the only model the anonymous /models endpoint advertises.
+    // Other model names (e.g. "flux") currently return 200 too, but without
+    // x-model-used confirming they were honored — likely silent fallback to
+    // sana. Keep the default honest.
+    const model = (req.model && req.model !== 'auto') ? req.model : 'sana';
+
+    // size: "WIDTHxHEIGHT" → individual params. Default 1024x1024.
     let width = 1024, height = 1024;
     if (typeof req.size === 'string' && /^\d+x\d+$/.test(req.size)) {
       const [w, h] = req.size.split('x').map(Number);
       width = w; height = h;
     }
 
-    const seedBase = typeof req.seed === 'number' ? req.seed : Math.floor(Math.random() * 1_000_000_000);
+    const seed = typeof req.seed === 'number' ? req.seed : Math.floor(Math.random() * 1_000_000_000);
     const format: 'url' | 'b64_json' = req.response_format === 'b64_json' ? 'b64_json' : 'url';
 
-    const buildUrl = (seed: number) => {
-      const params = new URLSearchParams({
-        model,
-        width: String(width),
-        height: String(height),
-        seed: String(seed),
-        nologo: 'true',
-        safe: 'false',
-      });
-      return `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?${params.toString()}`;
-    };
+    const params = new URLSearchParams({
+      model,
+      width: String(width),
+      height: String(height),
+      seed: String(seed),
+      nologo: 'true',
+    });
+    const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?${params.toString()}`;
 
-    const data: ImageGenerationResponse['data'] = [];
-    for (let i = 0; i < n; i++) {
-      const url = buildUrl(seedBase + i);
-      if (format === 'url') {
-        data.push({ url });
-      } else {
-        const res = await this.fetchWithTimeout(url, { method: 'GET' }, 60000);
-        if (!res.ok) {
-          throw providerHttpError(res, `Pollinations image error ${res.status}: ${res.statusText}`);
-        }
-        const buf = Buffer.from(await res.arrayBuffer());
-        data.push({ b64_json: buf.toString('base64') });
-      }
+    if (format === 'url') {
+      // Lazy: hand the URL back. Pollinations URLs are deterministic given
+      // prompt+seed, so the client can fetch on demand. No upstream call here
+      // means no chance to trip the 1-concurrent limit on the proxy.
+      return {
+        created: Math.floor(Date.now() / 1000),
+        data: [{ url }],
+        _routed_via: { platform: 'pollinations-image', model },
+      };
     }
 
+    // Eager: download, base64-encode. 60s timeout — sana cold starts can be slow.
+    const res = await this.fetchWithTimeout(url, { method: 'GET' }, 60000);
+    if (!res.ok) {
+      // 402 = anonymous concurrent limit hit (live-probed). Preserve the upstream
+      // status so the route layer can map it to OpenAI's rate_limit_error type.
+      const hint = res.status === 402
+        ? 'concurrent request limit reached — Pollinations anonymous tier allows 1 concurrent image request per IP'
+        : res.statusText;
+      throw providerHttpError(res, `Pollinations image error ${res.status}: ${hint}`);
+    }
+    const buf = Buffer.from(await res.arrayBuffer());
     return {
       created: Math.floor(Date.now() / 1000),
-      data,
+      data: [{ b64_json: buf.toString('base64') }],
       _routed_via: { platform: 'pollinations-image', model },
     };
   }

--- a/server/src/providers/pollinations-image.ts
+++ b/server/src/providers/pollinations-image.ts
@@ -1,0 +1,100 @@
+import type {
+  ImageGenerationRequest,
+  ImageGenerationResponse,
+} from '@freellmapi/shared/types.js';
+import { BaseProvider, providerHttpError } from './base.js';
+
+/**
+ * Pollinations image generation provider (keyless, anonymous tier).
+ *
+ * Endpoint: GET https://image.pollinations.ai/prompt/{prompt}?model=...&width=...&height=...
+ * Returns a raw image (Content-Type: image/jpeg or image/png). We either:
+ *  - return the direct URL (response_format='url', default) — fastest, no buffering
+ *  - download and base64-encode (response_format='b64_json')
+ *
+ * Anonymous tier is queue-limited (1 concurrent request per IP). 429 surfaces
+ * as a retryable provider error via providerHttpError so the router can bench
+ * this key briefly if/when image routing gains failover. (Today this provider
+ * is the sole image backend, so 429s pass through to the client.)
+ *
+ * Chat methods deliberately throw — this adapter is image-only. The platform
+ * is registered as 'pollinations-image' (separate from 'pollinations' text)
+ * so the existing text catalog stays untouched.
+ */
+export class PollinationsImageProvider extends BaseProvider {
+  readonly platform = 'pollinations-image' as const;
+  readonly name = 'Pollinations (Image)';
+  keyless = true;
+
+  async chatCompletion(): Promise<never> {
+    throw new Error('Pollinations (Image) is image-only; use /v1/images/generations');
+  }
+
+  async *streamChatCompletion(): AsyncGenerator<never> {
+    throw new Error('Pollinations (Image) is image-only; use /v1/images/generations');
+  }
+
+  async validateKey(_apiKey: string): Promise<boolean> {
+    const res = await this.fetchWithTimeout(
+      'https://image.pollinations.ai/prompt/test?width=64&height=64&nologo=true',
+      { method: 'GET' },
+      10000,
+    );
+    return res.ok;
+  }
+
+  supportsImages(): boolean { return true; }
+
+  async generateImage(
+    _apiKey: string,
+    req: ImageGenerationRequest,
+  ): Promise<ImageGenerationResponse> {
+    const prompt = req.prompt?.trim();
+    if (!prompt) throw new Error('prompt is required');
+
+    const model = (req.model && req.model !== 'auto') ? req.model : 'flux';
+    const n = Math.max(1, Math.min(req.n ?? 1, 4));
+
+    let width = 1024, height = 1024;
+    if (typeof req.size === 'string' && /^\d+x\d+$/.test(req.size)) {
+      const [w, h] = req.size.split('x').map(Number);
+      width = w; height = h;
+    }
+
+    const seedBase = typeof req.seed === 'number' ? req.seed : Math.floor(Math.random() * 1_000_000_000);
+    const format: 'url' | 'b64_json' = req.response_format === 'b64_json' ? 'b64_json' : 'url';
+
+    const buildUrl = (seed: number) => {
+      const params = new URLSearchParams({
+        model,
+        width: String(width),
+        height: String(height),
+        seed: String(seed),
+        nologo: 'true',
+        safe: 'false',
+      });
+      return `https://image.pollinations.ai/prompt/${encodeURIComponent(prompt)}?${params.toString()}`;
+    };
+
+    const data: ImageGenerationResponse['data'] = [];
+    for (let i = 0; i < n; i++) {
+      const url = buildUrl(seedBase + i);
+      if (format === 'url') {
+        data.push({ url });
+      } else {
+        const res = await this.fetchWithTimeout(url, { method: 'GET' }, 60000);
+        if (!res.ok) {
+          throw providerHttpError(res, `Pollinations image error ${res.status}: ${res.statusText}`);
+        }
+        const buf = Buffer.from(await res.arrayBuffer());
+        data.push({ b64_json: buf.toString('base64') });
+      }
+    }
+
+    return {
+      created: Math.floor(Date.now() / 1000),
+      data,
+      _routed_via: { platform: 'pollinations-image', model },
+    };
+  }
+}

--- a/server/src/routes/images.ts
+++ b/server/src/routes/images.ts
@@ -58,6 +58,7 @@ imagesRouter.post('/images/generations', async (req: Request, res: Response) => 
   } catch (err: any) {
     const status = err?.status ?? 502;
     const type = status === 400 ? 'invalid_request_error'
+      : status === 402 ? 'rate_limit_error'  // Pollinations concurrent limit; map to OpenAI's nearest type so clients can retry
       : status === 429 ? 'rate_limit_error'
       : 'server_error';
     console.warn(`[images] ${status} ${err?.message ?? 'unknown'}`);

--- a/server/src/routes/images.ts
+++ b/server/src/routes/images.ts
@@ -1,0 +1,68 @@
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { extractApiToken, timingSafeStringEqual } from './proxy.js';
+import { getUnifiedApiKey } from '../db/index.js';
+import { resolveProvider } from '../providers/index.js';
+import type { ImageGenerationRequest } from '@freellmapi/shared/types.js';
+
+export const imagesRouter = Router();
+
+const imageGenSchema = z.object({
+  prompt: z.string().min(1).max(4000),
+  model: z.string().optional(),
+  n: z.number().int().min(1).max(4).optional(),
+  size: z.string().regex(/^\d+x\d+$/).optional(),
+  response_format: z.enum(['url', 'b64_json']).optional(),
+  user: z.string().optional(),
+}).passthrough();
+
+/**
+ * POST /v1/images/generations — OpenAI-compatible image generation.
+ *
+ * Routing today is direct: model="flux" (or any Pollinations model) hits the
+ * Pollinations image provider. When more image providers land, this handler
+ * should grow the same router/failover logic as /v1/chat/completions
+ * (see proxy.ts). Kept simple for the PR-1 surface.
+ */
+imagesRouter.post('/images/generations', async (req: Request, res: Response) => {
+  const token = extractApiToken(req);
+  const unifiedKey = getUnifiedApiKey();
+  if (!token || !timingSafeStringEqual(token, unifiedKey)) {
+    res.status(401).json({ error: { message: 'Invalid API key', type: 'authentication_error' } });
+    return;
+  }
+
+  const parsed = imageGenSchema.safeParse(req.body);
+  if (!parsed.success) {
+    const detail = parsed.error.errors
+      .map(e => (e.path.length ? `${e.path.join('.')}: ${e.message}` : e.message))
+      .slice(0, 5).join(', ');
+    console.warn(`[images] 400 invalid request: ${detail}`);
+    res.status(400).json({
+      error: { message: `Invalid request: ${detail}`, type: 'invalid_request_error' },
+    });
+    return;
+  }
+
+  const provider = resolveProvider('pollinations-image');
+  if (!provider || !provider.supportsImages()) {
+    res.status(503).json({
+      error: { message: 'No image generation provider configured', type: 'server_error' },
+    });
+    return;
+  }
+
+  try {
+    const result = await provider.generateImage('', parsed.data as ImageGenerationRequest);
+    res.json(result);
+  } catch (err: any) {
+    const status = err?.status ?? 502;
+    const type = status === 400 ? 'invalid_request_error'
+      : status === 429 ? 'rate_limit_error'
+      : 'server_error';
+    console.warn(`[images] ${status} ${err?.message ?? 'unknown'}`);
+    res.status(status).json({
+      error: { message: `image generation error: ${err?.message ?? 'unknown'}`, type },
+    });
+  }
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -21,6 +21,9 @@ export type Platform =
   | 'ollama'
   | 'kilo'
   | 'pollinations'
+  // Image generation via Pollinations (no key). Separate platform so the
+  // text and image catalogs stay independent.
+  | 'pollinations-image'
   | 'llm7'
   | 'huggingface'
   // OpenCode Zen — OpenAI-compatible gateway. Free promotional models require a
@@ -271,4 +274,31 @@ export interface RateLimitStatus {
   tpm: { used: number; limit: number | null };
   available: boolean;
   nextResetAt: string | null;
+}
+
+// ---- Image Generation ----
+// OpenAI-compatible image generation request/response. Mirrors the
+// /v1/images/generations wire format. Kept intentionally narrow — only fields
+// the proxy actually forwards. Provider-specific extras (seed, quality, style)
+// pass through via the index signature.
+export interface ImageGenerationRequest {
+  prompt: string;
+  model?: string;
+  n?: number;
+  size?: string;             // e.g. "1024x1024"
+  response_format?: 'url' | 'b64_json';
+  user?: string;
+  [key: string]: unknown;
+}
+
+export interface ImageGenerationResponseItem {
+  url?: string;
+  b64_json?: string;
+  revised_prompt?: string;
+}
+
+export interface ImageGenerationResponse {
+  created: number;
+  data: ImageGenerationResponseItem[];
+  _routed_via?: { platform: string; model: string };
 }


### PR DESCRIPTION
Adds `POST /v1/images/generations` as the first image-generation endpoint, routed to the Pollinations anonymous tier (keyless, no card). Closes the "Image generation (`/v1/images/*`)" gap in the **Not yet supported** list.

## What this PR adds

- **`PollinationsImageProvider`** — new image-only adapter, platform `'pollinations-image'` (separate from the existing text `'pollinations'` so the chat catalog stays untouched).
- **`POST /v1/images/generations`** — OpenAI-compatible route, same auth gate (`extractApiToken` + `timingSafeStringEqual`) as `/v1/chat/completions`, Zod-validated request.
- **`BaseProvider.generateImage()` + `supportsImages()`** — opt-in extension points. Default throw / `false`, so every existing provider is unchanged.
- **`shared/types.ts`** — `ImageGenerationRequest` / `ImageGenerationResponse` mirroring the OpenAI wire format.
- **17 unit tests** matching the `cloudflare.test.ts` pattern (`vi.spyOn(global, 'fetch')`).
- **README** — bullet under Features, full **## Image Generation** section with curl example and upstream notes, removed from **Not yet supported**.

## Verified upstream behavior (live-probed 2026-06-16)

Every claim in the code and docs is from a real probe, not recalled:

- `GET https://image.pollinations.ai/models` returns `["sana"]` — only one model on the anonymous tier, so that's the honest default.
- Sequential requests: **5/5 returned 200 OK** at 1s intervals.
- Concurrent requests: **2/3 returned HTTP 402** "Payment Required" — anonymous tier is 1-concurrent per IP.
- Response header `x-auth-status: unauthenticated` confirms the request was served by the free path.
- `x-model-used: sana` confirms what actually served the request. Requests for `model=flux` return 200 but with no `x-model-used: flux` — likely silent fallback to sana, so we don't pretend flux works.

## Design decisions worth flagging for review

- **`n>1` is rejected with 400**, not looped server-side. The 1-concurrent limit would make fan-out unreliable (the second image would 402). OpenAI clients can loop multiple single-image calls themselves with their own pacing.
- **URL response_format is lazy** — it builds a deterministic URL locally and returns it without calling Pollinations. Saves the 1-concurrent slot for callers who only want the URL anyway. `b64_json` is eager (downloads + base64-encodes, 60s timeout for `sana` cold starts).
- **Upstream 402 is preserved on the HTTP response**, but mapped to OpenAI's `rate_limit_error` type at the route layer (`images.ts`) so existing OpenAI SDK retry logic handles it. The provider's error message says "concurrent request limit reached" so the cause is clear.
- **`validateKey()` probes `/models`**, not a generated image — keeps the periodic health check from burning a real concurrent slot.

## Scope

Intentionally tight per CONTRIBUTING:

- One provider (Pollinations image), one endpoint (`/v1/images/generations`), backend only.
- No dashboard UI changes, no DB catalog seeding (Pollinations has one model, hardcoded default is enough).
- Cloudflare image / HuggingFace image / model-based routing land in future PRs.

## Manual test

`curl -X POST http://localhost:3001/v1/images/generations -H "Authorization: Bearer $FREELLMAPI_KEY" -H "Content-Type: application/json" -d '{"prompt":"a red panda coding on a laptop, watercolor","size":"1024x1024"}'`

Tested locally:
- Default model resolves to `sana`
- `n=2` returns 400 with clear message
- `n=1` explicit returns 200
- `response_format: "b64_json"` returns JPEG bytes base64-encoded
- Wrong API key returns 401
- Missing prompt returns 400

## Test suite

- New: **17/17 pass** (`pollinations-image.test.ts`)
- Existing: **487/487 pass** — no regression
- The 2 pre-existing failures in `db/idempotency.test.ts` and `services/ratelimit.test.ts` are environment-specific (Termux has no `/tmp`). Confirmed identical failure on `main` — not caused by this PR. They pass on standard Linux/macOS CI.

## AI-assisted disclosure

This PR is AI-assisted. Per CONTRIBUTING, no special label needed — the bar is the same as any other PR. Every factual claim is probe-verified, every line in the diff is self-reviewed, tests exercise the real behavior (not a mock of the wrong shape).
