### PR TITLE
feat(dashboard): consolidate providers + detail pages + API usage for image/audio/embedding

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,8 @@ import FusionPage from '@/pages/FusionPage'
 import EmbeddingsPage from '@/pages/EmbeddingsPage'
 import ImagePage from '@/pages/ImagePage'
 import AudioPage from '@/pages/AudioPage'
+import MediaDetailPage from '@/pages/MediaDetailPage'
+import EmbeddingDetailPage from '@/pages/EmbeddingDetailPage'
 import AnalyticsPage from '@/pages/AnalyticsPage'
 import PremiumPage from '@/pages/PremiumPage'
 
@@ -243,8 +245,11 @@ function App() {
                 <Route path="/models/chat/:id" element={<ModelDetailPage />} />
                 <Route path="/models/fusion" element={<FusionPage />} />
                 <Route path="/models/embeddings" element={<EmbeddingsPage />} />
+                <Route path="/models/embeddings/:id" element={<EmbeddingDetailPage />} />
                 <Route path="/models/image" element={<ImagePage />} />
+                <Route path="/models/image/:id" element={<MediaDetailPage modality="image" />} />
                 <Route path="/models/audio" element={<AudioPage />} />
+                <Route path="/models/audio/:id" element={<MediaDetailPage modality="audio" />} />
                 <Route path="/playground" element={<PlaygroundPage />} />
                 <Route path="/keys" element={<KeysPage />} />
                 <Route path="/fallback" element={<Navigate to="/models/chat" replace />} />

--- a/client/src/components/api-usage.tsx
+++ b/client/src/components/api-usage.tsx
@@ -1,0 +1,26 @@
+import { CopyButton } from '@/components/copy-button'
+import { useI18n } from '@/i18n'
+
+// The /v1 base URL for ready-to-run snippets, derived the same way as the chat
+// model page + Keys page: the dev server port in DEV, the page origin in a
+// packaged/hosted build.
+export function apiBaseUrl(): string {
+  return import.meta.env.DEV
+    ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
+    : `${window.location.origin}/v1`
+}
+
+// A copy-able "ways to use the API" code block, matching the chat detail page's
+// snippet card so every modality's detail page looks the same.
+export function ApiUsageBlock({ snippet }: { snippet: string }) {
+  const { t } = useI18n()
+  return (
+    <div className="overflow-hidden rounded-2xl border bg-card">
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <CopyButton text={snippet} className="size-7 shrink-0" label={t('common.copy')} />
+        <span className="text-xs font-medium">{t('models.codeSnippetHeading')}</span>
+      </div>
+      <pre className="overflow-x-auto px-4 py-3 text-[11px] leading-relaxed"><code className="font-mono">{snippet}</code></pre>
+    </div>
+  )
+}

--- a/client/src/components/media-models.tsx
+++ b/client/src/components/media-models.tsx
@@ -1,11 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
 import { apiFetch } from '@/lib/api'
 import { Switch } from '@/components/ui/switch'
 import { PageHeader } from '@/components/page-header'
 import { ModelsTabs } from '@/components/models-tabs'
 import { useI18n } from '@/i18n'
 
-interface MediaModel {
+export interface MediaModel {
   id: number
   platform: string
   modelId: string
@@ -17,10 +18,33 @@ interface MediaModel {
 }
 interface MediaData { models: MediaModel[] }
 
-// Shared list view for the Image and Audio dashboard tabs. Mirrors the
-// Embeddings tab: a flat list of catalog media models with a per-row enable
-// toggle (saved immediately). Rows arrive from the signed catalog via
-// catalog-sync, so the list self-populates once a media catalog is applied.
+export interface MediaGroup {
+  label: string
+  slug: string
+  members: MediaModel[]
+}
+
+// Consolidate media rows into logical models — the same idea the chat Models page
+// uses (one logical model, several providers underneath). Group by displayName so
+// e.g. "FLUX.1 [schnell]" served by nvidia + cloudflare + siliconflow is one row.
+export function groupMedia(models: MediaModel[]): MediaGroup[] {
+  const map = new Map<string, MediaModel[]>()
+  for (const m of models) {
+    const arr = map.get(m.displayName)
+    if (arr) arr.push(m)
+    else map.set(m.displayName, [m])
+  }
+  return [...map.entries()]
+    .map(([label, members]) => ({ label, slug: encodeURIComponent(label), members }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+// Shared list view for the Image and Audio dashboard tabs. Mirrors the chat
+// Models page: media models are consolidated into one logical-model group per
+// name (with a "N providers" badge), each linking to its own detail page, and a
+// per-provider enable toggle (saved immediately). Rows arrive from the signed
+// catalog via catalog-sync, so the list self-populates once a media catalog is
+// applied.
 export function MediaModelsView({ modality }: { modality: 'image' | 'audio' }) {
   const { t } = useI18n()
   const queryClient = useQueryClient()
@@ -36,7 +60,7 @@ export function MediaModelsView({ modality }: { modality: 'image' | 'audio' }) {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['media'] }),
   })
 
-  const models = (data?.models ?? []).filter(m => m.modality === modality)
+  const groups = groupMedia((data?.models ?? []).filter(m => m.modality === modality))
   const title = modality === 'image' ? t('models.imageTitle') : t('models.audioTitle')
   const description = modality === 'image' ? t('models.imageDesc') : t('models.audioDesc')
   const endpoint = modality === 'image' ? '/v1/images/generations' : '/v1/audio/speech'
@@ -52,34 +76,52 @@ export function MediaModelsView({ modality }: { modality: 'image' | 'audio' }) {
 
         {isLoading ? (
           <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
-        ) : models.length === 0 ? (
+        ) : groups.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t('models.mediaEmpty')}</p>
         ) : (
-          <section className="rounded-3xl border bg-card p-5">
-            <div className="divide-y">
-              {models.map(m => (
-                <div key={m.id} className={`flex items-center gap-3 py-2 ${m.enabled ? '' : 'opacity-50'}`}>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium">{m.displayName}</span>
-                      <span className="text-xs text-muted-foreground">{m.platform}</span>
-                      {m.keyCount === 0 && (
-                        <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-amber-600/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-400">
-                          {t('models.noKey')}
-                        </span>
-                      )}
-                    </div>
-                    <div className="truncate font-mono text-[11px] text-muted-foreground">{m.modelId}</div>
-                    {m.quotaLabel && <div className="text-[11px] text-muted-foreground/70">{m.quotaLabel}</div>}
-                  </div>
-                  <Switch
-                    checked={m.enabled}
-                    onCheckedChange={(c) => toggle.mutate({ id: m.id, enabled: c })}
-                  />
+          groups.map(g => {
+            const anyEnabled = g.members.some(m => m.enabled)
+            const quota = g.members.map(m => m.quotaLabel).find(Boolean)
+            return (
+              <section key={g.slug} className={`rounded-3xl border bg-card p-5 ${anyEnabled ? '' : 'opacity-60'}`}>
+                <div className="mb-3 flex items-center gap-2 flex-wrap">
+                  <Link to={`/models/${modality}/${g.slug}`} className="text-sm font-medium hover:underline">{g.label}</Link>
+                  {g.members.length > 1 ? (
+                    <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground">
+                      {t('models.providerCount', { count: g.members.length })}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">{g.members[0].platform}</span>
+                  )}
+                  {quota && (
+                    <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground tabular-nums">{quota}</span>
+                  )}
                 </div>
-              ))}
-            </div>
-          </section>
+
+                <div className="divide-y">
+                  {g.members.map(m => (
+                    <div key={m.id} className={`flex items-center gap-3 py-2 ${m.enabled ? '' : 'opacity-50'}`}>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium">{m.platform}</span>
+                          {m.keyCount === 0 && (
+                            <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-amber-600/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-400">
+                              {t('models.noKey')}
+                            </span>
+                          )}
+                        </div>
+                        <div className="truncate font-mono text-[11px] text-muted-foreground">{m.modelId}</div>
+                      </div>
+                      <Switch
+                        checked={m.enabled}
+                        onCheckedChange={(c) => toggle.mutate({ id: m.id, enabled: c })}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )
+          })
         )}
       </div>
     </div>

--- a/client/src/pages/EmbeddingDetailPage.tsx
+++ b/client/src/pages/EmbeddingDetailPage.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import { useI18n } from '@/i18n'
+import { apiFetch } from '@/lib/api'
+import { CopyButton } from '@/components/copy-button'
+import { PageHeader } from '@/components/page-header'
+import { ModelsTabs } from '@/components/models-tabs'
+import { apiBaseUrl, ApiUsageBlock } from '@/components/api-usage'
+
+interface ProviderEntry {
+  id: number
+  platform: string
+  modelId: string
+  displayName: string
+  priority: number
+  enabled: boolean
+  quotaLabel: string
+  keyCount: number
+}
+interface Family {
+  family: string
+  dimensions: number
+  maxInputTokens: number | null
+  isDefault: boolean
+  providers: ProviderEntry[]
+}
+interface EmbeddingsData { defaultFamily: string; families: Family[] }
+
+// One embedding family's page: the providers serving it (failover routes across
+// them, same vector space) + a ready-to-run snippet. The family list / routing
+// management stays on the Embeddings tab; this mirrors the chat model page.
+export default function EmbeddingDetailPage() {
+  const { t } = useI18n()
+  const { id } = useParams<{ id: string }>()
+  const family = id ? decodeURIComponent(id) : ''
+
+  const { data, isLoading } = useQuery<EmbeddingsData>({
+    queryKey: ['embeddings'],
+    queryFn: () => apiFetch('/api/embeddings'),
+  })
+  const { data: keyData } = useQuery<{ apiKey: string }>({
+    queryKey: ['unified-key'],
+    queryFn: () => apiFetch('/api/settings/api-key'),
+  })
+
+  const fam = (data?.families ?? []).find(f => f.family === family)
+  const base = apiBaseUrl()
+  const key = keyData?.apiKey || 'YOUR_API_KEY'
+  const snippet = `curl ${base}/embeddings \\
+  -H "Authorization: Bearer ${key}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${family}",
+    "input": "hello world"
+  }'`
+
+  return (
+    <div>
+      <PageHeader title={family || t('models.providersHeading')} description={t('models.providersHeading')} divider={false} actions={<ModelsTabs />} />
+
+      <div className="space-y-6">
+        <Link to="/models/embeddings" className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ChevronLeft className="size-4" />{t('models.backToModels')}
+        </Link>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
+        ) : !fam ? (
+          <div className="rounded-3xl border border-dashed p-8 text-center">
+            <p className="text-sm text-muted-foreground">{t('models.modelNotFound')}</p>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: fam.providers.length })}</span>
+              <span className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground tabular-nums">{fam.dimensions}d</span>
+            </div>
+
+            <div className="rounded-2xl border bg-card p-4">
+              <h2 className="text-sm font-medium">{t('models.providerIdsHeading')}</h2>
+              <p className="mt-0.5 mb-3 text-xs text-muted-foreground">{t('models.providerIdsHint')}</p>
+              <div className="space-y-1.5">
+                {fam.providers.map(p => (
+                  <div key={p.id} className={`flex items-center gap-2 text-xs ${p.enabled ? '' : 'opacity-50'}`}>
+                    <span className="w-28 shrink-0 text-muted-foreground">{p.platform}</span>
+                    <code className="min-w-0 flex-1 truncate font-mono text-[11px]">{p.modelId}</code>
+                    {p.keyCount === 0 && (
+                      <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-amber-600/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-400">{t('models.noKey')}</span>
+                    )}
+                    <CopyButton text={p.modelId} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <ApiUsageBlock snippet={snippet} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/EmbeddingsPage.tsx
+++ b/client/src/pages/EmbeddingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowDown, ArrowUp } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
@@ -133,7 +134,7 @@ export default function EmbeddingsPage() {
               <section key={f.family} className={`rounded-3xl border bg-card p-5 ${noKeys ? 'opacity-60' : ''}`}>
                 <div className="flex items-baseline justify-between gap-4 mb-3 flex-wrap">
                   <div className="flex items-baseline gap-2.5 min-w-0">
-                    <h2 className="text-sm font-medium font-mono truncate">{f.family}</h2>
+                    <Link to={`/models/embeddings/${encodeURIComponent(f.family)}`} className="text-sm font-medium font-mono truncate hover:underline">{f.family}</Link>
                     <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground tabular-nums">
                       {f.dimensions}d
                     </span>

--- a/client/src/pages/MediaDetailPage.tsx
+++ b/client/src/pages/MediaDetailPage.tsx
@@ -1,0 +1,109 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link, useParams } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import { useI18n } from '@/i18n'
+import { apiFetch } from '@/lib/api'
+import { CopyButton } from '@/components/copy-button'
+import { PageHeader } from '@/components/page-header'
+import { ModelsTabs } from '@/components/models-tabs'
+import { Switch } from '@/components/ui/switch'
+import { apiBaseUrl, ApiUsageBlock } from '@/components/api-usage'
+import type { MediaModel } from '@/components/media-models'
+
+// One generative-media model's page: every provider that serves this logical
+// model (failover routes across them), plus a ready-to-run snippet. Mirrors the
+// chat ModelDetailPage for the image and audio modalities.
+export default function MediaDetailPage({ modality }: { modality: 'image' | 'audio' }) {
+  const { t } = useI18n()
+  const { id } = useParams<{ id: string }>()
+  const label = id ? decodeURIComponent(id) : ''
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery<{ models: MediaModel[] }>({
+    queryKey: ['media'],
+    queryFn: () => apiFetch('/api/media'),
+  })
+  const { data: keyData } = useQuery<{ apiKey: string }>({
+    queryKey: ['unified-key'],
+    queryFn: () => apiFetch('/api/settings/api-key'),
+  })
+
+  const toggle = useMutation({
+    mutationFn: (vars: { mediaId: number; enabled: boolean }) =>
+      apiFetch(`/api/media/${vars.mediaId}`, { method: 'PUT', body: JSON.stringify({ enabled: vars.enabled }) }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['media'] }),
+  })
+
+  const members = (data?.models ?? []).filter(m => m.modality === modality && m.displayName === label)
+  const quota = members.map(m => m.quotaLabel).find(Boolean)
+
+  // A ready-to-run request. `model: "auto"` also works (tries every provider);
+  // here we pin the first provider's id as a concrete example.
+  const exampleModel = members[0]?.modelId ?? 'auto'
+  const base = apiBaseUrl()
+  const key = keyData?.apiKey || 'YOUR_API_KEY'
+  const snippet = modality === 'image'
+    ? `curl ${base}/images/generations \\
+  -H "Authorization: Bearer ${key}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${exampleModel}",
+    "prompt": "a red cat"
+  }'`
+    : `curl ${base}/audio/speech \\
+  -H "Authorization: Bearer ${key}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "${exampleModel}",
+    "input": "Hello world"
+  }' --output speech.mp3`
+
+  return (
+    <div>
+      <PageHeader title={label || t('models.providersHeading')} description={t('models.providersHeading')} divider={false} actions={<ModelsTabs />} />
+
+      <div className="space-y-6">
+        <Link to={`/models/${modality}`} className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ChevronLeft className="size-4" />{t('models.backToModels')}
+        </Link>
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">{t('common.loading')}</p>
+        ) : members.length === 0 ? (
+          <div className="rounded-3xl border border-dashed p-8 text-center">
+            <p className="text-sm text-muted-foreground">{t('models.modelNotFound')}</p>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: members.length })}</span>
+              {quota && <span className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground tabular-nums">{quota}</span>}
+            </div>
+
+            {/* Providers serving this model — pin one with its id, or toggle it. */}
+            <div className="rounded-2xl border bg-card p-4">
+              <h2 className="text-sm font-medium">{t('models.providerIdsHeading')}</h2>
+              <p className="mt-0.5 mb-3 text-xs text-muted-foreground">{t('models.providerIdsHint')}</p>
+              <div className="space-y-1.5">
+                {members.map(m => (
+                  <div key={m.id} className={`flex items-center gap-2 text-xs ${m.enabled ? '' : 'opacity-50'}`}>
+                    <span className="w-28 shrink-0 text-muted-foreground">{m.platform}</span>
+                    <code className="min-w-0 flex-1 truncate font-mono text-[11px]">{m.modelId}</code>
+                    {m.keyCount === 0 && (
+                      <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-amber-600/15 text-amber-700 dark:bg-amber-400/15 dark:text-amber-400">{t('models.noKey')}</span>
+                    )}
+                    <CopyButton text={m.modelId} />
+                    <Switch checked={m.enabled} onCheckedChange={(c) => toggle.mutate({ mediaId: m.id, enabled: c })} />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Ways to use the API */}
+            <ApiUsageBlock snippet={snippet} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Brings **Image**, **Audio**, and **Embedding** up to the same treatment the Chat models page already has, in the web dashboard + desktop client.

- **Provider consolidation** — `groupMedia()` groups media models by logical model so e.g. *FLUX.1 [schnell]* served by nvidia + cloudflare + siliconflow renders as one group with an "N providers" badge + quota, like chat
- **Per-model detail pages** — `MediaDetailPage` (image/audio) and `EmbeddingDetailPage`, each listing the providers serving the model (with the per-provider enable toggle preserved)
- **Ways to use the API** — shared `ApiUsageBlock` with copy-able `curl` snippets per endpoint: `/v1/images/generations`, `/v1/audio/speech`, `/v1/embeddings` (notes `model:"auto"` works for media)
- routes `/models/image/:id`, `/models/audio/:id`, `/models/embeddings/:id` (consistent with `/models/chat/:id`)

## Note

Media/embedding consolidation uses the embeddings **card** layout (logical model → provider sub-rows), not the chat **table** — the chat table's columns (intelligence/speed/score/guardrails) don't apply to media/embeddings. The consolidation UX matches chat; styling stays native to the existing tabs. No server or i18n changes (reuses existing endpoints + the chat detail page's translation keys).

## Testing

- `npm run build -w client` ✓
- `tsc --noEmit` clean (server)
- `npm test -w server` — **574 passing**