### PR TITLE
fix: address urgent boot routing and desktop release bugs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -64,12 +64,62 @@ jobs:
           # root-hiding below; also makes local `desktop:dist:win` work on Windows.
           npm --prefix desktop run stage:client
 
+      - name: Validate macOS signing credentials
+        if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CSC_LINK:-}" ]; then
+            echo "Missing MACOS_CSC_LINK secret for signed macOS release builds."
+            exit 1
+          fi
+
+          has_api_key_creds=false
+          if [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
+            has_api_key_creds=true
+          fi
+
+          has_apple_id_creds=false
+          if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
+            has_apple_id_creds=true
+          fi
+
+          has_keychain_creds=false
+          if [ -n "${APPLE_KEYCHAIN_PROFILE:-}" ]; then
+            has_keychain_creds=true
+          fi
+
+          if [ "$has_api_key_creds" != true ] && [ "$has_apple_id_creds" != true ] && [ "$has_keychain_creds" != true ]; then
+            echo "Missing Apple notarization secrets. Provide APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER, APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID, or APPLE_KEYCHAIN_PROFILE."
+            exit 1
+          fi
+
       - name: Package installer
         shell: bash
         env:
-          # No signing certs in CI — build unsigned rather than failing on a
-          # missing identity. (The app already ships unsigned; see README.)
-          CSC_IDENTITY_AUTODISCOVERY: 'false'
+          # Pull-request and manual artifact builds stay unsigned. Tagged macOS
+          # release builds must use Developer ID signing + notarization so the
+          # downloaded DMG opens without Gatekeeper's "damaged" quarantine block.
+          CSC_IDENTITY_AUTODISCOVERY: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
+          APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
         run: |
           set -e
           # Run electron-builder with desktop/ as its own project root. Invoked

--- a/desktop/assets/entitlements.mac.inherit.plist
+++ b/desktop/assets/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/assets/entitlements.mac.plist
+++ b/desktop/assets/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -20,6 +20,11 @@ extraResources:
 mac:
   category: public.app-category.developer-tools
   icon: assets/icon.icns
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: assets/entitlements.mac.plist
+  entitlementsInherit: assets/entitlements.mac.inherit.plist
+  notarize: true
   target:
     - target: dmg
       arch:

--- a/server/src/__tests__/db/init-db-encryption.test.ts
+++ b/server/src/__tests__/db/init-db-encryption.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_ENCRYPTION_KEY = process.env.ENCRYPTION_KEY;
+
+let tempDir: string | undefined;
+
+function restoreEnv() {
+  if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env.ENCRYPTION_KEY;
+  else process.env.ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
+}
+
+describe('initDb encryption bootstrapping', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freellmapi-db-'));
+    process.env.ENCRYPTION_KEY = 'c'.repeat(64);
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.resetModules();
+    if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it('loads the encryption key on dev boot when migrations are already applied', async () => {
+    const dbPath = path.join(tempDir!, 'freeapi.db');
+
+    process.env.NODE_ENV = 'test';
+    vi.resetModules();
+    const firstDbModule = await import('../../db/index.js');
+    const firstCryptoModule = await import('../../lib/crypto.js');
+    const firstDb = firstDbModule.initDb(dbPath);
+    const encrypted = firstCryptoModule.encrypt('provider-secret');
+    firstDb.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES ('google', 'Google', ?, ?, ?, 'healthy', 1)
+    `).run(encrypted.encrypted, encrypted.iv, encrypted.authTag);
+    firstDb.close();
+
+    process.env.NODE_ENV = 'development';
+    vi.resetModules();
+    const secondDbModule = await import('../../db/index.js');
+    const secondCryptoModule = await import('../../lib/crypto.js');
+    const secondDb = secondDbModule.initDb(dbPath);
+    const row = secondDb.prepare(`
+      SELECT encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'google'
+    `).get() as { encrypted_key: string; iv: string; auth_tag: string };
+
+    expect(secondCryptoModule.decrypt(row.encrypted_key, row.iv, row.auth_tag)).toBe('provider-secret');
+    secondDb.close();
+  });
+});

--- a/server/src/__tests__/routes/proxy-tools-routing.test.ts
+++ b/server/src/__tests__/routes/proxy-tools-routing.test.ts
@@ -44,6 +44,16 @@ const TOOLS_RESPONSES = {
   }],
 };
 
+const BUILTIN_TOOL_RESPONSES = {
+  input: 'say hello',
+  tools: [{
+    type: 'local_shell',
+    name: 'exec_command',
+    description: 'Run a local shell command',
+    parameters: { type: 'object', properties: { cmd: { type: 'string' } } },
+  }],
+};
+
 describe('Tools-aware routing', () => {
   let app: Express;
   let key: string;
@@ -133,6 +143,16 @@ describe('Tools-aware routing', () => {
     getDb().prepare('UPDATE models SET enabled = 0 WHERE supports_tools = 1').run();
 
     const { status, body } = await post(app, '/v1/responses', TOOLS_RESPONSES, key);
+    expect(status).toBe(422);
+    expect(body.error.code).toBe('no_tools_model');
+
+    getDb().prepare('UPDATE models SET enabled = 1 WHERE supports_tools = 1').run();
+  });
+
+  it('applies the /v1/responses tools gate before dropping built-in tool descriptors', async () => {
+    getDb().prepare('UPDATE models SET enabled = 0 WHERE supports_tools = 1').run();
+
+    const { status, body } = await post(app, '/v1/responses', BUILTIN_TOOL_RESPONSES, key);
     expect(status).toBe(422);
     expect(body.error.code).toBe('no_tools_model');
 

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -143,4 +143,32 @@ describe('POST /v1/responses (#96)', () => {
     expect(text).toContain('event: response.function_call_arguments.done');
     expect(text).toContain('"arguments":"{\\"city\\":\\"SF\\"}"');
   });
+
+  it('routes built-in Responses tools through tool-capable models', async () => {
+    mockRouteRequest.mockClear();
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }));
+
+    const { status } = await post(app, '/v1/responses', {
+      input: 'say hello',
+      tools: [{
+        type: 'local_shell',
+        name: 'exec_command',
+        description: 'Run a local shell command',
+        parameters: { type: 'object', properties: { cmd: { type: 'string' } } },
+      }],
+    }, key);
+
+    expect(status).toBe(200);
+    const lastCall = mockRouteRequest.mock.calls.at(-1);
+    expect(lastCall?.[4]).toBe(true);
+  });
 });

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { runMigrationsSync } from './migrate/runner.js';
+import { initEncryptionKey, isEncryptionKeyInitialized } from '../lib/crypto.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DB_PATH = path.resolve(__dirname, '../../data/freeapi.db');
@@ -66,6 +67,8 @@ export function initDb(
       process.exit(1);
     }
   }
+
+  if (!isEncryptionKeyInitialized()) initEncryptionKey(db);
 
   return db;
 }

--- a/server/src/lib/crypto.ts
+++ b/server/src/lib/crypto.ts
@@ -82,6 +82,10 @@ function getEncryptionKey(): Buffer {
   return cachedKey;
 }
 
+export function isEncryptionKeyInitialized(): boolean {
+  return cachedKey !== null;
+}
+
 export function encrypt(text: string): { encrypted: string; iv: string; authTag: string } {
   const key = getEncryptionKey();
   const iv = crypto.randomBytes(16);

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -218,6 +218,10 @@ export function toChatToolChoice(tc?: ResponsesRequest['tool_choice']): ChatTool
   return { type: 'function', function: { name: tc.name } };
 }
 
+function requestDeclaresToolUse(req: ResponsesRequest): boolean {
+  return (req.tools?.length ?? 0) > 0 && req.tool_choice !== 'none';
+}
+
 // ── Build the final (non-stream) Responses object ─────────────────────────
 export function buildResponseObject(opts: {
   id: string;
@@ -322,7 +326,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   // name → parameter schema, for repairing double-encoded tool arguments on
   // the way back out (see lib/tool-args.ts).
   const toolSchemas = toolSchemaMap(tools);
-  const tool_choice = toChatToolChoice(reqData.tool_choice);
+  const tool_choice = tools?.length ? toChatToolChoice(reqData.tool_choice) : undefined;
   const completionOpts = {
     temperature: reqData.temperature ?? undefined,
     max_tokens: reqData.max_output_tokens ?? undefined,
@@ -344,10 +348,11 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   const requestedModelLabel = reqData.model ?? 'auto';
 
   // Tool-bearing requests (the normal case for Codex/agent clients on this
-  // endpoint) must stay on models that emit structured tool_calls — a model
-  // that serializes the call into text strands the agent harness with a
-  // "successful" run it can't act on. Mirrors the /chat/completions gate.
-  const wantsTools = (tools?.length ?? 0) > 0;
+  // endpoint) must stay on models that emit structured tool_calls. Make the
+  // routing decision from the original Responses payload, not the subset of
+  // function tools we can forward to chat providers, because Codex may include
+  // built-in tool descriptors alongside or instead of function descriptors.
+  const wantsTools = requestDeclaresToolUse(reqData);
   if (wantsTools && !hasEnabledToolsModel()) {
     res.status(422).json({
       error: {


### PR DESCRIPTION
## Summary

Fixes three urgent open issues:

- Fixes #396 by loading the encryption key during `initDb()` boot whenever the in-memory key has not been initialized yet. This covers development restarts where migrations are already marked applied, while preserving the existing migration-time initialization path.
- Fixes #371 by making `/v1/responses` decide tool-capable routing from the original Responses request, not only from the subset of function tools forwarded to chat providers. Codex-style built-in tool descriptors now still force tool-capable model routing.
- Fixes #373 by configuring macOS desktop releases for hardened-runtime signing and notarization, adding entitlements, and making tagged macOS release builds fail fast if signing/notarization secrets are missing instead of uploading another unsigned DMG.

## Reproduction / Checks

- Reproduced #396 with a regression test that writes an encrypted provider key, resets modules to simulate a fresh process, boots in development mode with migrations already applied, and verifies decrypt works.
- Confirmed #371 screenshot behavior is a literal JSON tool-call response; added Responses tests for built-in tool descriptors so these requests require tool-capable routing.
- Reproduced #373 locally against the existing macOS artifact: `codesign` reported ad-hoc signing and no team identifier, and `spctl` rejected the app.

## Validation

- `npm test -w server -- --run src/__tests__/db/init-db-encryption.test.ts src/__tests__/lib/crypto-init.test.ts src/__tests__/routes/proxy-tools-routing.test.ts src/__tests__/routes/responses.test.ts`
- `npm run build`
- `npm test -w server` — 64 files / 657 tests passed
- `npm --prefix desktop run build:all && npm --prefix desktop run stage:client && (cd desktop && CSC_IDENTITY_AUTODISCOVERY=false npx --no-install electron-builder --mac --arm64 --dir)`
- `.github/workflows/desktop-release.yml` parsed as YAML locally
