### PR TITLE
Add DGrid Free Models Router provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # FreeLLMAPI
 
-**One OpenAI-compatible endpoint. Sixteen free LLM providers. ~1.7B tokens per month.**
+**One OpenAI-compatible endpoint. Eighteen free LLM providers. ~1.7B tokens per month.**
 
-Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, OVH AI Endpoints, and OpenCode Zen — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
+Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, OVH AI Endpoints, OpenCode Zen, and DGrid — plus any custom OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, local Ollama) — behind a single `/v1/chat/completions` endpoint. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
 [![CI](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml/badge.svg)](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
@@ -43,7 +43,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRoute
 
 Every serious AI lab now offers a free tier — a few million tokens a month, a few thousand requests a day. On its own each tier is a toy. Stacked together, they add up to roughly **1.7 billion tokens per month** of working inference capacity, across 100+ models from small-and-fast to reasonably capable.
 
-The problem is that stacking them by hand is painful: seventeen different SDKs, seventeen different rate limits, seventeen places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
+The problem is that stacking them by hand is painful: eighteen different SDKs, eighteen different rate limits, eighteen places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
 
 ## Supported providers
 
@@ -74,11 +74,21 @@ The problem is that stacking them by hand is painful: seventeen different SDKs, 
 </tr>
 <tr>
 <td align="center"><a href="https://endpoints.ai.cloud.ovh.net"><b>OVH AI Endpoints</b><br/>Qwen3.5 397B · GPT-OSS · Llama 3.3 (anon ok)</a></td>
-<td align="center"></td>
+<td align="center"><a href="https://dgrid.ai/models/dgridai/free"><b>DGrid</b><br/>Free Models Router · smart free routing</a></td>
 <td align="center"></td>
 <td align="center"></td>
 </tr>
 </table>
+
+DGrid's `dgridai/free` route is a free intelligent inference gateway that
+dynamically chooses from DGrid's current free model pool based on availability,
+latency, reliability, and task fit. The underlying pool currently includes
+Llama 3.2 1B Instruct, GLM-4.7 Flash, DeepSeek R1 Distill Qwen 32B,
+Llama 3.3 70B Instruct FP8 Fast, Kimi K2.6, and GLM-5.2, with more free
+models expected over time. Default free quota is 10 requests/minute and
+100 requests/day; a one-time $5 lifetime top-up raises it to up to
+20 requests/minute and 1,000 requests/day. DGrid's broader AI Gateway also
+offers a larger paid/mixed model catalog through the same OpenAI-compatible API.
 
 Plus a **custom** provider — point at any OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, a local Ollama, or a remote gateway) from the Keys page.
 
@@ -386,7 +396,7 @@ print(resp.choices[0].message.content)
 
 If no vision-capable model is enabled in your Fallback Chain, an image request returns a clear `422` (`code: "no_vision_model"`) rather than silently dropping the image. (Image input on `/v1/responses` isn't supported yet — use `/v1/chat/completions`.)
 
-Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, Mistral, OpenRouter, GitHub Models, HuggingFace, Cloudflare, Cohere compat) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
+Works with `stream=True` as well — you'll get `delta.tool_calls` chunks followed by a `finish_reason: "tool_calls"` close. Under the hood, OpenAI-compatible providers (Groq, Cerebras, Mistral, OpenRouter, GitHub Models, HuggingFace, Cloudflare, Cohere compat, DGrid) get the request passed through; Gemini requests get translated into Google's `functionDeclarations` / `functionResponse` shape and the response is translated back.
 
 Every response carries an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
 

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -70,6 +70,7 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
   { value: 'reka', label: 'Reka (free key)', url: 'https://platform.reka.ai' },
   { value: 'siliconflow', label: 'SiliconFlow (image + TTS)', url: 'https://siliconflow.com' },
+  { value: 'dgrid', label: 'DGrid (free router)', url: 'https://dgrid.ai/api-keys' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -287,6 +287,46 @@ describe('Migration idempotency', () => {
     ]);
   });
 
+  it('V27: DGrid Free Models Router is seeded with conservative free-tier limits', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const row = db.prepare(`
+      SELECT platform, model_id, display_name, rpm_limit, rpd_limit, monthly_token_budget, enabled, supports_tools
+        FROM models
+       WHERE platform = 'dgrid' AND model_id = 'dgridai/free'
+    `).get() as {
+      platform: string;
+      model_id: string;
+      display_name: string;
+      rpm_limit: number;
+      rpd_limit: number;
+      monthly_token_budget: string;
+      enabled: number;
+      supports_tools: number;
+    } | undefined;
+
+    expect(row).toBeDefined();
+    expect(row).toMatchObject({
+      platform: 'dgrid',
+      model_id: 'dgridai/free',
+      display_name: 'DGrid Free Models Router',
+      rpm_limit: 10,
+      rpd_limit: 100,
+      monthly_token_budget: 'free · 100/day (1000/day w/ $5 lifetime top-up)',
+      enabled: 1,
+      supports_tools: 1,
+    });
+
+    const fallback = db.prepare(`
+      SELECT 1 FROM fallback_config
+       WHERE model_db_id = (
+         SELECT id FROM models WHERE platform = 'dgrid' AND model_id = 'dgridai/free'
+       )
+    `).get();
+    expect(fallback).toBeDefined();
+  });
+
   it('all enabled catalog platforms have a registered provider', async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getProvider } from '../../providers/index.js';
 import { OpenAICompatProvider } from '../../providers/openai-compat.js';
 
 describe('OpenAICompatProvider', () => {
@@ -10,6 +11,42 @@ describe('OpenAICompatProvider', () => {
       name: 'TestProvider',
       baseUrl: 'https://api.test.com/v1',
       extraHeaders: { 'X-Custom': 'test' },
+    });
+  });
+
+  describe('DGrid provider registration', () => {
+    it('registers DGrid as an OpenAI-compatible provider', async () => {
+      const dgrid = getProvider('dgrid') as OpenAICompatProvider | undefined;
+      expect(dgrid).toBeDefined();
+      expect(dgrid!.platform).toBe('dgrid');
+      expect(dgrid!.name).toBe('DGrid');
+
+      let capturedUrl = '';
+      let capturedHeaders: Record<string, string> = {};
+      let capturedBody: any = null;
+
+      vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+        capturedUrl = url as string;
+        capturedHeaders = (init as any).headers;
+        capturedBody = JSON.parse((init as any).body);
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'dgrid-test',
+            object: 'chat.completion',
+            created: 123,
+            model: 'dgridai/free',
+            choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+        } as any;
+      });
+
+      await dgrid!.chatCompletion('dg_test_key', [{ role: 'user', content: 'hello' }], 'dgridai/free');
+
+      expect(capturedUrl).toBe('https://api.dgrid.ai/v1/chat/completions');
+      expect(capturedHeaders.Authorization).toBe('Bearer dg_test_key');
+      expect(capturedBody.model).toBe('dgridai/free');
     });
   });
 

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -59,6 +59,19 @@ describe('Keys API', () => {
     expect(body.maskedKey).toContain('...');
   });
 
+  it('POST /api/keys accepts a DGrid model API key', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'dgrid',
+      key: 'dg_test123456789',
+      label: 'My DGrid Key',
+    });
+
+    expect(status).toBe(201);
+    expect(body.platform).toBe('dgrid');
+    expect(body.label).toBe('My DGrid Key');
+    expect(body.maskedKey).toContain('...');
+  });
+
   it('GET /api/keys returns the created key', async () => {
     // First create a key
     await request(app, 'POST', '/api/keys', {

--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -32,14 +32,13 @@ export function migrateDbSchema(db: Database.Database) {
   migrateModelsV23FreeTierAudit(db);
   migrateModelsV24ZenRefresh(db);
   migrateModelsV25ZenDeadPromos(db);
-  // V25 is the LAST model-data migration. Since the Premium live catalog
-  // shipped (June 2026), model/limit DATA is maintained in the published
-  // catalog (served signed by the catalog service) and reaches installs via
-  // catalog-sync — premium on the live tier within ~12h, free at the monthly
-  // promote. Shipping model data as a
-  // migration would hand it to free users on their next binary update,
-  // bypassing the tier gate. Migrations from here on are baseline/code-level
-  // only (schema, family rules, provider plumbing, quirk-seed corrections).
+  migrateModelsV27DGridFreeRouter(db);
+  // Most model/limit DATA is maintained in the published catalog (served signed
+  // by the catalog service) and reaches installs via catalog-sync — premium on
+  // the live tier within ~12h, free at the monthly promote. Avoid shipping broad
+  // catalog refreshes as migrations because that bypasses the tier gate. Narrow
+  // provider bootstrap rows for new recurring-free providers are the exception:
+  // without one, the provider cannot route until the external catalog catches up.
   // After all model migrations: add/refresh paid-equivalent pricing
   // (drives the realistic "Est. savings" analytics stat).
   applyModelPricing(db);
@@ -1941,6 +1940,49 @@ function migrateModelsV25ZenDeadPromos(db: Database.Database) {
   apply();
 }
 
+/**
+ * V27 (2026-06): DGrid Free Models Router.
+ *
+ * DGrid AI Gateway is OpenAI-compatible at https://api.dgrid.ai/v1. The only
+ * catalog row shipped here is the recurring-free router `dgridai/free`: DGrid
+ * dynamically routes it across its current free model pool, so FreeLLMAPI should
+ * treat it as one upstream model rather than trying to mirror every underlying
+ * free model. The broader DGrid catalog includes paid/mixed models and is left
+ * out of this free-tier seed.
+ *
+ * Default free quota is 10 RPM / 100 RPD. DGrid documents a higher 20 RPM /
+ * 1000 RPD tier after a one-time $5 lifetime top-up, but the router cannot
+ * detect that account state, so the built-in limits stay conservative.
+ */
+function migrateModelsV27DGridFreeRouter(db: Database.Database) {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, supports_vision, supports_tools)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const apply = db.transaction(() => {
+    insert.run(
+      'dgrid',
+      'dgridai/free',
+      'DGrid Free Models Router',
+      8,
+      5,
+      'Large',
+      10,
+      100,
+      null,
+      null,
+      'free · 100/day (1000/day w/ $5 lifetime top-up)',
+      null,
+      1,
+      0,
+      1,
+    );
+    backfillFallback(db);
+  });
+  apply();
+}
+
 // V26 NOTE (June 2026, recurring-free audit pass 2): the model-data changes
 // from this audit (4 OVH rows, opencode/north-mini-code-free, Cerebras
 // 5 RPM/30K TPM/1M TPD limits, NVIDIA "free · 40 RPM" labels, LLM7 60-100/hr
@@ -2288,4 +2330,3 @@ function migrateProfilesInit(db: Database.Database) {
     `).run();
   }
 }
-

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -229,6 +229,16 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.siliconflow.com/v1',
 }));
 
+// DGrid AI Gateway — OpenAI-compatible. This repo ships only the recurring-free
+// `dgridai/free` smart router row; DGrid's broader paid/mixed catalog stays out
+// of the free-tier catalog unless users add it as a custom provider or a future
+// catalog update explicitly includes eligible free models.
+register(new OpenAICompatProvider({
+  platform: 'dgrid',
+  name: 'DGrid',
+  baseUrl: 'https://api.dgrid.ai/v1',
+}));
+
 // Placeholder so getProvider('custom')/hasProvider('custom')/getAllProviders()
 // behave — but the real instance is built per-key by resolveProvider(), since
 // a custom provider's base URL is user-supplied and lives on the api_keys row.

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -14,7 +14,7 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow', 'dgrid', 'custom',
 ] as const;
 
 // `key` is optional so keyless providers (Kilo's anonymous gateway) can be added

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -42,6 +42,9 @@ export type Platform =
   // models (FLUX.1-schnell image, CosyVoice2 TTS) routed via services/media.ts;
   // chat is supported too. Key from siliconflow.com (no card).
   | 'siliconflow'
+  // DGrid AI Gateway — OpenAI-compatible. Free Models Router exposes
+  // `dgridai/free`, a zero-cost smart router over DGrid's free model pool.
+  | 'dgrid'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
## Summary

Adds DGrid as an OpenAI-compatible provider and seeds the `dgridai/free` Free Models Router as a recurring-free model.

The DGrid Free Models Router provides a single free smart-routing endpoint over DGrid's current free model pool, with conservative default limits of 10 requests/minute and 100 requests/day. The README also documents the optional $5 lifetime top-up quota and briefly notes DGrid's broader 200+ model catalog.

## Changes

- Register DGrid with the OpenAI-compatible provider registry
- Add `dgrid` to platform types, key creation, and the Keys page provider list
- Seed `dgridai/free` with free-tier limits and fallback config
- Document DGrid Free Models Router in the README
- Add provider, key route, and migration coverage

## Verification

- `npm run build`
- `npm test`