### PR TITLE
docs: credit @DemeulemeesterxMaxime (#343) and @HoodBlah (#318/#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ PRs should include a test, keep the existing test suite green, and match the `.e
 <a href="https://github.com/saifulaiub123"><img src="https://images.weserv.nl/?url=github.com/saifulaiub123.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@saifulaiub123" /></a>
 <a href="https://github.com/PietFourie"><img src="https://images.weserv.nl/?url=github.com/PietFourie.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@PietFourie" /></a>
 <a href="https://github.com/mhmdkrmabd"><img src="https://images.weserv.nl/?url=github.com/mhmdkrmabd.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@mhmdkrmabd" /></a>
+<a href="https://github.com/DemeulemeesterxMaxime"><img src="https://images.weserv.nl/?url=github.com/DemeulemeesterxMaxime.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@DemeulemeesterxMaxime" /></a>
+<a href="https://github.com/HoodBlah"><img src="https://images.weserv.nl/?url=github.com/HoodBlah.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@HoodBlah" /></a>
 
 ## Terms of Service review
 


### PR DESCRIPTION
Adds the contributors behind the just-merged catalog-filters (#343, #348) and Windows-installer (#318, #349) work to the README Contributors wall.

- **@DemeulemeesterxMaxime** — requested the catalog search / quick-copy / filters (#343).
- **@HoodBlah** — reported the Windows `curl … | bash` failure that motivated the PowerShell install path (#250, addressed in #349).

(@JammyJames1234 and @StealthTensor are already on the wall.)