### PR TITLE
feat: add Alibaba DashScope provider with dynamic model sync

### DIFF
--- a/client/src/components/api-usage.tsx
+++ b/client/src/components/api-usage.tsx
@@ -1,14 +1,7 @@
 import { CopyButton } from '@/components/copy-button'
 import { useI18n } from '@/i18n'
 
-// The /v1 base URL for ready-to-run snippets, derived the same way as the chat
-// model page + Keys page: the dev server port in DEV, the page origin in a
-// packaged/hosted build.
-export function apiBaseUrl(): string {
-  return import.meta.env.DEV
-    ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
-    : `${window.location.origin}/v1`
-}
+export { apiBaseUrl, apiOrigin } from '@/lib/api-base-url'
 
 // A copy-able "ways to use the API" code block, matching the chat detail page's
 // snippet card so every modality's detail page looks the same.

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -176,6 +176,7 @@
     "endpointEmbeddingsHint": "model: \"auto\" or a family from the Embeddings tab",
     "endpointMessages": "Messages",
     "endpointMessagesHint": "Anthropic-compatible (Claude)",
+    "endpointPathsHint": "OpenAI paths are appended to the Base URL above (e.g. …/v1/chat/completions). Do not add another /v1. Use the unified key above — not your provider keys.",
     "anthropicTitle": "Claude (Anthropic) models",
     "anthropicDesc": "Point a Claude or Anthropic SDK client at this server. Anthropic clients send Claude model names — map each to Auto (the router picks a free model) or pin a specific one.",
     "anthropicBaseUrl": "Base URL",
@@ -237,7 +238,9 @@
     "keyCountOther": "{count} keys",
     "proxyEnvHintBefore": "Also configurable via the ",
     "proxyEnvHintAfter": " environment variable (takes precedence). Leave blank to disable. Examples:",
-    "confirmRemove": "Confirm?"
+    "confirmRemove": "Confirm?",
+    "syncModels": "Sync models",
+    "syncingModels": "Syncing…"
   },
   "status": {
     "healthy": "healthy",

--- a/client/src/lib/api-base-url.ts
+++ b/client/src/lib/api-base-url.ts
@@ -1,0 +1,15 @@
+/** OpenAI-compatible /v1 base URL for external clients (direct to the backend).
+ *  In dev we pin 127.0.0.1 — on Windows, `localhost` can resolve to ::1 and
+ *  miss the Node listener while the Vite proxy (also on 127.0.0.1) still works. */
+export function apiBaseUrl(): string {
+  return import.meta.env.DEV
+    ? `http://127.0.0.1:${__SERVER_PORT__}/v1`
+    : `${window.location.origin}/v1`
+}
+
+/** Bare server origin for Anthropic clients (they append /v1/messages themselves). */
+export function apiOrigin(): string {
+  return import.meta.env.DEV
+    ? `http://127.0.0.1:${__SERVER_PORT__}`
+    : window.location.origin
+}

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -11,6 +11,8 @@ import { PageHeader } from '@/components/page-header'
 import type { ApiKey, Platform, ProviderQuotaState } from '../../../shared/types'
 import { Pencil, ExternalLink, Globe } from 'lucide-react'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
+import { apiBaseUrl, apiOrigin } from '@/lib/api-base-url'
+import { ApiUsageBlock } from '@/components/api-usage'
 import { useI18n } from '@/i18n'
 
 // Claude (Anthropic) model families the mapping editor exposes. Anthropic
@@ -49,6 +51,8 @@ function GetKeyLink({ url }: { url: string }) {
 // `keyless: true` providers (Kilo's anonymous free tier) need no API key — the
 // form disables the key field and submits a sentinel the backend stores so
 // routing treats the platform as configured.
+const DYNAMIC_MODEL_PLATFORMS: Platform[] = ['alibaba']
+
 const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolean }[] = [
   { value: 'google', label: 'Google AI Studio', url: 'https://aistudio.google.com/apikey' },
   { value: 'groq', label: 'Groq', url: 'https://console.groq.com/keys' },
@@ -70,6 +74,7 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
   { value: 'reka', label: 'Reka (free key)', url: 'https://platform.reka.ai' },
   { value: 'siliconflow', label: 'SiliconFlow (image + TTS)', url: 'https://siliconflow.com' },
+  { value: 'alibaba', label: 'Alibaba Model Studio', url: 'https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=api' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the
@@ -178,9 +183,17 @@ function UnifiedKeySection() {
 
   const apiKey = data?.apiKey ?? ''
   const masked = apiKey ? apiKey.slice(0, 13) + '•'.repeat(32) : '…'
-  const baseUrl = import.meta.env.DEV
-    ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
-    : `${window.location.origin}/v1`
+  const baseUrl = apiBaseUrl()
+  const origin = apiOrigin()
+  const snippet = `curl ${baseUrl}/chat/completions \\
+  -H "Authorization: Bearer ${apiKey || 'YOUR_API_KEY'}" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "auto",
+    "messages": [
+      { "role": "user", "content": "Hello!" }
+    ]
+  }'`
 
   function copy() {
     navigator.clipboard.writeText(apiKey)
@@ -229,13 +242,18 @@ function UnifiedKeySection() {
         <span className="text-muted-foreground">{t('keys.baseUrl')}</span>
         <code className="font-mono">{baseUrl}</code>
         <span className="text-muted-foreground">{t('keys.endpointChat')}</span>
-        <code className="font-mono">/v1/chat/completions</code>
+        <code className="font-mono">/chat/completions</code>
         <span className="text-muted-foreground">{t('keys.endpointResponses')}</span>
-        <code className="font-mono">/v1/responses</code>
+        <code className="font-mono">/responses</code>
         <span className="text-muted-foreground">{t('keys.endpointMessages')}</span>
-        <code className="font-mono">/v1/messages <span className="text-muted-foreground">({t('keys.endpointMessagesHint')})</span></code>
+        <code className="font-mono">{origin}/v1/messages <span className="text-muted-foreground">({t('keys.endpointMessagesHint')})</span></code>
         <span className="text-muted-foreground">{t('keys.endpointEmbeddings')}</span>
-        <code className="font-mono">/v1/embeddings <span className="text-muted-foreground">({t('keys.endpointEmbeddingsHint')})</span></code>
+        <code className="font-mono">/embeddings <span className="text-muted-foreground">({t('keys.endpointEmbeddingsHint')})</span></code>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">{t('keys.endpointPathsHint')}</p>
+
+      <div className="mt-4">
+        <ApiUsageBlock snippet={snippet} />
       </div>
     </section>
   )
@@ -449,9 +467,7 @@ function AnthropicSection() {
 
   // Anthropic clients append `/v1/messages` to the base URL, so they want the
   // bare origin (OpenAI clients use origin + /v1, shown in the key section).
-  const origin = import.meta.env.DEV
-    ? `http://${window.location.hostname}:${__SERVER_PORT__}`
-    : window.location.origin
+  const origin = apiOrigin()
 
   const { data: mapData } = useQuery<{ map: AnthropicMap }>({
     queryKey: ['anthropic-map'],
@@ -561,6 +577,7 @@ export default function KeysPage() {
       queryClient.invalidateQueries({ queryKey: ['keys'] })
       queryClient.invalidateQueries({ queryKey: ['health'] })
       queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      queryClient.invalidateQueries({ queryKey: ['models'] })
       setPlatform('')
       setApiKey('')
       setAccountId('')
@@ -573,6 +590,8 @@ export default function KeysPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['keys'] })
       queryClient.invalidateQueries({ queryKey: ['health'] })
+      queryClient.invalidateQueries({ queryKey: ['models'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
     },
   })
 
@@ -589,6 +608,15 @@ export default function KeysPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['health'] })
       queryClient.invalidateQueries({ queryKey: ['keys'] })
+    },
+  })
+
+  const syncModels = useMutation({
+    mutationFn: (keyId: number) => apiFetch(`/api/keys/${keyId}/sync-models`, { method: 'POST' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['models'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      queryClient.invalidateQueries({ queryKey: ['health'] })
     },
   })
 
@@ -875,6 +903,16 @@ export default function KeysPage() {
                           <Button variant="ghost" size="xs" onClick={() => checkKey.mutate(k.id)} disabled={checkKey.isPending}>
                             {t('common.check')}
                           </Button>
+                          {DYNAMIC_MODEL_PLATFORMS.includes(k.platform as Platform) && (
+                            <Button
+                              variant="ghost"
+                              size="xs"
+                              onClick={() => syncModels.mutate(k.id)}
+                              disabled={syncModels.isPending}
+                            >
+                              {syncModels.isPending && syncModels.variables === k.id ? t('keys.syncingModels') : t('keys.syncModels')}
+                            </Button>
+                          )}
                           <Button
                             variant="ghost"
                             size="xs"

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
+import { apiBaseUrl } from '@/lib/api-base-url'
 import { CopyButton } from '@/components/copy-button'
 import { Tooltip } from '@/components/tooltip'
 import { PageHeader } from '@/components/page-header'
@@ -71,9 +72,7 @@ export default function ModelDetailPage() {
 
   // A ready-to-run request referencing this model by its unified id, so it fails
   // over across every provider above. Same base-URL derivation as the Keys page.
-  const baseUrl = import.meta.env.DEV
-    ? `http://${window.location.hostname}:${__SERVER_PORT__}/v1`
-    : `${window.location.origin}/v1`
+  const baseUrl = apiBaseUrl()
   const snippet = `curl ${baseUrl}/chat/completions \\
   -H "Authorization: Bearer ${keyData?.apiKey || 'YOUR_API_KEY'}" \\
   -H "Content-Type: application/json" \\

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -546,6 +547,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -757,27 +759,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2180,6 +2161,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3290,6 +3272,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3404,6 +3387,7 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -3521,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3634,6 +3619,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -4023,6 +4009,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4221,6 +4208,7 @@
       "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4315,6 +4303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6022,6 +6011,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6319,6 +6309,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6993,6 +6984,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
       "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7419,6 +7411,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7557,6 +7550,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -8937,6 +8931,7 @@
       "integrity": "sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -9782,6 +9777,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9791,6 +9787,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9837,6 +9834,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9976,7 +9974,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11238,6 +11237,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11530,6 +11530,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -12774,6 +12775,7 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13020,6 +13022,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -80,6 +80,16 @@ describe('Keys API', () => {
     expect(status).toBe(400);
   });
 
+  it('POST /api/keys accepts alibaba platform', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'alibaba',
+      key: 'sk-test-alibaba-key',
+      label: 'DashScope Singapore',
+    });
+    expect(status).toBe(201);
+    expect(body.platform).toBe('alibaba');
+  });
+
   it('POST /api/keys rejects missing key', async () => {
     const { status } = await request(app, 'POST', '/api/keys', {
       platform: 'groq',

--- a/server/src/__tests__/services/provider-model-sync.test.ts
+++ b/server/src/__tests__/services/provider-model-sync.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initDb, getDb } from '../../db/index.js';
+import {
+  DYNAMIC_MODEL_PLATFORMS,
+  isLikelyChatModel,
+  inferIntelligenceRank,
+  syncProviderModels,
+  deleteModelsForKey,
+  backfillDiscoveredModelsToDefaultProfile,
+} from '../../services/provider-model-sync.js';
+import { OpenAICompatProvider } from '../../providers/openai-compat.js';
+
+describe('provider-model-sync', () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    vi.restoreAllMocks();
+  });
+
+  it('marks alibaba as a dynamic-catalog platform', () => {
+    expect(DYNAMIC_MODEL_PLATFORMS.has('alibaba')).toBe(true);
+  });
+
+  it('filters non-chat alibaba SKUs', () => {
+    expect(isLikelyChatModel('qwen-plus', 'alibaba')).toBe(true);
+    expect(isLikelyChatModel('text-embedding-v4', 'alibaba')).toBe(false);
+    expect(isLikelyChatModel('qwen-image-plus', 'alibaba')).toBe(false);
+    expect(isLikelyChatModel('qwen3-tts-flash', 'alibaba')).toBe(false);
+  });
+
+  it('ranks frontier alibaba models ahead of small ones', () => {
+    expect(inferIntelligenceRank('qwen3.7-max', 'alibaba')).toBeLessThan(inferIntelligenceRank('qwen3-8b', 'alibaba'));
+  });
+
+  it('syncs chat models from /v1/models and probes them', async () => {
+    const db = getDb();
+    const key = db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES ('alibaba', 'test', 'x', 'y', 'z', 'unknown', 1)
+    `).run();
+    const keyId = Number(key.lastInsertRowid);
+
+    vi.spyOn(OpenAICompatProvider.prototype, 'listModels').mockResolvedValue([
+      'qwen-plus',
+      'text-embedding-v4',
+      'qwen-image-plus',
+    ]);
+    vi.spyOn(OpenAICompatProvider.prototype, 'chatCompletion').mockResolvedValue({
+      id: 'x',
+      object: 'chat.completion',
+      created: 0,
+      model: 'qwen-plus',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+
+    const result = await syncProviderModels('alibaba', 'sk-test', keyId, { probe: true });
+    expect(result.fetched).toBe(3);
+    expect(result.chatCandidates).toBe(1);
+    expect(result.enabled).toBe(1);
+    expect(result.models[0]?.modelId).toBe('qwen-plus');
+
+    const row = db.prepare("SELECT * FROM models WHERE platform = 'alibaba' AND model_id = 'qwen-plus'").get() as {
+      key_id: number; enabled: number;
+    };
+    expect(row.key_id).toBe(keyId);
+    expect(row.enabled).toBe(1);
+    const inProfile = db.prepare(`
+      SELECT 1 FROM profile_models pm
+      JOIN profiles p ON p.id = pm.profile_id AND p.type = 'default'
+      WHERE pm.model_db_id = ?
+    `).get(row.id);
+    expect(inProfile).toBeTruthy();
+  });
+
+  it('backfillDiscoveredModelsToDefaultProfile adds missing profile rows', () => {
+    const db = getDb();
+    const model = db.prepare(`
+      INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, enabled, key_id)
+      VALUES ('alibaba', 'qwen-plus', 'Qwen Plus', 4, 4, 'Discovered', 1, 1)
+    `).run();
+    db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, 99, 1)').run(model.lastInsertRowid);
+
+    expect(backfillDiscoveredModelsToDefaultProfile(db, 'alibaba')).toBe(1);
+    expect(db.prepare('SELECT COUNT(1) AS c FROM profile_models WHERE model_db_id = ?').get(model.lastInsertRowid)).toEqual({ c: 1 });
+  });
+
+  it('deleteModelsForKey removes bound models and fallback rows', () => {
+    const db = getDb();
+    const key = db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES ('alibaba', 'test', 'x', 'y', 'z', 'unknown', 1)
+    `).run();
+    const keyId = Number(key.lastInsertRowid);
+    const model = db.prepare(`
+      INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, enabled, key_id)
+      VALUES ('alibaba', 'qwen-plus', 'Qwen Plus', 4, 4, 'Discovered', 1, ?)
+    `).run(keyId);
+    db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, 1, 1)').run(model.lastInsertRowid);
+
+    expect(deleteModelsForKey(db, 'alibaba', keyId)).toBe(1);
+    expect(db.prepare("SELECT COUNT(*) AS c FROM models WHERE platform = 'alibaba'").get()).toEqual({ c: 0 });
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import { initDb, getSetting } from './db/index.js';
 import { startHealthChecker } from './services/health.js';
 import { applyProxyUrl, applyProxyEnabled, applyProxyBypass } from './lib/proxy.js';
 import { startCatalogSync } from './services/catalog-sync.js';
+import { scheduleMissingDynamicProviderSync } from './services/provider-model-sync.js';
 import { installProcessSafetyNet } from './lib/process-safety-net.js';
 
 const PORT = process.env.PORT ?? 3001;
@@ -33,6 +34,7 @@ async function main() {
     console.log(`Proxy endpoint: http://${display}:${PORT}/v1/chat/completions`);
     startHealthChecker();
     startCatalogSync();
+    scheduleMissingDynamicProviderSync();
   };
 
   const server = app.listen(Number(PORT), HOST, onReady(HOST));

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -229,6 +229,23 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.siliconflow.com/v1',
 }));
 
+// Alibaba Cloud Model Studio (DashScope) — OpenAI-compatible. Serves the Qwen
+// series and third-party models via the compatible-mode Chat Completions API.
+// API keys are region-specific and not interchangeable across endpoints; this
+// registration targets the Singapore (intl) region — the default in Alibaba's
+// docs for international users. Beijing: dashscope.aliyuncs.com; US:
+// dashscope-us.aliyuncs.com. Key from modelstudio.console.alibabacloud.com.
+//
+// Frontier / thinking models (qwen3.7-max, deepseek-v4-pro, etc.) can exceed
+// the default 15s cloud timeout from high-latency regions; bump to 120s like
+// Ollama Cloud so a slow first byte doesn't abort and burn a fallback slot.
+register(new OpenAICompatProvider({
+  platform: 'alibaba',
+  name: 'Alibaba Model Studio',
+  baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  timeoutMs: 120000,
+}));
+
 // Placeholder so getProvider('custom')/hasProvider('custom')/getAllProviders()
 // behave — but the real instance is built per-key by resolveProvider(), since
 // a custom provider's base URL is user-supplied and lives on the api_keys row.

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -242,6 +242,31 @@ export class OpenAICompatProvider extends BaseProvider {
     });
     return res.status !== 401 && res.status !== 403;
   }
+
+  /** List model ids from the provider's OpenAI-compatible GET /v1/models. */
+  async listModels(apiKey: string, quotaContext?: QuotaObservationContext): Promise<string[]> {
+    const url = this.validateUrl ?? `${this.baseUrl}/models`;
+    const res = await this.fetchWithTimeout(url, {
+      method: 'GET',
+      headers: {
+        ...this.authHeader(apiKey),
+        ...this.extraHeaders,
+      },
+    }, 30000);
+    recordQuotaObservationsFromResponse(res, {
+      platform: this.platform,
+      keyId: quotaContext?.keyId,
+      providerAccountId: quotaContext?.providerAccountId,
+      quotaPoolKey: quotaContext?.quotaPoolKey,
+      endpoint: 'models',
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw providerHttpError(res, `${this.name} /models error ${res.status}: ${(err as { error?: { message?: string } }).error?.message ?? res.statusText}`);
+    }
+    const body = await res.json() as { data?: { id: string }[] };
+    return (body.data ?? []).map(m => m.id).filter(Boolean);
+  }
 }
 
 /**

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -4,6 +4,13 @@ import { z } from 'zod';
 import { getDb } from '../db/index.js';
 import { resolveProvider } from '../providers/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
+import {
+  DYNAMIC_MODEL_PLATFORMS,
+  deleteModelsForKey,
+  scheduleProviderModelSync,
+  syncProviderModels,
+} from '../services/provider-model-sync.js';
+import type { Platform } from '@freellmapi/shared/types.js';
 
 export const keysRouter = Router();
 
@@ -14,7 +21,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow', 'alibaba', 'custom',
 ] as const;
 
 // `key` is optional so keyless providers (Kilo's anonymous gateway) can be added
@@ -90,6 +97,7 @@ keysRouter.post('/', (req: Request, res: Response) => {
     const existing = db.prepare('SELECT id FROM api_keys WHERE platform = ? LIMIT 1').get(platform) as { id: number } | undefined;
     if (existing) {
       db.prepare("UPDATE api_keys SET enabled = 1, status = 'unknown' WHERE id = ?").run(existing.id);
+      scheduleProviderModelSync(existing.id, platform);
       res.status(200).json({
         id: existing.id,
         platform,
@@ -107,6 +115,9 @@ keysRouter.post('/', (req: Request, res: Response) => {
     INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
     VALUES (?, ?, ?, ?, ?, 'unknown', 1)
   `).run(platform, label ?? '', encrypted, iv, authTag);
+
+  const keyId = Number(result.lastInsertRowid);
+  scheduleProviderModelSync(keyId, platform);
 
   res.status(201).json({
     id: result.lastInsertRowid,
@@ -247,6 +258,39 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
   });
 });
 
+// Fetch + evaluate models from the provider's own /v1/models (Alibaba Model Studio, etc.).
+keysRouter.post('/:id/sync-models', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id as string, 10);
+  if (isNaN(id)) {
+    res.status(400).json({ error: { message: 'Invalid key ID' } });
+    return;
+  }
+
+  const db = getDb();
+  const row = db.prepare('SELECT * FROM api_keys WHERE id = ?').get(id) as {
+    id: number; platform: string; encrypted_key: string; iv: string; auth_tag: string; base_url?: string | null;
+  } | undefined;
+  if (!row) {
+    res.status(404).json({ error: { message: 'Key not found' } });
+    return;
+  }
+
+  const platform = row.platform as Platform;
+  if (!DYNAMIC_MODEL_PLATFORMS.has(platform)) {
+    res.status(400).json({ error: { message: `Platform '${platform}' does not support model sync from its endpoint` } });
+    return;
+  }
+
+  try {
+    const apiKey = decrypt(row.encrypted_key, row.iv, row.auth_tag);
+    const result = await syncProviderModels(platform, apiKey, id, { baseUrl: row.base_url });
+    res.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(502).json({ error: { message } });
+  }
+});
+
 // Delete a key
 keysRouter.delete('/:id', (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);
@@ -263,6 +307,9 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   }
 
   const remove = db.transaction(() => {
+    if (DYNAMIC_MODEL_PLATFORMS.has(row.platform as Platform)) {
+      deleteModelsForKey(db, row.platform as Platform, id);
+    }
     db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
     // Custom models exist only because POST /custom registered them alongside
     // their endpoint key (#117) — they can't route without it. Cascade away

--- a/server/src/scripts/sync-alibaba-models.ts
+++ b/server/src/scripts/sync-alibaba-models.ts
@@ -1,0 +1,32 @@
+/**
+ * One-shot: sync Alibaba models for the first enabled alibaba key.
+ * Usage: npx tsx src/scripts/sync-alibaba-models.ts
+ */
+import '../env.js';
+import { initDb, getDb } from '../db/index.js';
+import { decrypt } from '../lib/crypto.js';
+import { syncProviderModels } from '../services/provider-model-sync.js';
+
+initDb();
+const db = getDb();
+const row = db.prepare("SELECT * FROM api_keys WHERE platform = 'alibaba' AND enabled = 1 LIMIT 1").get() as {
+  id: number; encrypted_key: string; iv: string; auth_tag: string;
+} | undefined;
+if (!row) {
+  console.error('No enabled alibaba key');
+  process.exit(1);
+}
+
+const apiKey = decrypt(row.encrypted_key, row.iv, row.auth_tag);
+console.log('Syncing models for alibaba key', row.id, '…');
+const result = await syncProviderModels('alibaba', apiKey, row.id, { probe: true, probeConcurrency: 6 });
+console.log(JSON.stringify({
+  fetched: result.fetched,
+  chatCandidates: result.chatCandidates,
+  enabled: result.enabled,
+  disabled: result.disabled,
+  inserted: result.inserted,
+  updated: result.updated,
+}, null, 2));
+console.log('\nEnabled models:');
+for (const m of result.models.filter(m => m.enabled)) console.log(' ', m.modelId);

--- a/server/src/services/provider-model-sync.ts
+++ b/server/src/services/provider-model-sync.ts
@@ -1,0 +1,312 @@
+import type Database from 'better-sqlite3';
+import { getDb } from '../db/index.js';
+import { decrypt } from '../lib/crypto.js';
+import { resolveProvider } from '../providers/index.js';
+import { OpenAICompatProvider } from '../providers/openai-compat.js';
+import type { Platform } from '@freellmapi/shared/types.js';
+
+/** Built-in providers whose chat catalog is fetched from the provider's own
+ *  OpenAI-compatible GET /v1/models instead of the signed freellmapi catalog.
+ *  Rows are bound to the discovering api_keys.id so catalog-sync won't delete
+ *  them (it only prunes key_id IS NULL catalog-managed rows). */
+export const DYNAMIC_MODEL_PLATFORMS = new Set<Platform>(['alibaba']);
+
+export interface ProviderModelSyncResult {
+  platform: Platform;
+  fetched: number;
+  chatCandidates: number;
+  inserted: number;
+  updated: number;
+  removed: number;
+  probed: number;
+  enabled: number;
+  disabled: number;
+  models: Array<{ modelId: string; displayName: string; enabled: boolean; probed: boolean; error?: string }>;
+}
+
+/** The router walks profile_models when a profile is active — discovered models
+ *  must live there too, not only in fallback_config. */
+function ensureModelInDefaultProfile(db: Database.Database, modelDbId: number, priority?: number): void {
+  const defaultProfile = db.prepare("SELECT id FROM profiles WHERE type = 'default' LIMIT 1").get() as { id: number } | undefined;
+  if (!defaultProfile) return;
+  const exists = db.prepare('SELECT 1 FROM profile_models WHERE profile_id = ? AND model_db_id = ?')
+    .get(defaultProfile.id, modelDbId);
+  if (exists) return;
+  const pri = priority ?? (
+    db.prepare('SELECT COALESCE(MAX(priority), 0) AS m FROM profile_models WHERE profile_id = ?')
+      .get(defaultProfile.id) as { m: number }
+  ).m + 1;
+  db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, 1)')
+    .run(defaultProfile.id, modelDbId, pri);
+}
+
+/** Backfill models that were synced before profile wiring landed. */
+export function backfillDiscoveredModelsToDefaultProfile(db: Database.Database, platform: Platform): number {
+  const defaultProfile = db.prepare("SELECT id FROM profiles WHERE type = 'default' LIMIT 1").get() as { id: number } | undefined;
+  if (!defaultProfile) return 0;
+  const missing = db.prepare(`
+    SELECT m.id, fc.priority
+    FROM models m
+    JOIN fallback_config fc ON fc.model_db_id = m.id
+    LEFT JOIN profile_models pm ON pm.model_db_id = m.id AND pm.profile_id = ?
+    WHERE m.platform = ? AND m.key_id IS NOT NULL AND pm.id IS NULL
+  `).all(defaultProfile.id, platform) as { id: number; priority: number }[];
+  for (const row of missing) ensureModelInDefaultProfile(db, row.id, row.priority);
+  return missing.length;
+}
+
+/** Drop obvious non-chat SKUs (image/TTS/embedding/realtime/etc.) from /v1/models. */
+export function isLikelyChatModel(modelId: string, platform: Platform): boolean {
+  const lower = modelId.toLowerCase();
+  if (platform === 'alibaba') {
+    const exclude = [
+      'embedding', 'image', 'tts', 'asr', 'wan', 'ocr', 'livetranslate', 'realtime',
+      's2s', 'captioner', 'tingwu', 'ccai-pro', 'z-image', 'image-edit', '-edit-',
+      'vc-realtime', 'vd-realtime', 'qwen-mt', 'qwen-vl-ocr', 'qwen-omni-turbo',
+    ];
+    if (exclude.some(p => lower.includes(p))) return false;
+  }
+  return true;
+}
+
+function humanizeModelId(modelId: string): string {
+  return modelId
+    .split(/[-_/]+/)
+    .filter(Boolean)
+    .map(part => (/^\d/.test(part) || part.length <= 4 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join(' ');
+}
+
+/** Rough intelligence ordering for dynamically discovered rows. */
+export function inferIntelligenceRank(modelId: string, platform: Platform): number {
+  const id = modelId.toLowerCase();
+  if (platform === 'alibaba') {
+    if (id.includes('max') || id.includes('480b') || id.includes('235b') || id.includes('397b')) return 2;
+    if (id.includes('plus') || id.includes('pro') || id.includes('coder') || id.includes('glm')) return 4;
+    if (id.includes('flash') || id.includes('turbo') || id.includes('next')) return 6;
+    if (id.includes('7b') || id.includes('8b') || id.includes('14b')) return 12;
+  }
+  return 20;
+}
+
+export async function fetchProviderModelIds(platform: Platform, apiKey: string, baseUrl?: string | null): Promise<string[]> {
+  const provider = resolveProvider(platform, baseUrl);
+  if (!provider) throw new Error(`Unknown platform: ${platform}`);
+  if (!(provider instanceof OpenAICompatProvider)) {
+    throw new Error(`Platform '${platform}' does not expose OpenAI-compatible /v1/models`);
+  }
+  return provider.listModels(apiKey);
+}
+
+async function probeChatModel(
+  platform: Platform,
+  apiKey: string,
+  modelId: string,
+  baseUrl?: string | null,
+): Promise<{ ok: boolean; error?: string }> {
+  const provider = resolveProvider(platform, baseUrl);
+  if (!provider) return { ok: false, error: 'no provider' };
+  try {
+    await provider.chatCompletion(
+      apiKey,
+      [{ role: 'user', content: 'Reply with one word: hi' }],
+      modelId,
+      { max_tokens: 8, timeoutMs: 45000 },
+    );
+    return { ok: true };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg.slice(0, 200) };
+  }
+}
+
+export interface SyncProviderModelsOptions {
+  /** When true (default), chat-probe each candidate and only enable successes. */
+  probe?: boolean;
+  /** Max concurrent probes. */
+  probeConcurrency?: number;
+  baseUrl?: string | null;
+}
+
+export async function syncProviderModels(
+  platform: Platform,
+  apiKey: string,
+  keyId: number,
+  opts: SyncProviderModelsOptions = {},
+): Promise<ProviderModelSyncResult> {
+  if (!DYNAMIC_MODEL_PLATFORMS.has(platform)) {
+    throw new Error(`Platform '${platform}' does not support dynamic model sync`);
+  }
+
+  const probe = opts.probe ?? true;
+  const concurrency = opts.probeConcurrency ?? 4;
+  const db = getDb();
+
+  const fetchedIds = await fetchProviderModelIds(platform, apiKey, opts.baseUrl);
+  const chatIds = fetchedIds.filter(id => isLikelyChatModel(id, platform));
+
+  const probeResults = new Map<string, { ok: boolean; error?: string }>();
+  if (probe) {
+    let idx = 0;
+    const workers = Array.from({ length: Math.min(concurrency, chatIds.length) }, async () => {
+      while (idx < chatIds.length) {
+        const modelId = chatIds[idx++];
+        probeResults.set(modelId, await probeChatModel(platform, apiKey, modelId, opts.baseUrl));
+      }
+    });
+    await Promise.all(workers);
+  }
+
+  const result: ProviderModelSyncResult = {
+    platform,
+    fetched: fetchedIds.length,
+    chatCandidates: chatIds.length,
+    inserted: 0,
+    updated: 0,
+    removed: 0,
+    probed: probeResults.size,
+    enabled: 0,
+    disabled: 0,
+    models: [],
+  };
+
+  const upsert = db.transaction(() => {
+    const select = db.prepare('SELECT id, enabled FROM models WHERE platform = ? AND model_id = ?');
+    const insert = db.prepare(`
+      INSERT INTO models
+        (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+         rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window,
+         enabled, supports_vision, supports_tools, key_id)
+      VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, '', NULL, ?, 0, 1, ?)
+    `);
+    const update = db.prepare(`
+      UPDATE models SET
+        display_name = ?, intelligence_rank = ?, speed_rank = ?, size_label = ?,
+        enabled = ?, key_id = ?
+      WHERE id = ?
+    `);
+
+    const seen = new Set<string>();
+    for (const modelId of chatIds) {
+      seen.add(modelId);
+      const displayName = humanizeModelId(modelId);
+      const intelligenceRank = inferIntelligenceRank(modelId, platform);
+      const probed = probeResults.get(modelId);
+      const enabled = probe ? (probed?.ok ? 1 : 0) : 1;
+      if (enabled) result.enabled++;
+      else result.disabled++;
+
+      const row = select.get(platform, modelId) as { id: number; enabled: number } | undefined;
+      if (row) {
+        // Respect a user's manual disable only when we're not re-probing.
+        const nextEnabled = probe ? enabled : row.enabled;
+        update.run(displayName, intelligenceRank, intelligenceRank, 'Discovered', nextEnabled, keyId, row.id);
+        const fb = db.prepare('SELECT priority FROM fallback_config WHERE model_db_id = ?').get(row.id) as { priority: number } | undefined;
+        if (nextEnabled) ensureModelInDefaultProfile(db, row.id, fb?.priority);
+        result.updated++;
+        result.models.push({
+          modelId,
+          displayName,
+          enabled: nextEnabled === 1,
+          probed: !!probed,
+          error: probed && !probed.ok ? probed.error : undefined,
+        });
+      } else {
+        insert.run(platform, modelId, displayName, intelligenceRank, intelligenceRank, 'Discovered', enabled, keyId);
+        const inserted = select.get(platform, modelId) as { id: number };
+        const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(inserted.id);
+        let fbPriority: number | undefined;
+        if (!inChain) {
+          const max = db.prepare('SELECT COALESCE(MAX(priority), 0) AS m FROM fallback_config').get() as { m: number };
+          fbPriority = max.m + 1;
+          db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(inserted.id, fbPriority);
+        } else {
+          fbPriority = (db.prepare('SELECT priority FROM fallback_config WHERE model_db_id = ?').get(inserted.id) as { priority: number }).priority;
+        }
+        if (enabled) ensureModelInDefaultProfile(db, inserted.id, fbPriority);
+        result.inserted++;
+        result.models.push({
+          modelId,
+          displayName,
+          enabled: enabled === 1,
+          probed: !!probed,
+          error: probed && !probed.ok ? probed.error : undefined,
+        });
+      }
+    }
+
+    // Drop models previously discovered by THIS key that vanished upstream.
+    const stale = db.prepare(`
+      SELECT id, model_id FROM models
+       WHERE platform = ? AND key_id = ?
+    `).all(platform, keyId) as { id: number; model_id: string }[];
+    const deleteFb = db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?');
+    const deleteProfile = db.prepare('DELETE FROM profile_models WHERE model_db_id = ?');
+    const deleteModel = db.prepare('DELETE FROM models WHERE id = ?');
+    for (const row of stale) {
+      if (!seen.has(row.model_id)) {
+        deleteFb.run(row.id);
+        deleteProfile.run(row.id);
+        deleteModel.run(row.id);
+        result.removed++;
+      }
+    }
+  });
+
+  upsert();
+  backfillDiscoveredModelsToDefaultProfile(db, platform);
+  return result;
+}
+
+/** Remove all models bound to a provider key (used when deleting dynamic-sync keys). */
+export function deleteModelsForKey(db: Database.Database, platform: Platform, keyId: number): number {
+  if (!DYNAMIC_MODEL_PLATFORMS.has(platform)) return 0;
+  const rows = db.prepare('SELECT id FROM models WHERE platform = ? AND key_id = ?').all(platform, keyId) as { id: number }[];
+  const deleteFb = db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?');
+  const deleteProfile = db.prepare('DELETE FROM profile_models WHERE model_db_id = ?');
+  const deleteModel = db.prepare('DELETE FROM models WHERE id = ?');
+  for (const row of rows) {
+    deleteFb.run(row.id);
+    deleteProfile.run(row.id);
+    deleteModel.run(row.id);
+  }
+  return rows.length;
+}
+
+/** Kick off a background /v1/models fetch + chat probe for dynamic-catalog providers. */
+export function scheduleProviderModelSync(keyId: number, platform: Platform): void {
+  if (!DYNAMIC_MODEL_PLATFORMS.has(platform)) return;
+  void (async () => {
+    try {
+      const db = getDb();
+      const row = db.prepare('SELECT * FROM api_keys WHERE id = ?').get(keyId) as {
+        encrypted_key: string; iv: string; auth_tag: string; enabled: number; base_url?: string | null;
+      } | undefined;
+      if (!row || row.enabled !== 1) return;
+      const apiKey = decrypt(row.encrypted_key, row.iv, row.auth_tag);
+      const result = await syncProviderModels(platform, apiKey, keyId, { baseUrl: row.base_url });
+      console.log(
+        `[provider-model-sync] ${platform} key ${keyId}: ${result.enabled} enabled, ${result.disabled} disabled ` +
+        `(${result.fetched} fetched, ${result.chatCandidates} chat candidates)`,
+      );
+    } catch (err) {
+      console.warn(
+        `[provider-model-sync] ${platform} key ${keyId} failed:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  })();
+}
+
+/** On boot, sync dynamic-catalog providers that have a key but no models yet,
+ *  and backfill any discovered models missing from the active Default profile. */
+export function scheduleMissingDynamicProviderSync(): void {
+  const db = getDb();
+  for (const platform of DYNAMIC_MODEL_PLATFORMS) {
+    backfillDiscoveredModelsToDefaultProfile(db, platform);
+    const modelCount = (db.prepare('SELECT COUNT(1) AS c FROM models WHERE platform = ?').get(platform) as { c: number }).c;
+    if (modelCount > 0) continue;
+    const keys = db.prepare('SELECT id FROM api_keys WHERE platform = ? AND enabled = 1').all(platform) as { id: number }[];
+    for (const key of keys) scheduleProviderModelSync(key.id, platform);
+  }
+}

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -136,11 +136,12 @@ function inferPoolForPlatform(platform: Platform, modelId?: string | null): stri
   if (platform === 'llm7') return 'llm7::anonymous';
   if (platform === 'huggingface') return 'huggingface::router';
   if (platform === 'opencode') return 'opencode::promo';
+  if (platform === 'alibaba') return 'alibaba::account';
   return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode'].includes(platform);
+  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'alibaba'].includes(platform);
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -42,6 +42,10 @@ export type Platform =
   // models (FLUX.1-schnell image, CosyVoice2 TTS) routed via services/media.ts;
   // chat is supported too. Key from siliconflow.com (no card).
   | 'siliconflow'
+  // Alibaba Cloud Model Studio (DashScope) — OpenAI-compatible. Qwen and
+  // third-party models; key from modelstudio.console.alibabacloud.com (region-
+  // specific — Singapore intl endpoint below). See providers/index.ts.
+  | 'alibaba'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
Fetch chat models from DashScope /v1/models and register them in the Default routing profile. Pin the dev API base URL to 127.0.0.1 and update Keys/API docs so external SDK clients match the Playground proxy.