### PR TITLE
fix: fail over on 410 Gone and un-enumerated upstream statuses (#337, #339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/dashitongzhi"><img src="https://images.weserv.nl/?url=github.com/dashitongzhi.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@dashitongzhi" /></a>
 <a href="https://github.com/QingJ01"><img src="https://images.weserv.nl/?url=github.com/QingJ01.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@QingJ01" /></a>
 <a href="https://github.com/3215"><img src="https://images.weserv.nl/?url=github.com/3215.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@3215" /></a>
+<a href="https://github.com/saifulaiub123"><img src="https://images.weserv.nl/?url=github.com/saifulaiub123.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@saifulaiub123" /></a>
+<a href="https://github.com/PietFourie"><img src="https://images.weserv.nl/?url=github.com/PietFourie.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@PietFourie" /></a>
 
 ## Terms of Service review
 

--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -26,6 +26,11 @@ describe('isModelNotFoundError (drives whole-model skip within a request)', () =
     expect(isModelNotFoundError(new Error('No endpoints found for openrouter/minimax/minimax-m2.5:free'))).toBe(true);
   });
 
+  it('flags 410 Gone (model pulled upstream) by message or attached status — #339', () => {
+    expect(isModelNotFoundError(new Error('Ollama Cloud API error 410: Gone'))).toBe(true);
+    expect(isModelNotFoundError(Object.assign(new Error('Gone'), { status: 410 }))).toBe(true);
+  });
+
   it('does not flag rate limits, 5xx, or payment errors', () => {
     expect(isModelNotFoundError(new Error('429 Too Many Requests'))).toBe(false);
     expect(isModelNotFoundError(new Error('503 Service Unavailable'))).toBe(false);
@@ -117,6 +122,37 @@ describe('isRetryableError', () => {
       expect(isPaymentRequiredError(new Error('HuggingFace Router API error 402: Payment required'))).toBe(true);
       expect(isPaymentRequiredError(new Error('429 Too Many Requests'))).toBe(false);
       expect(isPaymentRequiredError(new Error('503 Service Unavailable'))).toBe(false);
+    });
+  });
+
+  describe('410 Gone & un-enumerated upstream statuses fail over instead of 502 (#337/#339)', () => {
+    // The headline bug: a provider error whose HTTP status the substring allowlist
+    // never enumerated (410 Gone, 502, 504, 408 …) used to abort the whole chain
+    // with a 502 — stranding the healthy paid routes still queued later in the
+    // fallback order. It must rotate to the next route instead.
+    it('treats an Ollama "410: Gone" as retryable, by message and by attached status', () => {
+      // openai-compat throws via providerHttpError, so the real error carries both.
+      expect(isRetryableError(new Error('Ollama Cloud API error 410: Gone'))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error('Ollama Cloud API error 410: Gone'), { status: 410 }))).toBe(true);
+    });
+
+    it('fails over on any 5xx the substring rules never listed, via the structured status', () => {
+      // No '502'/'504'/'507' substring rule exists; the err.status catch-all covers them.
+      expect(isRetryableError(Object.assign(new Error('Bad Gateway'), { status: 502 }))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error('Gateway Timeout'), { status: 504 }))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error('Insufficient Storage'), { status: 507 }))).toBe(true);
+    });
+
+    it('fails over on 408 request-timeout / 409 conflict by status', () => {
+      expect(isRetryableError(Object.assign(new Error('Request Timeout'), { status: 408 }))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error('Conflict'), { status: 409 }))).toBe(true);
+    });
+
+    it('still treats genuinely-fatal 400/401 as NON-retryable even with an attached status', () => {
+      // The structured catch-all must not swallow client-fatal errors — they fail on
+      // every provider identically, so aborting the request is the correct behavior.
+      expect(isRetryableError(Object.assign(new Error('Bad Request'), { status: 400 }))).toBe(false);
+      expect(isRetryableError(Object.assign(new Error('Unauthorized'), { status: 401 }))).toBe(false);
     });
   });
 

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -5,6 +5,20 @@
 
 export function isRetryableError(err: any): boolean {
   const msg = (err.message ?? '').toLowerCase();
+  // Trust the upstream HTTP status the provider attached to the error first
+  // (providerHttpError in providers/base.ts sets err.status on every adapter).
+  // This structured check is the robust primary signal; the message-substring
+  // rules below are the fallback for errors that carry a code in their text but
+  // no numeric status. It's the fix for #337/#339: an Ollama "410 Gone", or any
+  // upstream 5xx the substring allowlist never enumerated (502/504/507…), used to
+  // fall through to a 502 and STRAND the healthy paid routes still queued later in
+  // the chain — because the old code matched specific substrings and ignored
+  // err.status for every code except 403. 408 (request timeout), 409 (conflict),
+  // 410 (model pulled upstream), 429 (rate limit) and all 5xx are transient or
+  // fail-over-able; 400/401 stay fatal (status 0 here, handled by the absence of a
+  // matching rule) and 403 is handled by isModelAccessForbiddenError below.
+  const status = typeof err?.status === 'number' ? err.status : 0;
+  if (status === 408 || status === 409 || status === 410 || status === 429 || status >= 500) return true;
   return msg.includes('429') || msg.includes('rate limit') || msg.includes('too many requests')
     || msg.includes('quota') || msg.includes('resource_exhausted')
     || msg.includes('aborted') || msg.includes('timeout') || msg.includes('etimedout')
@@ -20,6 +34,12 @@ export function isRetryableError(err: any): boolean {
     // for a model that's been pulled). Rotate to the next model in the chain —
     // setCooldown + the health checker will avoid this model on subsequent requests.
     || msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
+    // 410: the model/endpoint was permanently removed upstream (e.g. Ollama Cloud
+    // "API error 410: Gone", #339). Like a 404 it won't return on this provider, so
+    // rotate to the next route; isModelNotFoundError benches the whole model. The
+    // structured status check above already catches the 410 when the provider
+    // attaches err.status — this is the text fallback for errors that don't.
+    || msg.includes('410') || msg.includes('gone')
     // 403: the key is valid (it passed validateKey, and the health checker
     // disables truly-forbidden keys) but this specific model is off-limits to
     // the key's tier — e.g. gpt-4o on GitHub Models' free tier, subscription-only
@@ -64,8 +84,14 @@ export function isPaymentRequiredError(err: any): boolean {
 // burning one fallback attempt per key on the same dead route.
 // (PR #111, credits @barbotkonv.)
 export function isModelNotFoundError(err: any): boolean {
-  const msg = (err.message ?? '').toLowerCase();
-  return msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found');
+  // 404 (removed/deprecated) and 410 (permanently Gone) are both MODEL-level: every
+  // key for the platform fails the same way, so skip the whole model for the rest
+  // of the request instead of burning one fallback attempt per sibling key. 410
+  // added for #339 (Ollama Cloud "Gone"); prefer the structured status when present.
+  if (err?.status === 404 || err?.status === 410) return true;
+  const msg = (err?.message ?? '').toLowerCase();
+  return msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
+    || msg.includes('410') || msg.includes('gone');
 }
 
 // A 403 Forbidden returned for a specific model behind an otherwise-valid key.


### PR DESCRIPTION
Closes #337. Closes #339.

## The bug
In priority/manual mode the fallback chain returns a `502` and stops on certain provider errors even when healthy routes (e.g. a paid final-fallback model) are still queued later in the chain.

Root cause: the retry gate `isRetryableError` (server/src/lib/error-classify.ts), shared by `/v1/chat/completions` and `/v1/responses`, was an **allowlist over error-message substrings** that ignored the structured `err.status` for every code except 403. Any upstream status it never enumerated fell through to the non-retryable branch and aborted the request:

- **410 Gone** (Ollama Cloud "API error 410: Gone") — the #339 case, not handled anywhere.
- **502 / 504 / 507 / 408** — un-enumerated 5xx/timeout statuses.

(402 Payment Required, 503 and abort were *already* handled and already fail over — the reports conflated those with the genuinely-unhandled 410/un-enumerated cases.)

## The fix (minimal, no control-flow changes)
Entirely in the shared classifier, so both endpoints are fixed at once:

1. `isRetryableError` now reads the **structured `err.status`** first (providers attach it via `providerHttpError`) and fails over on `408/409/410/429` and **all 5xx**. The message-substring rules remain as a text fallback, plus an explicit `410`/`gone` rule next to the sibling `404`.
2. `isModelNotFoundError` treats `410` like `404`, so a permanently-gone model is benched **wholesale** (`skipModels`) rather than retrying its sibling keys.
3. `400`/`401` stay **fatal** — the status catch-all deliberately excludes them, so genuinely client-fatal errors still abort instead of burning 20 fallback hops. `403` is unchanged (handled by `isModelAccessForbiddenError`).

## Tests
- 10 new assertions in `proxy-retry.test.ts`: Ollama 410 (message + status), 502/504/507/408/409 via structured status, and a guard that 400/401-with-status remain non-retryable.
- Full server suite green: **499 tests pass** under the CI config (`vitest --pool=forks`). `tsc --noEmit` clean.

## Follow-up (out of scope here)
Deeper hardening would invert the gate to a denylist (advance by default, abort only on a small fatal set) and add a loop-level integration test driving a mocked 410 → next-route. Left out to keep this change minimal and reviewable.

Reported by @saifulaiub123 (#337) and @PietFourie (#339); both credited in the README.