### PR TITLE
i18n: translate Fusion feature into all supported locales

### DIFF
--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -66,7 +66,9 @@
   "models": {
     "title": "Modelos",
     "chatModelsTab": "Modelos de chat",
+    "fusionTab": "Fusión",
     "embeddingsTab": "Embeddings",
+    "newBadge": "Nuevo",
     "monthlyTokenBudget": "Presupuesto mensual de tokens",
     "remaining": "restante",
     "of": "de",
@@ -240,6 +242,7 @@
     "title": "Entorno de pruebas",
     "description": "Envía una finalización de chat a través del enrutador y observa qué proveedor la atiende.",
     "autoModel": "Auto (cadena de reserva)",
+    "fusionModel": "Fusión (síntesis multimodelo)",
     "send": "Enviar",
     "sending": "Enviando…",
     "clear": "Limpiar",
@@ -250,6 +253,11 @@
     "copyReply": "Copiar respuesta",
     "fallback": "reserva",
     "fallbacks": "reservas",
+    "fusionPanel": "Panel",
+    "fusionJudge": "Juez",
+    "fusionTrace": "{count} respuestas de modelos",
+    "fusionFailed": "sin respuesta",
+    "fusionJudgeSynth": "sintetizó la respuesta final",
     "errorPrefix": "Error:"
   },
   "embeddings": {
@@ -266,6 +274,37 @@
     "saveChanges": "Guardar cambios",
     "savingChanges": "Guardando…",
     "tokMax": "{tokens} tok máx."
+  },
+  "fusion": {
+    "title": "Fusión",
+    "description": "Un panel de modelos responde en paralelo y luego un juez sintetiza una respuesta más sólida. Úsala llamando a la API con el modelo «fusion».",
+    "panelSource": "Origen del panel",
+    "panelSourceHelp": "De dónde provienen los modelos del panel cuando una solicitud no especifica los suyos.",
+    "mode": {
+      "auto": "Auto (cadena de reserva)",
+      "autoHelp": "Elige un conjunto diverso de modelos de tu cadena de reserva, ordenados según tu estrategia de enrutamiento activa.",
+      "explicit": "Panel explícito",
+      "explicitHelp": "Usar siempre los modelos específicos que elijas a continuación."
+    },
+    "panelModels": "Modelos del panel",
+    "selectedCount": "{count} de {max} seleccionados",
+    "noModels": "Aún no hay modelos conectados. Añade una clave API y luego activa modelos en la cadena de reserva.",
+    "panelSize": "Tamaño del panel",
+    "panelSizeHelp": "Cuántos modelos diversos seleccionar automáticamente (1–{max}).",
+    "judge": "Modelo juez",
+    "judgeHelp": "El modelo que sintetiza las respuestas del panel en una sola. «Auto» usa tu mejor modelo disponible.",
+    "judgeAuto": "Auto (mejor disponible)",
+    "strategy": "Estrategia",
+    "strategySynthesize": "Síntesis: combina el panel en una sola respuesta",
+    "strategyBestOf": "Mejor respuesta: devuelve la respuesta más sólida (sin llamar al juez)",
+    "strategySynthesizeShort": "Síntesis",
+    "strategyBestOfShort": "Mejor respuesta",
+    "exposePanel": "Exponer detalles del panel",
+    "exposePanelHelp": "Adjunta la respuesta de cada modelo y los metadatos del juez en un campo x_fusion de la respuesta.",
+    "howToUse": "Cómo usarlo",
+    "howToUseHelp": "Envía una solicitud de chat normal con el modelo «fusion». Estos ajustes son los predeterminados; cualquier solicitud puede anularlos con un campo «fusion».",
+    "unsavedChanges": "Cambios sin guardar",
+    "save": "Guardar"
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -66,7 +66,9 @@
   "models": {
     "title": "Modèles",
     "chatModelsTab": "Modèles de chat",
+    "fusionTab": "Fusion",
     "embeddingsTab": "Embeddings",
+    "newBadge": "Nouveau",
     "monthlyTokenBudget": "Budget mensuel de tokens",
     "remaining": "restant",
     "of": "sur",
@@ -240,6 +242,7 @@
     "title": "Bac à sable",
     "description": "Envoyez une complétion de chat via le routeur et voyez quel fournisseur la traite.",
     "autoModel": "Auto (chaîne de repli)",
+    "fusionModel": "Fusion (synthèse multi-modèles)",
     "send": "Envoyer",
     "sending": "Envoi…",
     "clear": "Effacer",
@@ -250,6 +253,11 @@
     "copyReply": "Copier la réponse",
     "fallback": "repli",
     "fallbacks": "replis",
+    "fusionPanel": "Panel",
+    "fusionJudge": "Juge",
+    "fusionTrace": "{count} réponses de modèles",
+    "fusionFailed": "aucune réponse",
+    "fusionJudgeSynth": "a synthétisé la réponse finale",
     "errorPrefix": "Erreur :"
   },
   "embeddings": {
@@ -266,6 +274,37 @@
     "saveChanges": "Enregistrer les modifications",
     "savingChanges": "Enregistrement…",
     "tokMax": "{tokens} tok max."
+  },
+  "fusion": {
+    "title": "Fusion",
+    "description": "Un panel de modèles répond en parallèle, puis un juge synthétise une réponse plus solide. Utilisez-la en appelant l’API avec le modèle « fusion ».",
+    "panelSource": "Source du panel",
+    "panelSourceHelp": "D’où proviennent les modèles du panel lorsqu’une requête n’en spécifie pas.",
+    "mode": {
+      "auto": "Auto (chaîne de repli)",
+      "autoHelp": "Sélectionne un ensemble varié de modèles depuis votre chaîne de repli, classés selon votre stratégie de routage active.",
+      "explicit": "Panel explicite",
+      "explicitHelp": "Toujours utiliser les modèles spécifiques que vous choisissez ci-dessous."
+    },
+    "panelModels": "Modèles du panel",
+    "selectedCount": "{count} sur {max} sélectionnés",
+    "noModels": "Aucun modèle connecté pour l’instant. Ajoutez une clé API, puis activez des modèles dans la chaîne de repli.",
+    "panelSize": "Taille du panel",
+    "panelSizeHelp": "Nombre de modèles variés à sélectionner automatiquement (1–{max}).",
+    "judge": "Modèle juge",
+    "judgeHelp": "Le modèle qui synthétise les réponses du panel en une seule. « Auto » utilise votre meilleur modèle disponible.",
+    "judgeAuto": "Auto (meilleur disponible)",
+    "strategy": "Stratégie",
+    "strategySynthesize": "Synthèse : fusionne le panel en une seule réponse",
+    "strategyBestOf": "Meilleure réponse : renvoie la réponse la plus solide (sans appel au juge)",
+    "strategySynthesizeShort": "Synthèse",
+    "strategyBestOfShort": "Meilleure réponse",
+    "exposePanel": "Exposer les détails du panel",
+    "exposePanelHelp": "Joint la réponse de chaque modèle et les métadonnées du juge dans un champ x_fusion de la réponse.",
+    "howToUse": "Comment l’utiliser",
+    "howToUseHelp": "Envoyez une requête de chat normale avec le modèle « fusion ». Ces réglages sont les valeurs par défaut ; toute requête peut les remplacer via un champ « fusion ».",
+    "unsavedChanges": "Modifications non enregistrées",
+    "save": "Enregistrer"
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -66,7 +66,9 @@
   "models": {
     "title": "Modelos",
     "chatModelsTab": "Modelos de chat",
+    "fusionTab": "Fusão",
     "embeddingsTab": "Embeddings",
+    "newBadge": "Novo",
     "monthlyTokenBudget": "Orçamento mensal de tokens",
     "remaining": "restante",
     "of": "de",
@@ -240,6 +242,7 @@
     "title": "Playground",
     "description": "Envie uma conclusão de chat pelo roteador e veja qual provedor a atende.",
     "autoModel": "Auto (cadeia de fallback)",
+    "fusionModel": "Fusão (síntese multimodelo)",
     "send": "Enviar",
     "sending": "Enviando…",
     "clear": "Limpar",
@@ -250,6 +253,11 @@
     "copyReply": "Copiar resposta",
     "fallback": "fallback",
     "fallbacks": "fallbacks",
+    "fusionPanel": "Painel",
+    "fusionJudge": "Juiz",
+    "fusionTrace": "{count} respostas de modelos",
+    "fusionFailed": "sem resposta",
+    "fusionJudgeSynth": "sintetizou a resposta final",
     "errorPrefix": "Erro:"
   },
   "embeddings": {
@@ -266,6 +274,37 @@
     "saveChanges": "Salvar alterações",
     "savingChanges": "Salvando…",
     "tokMax": "{tokens} tok máx."
+  },
+  "fusion": {
+    "title": "Fusão",
+    "description": "Um painel de modelos responde em paralelo e, em seguida, um juiz sintetiza uma resposta mais forte. Use-a chamando a API com o modelo \"fusion\".",
+    "panelSource": "Origem do painel",
+    "panelSourceHelp": "De onde vêm os modelos do painel quando uma requisição não especifica os seus.",
+    "mode": {
+      "auto": "Auto (cadeia de fallback)",
+      "autoHelp": "Escolhe um conjunto diverso de modelos da sua cadeia de fallback, ordenados pela sua estratégia de roteamento ativa.",
+      "explicit": "Painel explícito",
+      "explicitHelp": "Sempre usar os modelos específicos que você escolher abaixo."
+    },
+    "panelModels": "Modelos do painel",
+    "selectedCount": "{count} de {max} selecionados",
+    "noModels": "Nenhum modelo conectado ainda. Adicione uma chave de API e depois ative modelos na cadeia de fallback.",
+    "panelSize": "Tamanho do painel",
+    "panelSizeHelp": "Quantos modelos diversos selecionar automaticamente (1–{max}).",
+    "judge": "Modelo juiz",
+    "judgeHelp": "O modelo que sintetiza as respostas do painel em uma só. \"Auto\" usa o seu melhor modelo disponível.",
+    "judgeAuto": "Auto (melhor disponível)",
+    "strategy": "Estratégia",
+    "strategySynthesize": "Síntese: combina o painel em uma única resposta",
+    "strategyBestOf": "Melhor resposta: retorna a resposta mais forte (sem chamar o juiz)",
+    "strategySynthesizeShort": "Síntese",
+    "strategyBestOfShort": "Melhor resposta",
+    "exposePanel": "Expor detalhes do painel",
+    "exposePanelHelp": "Anexa a resposta de cada modelo e os metadados do juiz em um campo x_fusion na resposta.",
+    "howToUse": "Como usar",
+    "howToUseHelp": "Envie uma requisição de chat normal com o modelo \"fusion\". Estas configurações são o padrão; qualquer requisição pode sobrescrevê-las com um campo \"fusion\".",
+    "unsavedChanges": "Alterações não salvas",
+    "save": "Salvar"
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -66,7 +66,9 @@
   "models": {
     "title": "模型",
     "chatModelsTab": "对话模型",
+    "fusionTab": "融合",
     "embeddingsTab": "嵌入模型",
+    "newBadge": "新",
     "monthlyTokenBudget": "每月令牌额度",
     "remaining": "剩余",
     "of": "共",
@@ -240,6 +242,7 @@
     "title": "试玩台",
     "description": "通过路由器发送一次对话补全请求,看看是哪个提供商在服务。",
     "autoModel": "自动(回退链)",
+    "fusionModel": "融合(多模型综合)",
     "send": "发送",
     "sending": "发送中…",
     "clear": "清空",
@@ -250,6 +253,11 @@
     "copyReply": "复制回复",
     "fallback": "次回退",
     "fallbacks": "次回退",
+    "fusionPanel": "模型组",
+    "fusionJudge": "评审",
+    "fusionTrace": "{count} 个模型的回答",
+    "fusionFailed": "无回应",
+    "fusionJudgeSynth": "综合出最终答案",
     "errorPrefix": "错误:"
   },
   "embeddings": {
@@ -266,6 +274,37 @@
     "saveChanges": "保存修改",
     "savingChanges": "保存中…",
     "tokMax": "最多 {tokens} tok"
+  },
+  "fusion": {
+    "title": "融合",
+    "description": "由一组模型并行作答，再由评审模型综合出更优的答案。在调用 API 时将 model 设为 “fusion” 即可使用。",
+    "panelSource": "模型组来源",
+    "panelSourceHelp": "当请求未自行指定时，模型组所采用的来源。",
+    "mode": {
+      "auto": "自动(回退链)",
+      "autoHelp": "从你的回退链中挑选一组多样化的模型，并按当前启用的路由策略排序。",
+      "explicit": "指定模型组",
+      "explicitHelp": "始终使用你在下方选择的特定模型。"
+    },
+    "panelModels": "组内模型",
+    "selectedCount": "已选择 {count} / {max}",
+    "noModels": "尚未连接任何模型。请先添加 API 密钥，然后在回退链中启用模型。",
+    "panelSize": "模型组规模",
+    "panelSizeHelp": "自动挑选的多样化模型数量(1–{max})。",
+    "judge": "评审模型",
+    "judgeHelp": "将模型组的回答综合为一个答案的模型。“自动”会使用你排名最高的可用模型。",
+    "judgeAuto": "自动(排名最高的可用模型)",
+    "strategy": "策略",
+    "strategySynthesize": "综合：将模型组的回答融合为一个答案",
+    "strategyBestOf": "择优：返回单个最强的答案(不调用评审)",
+    "strategySynthesizeShort": "综合",
+    "strategyBestOfShort": "择优",
+    "exposePanel": "暴露模型组细节",
+    "exposePanelHelp": "在响应的 x_fusion 字段中附上每个模型的回答以及评审的元数据。",
+    "howToUse": "如何使用",
+    "howToUseHelp": "发送普通的对话请求，并将 model 设为 “fusion”。这些设置为默认值；任何请求都可以通过 “fusion” 字段覆盖它们。",
+    "unsavedChanges": "有未保存的更改",
+    "save": "保存"
   },
   "premium": {
     "title": "高级版",


### PR DESCRIPTION
## Problem

The Fusion feature (Models → Fusion page, the Fusion tab + "New" badge, and the Playground fusion model picker / trace / footer) was wired with `t()` calls, but all **35 fusion-related keys existed only in `en.json`**. They were missing from `zh-CN`, `fr`, `es`, and `pt-BR`, so `t()` silently fell back to English and the feature rendered untranslated in every non-English language.

## Change

Added proper translations for all 35 keys to each of the four non-English locales:

- `models.fusionTab`, `models.newBadge`
- Playground fusion keys: `fusionModel`, `fusionPanel`, `fusionJudge`, `fusionTrace`, `fusionFailed`, `fusionJudgeSynth`
- The full `fusion.*` namespace (27 keys): panel source, auto/explicit modes, panel models/size, judge, strategy (synthesize / best-of), expose-panel, how-to-use, save, etc.

Keys are inserted at positions matching `en.json` for clean diffs, and reuse the dashboard's existing terminology (Fallback Chain, routing strategy, Save) for consistency. Interpolation placeholders (`{count}`, `{max}`) and literal API identifiers (`fusion`, `x_fusion`) are preserved verbatim.

## Verification

- Flat-key parity diff: **0 missing keys** in every locale; `fusion` namespace ordered between `embeddings` and `premium` in all files.
- `client` builds clean (Vite, 2909 modules).
- JSON round-trip byte-stable (no spurious reformatting).