### PR TITLE
Fix /v1/messages 400 on inlined system role

### DIFF
--- a/server/src/__tests__/routes/anthropic.test.ts
+++ b/server/src/__tests__/routes/anthropic.test.ts
@@ -307,6 +307,21 @@ describe('Anthropic-compatible /v1/messages', () => {
     expect(body.error.type).toBe('invalid_request_error');
   });
 
+  it('accepts a system role inlined in the messages array (does not 400; folds into system)', async () => {
+    const captured = mockJson(textCompletion('ok'));
+    const { status } = await request(app, '/v1/messages', {
+      model: 'claude-sonnet-4-5', max_tokens: 32,
+      messages: [
+        { role: 'user', content: 'hello' },
+        { role: 'system', content: 'You are concise.' },
+        { role: 'user', content: [{ type: 'text', text: 'continue' }] },
+      ],
+    }, anthropicHeaders());
+    expect(status).toBe(200); // previously 400: "messages.1.role ... received 'system'"
+    const sys = captured.body.messages.filter((m: any) => m.role === 'system')
+    expect(sys.some((m: any) => m.content === 'You are concise.')).toBe(true);
+  });
+
   it('GET /v1/models returns the Anthropic shape for Anthropic clients', async () => {
     const { status, body } = await send(app, 'GET', '/v1/models', undefined, anthropicHeaders());
     expect(status).toBe(200);

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -54,7 +54,11 @@ const IMAGE_TOKEN_ESTIMATE = 1000;
 const contentBlockSchema = z.object({ type: z.string() }).passthrough();
 
 const anthropicMessageSchema = z.object({
-  role: z.enum(['user', 'assistant']),
+  // Anthropic's own API only allows user/assistant here, but real clients
+  // (Claude Code, routers) sometimes inline a `system` turn in the messages
+  // array. Accept it and fold it into the system context rather than 400-ing —
+  // same tolerance philosophy as the OpenAI route's developer/function roles.
+  role: z.enum(['user', 'assistant', 'system']),
   content: z.union([z.string(), z.array(contentBlockSchema)]),
 }).passthrough();
 
@@ -195,6 +199,17 @@ function convertRequest(input: AnthropicRequest): ConvertedRequest {
   if (system) messages.push({ role: 'system', content: system });
 
   for (const message of input.messages) {
+    // A `system` turn inlined in the messages array → fold into system context
+    // (flatten text blocks). Anthropic clients occasionally send this; the real
+    // API rejects it, but we'd rather route the request than 400.
+    if (message.role === 'system') {
+      const sysText = typeof message.content === 'string'
+        ? message.content
+        : message.content.map(b => (typeof (b as any).text === 'string' ? (b as any).text : '')).filter(Boolean).join('\n');
+      if (sysText) messages.push({ role: 'system', content: sysText });
+      continue;
+    }
+
     if (typeof message.content === 'string') {
       messages.push({ role: message.role, content: message.content });
       continue;


### PR DESCRIPTION
Claude Code (and some routers) occasionally inline a `system` turn in the Messages array, which our schema rejected with `400 messages.N.role: Invalid enum value ... received 'system'`. Accept user/assistant/system and fold an inlined system turn into the system context. Adds a regression test. Full suite green (588).