### PR TITLE
Add Reka provider (OpenAI-compatible)

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -55,6 +55,7 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'huggingface', label: 'HuggingFace Router', url: 'https://huggingface.co/settings/tokens' },
   { value: 'opencode', label: 'OpenCode Zen (free key)', url: 'https://opencode.ai/auth' },
   { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
+  { value: 'reka', label: 'Reka (free key)', url: 'https://platform.reka.ai' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/server/src/db/model-pricing.ts
+++ b/server/src/db/model-pricing.ts
@@ -173,6 +173,10 @@ export const MODEL_PRICING: PricingRow[] = [
   // Pollinations (serves gpt-oss-20b)
   ['pollinations', 'openai-fast', 0.029, 0.14],
 
+  // Reka (live /v1/models pricing, 2026-06-17)
+  ['reka', 'reka-flash-3', 0.10, 0.20],
+  ['reka', 'reka-edge-2603', 0.10, 0.10],
+
   // SambaNova rows were removed in V23 (platform dropped — free tier retired).
 
   // Zhipu (4.5-flash estimated at the 4.7-flash rate — no paid 4.5-flash;

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -205,6 +205,19 @@ register(new OpenAICompatProvider({
 // $0.0, please pay with fiat or send tao". The "free" tier requires a
 // non-zero balance, which conflicts with the project's no-card criterion.
 
+// Reka — OpenAI-compatible (api.reka.ai/v1). Live-probed 2026-06-17: free via a
+// recurring monthly credit grant (no card; key from platform.reka.ai), billed
+// calls succeed with no 402. The OpenAI-compatible /v1/models lists two models:
+// reka-flash-3 (text reasoning) and reka-edge-2603 (natively multimodal —
+// accepts image/video input). Balance is dashboard-only (no credits API).
+// Catalog rows live in the catalog (premium → age into free); they are NOT
+// shipped as freeapi model migrations.
+register(new OpenAICompatProvider({
+  platform: 'reka',
+  name: 'Reka',
+  baseUrl: 'https://api.reka.ai/v1',
+}));
+
 // Placeholder so getProvider('custom')/hasProvider('custom')/getAllProviders()
 // behave — but the real instance is built per-key by resolveProvider(), since
 // a custom provider's base URL is user-supplied and lives on the api_keys row.

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -14,7 +14,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'custom',
 ] as const;
 
 // `key` is optional so keyless providers (Kilo's anonymous gateway) can be added

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -33,6 +33,10 @@ export type Platform =
   // its own proprietary Agnes models; the free key comes from
   // platform.agnes-ai.com (no card).
   | 'agnes'
+  // Reka — OpenAI-compatible. Native multimodal models (reka-edge takes
+  // image/video); free via a recurring monthly credit grant, key from
+  // platform.reka.ai (no card).
+  | 'reka'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
## Summary
Adds **Reka** (`api.reka.ai/v1`) as a new OpenAI-compatible free provider.

Reka is free via a recurring monthly credit grant (no card; key from `platform.reka.ai`). Live-probed 2026-06-17 against a real key:

| Model | Context | Modalities | $/1M (in/out) | Result |
|---|--:|---|---|--|
| `reka-flash-3` | 65,536 | text | 0.10 / 0.20 | 200 OK (reasoning model) |
| `reka-edge-2603` | 16,384 | text + image + video | 0.10 / 0.10 | 200 OK; read an inline image correctly |

These two are the only models exposed by Reka's OpenAI-compatible `/v1/models`. Billed calls succeed with no 402, confirming the grant is active; balance is dashboard-only (no credits API).

## Changes
- Register the Reka provider (generic `OpenAICompatProvider`, no new class needed).
- Add `'reka'` to the `Platform` union (`shared/types.ts`) and the keys validation enum (`routes/keys.ts`).
- Add Reka to the client key-entry provider list (`KeysPage.tsx`) so it appears in the app/desktop.
- Add `reka-flash-3` / `reka-edge-2603` pricing rows.

## Notes
- Catalog rows for Reka are authored separately (premium first, then age into the free tier); they are **not** shipped as freeapi model migrations.
- Build green; server suite 494/494 pass (`vitest --pool=forks`).