### PR TITLE
Tab the Keys page; subtle copy button on model page

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -103,6 +103,7 @@
     "modelNotFound": "This model is not available, or it has no configured providers.",
     "providerIdsHeading": "Provider model ids",
     "providerIdsHint": "Send the unified model id to fail over across every provider, or a provider-specific id to pin one provider.",
+    "copyModelName": "Copy model name",
     "aggregateBudget": "{count}/mo",
     "aggregateBudgetTitle": "Total free tokens per month across this model's providers",
     "rateRpm": "{count} RPM",
@@ -159,6 +160,9 @@
   "keys": {
     "pageTitle": "Keys",
     "pageDescription": "Provider credentials and the unified API key your apps connect with.",
+    "tabProviders": "Providers",
+    "tabApiKey": "Unified API key",
+    "tabAnthropic": "Anthropic",
     "unifiedKey": "Your unified API key",
     "regenerate": "Regenerate",
     "showKey": "Show",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -142,6 +142,9 @@
   "keys": {
     "pageTitle": "Claves",
     "pageDescription": "Las credenciales de los proveedores y la clave API unificada con la que se conectan tus aplicaciones.",
+    "tabProviders": "Proveedores",
+    "tabApiKey": "Clave de API unificada",
+    "tabAnthropic": "Anthropic",
     "unifiedKey": "Tu clave API unificada",
     "regenerate": "Regenerar",
     "showKey": "Mostrar",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -142,6 +142,9 @@
   "keys": {
     "pageTitle": "Clés",
     "pageDescription": "Les identifiants des fournisseurs et la clé API unifiée à laquelle vos applications se connectent.",
+    "tabProviders": "Fournisseurs",
+    "tabApiKey": "Clé d'API unifiée",
+    "tabAnthropic": "Anthropic",
     "unifiedKey": "Votre clé API unifiée",
     "regenerate": "Régénérer",
     "showKey": "Afficher",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -142,6 +142,9 @@
   "keys": {
     "pageTitle": "Chaves",
     "pageDescription": "As credenciais dos provedores e a chave de API unificada à qual seus aplicativos se conectam.",
+    "tabProviders": "Provedores",
+    "tabApiKey": "Chave de API unificada",
+    "tabAnthropic": "Anthropic",
     "unifiedKey": "Sua chave de API unificada",
     "regenerate": "Regenerar",
     "showKey": "Mostrar",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -142,6 +142,9 @@
   "keys": {
     "pageTitle": "密钥",
     "pageDescription": "各提供方的凭据，以及你的应用用来连接的统一 API 密钥。",
+    "tabProviders": "提供方",
+    "tabApiKey": "统一 API 密钥",
+    "tabAnthropic": "Anthropic",
     "unifiedKey": "您的统一 API 密钥",
     "regenerate": "重新生成",
     "showKey": "显示",

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -474,9 +474,17 @@ function AnthropicSection() {
   )
 }
 
+type KeysTab = 'providers' | 'apiKey' | 'anthropic'
+const KEYS_TABS: { id: KeysTab; labelKey: string }[] = [
+  { id: 'providers', labelKey: 'keys.tabProviders' },
+  { id: 'apiKey', labelKey: 'keys.tabApiKey' },
+  { id: 'anthropic', labelKey: 'keys.tabAnthropic' },
+]
+
 export default function KeysPage() {
   const { t } = useI18n()
   const queryClient = useQueryClient()
+  const [tab, setTab] = useState<KeysTab>('providers')
   const [platform, setPlatform] = useState<Platform | ''>('')
   const [apiKey, setApiKey] = useState('')
   const [accountId, setAccountId] = useState('')
@@ -628,21 +636,42 @@ export default function KeysPage() {
         title={t('keys.pageTitle')}
         description={t('keys.pageDescription')}
         actions={
-          keys.length > 0 && (
-            <Button variant="outline" size="sm" onClick={() => checkAll.mutate()} disabled={checkAll.isPending}>
-              {checkAll.isPending ? t('keys.checking') : t('keys.checkAll')}
-            </Button>
-          )
+          <>
+            {tab === 'providers' && keys.length > 0 && (
+              <Button variant="outline" size="sm" onClick={() => checkAll.mutate()} disabled={checkAll.isPending}>
+                {checkAll.isPending ? t('keys.checking') : t('keys.checkAll')}
+              </Button>
+            )}
+            <div className="inline-flex gap-1 rounded-xl border p-1">
+              {KEYS_TABS.map(tb => (
+                <button
+                  key={tb.id}
+                  type="button"
+                  onClick={() => setTab(tb.id)}
+                  className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg transition-colors ${
+                    tab === tb.id ? 'bg-foreground text-background font-medium' : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                  }`}
+                >
+                  {t(tb.labelKey)}
+                </button>
+              ))}
+            </div>
+          </>
         }
       />
 
       <div className="space-y-8">
-        <UnifiedKeySection />
+        {tab === 'apiKey' && (
+          <>
+            <UnifiedKeySection />
+            <ProxySettingsSection />
+          </>
+        )}
 
-        <AnthropicSection />
+        {tab === 'anthropic' && <AnthropicSection />}
 
-        <ProxySettingsSection />
-
+        {tab === 'providers' && (
+        <>
         <section>
           <h2 className="text-sm font-medium mb-3">{t('keys.addProvider')}</h2>
           <form onSubmit={handleSubmit} className="flex flex-wrap gap-3 rounded-3xl border p-4 bg-card">
@@ -821,6 +850,8 @@ export default function KeysPage() {
             </div>
           )}
         </section>
+        </>
+        )}
       </div>
     </div>
   )

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 import { CopyButton } from '@/components/copy-button'
+import { Tooltip } from '@/components/tooltip'
 import { PageHeader } from '@/components/page-header'
 import { ModelsTabs } from '@/components/models-tabs'
 import {
@@ -131,7 +132,9 @@ export default function ModelDetailPage() {
                   <div key={m.modelDbId} className="flex items-center gap-2 text-xs">
                     <span className="w-28 shrink-0 text-muted-foreground">{m.platform}</span>
                     <code className="min-w-0 flex-1 truncate font-mono text-[11px]">{m.modelId}</code>
-                    <CopyButton text={m.modelId} />
+                    <Tooltip text={t('models.copyModelName')}>
+                      <CopyButton text={m.modelId} label={t('models.copyModelName')} className="border-0 bg-transparent" />
+                    </Tooltip>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## What

- **Keys page → tabs.** The page was one long scroll; it's now split into three tabs that reuse the Models page tab strip:
  - **Providers** — add/configure provider keys + the configured list. *Check all* moved into the header (left of the tabs) and only renders on this tab.
  - **Unified API key** — the unified key + endpoints, with the outbound proxy under it.
  - **Anthropic** — the Claude model-family mapping editor.
- **Model detail page → subtle copy button.** The per-provider model-id copy icon is now borderless and background-less (a muted icon that darkens on hover) with a "Copy model name" tooltip. The shared `CopyButton` default (used by code blocks / Playground) is unchanged — the subtle look is scoped via a className override.

## i18n

Adds `keys.tabProviders` / `tabApiKey` / `tabAnthropic` to all 5 locales and `models.copyModelName` (English, with the existing runtime fallback used by its `providerIds*` siblings).

## Verified

- `npm run build` (server + client) clean, `tsc --noEmit` clean.
- Ran locally on the Vite dev server; tabs switch correctly, Check all scoped to Providers, copy button + tooltip behave as intended.