### PR TITLE
docs: document supported languages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRoute
 - [Quick start](#quick-start)
 - [Docker](#docker)
 - [Desktop app](#desktop-app)
+- [Languages](#languages)
 - [Premium (live catalog)](#premium-live-catalog)
 - [Using the API](#using-the-api)
 - [Screenshots](#screenshots)
@@ -224,6 +225,26 @@ npm run desktop:dist:win    # Windows → "desktop/dist-electron/FreeLLMAPI Setu
 
 > Locally built apps are unsigned, so Windows SmartScreen may warn on first run
 > ("More info" → "Run anyway"); the macOS build launches without Gatekeeper prompts.
+
+## Languages
+
+The dashboard and the desktop tray ship in 6 languages. The UI auto-detects your
+browser/system language on first load and you can switch any time from the **⋯**
+menu; the choice is remembered.
+
+| Language | Locale |
+| --- | --- |
+| English | `en` |
+| 中文 (简体) | `zh-CN` |
+| Français | `fr` |
+| Español | `es` |
+| Português (Brasil) | `pt-BR` |
+| Italiano | `it` |
+
+Translations live in [`client/src/i18n/locales/`](./client/src/i18n/locales) as
+flat JSON files. To add a language, copy `en.json`, translate the values, and
+register the locale in `client/src/i18n/I18nProvider.tsx` (and
+`desktop/src/i18n.ts` for the tray strings) — PRs welcome.
 
 ## Premium (live catalog)
 


### PR DESCRIPTION
Adds a **Languages** section (and a Contents entry) listing the 6 locales the dashboard and desktop tray ship in:

| Language | Locale |
| --- | --- |
| English | `en` |
| 中文 (简体) | `zh-CN` |
| Français | `fr` |
| Español | `es` |
| Português (Brasil) | `pt-BR` |
| Italiano | `it` |

Plus a short note on auto-detection, the ⋯ language switcher, and how to contribute a new translation.