### PR TITLE
refactor: add Scheduler abstraction for testable timer injection

### DIFF
--- a/server/src/__tests__/services/catalog-sync-scheduler.test.ts
+++ b/server/src/__tests__/services/catalog-sync-scheduler.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { initDb } from '../../db/index.js';
+import { startCatalogSync, stopCatalogSync } from '../../services/catalog-sync.js';
+import type { Scheduler } from '../../lib/scheduler.js';
+
+function makeScheduler() {
+  const every: { ms: number; fn: () => void | Promise<void> }[] = [];
+  const after: { ms: number; fn: () => void | Promise<void> }[] = [];
+  const cancels: ReturnType<typeof vi.fn>[] = [];
+  const scheduler: Scheduler = {
+    every(ms, fn) {
+      const cancel = vi.fn();
+      every.push({ ms, fn });
+      cancels.push(cancel);
+      return cancel;
+    },
+    after(ms, fn) {
+      const cancel = vi.fn();
+      after.push({ ms, fn });
+      cancels.push(cancel);
+      return cancel;
+    },
+  };
+  return { scheduler, every, after, cancels };
+}
+
+describe('startCatalogSync / stopCatalogSync', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+  });
+
+  afterEach(() => {
+    stopCatalogSync();
+    delete process.env.CATALOG_SYNC_DISABLED;
+  });
+
+  it('registers a 10-second boot delay and a 12-hour interval', () => {
+    const { scheduler, every, after } = makeScheduler();
+    startCatalogSync(scheduler);
+    expect(after).toHaveLength(1);
+    expect(after[0].ms).toBe(10 * 1000);
+    expect(every).toHaveLength(1);
+    expect(every[0].ms).toBe(12 * 60 * 60 * 1000);
+  });
+
+  it('is idempotent — double-start registers only one set of jobs', () => {
+    const { scheduler, every, after } = makeScheduler();
+    startCatalogSync(scheduler);
+    startCatalogSync(scheduler);
+    expect(after).toHaveLength(1);
+    expect(every).toHaveLength(1);
+  });
+
+  it('registers nothing when CATALOG_SYNC_DISABLED=1', () => {
+    process.env.CATALOG_SYNC_DISABLED = '1';
+    const { scheduler, every, after } = makeScheduler();
+    startCatalogSync(scheduler);
+    expect(after).toHaveLength(0);
+    expect(every).toHaveLength(0);
+  });
+
+  it('stop invokes both cancel handles', () => {
+    const { scheduler, cancels } = makeScheduler();
+    startCatalogSync(scheduler);
+    stopCatalogSync();
+    expect(cancels).toHaveLength(2);
+    cancels.forEach((c) => expect(c).toHaveBeenCalledOnce());
+  });
+
+  it('can re-register after stop', () => {
+    const { scheduler: s1 } = makeScheduler();
+    startCatalogSync(s1);
+    stopCatalogSync();
+
+    const { scheduler: s2, every, after } = makeScheduler();
+    startCatalogSync(s2);
+    expect(after).toHaveLength(1);
+    expect(every).toHaveLength(1);
+  });
+});

--- a/server/src/__tests__/services/health-scheduler.test.ts
+++ b/server/src/__tests__/services/health-scheduler.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { initDb } from '../../db/index.js';
+import { startHealthChecker, stopHealthChecker } from '../../services/health.js';
+import type { Scheduler } from '../../lib/scheduler.js';
+
+function makeScheduler() {
+  const every: { ms: number; fn: () => void | Promise<void> }[] = [];
+  const cancels: ReturnType<typeof vi.fn>[] = [];
+  const scheduler: Scheduler = {
+    every(ms, fn) {
+      const cancel = vi.fn();
+      every.push({ ms, fn });
+      cancels.push(cancel);
+      return cancel;
+    },
+    after(_ms, _fn) {
+      return vi.fn();
+    },
+  };
+  return { scheduler, every, cancels };
+}
+
+describe('startHealthChecker / stopHealthChecker', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+  });
+
+  afterEach(() => {
+    stopHealthChecker();
+  });
+
+  it('registers one every-5-minute job', () => {
+    const { scheduler, every } = makeScheduler();
+    startHealthChecker(scheduler);
+    expect(every).toHaveLength(1);
+    expect(every[0].ms).toBe(5 * 60 * 1000);
+  });
+
+  it('is idempotent — double-start registers only one job', () => {
+    const { scheduler, every } = makeScheduler();
+    startHealthChecker(scheduler);
+    startHealthChecker(scheduler);
+    expect(every).toHaveLength(1);
+  });
+
+  it('stop invokes the cancel handle', () => {
+    const { scheduler, cancels } = makeScheduler();
+    startHealthChecker(scheduler);
+    stopHealthChecker();
+    expect(cancels[0]).toHaveBeenCalledOnce();
+  });
+
+  it('can re-register after stop', () => {
+    const { scheduler: s1 } = makeScheduler();
+    startHealthChecker(s1);
+    stopHealthChecker();
+
+    const { scheduler: s2, every } = makeScheduler();
+    startHealthChecker(s2);
+    expect(every).toHaveLength(1);
+  });
+
+  it('the registered job runs checkAllKeys without throwing', async () => {
+    const { scheduler, every } = makeScheduler();
+    startHealthChecker(scheduler);
+    await expect(every[0].fn()).resolves.toBeUndefined();
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { startHealthChecker } from './services/health.js';
 import { applyProxyUrl, applyProxyEnabled, applyProxyBypass } from './lib/proxy.js';
 import { startCatalogSync } from './services/catalog-sync.js';
 import { installProcessSafetyNet } from './lib/process-safety-net.js';
+import { NodeScheduler } from './lib/scheduler.js';
 
 const PORT = process.env.PORT ?? 3001;
 // Dual-stack ('::') by default so the dashboard is reachable over both IPv4
@@ -16,6 +17,8 @@ async function main() {
   // Install first so a late provider socket reset (undici HTTP/2 error with no
   // listener) can't take the proxy down. Genuine bugs still exit 1.
   installProcessSafetyNet();
+
+  const scheduler = new NodeScheduler();
 
   initDb();
 
@@ -31,8 +34,8 @@ async function main() {
     const display = host.includes(':') ? `[${host}]` : host;
     console.log(`Server running on http://${display}:${PORT}`);
     console.log(`Proxy endpoint: http://${display}:${PORT}/v1/chat/completions`);
-    startHealthChecker();
-    startCatalogSync();
+    startHealthChecker(scheduler);
+    startCatalogSync(scheduler);
   };
 
   const server = app.listen(Number(PORT), HOST, onReady(HOST));

--- a/server/src/lib/scheduler.ts
+++ b/server/src/lib/scheduler.ts
@@ -1,0 +1,16 @@
+export interface Scheduler {
+  every(ms: number, fn: () => void | Promise<void>, opts?: { name?: string }): () => void;
+  after(ms: number, fn: () => void | Promise<void>): () => void;
+}
+
+export class NodeScheduler implements Scheduler {
+  every(ms: number, fn: () => void | Promise<void>, _opts?: { name?: string }): () => void {
+    const id = setInterval(() => { void fn(); }, ms);
+    return () => clearInterval(id);
+  }
+
+  after(ms: number, fn: () => void | Promise<void>): () => void {
+    const id = setTimeout(() => { void fn(); }, ms);
+    return () => clearTimeout(id);
+  }
+}

--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -4,6 +4,7 @@ import { getDb, getSetting, setSetting } from '../db/index.js';
 import { hasProvider } from '../providers/index.js';
 import { MEDIA_PLATFORMS } from './media.js';
 import type { Platform } from '@freellmapi/shared/types.js';
+import type { Scheduler } from '../lib/scheduler.js';
 
 // Generative-media modalities are routed into the separate media_models table
 // (see services/media.ts), never into the chat `models` table.
@@ -475,11 +476,11 @@ export function reapplyCachedCatalog(): { reapplied: boolean; version?: string }
   }
 }
 
-let intervalId: ReturnType<typeof setInterval> | null = null;
-let bootTimer: ReturnType<typeof setTimeout> | null = null;
+let cancelBootTimer: (() => void) | null = null;
+let cancelInterval: (() => void) | null = null;
 
-export function startCatalogSync(): void {
-  if (intervalId) return;
+export function startCatalogSync(scheduler: Scheduler): void {
+  if (cancelInterval) return;
   if (process.env.CATALOG_SYNC_DISABLED === '1') {
     console.log('[catalog-sync] disabled via CATALOG_SYNC_DISABLED=1');
     return;
@@ -489,18 +490,18 @@ export function startCatalogSync(): void {
     void refreshLicenseStatus();
     void syncCatalog();
   };
-  bootTimer = setTimeout(run, BOOT_DELAY_MS);
-  intervalId = setInterval(run, SYNC_INTERVAL_MS);
+  cancelBootTimer = scheduler.after(BOOT_DELAY_MS, run);
+  cancelInterval = scheduler.every(SYNC_INTERVAL_MS, run);
   console.log(`[catalog-sync] polling ${catalogBaseUrl()} every ${SYNC_INTERVAL_MS / 3600000}h`);
 }
 
 export function stopCatalogSync(): void {
-  if (bootTimer) {
-    clearTimeout(bootTimer);
-    bootTimer = null;
+  if (cancelBootTimer) {
+    cancelBootTimer();
+    cancelBootTimer = null;
   }
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
+  if (cancelInterval) {
+    cancelInterval();
+    cancelInterval = null;
   }
 }

--- a/server/src/services/health.ts
+++ b/server/src/services/health.ts
@@ -3,6 +3,7 @@ import { resolveProvider } from '../providers/index.js';
 import { decrypt } from '../lib/crypto.js';
 import type { Platform, KeyStatus } from '@freellmapi/shared/types.js';
 import { inferQuotaPoolKey } from './provider-quota.js';
+import type { Scheduler } from '../lib/scheduler.js';
 
 const CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const CONSECUTIVE_FAILURES_TO_DISABLE = 3;
@@ -70,19 +71,19 @@ export async function checkAllKeys(): Promise<void> {
   console.log(`[Health] Check complete.`);
 }
 
-let intervalId: ReturnType<typeof setInterval> | null = null;
+let cancelHealthCheck: (() => void) | null = null;
 
-export function startHealthChecker(): void {
-  if (intervalId) return;
+export function startHealthChecker(scheduler: Scheduler): void {
+  if (cancelHealthCheck) return;
   console.log(`[Health] Starting health checker (every ${CHECK_INTERVAL_MS / 1000}s)`);
-  intervalId = setInterval(() => {
-    checkAllKeys().catch(err => console.error('[Health] Check failed:', err));
-  }, CHECK_INTERVAL_MS);
+  cancelHealthCheck = scheduler.every(CHECK_INTERVAL_MS, () =>
+    checkAllKeys().catch(err => console.error('[Health] Check failed:', err)),
+  );
 }
 
 export function stopHealthChecker(): void {
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
+  if (cancelHealthCheck) {
+    cancelHealthCheck();
+    cancelHealthCheck = null;
   }
 }


### PR DESCRIPTION
## Problem
`services/health.ts` and `services/catalog-sync.ts` called setInterval/setTimeout directly, which makes the background loops opaque to tests and hard to shut down cleanly. 

This PR routes both through an injected Scheduler interface.

Works towards #372 

## Solution 
Add a Scheduler interface (every/after) and NodeScheduler default implementation so `services/health.ts` and `services/catalog-sync.ts` no longer call `setInterval()`/`setTimeout()` directly.  
Both services now accept a Scheduler param; index.ts wires in NodeScheduler at startup. 

Runtime behaviour on Node is identical; all 588 existing tests pass, with 10 new tests added to exercise the changed files.
