### PR TITLE
fix(desktop): pass a Scheduler to health/catalog-sync on boot

### DIFF
--- a/desktop/src/server-host.ts
+++ b/desktop/src/server-host.ts
@@ -14,6 +14,7 @@ import { initDb, getDb, getUnifiedApiKey } from '../../server/src/db/index.js';
 import { startHealthChecker } from '../../server/src/services/health.js';
 import { startCatalogSync } from '../../server/src/services/catalog-sync.js';
 import { userCount, createUser, createSession } from '../../server/src/services/auth.js';
+import { NodeScheduler } from '../../server/src/lib/scheduler.js';
 
 export { getDb, getUnifiedApiKey };
 
@@ -34,8 +35,12 @@ export async function startServer(opts: StartOptions): Promise<ServerHandle> {
   initDb(opts.dbPath);
   const app = createApp();
   const { server, port } = await listenWithScan(app, opts.host, opts.preferredPort);
-  startHealthChecker();
-  startCatalogSync();
+  // Background timers need a Scheduler since the abstraction landed (4cbb571);
+  // mirror server/src/index.ts. Without it both calls receive `undefined` and
+  // throw "reading 'every'" on the first scheduler.every() during boot.
+  const scheduler = new NodeScheduler();
+  startHealthChecker(scheduler);
+  startCatalogSync(scheduler);
   return { server, port };
 }
 


### PR DESCRIPTION
**Bug:** the desktop app crashes on launch with `Cannot read properties of undefined (reading 'every')`, before the embedded server can listen.

**Cause:** the Scheduler abstraction (4cbb571) made `startHealthChecker` and `startCatalogSync` require a `Scheduler` argument and updated `server/src/index.ts` accordingly — but `desktop/src/server-host.ts` still called them with no argument. The bundled desktop server passed `undefined`, so the first `scheduler.every(...)` during boot threw. (Latent since that refactor; surfaced on the next desktop rebuild.)

**Fix:** construct a `NodeScheduler` in `startServer()` and pass it to both, mirroring `index.ts`. One file, +7/-2.

**Verified:** desktop rebuilt and relaunched — boots cleanly through `FreeLLMAPI running on http://127.0.0.1:31415`, catalog-sync runs, `/api/ping` → 200, no TypeError. `tsc -p desktop/tsconfig.json --noEmit` clean.
