### PR TITLE
feat(providers): add Routeway, BazaarLink, AINative free providers

### DIFF
--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -292,6 +292,9 @@ const platformColors: Record<string, string> = {
   pollinations: '#a855f7',
   llm7:        '#0ea5e9',
   huggingface: '#ff9d00',
+  routeway:    '#14b8a6',
+  bazaarlink:  '#e11d48',
+  ainative:    '#22c55e',
 }
 
 // A 0..1 value as a thin horizontal bar with the number beside it.

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -70,6 +70,9 @@ const PLATFORMS: { value: Platform; label: string; url: string; keyless?: boolea
   { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
   { value: 'reka', label: 'Reka (free key)', url: 'https://platform.reka.ai' },
   { value: 'siliconflow', label: 'SiliconFlow (image + TTS)', url: 'https://siliconflow.com' },
+  { value: 'routeway', label: 'Routeway (free key)', url: 'https://routeway.ai' },
+  { value: 'bazaarlink', label: 'BazaarLink (free key)', url: 'https://bazaarlink.ai' },
+  { value: 'ainative', label: 'AINative Studio (free key)', url: 'https://ainative.studio' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -229,6 +229,44 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.siliconflow.com/v1',
 }));
 
+// Routeway — OpenAI-compatible aggregator (api.routeway.ai/v1). Free models
+// carry a ':free' suffix and cost $0; the free pool is rate-limited (docs say
+// 20 rpm / 200 rpd, but a live test on 2026-06-26 observed a stricter 5 rpm).
+// Cloudflare in front rejects non-browser User-Agents with error 1010, so a
+// browser-style UA is required. Free key from routeway.ai (no card). Catalog
+// rows live in the catalog (premium → age into free).
+register(new OpenAICompatProvider({
+  platform: 'routeway',
+  name: 'Routeway',
+  baseUrl: 'https://api.routeway.ai/v1',
+  extraHeaders: {
+    'User-Agent': 'Mozilla/5.0 FreeLLMAPI/1.0',
+  },
+}));
+
+// BazaarLink — OpenAI-compatible aggregator (bazaarlink.ai/api/v1). The
+// 'auto:free' route picks a currently-available zero-cost model (routed to
+// deepseek-v4-flash in a 2026-06-26 live test, usage.cost 0); direct model IDs
+// are paid, so only 'auto:free' is cataloged. Free key from bazaarlink.ai
+// (no card, supports agent self-registration). Reasoning models can consume a
+// tiny max_tokens internally, so default to a non-trivial output cap.
+register(new OpenAICompatProvider({
+  platform: 'bazaarlink',
+  name: 'BazaarLink',
+  baseUrl: 'https://bazaarlink.ai/api/v1',
+}));
+
+// AINative Studio — OpenAI-compatible aggregator (api.ainative.studio/api/v1).
+// Advertises a recurring ~10M tokens/month free allocation (no card), though
+// its own pages disagree on scale; treat the quota as unverified until a real
+// account confirms it. Bearer auth works (X-API-Key also accepted). Catalog
+// rows live in the catalog (premium → age into free).
+register(new OpenAICompatProvider({
+  platform: 'ainative',
+  name: 'AINative Studio',
+  baseUrl: 'https://api.ainative.studio/api/v1',
+}));
+
 // Placeholder so getProvider('custom')/hasProvider('custom')/getAllProviders()
 // behave — but the real instance is built per-key by resolveProvider(), since
 // a custom provider's base URL is user-supplied and lives on the api_keys row.

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -14,7 +14,8 @@ export const keysRouter = Router();
 const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
-  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow', 'custom',
+  'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
+  'routeway', 'bazaarlink', 'ainative', 'custom',
 ] as const;
 
 // `key` is optional so keyless providers (Kilo's anonymous gateway) can be added

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -136,11 +136,15 @@ function inferPoolForPlatform(platform: Platform, modelId?: string | null): stri
   if (platform === 'llm7') return 'llm7::anonymous';
   if (platform === 'huggingface') return 'huggingface::router';
   if (platform === 'opencode') return 'opencode::promo';
+  // Aggregators with a single shared free pool across all ':free'/'auto:free' models.
+  if (platform === 'routeway') return 'routeway::free';
+  if (platform === 'bazaarlink') return 'bazaarlink::free';
+  if (platform === 'ainative') return 'ainative::account';
   return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode'].includes(platform);
+  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative'].includes(platform);
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -42,6 +42,17 @@ export type Platform =
   // models (FLUX.1-schnell image, CosyVoice2 TTS) routed via services/media.ts;
   // chat is supported too. Key from siliconflow.com (no card).
   | 'siliconflow'
+  // Routeway — OpenAI-compatible aggregator. Free ':free' models ($0) on a
+  // rate-limited pool (~5 rpm observed); requires a browser User-Agent (CF
+  // blocks others). Key from routeway.ai (no card).
+  | 'routeway'
+  // BazaarLink — OpenAI-compatible aggregator. Free 'auto:free' route picks an
+  // available zero-cost model. Key from bazaarlink.ai (no card).
+  | 'bazaarlink'
+  // AINative Studio — OpenAI-compatible aggregator. Advertises a recurring
+  // ~10M tokens/month free allocation (no card); quota unverified. Key from
+  // ainative.studio.
+  | 'ainative'
   // User-configured OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM,
   // Ollama, any base_url). The endpoint URL lives on the api_keys row; see #117.
   | 'custom';


### PR DESCRIPTION
Adds three OpenAI-compatible aggregators with no-card free tiers, each live-tested 2026-06-26.

## Providers
- **Routeway** (`api.routeway.ai/v1`) — `:free` models at \$0 on a shared rate-limited pool (~5 rpm observed, docs claim 20 rpm / 200 rpd). Requires a browser-style `User-Agent` (Cloudflare fronts it and rejects others with error 1010). Free key from routeway.ai, no card.
- **BazaarLink** (`bazaarlink.ai/api/v1`) — `auto:free` route auto-selects an available zero-cost model. Free key, no card.
- **AINative Studio** (`api.ainative.studio/api/v1`) — advertises a recurring ~10M tokens/month free allocation (no card); quota unverified, treated conservatively.

## Changes
- Register each as `OpenAICompatProvider` (Routeway gets the browser `User-Agent` via `extraHeaders`).
- Extend the `Platform` union, the keys allowlist, the shared quota pools (`isSharedPool` + `inferPoolForPlatform`), and the Keys/Fallback UI.

Catalog model rows ship through the catalog (premium → age into free after the monthly promote), not via freeapi migrations.

## Verification
- `npm run build` (server + client) — clean
- `npm run test -w server` — 588 passing