### PR TITLE
ci(desktop): build & publish Windows .exe (+ macOS .dmg) installers; add Windows install path (#318)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Install desktop dependencies
         run: npm --prefix desktop install
 
+      # electron-builder (on Windows) walks up to the repo root and errors on the
+      # parent .dockerignore ("must be under .../desktop/"). It's irrelevant to the
+      # desktop installer, so drop it from this ephemeral checkout before building.
+      - name: Remove repo-root .dockerignore (electron-builder path quirk)
+        shell: bash
+        run: rm -f .dockerignore
+
       - name: Build installer
         run: npm run ${{ matrix.script }}
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -34,11 +34,11 @@ jobs:
           # Pinned to windows-2022 (VS 2022): node-gyp can't yet parse the VS "18"
           # toolset on windows-latest, which breaks the better-sqlite3 native build.
           - os: windows-2022
-            script: desktop:dist:win
+            ebArgs: --win --x64
             artifact: windows-installer
             glob: desktop/dist-electron/*.exe
           - os: macos-latest
-            script: desktop:dist
+            ebArgs: --mac --arm64
             artifact: macos-dmg
             glob: desktop/dist-electron/*.dmg
     steps:
@@ -54,19 +54,30 @@ jobs:
       - name: Install desktop dependencies
         run: npm --prefix desktop install
 
-      # electron-builder (on Windows) walks up to the repo root and errors on the
-      # parent .dockerignore ("must be under .../desktop/"). It's irrelevant to the
-      # desktop installer, so drop it from this ephemeral checkout before building.
-      - name: Remove repo-root .dockerignore (electron-builder path quirk)
+      - name: Build client + desktop bundles
         shell: bash
-        run: rm -f .dockerignore
+        run: |
+          npm run build -w client
+          npm --prefix desktop run build:all
 
-      - name: Build installer
-        run: npm run ${{ matrix.script }}
+      - name: Package installer
+        shell: bash
         env:
           # No signing certs in CI — build unsigned rather than failing on a
           # missing identity. (The app already ships unsigned; see README.)
           CSC_IDENTITY_AUTODISCOVERY: 'false'
+        run: |
+          set -e
+          # Run electron-builder with desktop/ as its own project root. Invoked
+          # from the monorepo root (e.g. via `npm --prefix desktop run`), it walks
+          # up, treats the repo root as the project, and on Windows pulls parent
+          # files (.dockerignore, .env.example, …) into the asar — failing with
+          # "<file> must be under …/desktop/". Running from desktop/ and hiding the
+          # root package.json (whose `workspaces` field triggers the upward scan)
+          # makes desktop/ the detected project root.
+          mv package.json "$RUNNER_TEMP/root-package.json"
+          cd desktop
+          npx --no-install electron-builder ${{ matrix.ebArgs }}
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,73 @@
+name: Desktop release
+
+# Builds the menu-bar desktop app installers (Windows .exe + macOS .dmg) and,
+# on a version tag, attaches them to the GitHub Release. Closes #318 — the
+# dist:win build config already existed; this is the missing publish step.
+#
+# Triggers:
+#   - workflow_dispatch        manual build (artifacts only)
+#   - push tags 'v*'           build + attach the installers to the release
+#   - pull_request (desktop)   build-only smoke test so the Windows build can't
+#                              silently rot (only when desktop/CI files change)
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    paths:
+      - 'desktop/**'
+      - '.github/workflows/desktop-release.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            script: desktop:dist:win
+            artifact: windows-installer
+            glob: desktop/dist-electron/*.exe
+          - os: macos-latest
+            script: desktop:dist
+            artifact: macos-dmg
+            glob: desktop/dist-electron/*.dmg
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: Install desktop dependencies
+        run: npm --prefix desktop install
+
+      - name: Build installer
+        run: npm run ${{ matrix.script }}
+        env:
+          # No signing certs in CI — build unsigned rather than failing on a
+          # missing identity. (The app already ships unsigned; see README.)
+          CSC_IDENTITY_AUTODISCOVERY: 'false'
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.glob }}
+          if-no-files-found: error
+
+      - name: Attach installer to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.glob }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -31,7 +31,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          # Pinned to windows-2022 (VS 2022): node-gyp can't yet parse the VS "18"
+          # toolset on windows-latest, which breaks the better-sqlite3 native build.
+          - os: windows-2022
             script: desktop:dist:win
             artifact: windows-installer
             glob: desktop/dist-electron/*.exe

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           npm run build -w client
           npm --prefix desktop run build:all
+          # Stage client/dist into desktop/ so electron-builder's extraResources
+          # source stays inside desktop/ (no `../`). Belt-and-suspenders with the
+          # root-hiding below; also makes local `desktop:dist:win` work on Windows.
+          npm --prefix desktop run stage:client
 
       - name: Package installer
         shell: bash

--- a/README.md
+++ b/README.md
@@ -117,11 +117,19 @@ PRs that add any of these are very welcome. See [Contributing](#contributing).
 
 **One-liner** (Docker required — sets up `~/freellmapi`, generates an encryption key, pulls the image, and starts the container):
 
+macOS / Linux:
+
 ```bash
 curl -fsSL https://freellmapi.co/install.sh | bash
 ```
 
-Prefer to read before you pipe to bash? [The script is here](https://freellmapi.co/install.sh). Re-running it is safe: your `.env` (and encryption key) is preserved and the container updates to `:latest`. Override the defaults with `FREELLMAPI_DIR`, `PORT`, or `HOST_BIND` env vars.
+Windows (PowerShell):
+
+```powershell
+iwr -useb https://freellmapi.co/install.ps1 | iex
+```
+
+Prefer to read before you pipe? Here are the scripts: [install.sh](https://freellmapi.co/install.sh) · [install.ps1](https://freellmapi.co/install.ps1). Re-running is safe: your `.env` (and encryption key) is preserved and the container updates to `:latest`. Override the defaults with `FREELLMAPI_DIR`, `PORT`, or `HOST_BIND` env vars.
 
 **Or manually with Docker Compose.** It runs the API and dashboard together on port 3001 and persists SQLite in a named volume.
 
@@ -212,16 +220,16 @@ request stats.
 
 ![FreeLLMAPI desktop app](repo-assets/desktop.png)
 
-**[Download the macOS app from Releases](https://github.com/tashfeenahmed/freellmapi/releases/latest)**, or build it from this repo in a few minutes:
+**[Download from Releases](https://github.com/tashfeenahmed/freellmapi/releases/latest)** — the macOS `.dmg` and the Windows `.exe` installer are built and attached to every release by the [`desktop-release`](.github/workflows/desktop-release.yml) workflow. Or build it from this repo in a few minutes:
 
 ```bash
 npm install
-npm run desktop:dist        # macOS: desktop/dist-electron/FreeLLMAPI-…-arm64.dmg
-npm run desktop:dist:win    # Windows installer
+npm run desktop:dist        # macOS  → desktop/dist-electron/FreeLLMAPI-…-arm64.dmg
+npm run desktop:dist:win    # Windows → "desktop/dist-electron/FreeLLMAPI Setup ….exe"
 ```
 
-> **Windows:** the build config is in place but not tested yet — if you try it,
-> a quick report (working or not) in an issue would be much appreciated.
+> Locally built apps are unsigned, so Windows SmartScreen may warn on first run
+> ("More info" → "Run anyway"); the macOS build launches without Gatekeeper prompts.
 
 ## Premium (live catalog)
 

--- a/desktop/.gitignore
+++ b/desktop/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 build/
 dist-electron/
+client-dist/
 .DS_Store
 
 # Monetization planning — private, never committed

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -11,8 +11,11 @@ asar: true
 asarUnpack:
   - "**/node_modules/better-sqlite3/**/*.node"
   - "**/node_modules/better-sqlite3/build/Release/**"
+# client-dist is staged into desktop/ by `npm run stage:client` (scripts/stage-client.mjs).
+# It MUST stay a path inside desktop/: a `../` source makes electron-builder treat the
+# repo root as a copy base and reject every root file ("must be under .../desktop/").
 extraResources:
-  - from: ../client/dist
+  - from: client-dist
     to: client-dist
 mac:
   category: public.app-category.developer-tools

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -10,10 +10,11 @@
     "build:main": "esbuild src/main.ts --bundle --platform=node --format=esm --external:electron --external:./server.mjs --outfile=build/main.mjs",
     "build:preload": "esbuild src/preload.ts src/preload-popover.ts --bundle --platform=node --format=cjs --external:electron --outdir=build --out-extension:.js=.cjs",
     "build:all": "npm run bundle:server && npm run build:main && npm run build:preload",
+    "stage:client": "node scripts/stage-client.mjs",
     "rebuild:native": "electron-rebuild -f -w better-sqlite3",
     "dev": "npm run build:all && electron .",
-    "dist": "npm run build:all && electron-builder --mac --arm64",
-    "dist:win": "npm run build:all && electron-builder --win --x64"
+    "dist": "npm run build:all && npm run stage:client && electron-builder --mac --arm64",
+    "dist:win": "npm run build:all && npm run stage:client && electron-builder --win --x64"
   },
   "dependencies": {
     "better-sqlite3": "^12.10.0"

--- a/desktop/scripts/stage-client.mjs
+++ b/desktop/scripts/stage-client.mjs
@@ -1,0 +1,25 @@
+// Stages the built web client into desktop/client-dist so electron-builder can
+// pick it up via a path *inside* the app dir.
+//
+// Why: electron-builder's extraResources used `from: ../client/dist`. That `../`
+// reaches above desktop/, and on Windows it makes electron-builder treat the repo
+// root as a copy base and then reject every repo-root file with
+// "<file> must be under .../desktop/" (.dockerignore, .env.example, ...). Copying
+// the client build into desktop/ first keeps every electron-builder path under
+// desktop/ and sidesteps the whole class of errors cross-platform.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const src = path.resolve(__dirname, '../../client/dist');
+const dest = path.resolve(__dirname, '../client-dist');
+
+if (!fs.existsSync(src)) {
+  console.error(`stage-client: ${src} not found — build the web client first (npm run build -w client).`);
+  process.exit(1);
+}
+
+fs.rmSync(dest, { recursive: true, force: true });
+fs.cpSync(src, dest, { recursive: true });
+console.log(`stage-client: copied ${src} -> ${dest}`);

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -1,0 +1,4 @@
+# The FreeLLMAPI Windows installer lives at https://freellmapi.co/install.ps1
+# This shim keeps old `iwr ... github.io ... | iex` one-liners working.
+$ErrorActionPreference = 'Stop'
+Invoke-Expression (Invoke-RestMethod -UseBasicParsing https://freellmapi.co/install.ps1)


### PR DESCRIPTION
Resolves #318 ("需要exe") and the Windows follow-up under #250.

The `dist:win` electron-builder target already existed and is correctly configured (`desktop/electron-builder.yml` → NSIS x64). What was missing was a step that actually **builds and publishes** the Windows installer, plus Windows install docs.

## What's in here
- **`desktop-release` workflow** — builds the menu-bar app on `windows-latest` and `macos-latest`:
  - On a version tag (`v*`): attaches the `.exe` and `.dmg` to the GitHub Release.
  - On `workflow_dispatch` or a desktop-touching PR: uploads the installers as build artifacts (a build-only smoke test so the Windows build can't silently rot).
- **README** — adds the Windows PowerShell one-liner to Quick start and points Windows users at the Releases `.exe` (replaces the old "not tested yet" note).
- **`docs/install.ps1`** — PowerShell shim mirroring `docs/install.sh`, so the github.io install path works on Windows.

## Companion (ships with the website, not this repo)
The hosted installer at `freellmapi.co/install.ps1` (what the one-liner fetches) mirrors `install.sh`: Docker/Compose check, generated `ENCRYPTION_KEY` preserved across re-runs, `docker compose up -d`, health wait. It lives with the site like `install.sh` does, so it's not part of this PR.

## Verification
- Workflow YAML validated.
- This PR triggers the new workflow (it touches the workflow file), so its own CI run does a real Windows + macOS installer build — see the checks below for the produced `windows-installer` / `macos-dmg` artifacts.
- After merge, cutting a `v*` tag attaches the installers to the release.

Closes #318