### PR TITLE
chore: prep v0.4.1 release (bump desktop 0.4.1; drop unshipped Windows one-liner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,19 +117,13 @@ PRs that add any of these are very welcome. See [Contributing](#contributing).
 
 **One-liner** (Docker required — sets up `~/freellmapi`, generates an encryption key, pulls the image, and starts the container):
 
-macOS / Linux:
-
 ```bash
 curl -fsSL https://freellmapi.co/install.sh | bash
 ```
 
-Windows (PowerShell):
+Prefer to read before you pipe to bash? [The script is here](https://freellmapi.co/install.sh). Re-running it is safe: your `.env` (and encryption key) is preserved and the container updates to `:latest`. Override the defaults with `FREELLMAPI_DIR`, `PORT`, or `HOST_BIND` env vars.
 
-```powershell
-iwr -useb https://freellmapi.co/install.ps1 | iex
-```
-
-Prefer to read before you pipe? Here are the scripts: [install.sh](https://freellmapi.co/install.sh) · [install.ps1](https://freellmapi.co/install.ps1). Re-running is safe: your `.env` (and encryption key) is preserved and the container updates to `:latest`. Override the defaults with `FREELLMAPI_DIR`, `PORT`, or `HOST_BIND` env vars.
+On Windows, the easiest path is the desktop **[`.exe` installer from Releases](https://github.com/tashfeenahmed/freellmapi/releases/latest)** (below); the Docker steps work in WSL or any bash shell.
 
 **Or manually with Docker Compose.** It runs the API and dashboard together on port 3001 and persists SQLite in a named volume.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Release prep for **v0.4.1** (which publishes the Windows `.exe` + macOS `.dmg` once tagged).

- Bumps desktop `0.3.0 → 0.4.1` so the installers are named `FreeLLMAPI Setup 0.4.1.exe` / `FreeLLMAPI-0.4.1-arm64.dmg`.
- Removes the Windows PowerShell one-liner from the README — `install.ps1` isn't hosted on the site, so the command would 404. Windows users are pointed at the `.exe` installer from Releases instead (the Docker one-liner still works under WSL/bash). The `install.ps1` script stays staged in `landing page/` for whenever the site is next deployed.