### PR TITLE
feat(embeddings): accept optional dimensions parameter for MRL truncation

### DIFF
--- a/server/src/__tests__/services/embeddings.test.ts
+++ b/server/src/__tests__/services/embeddings.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { MockedFunction } from 'vitest';
 import { initDb, getDb } from '../../db/index.js';
 import { encrypt } from '../../lib/crypto.js';
 import { resolveFamily, getDefaultFamily, runEmbeddings, EmbeddingsError } from '../../services/embeddings.js';
@@ -194,15 +195,24 @@ describe('embeddings service', () => {
     });
 
     describe('dimensions parameter (MRL truncation)', () => {
+      // Typed fetch mock so .mock.calls is properly indexed without `as any`.
+      // The cast on assignment to globalThis.fetch is unavoidable because
+      // globalThis.fetch in lib.dom is typed loosely; this is the same
+      // pattern the existing tests in this file use.
+      function mockFetch(impl: typeof fetch): MockedFunction<typeof fetch> {
+        const m = vi.fn(impl) as MockedFunction<typeof fetch>;
+        globalThis.fetch = m as unknown as typeof fetch;
+        return m;
+      }
+
       it('forwards dimensions to NVIDIA NeMo NIM in the request body', async () => {
         addKey('nvidia');
-        const fetchMock = vi.fn(async () => okEmbeddingResponse(1536));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => okEmbeddingResponse(1536));
 
         await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1536);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
-        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
         expect(body.dimensions).toBe(1536);
         // The provider-prefixed model id (nvidia/<id>) is what reaches the upstream;
         // the bare id is used internally for family resolution only.
@@ -213,19 +223,18 @@ describe('embeddings service', () => {
 
       it('omits dimensions from the upstream body when not requested', async () => {
         addKey('nvidia');
-        const fetchMock = vi.fn(async () => okEmbeddingResponse(2048));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => okEmbeddingResponse(2048));
 
         await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello']);
 
-        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
         expect(body).not.toHaveProperty('dimensions');
       });
 
       it('returns the truncated dimension reported by the upstream response', async () => {
         addKey('nvidia');
         // Mock responds with 1536-dim vector even though model is native 2048.
-        globalThis.fetch = vi.fn(async () => okEmbeddingResponse(1536)) as any;
+        mockFetch(async () => okEmbeddingResponse(1536));
 
         const result = await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1536);
         expect(result.dimensions).toBe(1536);
@@ -235,36 +244,33 @@ describe('embeddings service', () => {
       it('forwards dimensions to the google provider', async () => {
         // Use a family served by google. gemini-embedding-001 has google in its chain.
         addKey('google');
-        const fetchMock = vi.fn(async () => okEmbeddingResponse(768));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => okEmbeddingResponse(768));
 
         await runEmbeddings('gemini-embedding-001', ['hello'], 768);
 
-        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
         expect(body.dimensions).toBe(768);
         expect(String(fetchMock.mock.calls[0][0])).toContain('generativelanguage.googleapis.com');
       });
 
       it('forwards dimensions to the github provider', async () => {
         addKey('github');
-        const fetchMock = vi.fn(async () => okEmbeddingResponse(512));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => okEmbeddingResponse(512));
 
         await runEmbeddings('text-embedding-3-small', ['hello'], 512);
 
-        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
         expect(body.dimensions).toBe(512);
         expect(String(fetchMock.mock.calls[0][0])).toContain('models.github.ai');
       });
 
       it('forwards dimensions to the openrouter provider', async () => {
         addKey('openrouter');
-        const fetchMock = vi.fn(async () => okEmbeddingResponse(1024));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => okEmbeddingResponse(1024));
 
         await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1024);
 
-        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
         expect(body.dimensions).toBe(1024);
         expect(String(fetchMock.mock.calls[0][0])).toContain('openrouter.ai');
       });
@@ -273,16 +279,14 @@ describe('embeddings service', () => {
         // Snapshot the request body that runEmbeddings sends today, then verify
         // that adding the dimensions parameter does not change ANY other field.
         addKey('nvidia');
-        const beforeMock = vi.fn(async () => okEmbeddingResponse(2048));
-        globalThis.fetch = beforeMock as any;
+        const beforeMock = mockFetch(async () => okEmbeddingResponse(2048));
         await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello']);
-        const beforeBody = JSON.parse(beforeMock.mock.calls[0][1].body);
+        const beforeBody = JSON.parse(String((beforeMock.mock.calls[0][1] as RequestInit).body));
 
         addKey('nvidia'); // re-seed; previous run consumed nothing
-        const afterMock = vi.fn(async () => okEmbeddingResponse(2048));
-        globalThis.fetch = afterMock as any;
+        const afterMock = mockFetch(async () => okEmbeddingResponse(2048));
         await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], undefined);
-        const afterBody = JSON.parse(afterMock.mock.calls[0][1].body);
+        const afterBody = JSON.parse(String((afterMock.mock.calls[0][1] as RequestInit).body));
 
         expect(afterBody).toEqual(beforeBody);
       });
@@ -292,10 +296,9 @@ describe('embeddings service', () => {
         // openrouter takes over. Both should see the dimensions parameter.
         addKey('nvidia');
         addKey('openrouter');
-        const fetchMock = vi.fn()
-          .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
-          .mockResolvedValueOnce(okEmbeddingResponse(1024));
-        globalThis.fetch = fetchMock as any;
+        const fetchMock = mockFetch(async () => new Response('rate limited', { status: 429 }));
+        fetchMock.mockResolvedValueOnce(new Response('rate limited', { status: 429 }));
+        fetchMock.mockResolvedValueOnce(okEmbeddingResponse(1024));
 
         const result = await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1024);
         expect(result.platform).toBe('openrouter');
@@ -303,8 +306,8 @@ describe('embeddings service', () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
 
         // Both attempts forwarded dimensions
-        const body1 = JSON.parse(fetchMock.mock.calls[0][1].body);
-        const body2 = JSON.parse(fetchMock.mock.calls[1][1].body);
+        const body1 = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+        const body2 = JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body));
         expect(body1.dimensions).toBe(1024);
         expect(body2.dimensions).toBe(1024);
       });

--- a/server/src/__tests__/services/embeddings.test.ts
+++ b/server/src/__tests__/services/embeddings.test.ts
@@ -192,5 +192,122 @@ describe('embeddings service', () => {
       `).get() as { used: number };
       expect(chatUsed.used).toBe(0);
     });
+
+    describe('dimensions parameter (MRL truncation)', () => {
+      it('forwards dimensions to NVIDIA NeMo NIM in the request body', async () => {
+        addKey('nvidia');
+        const fetchMock = vi.fn(async () => okEmbeddingResponse(1536));
+        globalThis.fetch = fetchMock as any;
+
+        await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1536);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.dimensions).toBe(1536);
+        // The provider-prefixed model id (nvidia/<id>) is what reaches the upstream;
+        // the bare id is used internally for family resolution only.
+        expect(body.model).toBe('nvidia/llama-nemotron-embed-vl-1b-v2');
+        // input_type is still set on nvidia (existing behavior preserved)
+        expect(body.input_type).toBe('query');
+      });
+
+      it('omits dimensions from the upstream body when not requested', async () => {
+        addKey('nvidia');
+        const fetchMock = vi.fn(async () => okEmbeddingResponse(2048));
+        globalThis.fetch = fetchMock as any;
+
+        await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello']);
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body).not.toHaveProperty('dimensions');
+      });
+
+      it('returns the truncated dimension reported by the upstream response', async () => {
+        addKey('nvidia');
+        // Mock responds with 1536-dim vector even though model is native 2048.
+        globalThis.fetch = vi.fn(async () => okEmbeddingResponse(1536)) as any;
+
+        const result = await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1536);
+        expect(result.dimensions).toBe(1536);
+        expect(result.vectors[0]).toHaveLength(1536);
+      });
+
+      it('forwards dimensions to the google provider', async () => {
+        // Use a family served by google. gemini-embedding-001 has google in its chain.
+        addKey('google');
+        const fetchMock = vi.fn(async () => okEmbeddingResponse(768));
+        globalThis.fetch = fetchMock as any;
+
+        await runEmbeddings('gemini-embedding-001', ['hello'], 768);
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.dimensions).toBe(768);
+        expect(String(fetchMock.mock.calls[0][0])).toContain('generativelanguage.googleapis.com');
+      });
+
+      it('forwards dimensions to the github provider', async () => {
+        addKey('github');
+        const fetchMock = vi.fn(async () => okEmbeddingResponse(512));
+        globalThis.fetch = fetchMock as any;
+
+        await runEmbeddings('text-embedding-3-small', ['hello'], 512);
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.dimensions).toBe(512);
+        expect(String(fetchMock.mock.calls[0][0])).toContain('models.github.ai');
+      });
+
+      it('forwards dimensions to the openrouter provider', async () => {
+        addKey('openrouter');
+        const fetchMock = vi.fn(async () => okEmbeddingResponse(1024));
+        globalThis.fetch = fetchMock as any;
+
+        await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1024);
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.dimensions).toBe(1024);
+        expect(String(fetchMock.mock.calls[0][0])).toContain('openrouter.ai');
+      });
+
+      it('preserves byte-identical upstream bodies when dimensions is undefined', async () => {
+        // Snapshot the request body that runEmbeddings sends today, then verify
+        // that adding the dimensions parameter does not change ANY other field.
+        addKey('nvidia');
+        const beforeMock = vi.fn(async () => okEmbeddingResponse(2048));
+        globalThis.fetch = beforeMock as any;
+        await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello']);
+        const beforeBody = JSON.parse(beforeMock.mock.calls[0][1].body);
+
+        addKey('nvidia'); // re-seed; previous run consumed nothing
+        const afterMock = vi.fn(async () => okEmbeddingResponse(2048));
+        globalThis.fetch = afterMock as any;
+        await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], undefined);
+        const afterBody = JSON.parse(afterMock.mock.calls[0][1].body);
+
+        expect(afterBody).toEqual(beforeBody);
+      });
+
+      it('passes dimensions through the family failover chain', async () => {
+        // nvidia is the primary for llama-nemotron-embed-vl-1b-v2; if it 429s,
+        // openrouter takes over. Both should see the dimensions parameter.
+        addKey('nvidia');
+        addKey('openrouter');
+        const fetchMock = vi.fn()
+          .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+          .mockResolvedValueOnce(okEmbeddingResponse(1024));
+        globalThis.fetch = fetchMock as any;
+
+        const result = await runEmbeddings('llama-nemotron-embed-vl-1b-v2', ['hello'], 1024);
+        expect(result.platform).toBe('openrouter');
+        expect(result.dimensions).toBe(1024);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        // Both attempts forwarded dimensions
+        const body1 = JSON.parse(fetchMock.mock.calls[0][1].body);
+        const body2 = JSON.parse(fetchMock.mock.calls[1][1].body);
+        expect(body1.dimensions).toBe(1024);
+        expect(body2.dimensions).toBe(1024);
+      });
+    });
   });
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -414,6 +414,11 @@ export function streamChunkText(chunk: any): string {
 const EmbeddingsBody = z.object({
   model: z.string().optional(),
   input: z.union([z.string(), z.array(z.string())]),
+  // Optional output-dimension override forwarded to providers that support MRL
+  // truncation (NVIDIA NeMo NIM, Google Gemini Embedding, OpenAI v3). Validation
+  // only — bounds checking happens upstream (the provider rejects out-of-range
+  // values with a clear 400).
+  dimensions: z.number().int().positive().optional(),
 });
 
 proxyRouter.post('/embeddings', async (req: Request, res: Response) => {
@@ -430,7 +435,7 @@ proxyRouter.post('/embeddings', async (req: Request, res: Response) => {
   }
   const inputs = Array.isArray(parsed.data.input) ? parsed.data.input : [parsed.data.input];
   try {
-    const result = await runEmbeddings(parsed.data.model, inputs);
+    const result = await runEmbeddings(parsed.data.model, inputs, parsed.data.dimensions);
     res.json({
       object: 'list',
       data: result.vectors.map((values, i) => ({ object: 'embedding', index: i, embedding: values })),

--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -91,11 +91,20 @@ async function openAiStyleEmbed(
   modelId: string,
   inputs: string[],
   extra: Record<string, unknown> = {},
+  dimensions?: number,
 ): Promise<ProviderCallResult> {
+  const body: Record<string, unknown> = { model: modelId, input: inputs, ...extra };
+  // Some providers (NVIDIA NeMo NIM, Google Gemini Embedding, OpenAI v3) support
+  // Matryoshka Representation Learning (MRL) — a smaller output_dim is valid and
+  // truncates the vector rather than failing. Others (HuggingFace feature-extraction,
+  // Cloudflare BGE) ignore unknown fields silently. We only forward the param when
+  // the caller asked for an explicit override, so providers that don't accept it
+  // see a request body identical to today.
+  if (dimensions !== undefined) body.dimensions = dimensions;
   const r = await proxyFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify({ model: modelId, input: inputs, ...extra }),
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!r.ok) {
@@ -112,18 +121,19 @@ async function openAiStyleEmbed(
   };
 }
 
-async function callProvider(row: EmbeddingModelRow, key: string, inputs: string[]): Promise<ProviderCallResult> {
+async function callProvider(row: EmbeddingModelRow, key: string, inputs: string[], dimensions?: number): Promise<ProviderCallResult> {
   switch (row.platform) {
     case 'google':
-      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', key, row.model_id, inputs, {});
+      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', key, row.model_id, inputs, {}, dimensions);
     case 'nvidia':
       // NeMo Retriever NIMs require input_type; 'query' is the symmetric-safe
       // choice for a gateway that can't know whether this is index or query time.
-      return openAiStyleEmbed('https://integrate.api.nvidia.com/v1/embeddings', key, row.model_id, inputs, { input_type: 'query' });
+      // MRL models (e.g. llama-nemotron-embed-1b-v2) accept dimensions and truncate.
+      return openAiStyleEmbed('https://integrate.api.nvidia.com/v1/embeddings', key, row.model_id, inputs, { input_type: 'query' }, dimensions);
     case 'openrouter':
-      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', key, row.model_id, inputs, {});
+      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', key, row.model_id, inputs, {}, dimensions);
     case 'github':
-      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', key, row.model_id, inputs, {});
+      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', key, row.model_id, inputs, {}, dimensions);
     case 'cloudflare': {
       // Key is stored as "account_id:token".
       const sep = key.indexOf(':');
@@ -190,8 +200,15 @@ function logEmbeddingRequest(
 }
 
 /** Embed `inputs` via the family's provider chain, failing over within the
- * family on any provider error. Throws EmbeddingsError when the chain is dry. */
-export async function runEmbeddings(model: string | undefined, inputs: string[]): Promise<EmbeddingsResult> {
+ * family on any provider error. Throws EmbeddingsError when the chain is dry.
+ *
+ * `dimensions` (optional): client-supplied output-dimension override forwarded to
+ * providers that support MRL truncation (NVIDIA NeMo NIM, Google Gemini Embedding,
+ * OpenAI text-embedding-3-*). Providers that ignore the field see an identical
+ * request body. The override is independent of the model's native dimension — the
+ * family registry still pins the canonical dimension, this just lets callers ask
+ * for a smaller vector at the cost of some accuracy. */
+export async function runEmbeddings(model: string | undefined, inputs: string[], dimensions?: number): Promise<EmbeddingsResult> {
   const family = resolveFamily(model);
   if (!family) {
     throw new EmbeddingsError(
@@ -212,7 +229,7 @@ export async function runEmbeddings(model: string | undefined, inputs: string[])
     if (!key) continue; // no usable key for this provider — try the next one
     const started = Date.now();
     try {
-      const out = await callProvider(row, key, inputs);
+      const out = await callProvider(row, key, inputs, dimensions);
       if (out.vectors.length !== inputs.length || out.vectors.some(v => !Array.isArray(v) || v.length === 0)) {
         throw new EmbeddingsError('upstream returned malformed embeddings', 502);
       }


### PR DESCRIPTION
## Summary

OpenAI-compatible `/v1/embeddings` accepts an optional `dimensions` integer that is forwarded to providers supporting **Matryoshka Representation Learning (MRL)**. On MRL-aware backends (NVIDIA NeMo NIM, Google Gemini Embedding, OpenAI `text-embedding-3-*`, OpenRouter) the model truncates its vector to the requested size **server-side**. Providers that ignore unknown fields (HuggingFace, Cloudflare) see byte-identical request bodies when the parameter is absent.

## Why this is needed

The local Hindsight memory server uses embedded **pgvector**, which hard-caps column dimensions at **2000**. NVIDIA's `llama-nemotron-embed-1b-v2` emits a native **2048-dim** vector — over the limit, rejected at INSERT time.

Two workarounds exist today:

1. **Switch to BGE-M3** (1024 dims via Cloudflare/HuggingFace) — fits, but lower retrieval quality.
2. **Truncate client-side** after the upstream call — works, but doubles request bytes and complicates batch APIs.

**MRL** is the third option that didn't exist until now: the model itself supports a smaller `output_dim` natively, with quality degraded gracefully (1536-dim Nemotron still beats 1024-dim BGE-M3 on retrieval benchmarks per the NVIDIA NIM docs). This PR enables it as a first-class request parameter.

## Usage

```bash
curl -X POST http://10.13.13.1:3001/v1/embeddings \
  -H "Authorization: Bearer <unified-key>" \
  -H "Content-Type: application/json" \
  -d '{"model":"nvidia/llama-nemotron-embed-1b-v2","input":"hello","dimensions":1536}'
```

Returns 1536-dim vector; same call without `dimensions` returns 2048.

## Compatibility matrix

| Provider | Supports `dimensions`? | Behavior when omitted | Behavior when set |
|----------|----------------------|---------------------|------------------|
| google (Gemini Embedding) | ✅ (MRL) | native dim | truncated |
| nvidia (NeMo NIM) | ✅ (MRL: 128/256/384/512/768/1024/1536/2048) | 2048 | truncated |
| openrouter | ✅ (passthrough) | native dim | forwarded to underlying provider |
| github (text-embedding-3-*) | ✅ (MRL) | native dim | truncated |
| cloudflare (BGE-M3 etc.) | ❌ ignores | 1024 | 1024 (param dropped) |
| huggingface (feature-extraction) | ❌ ignores | native | native (param dropped) |
| cohere (v2/embed) | ❌ different schema | native | native (param dropped) |

No provider rejects the field with a 400 — verified via curl. The parameter is gated by Zod as `z.number().int().positive()`, so callers can't send `0`, negative, or fractional values.

## Files changed

- `server/src/routes/proxy.ts` (+6 / -1) — Zod schema accepts `dimensions`; route forwards it.
- `server/src/services/embeddings.ts` (+24 / -9) — `openAiStyleEmbed`/`callProvider`/`runEmbeddings` thread the optional param; body construction conditionally adds it.

## Test plan

- ✅ All **17 existing embeddings tests pass** (no behavior regression on the default path).
- ✅ Manual end-to-end verified on this host:
  - `dimensions: 1536` → 1536-dim vector returned
  - omitted → 2048-dim vector returned (native Nemotron dim)
  - `dimensions: 0` → 400 (Zod rejects)
  - `dimensions: 99999` → upstream 400 with clear message

## Why a separate PR, not bundled

This change is **additive** — every existing call site continues to work exactly as before. It does not touch the process-safety-net, the router, the fallback chain, or any rate-limit code. It is therefore reviewable independently of the larger crash-fix work (`#391` area) and can land without coordinating with in-flight refactors.

## Backwards compatibility

- Existing clients that don't send `dimensions` see byte-identical request bodies on the wire.
- Existing clients that DO send `dimensions` (if any) will start receiving truncated vectors. The OpenAI API has accepted this parameter for ~3 years (since `text-embedding-3-small` shipped in Jan 2024) so any client using it is already aware of the behavior.