### PR TITLE
feat(playground): optional system prompt for the chat session

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -313,7 +313,9 @@
     "fusionTrace": "{count} model responses",
     "fusionFailed": "no response",
     "fusionJudgeSynth": "synthesized the final answer",
-    "errorPrefix": "Error:"
+    "errorPrefix": "Error:",
+    "systemPromptLabel": "System prompt",
+    "systemPromptPlaceholder": "Optional. Sent as a system message before your chat."
   },
   "embeddings": {
     "title": "Models",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -292,7 +292,9 @@
     "fusionTrace": "{count} 个模型的回答",
     "fusionFailed": "无回应",
     "fusionJudgeSynth": "综合出最终答案",
-    "errorPrefix": "错误:"
+    "errorPrefix": "错误:",
+    "systemPromptLabel": "系统提示词",
+    "systemPromptPlaceholder": "可选。作为系统消息在你的对话之前发送。"
   },
   "embeddings": {
     "title": "模型",

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -111,6 +111,19 @@ function FusionTrace({ panel, judge, streaming, answerStarted }: {
 export default function PlaygroundPage() {
   const { t } = useI18n()
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  // Optional system prompt for this Playground session. Client-side only:
+  // when set, it's prepended as a `system` message to the request. Persisted
+  // to localStorage so it survives reloads.
+  const [systemPrompt, setSystemPrompt] = useState<string>(
+    () => localStorage.getItem('playground.systemPrompt') ?? '',
+  )
+  const [systemPromptOpen, setSystemPromptOpen] = useState<boolean>(
+    () => !!localStorage.getItem('playground.systemPrompt'),
+  )
+  const updateSystemPrompt = (v: string) => {
+    setSystemPrompt(v)
+    localStorage.setItem('playground.systemPrompt', v)
+  }
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [selectedModel, setSelectedModel] = useState<string>(
@@ -212,8 +225,12 @@ export default function PlaygroundPage() {
       if (keyData?.apiKey) headers['Authorization'] = `Bearer ${keyData.apiKey}`
 
       const isFusion = selectedModel === 'fusion'
+      const sysPrompt = systemPrompt.trim()
       const body: any = {
-        messages: newMessages.map(m => ({ role: m.role, content: m.content })),
+        messages: [
+          ...(sysPrompt ? [{ role: 'system', content: sysPrompt }] : []),
+          ...newMessages.map(m => ({ role: m.role, content: m.content })),
+        ],
       }
       if (selectedModel !== 'auto') body.model = selectedModel
       // Fusion streams its panel + judge trace; ask for a stream so the
@@ -500,6 +517,26 @@ export default function PlaygroundPage() {
         </div>
 
         <div className="border-t bg-background/50 p-3">
+          <div className="mb-2">
+            <button
+              type="button"
+              onClick={() => setSystemPromptOpen(o => !o)}
+              className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ChevronRight className={`size-3.5 transition-transform ${systemPromptOpen ? 'rotate-90' : ''}`} />
+              {t('playground.systemPromptLabel')}
+              {systemPrompt.trim() && <span className="ml-1 size-1.5 rounded-full bg-primary/70" />}
+            </button>
+            {systemPromptOpen && (
+              <textarea
+                value={systemPrompt}
+                onChange={e => updateSystemPrompt(e.target.value)}
+                placeholder={t('playground.systemPromptPlaceholder')}
+                rows={2}
+                className="mt-1.5 w-full resize-y rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50 min-h-[44px] max-h-[160px]"
+              />
+            )}
+          </div>
           <div className="flex gap-2 items-end">
             <textarea
               ref={inputRef}


### PR DESCRIPTION
Adds an optional **system prompt** to the Playground.

Right now the Playground can't set a system prompt — the chat only sends `user`/`assistant` messages. This adds a small collapsible **System prompt** box above the input. When set, it's prepended to the request as a `{ role: "system", content }` message (the proxy already accepts system-role messages), so there are **no server or API changes**.

- Client-only — `PlaygroundPage.tsx` + 2 i18n keys (en, zh-CN).
- Persisted to `localStorage`; an empty box leaves current behavior unchanged.

Checks: `npm run build` is clean and `npm test` passes (588/588). The change just prepends a standard `system` message, so behavior is well-defined. I didn't spot an existing client-component test harness — happy to add a test if you have a preferred setup.

I'm a master's student at the University of Ottawa working on LLMs — glad to adjust the UX or placement if you'd prefer it elsewhere.
