### PR TITLE
fix(anthropic-map): route opusplan aliases to the default family

### DIFF
--- a/server/src/__tests__/services/anthropic-map.test.ts
+++ b/server/src/__tests__/services/anthropic-map.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { classifyClaudeFamily } from '../../services/anthropic-map.js';
+
+// classifyClaudeFamily maps a requested model alias to a Claude family (or null
+// for a concrete catalog id). Claude Code's planning alias `opusplan` is
+// opus-ish by name, but the operator map has no `opusplan` slot — it must fall
+// through to the `default` family, as the function's own comment states.
+describe('classifyClaudeFamily', () => {
+  it('routes Claude Code opusplan aliases to the default family', () => {
+    expect(classifyClaudeFamily('opusplan')).toBe('default');
+    expect(classifyClaudeFamily('opusplan-4')).toBe('default');
+    expect(classifyClaudeFamily('OpusPlan')).toBe('default');
+  });
+
+  it('still classifies real opus models as the opus family', () => {
+    expect(classifyClaudeFamily('opus')).toBe('opus');
+    expect(classifyClaudeFamily('claude-opus-4-1')).toBe('opus');
+  });
+
+  it('classifies the other Claude families and aliases as before', () => {
+    expect(classifyClaudeFamily('claude-sonnet-4-5')).toBe('sonnet');
+    expect(classifyClaudeFamily('claude-3-5-haiku')).toBe('haiku');
+    expect(classifyClaudeFamily('claude-something-new')).toBe('default');
+    expect(classifyClaudeFamily('')).toBe('default');
+    expect(classifyClaudeFamily('auto')).toBe('default');
+  });
+
+  it('returns null for a non-Claude concrete catalog id', () => {
+    expect(classifyClaudeFamily('llama-3.1-70b')).toBeNull();
+  });
+});

--- a/server/src/services/anthropic-map.ts
+++ b/server/src/services/anthropic-map.ts
@@ -62,11 +62,14 @@ export function setClaudeModelMap(input: unknown): AnthropicModelMap {
 export function classifyClaudeFamily(model?: string): ClaudeFamily | null {
   const m = (model ?? '').trim().toLowerCase();
   if (!m || m === 'auto' || m === 'default' || m === 'freellmapi-auto') return 'default';
+  // Claude Code's planning alias is opus-ish by name but must hit the catch-all,
+  // so match it before the substring family checks below.
+  if (m === 'opusplan' || m === 'opusplan-4') return 'default';
   if (m.includes('opus')) return 'opus';
   if (m.includes('sonnet')) return 'sonnet';
   if (m.includes('haiku')) return 'haiku';
-  // Any other claude-ish alias (incl. Claude Code's opusplan) → the catch-all.
-  if (m.startsWith('claude') || m === 'opusplan' || m === 'opusplan-4') return 'default';
+  // Any other claude-ish alias → the catch-all.
+  if (m.startsWith('claude')) return 'default';
   return null;
 }
 


### PR DESCRIPTION
## Summary

`classifyClaudeFamily` (`server/src/services/anthropic-map.ts`) maps a requested model alias to a Claude family. It checked `m.includes('opus')` **before** the explicit `opusplan` / `opusplan-4` branch:

```ts
if (m.includes('opus')) return 'opus';
// ...
// Any other claude-ish alias (incl. Claude Code's opusplan) → the catch-all.
if (m.startsWith('claude') || m === 'opusplan' || m === 'opusplan-4') return 'default';
```

Because `'opusplan'.includes('opus')` is `true`, an `opusplan` request returned the `'opus'` family and the dedicated `opusplan` / `opusplan-4` arm was **dead code** — directly contradicting the comment, which says opusplan should fall through to the catch-all (`'default'`).

### Impact
Claude Code uses `opusplan` for its planning model. With this bug, an `opusplan` request resolves through the operator's **opus** family pin instead of the **default** family, so it can route to a different pinned model than intended.

## Fix

Match the explicit `opusplan` / `opusplan-4` aliases **before** the substring family checks, so they correctly resolve to `'default'`. Real opus models (e.g. `claude-opus-4-1`) still classify as `'opus'`, and all other families are unchanged.

## Test Plan

Added `server/src/__tests__/services/anthropic-map.test.ts` covering `classifyClaudeFamily`.

- **Before:** `classifyClaudeFamily('opusplan')` → `'opus'` ❌ (test fails: `expected 'opus' to be 'default'`)
- **After:** `'opusplan'` / `'opusplan-4'` → `'default'`; `'claude-opus-4-1'` → `'opus'`; sonnet/haiku/default/null cases unchanged ✅

```
Test Files  55 passed (55)
     Tests  592 passed (592)
```
`npm run build` (all workspaces) succeeds.

---
*Prepared with AI assistance (Claude Code); the change was reviewed, built, and tested by a human before submitting.*
