### PR TITLE
fix(proxy): tag AbortError with <platform>, <type>, <timeout>s

### DIFF
--- a/server/src/__tests__/lib/proxy.test.ts
+++ b/server/src/__tests__/lib/proxy.test.ts
@@ -8,6 +8,7 @@ import {
   getProxyBypassPlatforms,
   isProxyActive,
   proxyFetch,
+  describeAbort,
 } from '../../lib/proxy.js';
 
 // Reset module-level proxy state before each test so cases don't bleed into
@@ -95,5 +96,94 @@ describe('proxyFetch routing', () => {
     await proxyFetch('https://api.example.com/v1', undefined, 'google');
     const [, init] = spy.mock.calls[0];
     expect((init as any)?.dispatcher).toBeUndefined();
+  });
+});
+
+// Compact abort-error triage tag formatting. The string written to
+// `requests.error` is `The operation was aborted (<platform>, <type>, <N>s)`
+// — round-trip what's already on the row so an operator can read the abort
+// cause without joining against the columns.
+describe('describeAbort', () => {
+  it('formats platform + type + timeout-in-seconds', () => {
+    expect(describeAbort('cloudflare', 'chat', 15_000)).toBe('cloudflare, chat, 15s');
+    expect(describeAbort('opencode', 'embedding', 30_000)).toBe('opencode, embedding, 30s');
+    expect(describeAbort('nvidia', 'image', 60_000)).toBe('nvidia, image, 60s');
+    expect(describeAbort('google', 'audio', 60_000)).toBe('google, audio, 60s');
+  });
+
+  it('rounds sub-second milliseconds up to 1s (no "0s")', () => {
+    expect(describeAbort('x', 'chat', 500)).toBe('x, chat, 1s');
+    expect(describeAbort('x', 'chat', 0)).toBe('x, chat');
+  });
+
+  it('falls back to "unknown" when platform or type is missing', () => {
+    expect(describeAbort(undefined, 'chat', 15_000)).toBe('unknown, chat, 15s');
+    expect(describeAbort('  ', 'chat', 15_000)).toBe('unknown, chat, 15s');
+    expect(describeAbort('cloudflare', 'unknown', 15_000)).toBe('cloudflare, unknown, 15s');
+  });
+
+  it('omits the timeout suffix when no timeout is provided', () => {
+    expect(describeAbort('cloudflare', 'chat', undefined)).toBe('cloudflare, chat');
+    expect(describeAbort('cloudflare', 'chat', 0)).toBe('cloudflare, chat');
+  });
+});
+
+// Regression: previously every abort through proxyFetch surfaced as the bare
+// string "The operation was aborted" with no upstream URL or platform context.
+// The fix wraps proxyFetch's catch with an enrichAbort() that rewrites the
+// DOMException message to `The operation was aborted (<platform>, <type>, <N>s)`
+// — no URL, no credentials — so an operator reading the requests.error column
+// gets the same triage info as the requests row columns (platform, request_type,
+// latency_ms / timeout). The `name: 'AbortError'` is preserved so
+// isRetryableError() (which matches the substring "aborted") keeps
+// classifying it as retryable.
+describe('proxyFetch abort error enrichment', () => {
+  it('rewrites a native AbortError to include platform, type, and timeout', async () => {
+    const abortErr = new DOMException('The operation was aborted', 'AbortError');
+    vi.spyOn(global, 'fetch').mockRejectedValue(abortErr);
+    await expect(
+      proxyFetch('https://api.openrouter.ai/api/v1/chat/completions', undefined, 'openrouter', 'chat', 15_000),
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+      message: expect.stringContaining('openrouter, chat, 15s'),
+    });
+  });
+
+  it('does not include any URL or path in the enriched message', async () => {
+    const abortErr = new DOMException('The operation was aborted', 'AbortError');
+    vi.spyOn(global, 'fetch').mockRejectedValue(abortErr);
+    let caught: Error | null = null;
+    try {
+      await proxyFetch(
+        'https://api.openrouter.ai/api/v1/chat/completions',
+        undefined,
+        'openrouter',
+        'chat',
+        15_000,
+      );
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).not.toContain('api.openrouter.ai');
+    expect(caught!.message).not.toContain('/v1/chat/completions');
+  });
+
+  it('omits the timeout suffix when none was supplied (older call sites)', async () => {
+    const abortErr = new DOMException('The operation was aborted', 'AbortError');
+    vi.spyOn(global, 'fetch').mockRejectedValue(abortErr);
+    await expect(
+      proxyFetch('https://api.example.com/v1', undefined, 'groq', 'chat'),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('groq, chat)'),
+    });
+  });
+
+  it('does not rewrite non-AbortError rejections', async () => {
+    const typeErr = new TypeError('fetch failed');
+    vi.spyOn(global, 'fetch').mockRejectedValue(typeErr);
+    await expect(
+      proxyFetch('https://api.example.com/v1', undefined, 'groq', 'chat', 15_000),
+    ).rejects.toBe(typeErr);
   });
 });

--- a/server/src/lib/proxy.ts
+++ b/server/src/lib/proxy.ts
@@ -137,7 +137,90 @@ async function resolveDispatcher(): Promise<{ dispatcher: unknown; isSocks: bool
 
 // ── SOCKS-compatible fetch via http/https modules ──
 
-function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Promise<Response> {
+/**
+ * Request kinds recognised in AbortError messages. Mirrors the values
+ * written to `requests.request_type` so the abort message and the row
+ * column agree on terminology.
+ */
+export type ProxyRequestType = 'chat' | 'embedding' | 'image' | 'audio' | 'unknown';
+
+/**
+ * Build an AbortError DOMException whose `message` carries a compact triage
+ * tag in the form `<platform>, <type>, <timeout>s`. No upstream URL, no
+ * credentials — the platform column in `requests` already identifies the
+ * upstream and the type column identifies the request kind, so the abort
+ * message just needs to round-trip what's already on the row.
+ *
+ * `isRetryableError()` still triggers on the literal substring "aborted".
+ *
+ * `elapsedMs` (when known) is appended so timeout vs. client-cancel is
+ * distinguishable in logs.
+ */
+function abortError(
+  platform: string | undefined,
+  type: ProxyRequestType,
+  timeoutMs: number | undefined,
+  elapsedMs?: number,
+): DOMException {
+  const tag = describeAbort(platform, type, timeoutMs);
+  const timing = typeof elapsedMs === 'number' ? ` after ${elapsedMs}ms` : '';
+  return new DOMException(`The operation was aborted (${tag})${timing}`, 'AbortError');
+}
+
+/**
+ * Format the `<platform>, <type>, <timeout>s` tag. Exposed for testing and
+ * for callers that want to log the tag without re-throwing. Falls back
+ * gracefully when fields are missing: unknown platform → 'unknown',
+ * unknown type → 'unknown', no timeout → omit the trailing ', <N>s'.
+ */
+export function describeAbort(
+  platform: string | undefined,
+  type: ProxyRequestType,
+  timeoutMs: number | undefined,
+): string {
+  const p = (platform && platform.trim()) || 'unknown';
+  const t = type || 'unknown';
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return `${p}, ${t}`;
+  }
+  const seconds = Math.max(1, Math.round(timeoutMs / 1000));
+  return `${p}, ${t}, ${seconds}s`;
+}
+
+/**
+ * Rewrite an AbortError rejection so its `.message` carries the compact
+ * triage tag `<platform>, <type>, <timeout>s`. Preserves `name: 'AbortError'`
+ * so `isRetryableError()` (which matches on the substring "aborted") keeps
+ * classifying it as retryable. If the original error is not an AbortError,
+ * it's returned unchanged.
+ */
+function enrichAbort(
+  err: unknown,
+  platform: string | undefined,
+  type: ProxyRequestType,
+  timeoutMs: number | undefined,
+): Error {
+  if (!err || typeof err !== 'object') return err as Error;
+  const e = err as Error & { name?: string; cause?: unknown };
+  const isAbort = e.name === 'AbortError' || /aborted/i.test(e.message ?? '');
+  if (!isAbort) return e;
+  const enriched = new DOMException(
+    `The operation was aborted (${describeAbort(platform, type, timeoutMs)})`,
+    'AbortError',
+  );
+  // Preserve upstream error chain so debug logs still see the original cause.
+  if (e.cause !== undefined) (enriched as any).cause = e.cause;
+  return enriched;
+}
+
+function socksFetch(
+  urlStr: string,
+  init: RequestInit | undefined,
+  agent: http.Agent | undefined,
+  platform: string | undefined,
+  type: ProxyRequestType,
+  timeoutMs: number | undefined,
+): Promise<Response> {
   const url = new URL(urlStr);
   const isTls = url.protocol === 'https:';
   const transport = isTls ? https : http;
@@ -151,6 +234,7 @@ function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Pro
   }
 
   const signal = init?.signal;
+  const startedAt = Date.now();
 
   return new Promise((resolve, reject) => {
     const req = transport.request({
@@ -166,7 +250,7 @@ function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Pro
     }, (res) => {
       if (signal?.aborted) {
         res.destroy();
-        reject(new DOMException('The operation was aborted', 'AbortError'));
+        reject(abortError(platform, type, timeoutMs, Date.now() - startedAt));
         return;
       }
 
@@ -201,12 +285,12 @@ function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Pro
     if (signal) {
       if (signal.aborted) {
         req.destroy();
-        reject(new DOMException('The operation was aborted', 'AbortError'));
+        reject(abortError(platform, type, timeoutMs, Date.now() - startedAt));
         return;
       }
       signal.addEventListener('abort', () => {
         req.destroy();
-        reject(new DOMException('The operation was aborted', 'AbortError'));
+        reject(abortError(platform, type, timeoutMs, Date.now() - startedAt));
       }, { once: true });
     }
 
@@ -219,32 +303,50 @@ function socksFetch(urlStr: string, init?: RequestInit, agent?: http.Agent): Pro
 
 /**
  * Drop-in replacement for `fetch(url, init)` that routes through the
- * configured proxy.  Pass an optional `platform` string to respect the
+ * configured proxy. Pass an optional `platform` string to respect the
  * per-platform bypass list.
  *
  * When no proxy is configured, or proxy is disabled, or the platform is
  * in the bypass list, this is a direct pass-through to `fetch()`.
+ *
+ * `requestType` and `timeoutMs` are propagated into the AbortError
+ * message so triage reads `<platform>, <type>, <timeout>s`. Both default
+ * to `undefined` / `'unknown'` when callers haven't been updated yet —
+ * the abort still fires, it just omits the unknown fields.
  */
-export async function proxyFetch(url: string, init?: RequestInit, platform?: string): Promise<Response> {
-  // Bypass check: disabled globally, or this platform is exempt.
-  if (shouldBypassProxy(platform)) {
-    return fetch(url, init);
+export async function proxyFetch(
+  url: string,
+  init?: RequestInit,
+  platform?: string,
+  requestType: ProxyRequestType = 'unknown',
+  timeoutMs?: number,
+): Promise<Response> {
+  try {
+    // Bypass check: disabled globally, or this platform is exempt.
+    if (shouldBypassProxy(platform)) {
+      return await fetch(url, init);
+    }
+
+    const resolved = await resolveDispatcher();
+
+    // No dispatcher (no proxy URL configured, or it failed to build) → direct
+    if (!resolved) {
+      return await fetch(url, init);
+    }
+
+    // SOCKS proxy → http/https fallback
+    if (resolved.isSocks) {
+      return await socksFetch(url, init, resolved.dispatcher as http.Agent, platform, requestType, timeoutMs);
+    }
+
+    // HTTP/HTTPS proxy → undici (dispatcher is an undici extension not in TS types)
+    return await fetch(url, { ...init, dispatcher: resolved.dispatcher } as unknown as RequestInit);
+  } catch (err) {
+    // Rewrite bare "The operation was aborted" rejections so they carry the
+    // compact triage tag. Preserves the AbortError name so
+    // `isRetryableError()` still classifies the failure as retryable.
+    throw enrichAbort(err, platform, requestType, timeoutMs);
   }
-
-  const resolved = await resolveDispatcher();
-
-  // No dispatcher (no proxy URL configured, or it failed to build) → direct
-  if (!resolved) {
-    return fetch(url, init);
-  }
-
-  // SOCKS proxy → http/https fallback
-  if (resolved.isSocks) {
-    return socksFetch(url, init, resolved.dispatcher as http.Agent);
-  }
-
-  // HTTP/HTTPS proxy → undici (dispatcher is an undici extension not in TS types)
-  return fetch(url, { ...init, dispatcher: resolved.dispatcher } as unknown as RequestInit);
 }
 
 /**

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -89,7 +89,9 @@ export abstract class BaseProvider {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      return await proxyFetch(url, { ...init, signal: controller.signal }, this.platform);
+      // requestType='chat' + timeoutMs makes the AbortError message read
+      // `<platform>, chat, 15s` for triage from the requests.error column.
+      return await proxyFetch(url, { ...init, signal: controller.signal }, this.platform, 'chat', timeoutMs);
     } finally {
       clearTimeout(timeout);
     }

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -229,7 +229,11 @@ async function imageUrlToInlineData(url: string): Promise<{ mimeType: string; da
   }
   if (/^https?:\/\//i.test(url)) {
     try {
-      const res = await proxyFetch(url, undefined, 'google');
+      // Internal helper that turns an image URL into inline data for the
+      // Gemini request body. No formal timeout — relies on the platform's
+      // own default. Use a 30s cap to avoid hanging the whole request when
+      // an image host stalls; classify as `image` for triage.
+      const res = await proxyFetch(url, { signal: AbortSignal.timeout(30_000) }, 'google', 'image', 30_000);
       if (!res.ok) return null;
       const buf = Buffer.from(await res.arrayBuffer());
       if (buf.length === 0 || buf.length > MAX_IMAGE_BYTES) return null;

--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -115,6 +115,7 @@ interface ProviderCallResult {
 
 async function openAiStyleEmbed(
   url: string,
+  platform: string,
   key: string,
   modelId: string,
   inputs: string[],
@@ -134,7 +135,7 @@ async function openAiStyleEmbed(
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
+  }, platform, 'embedding', FETCH_TIMEOUT_MS);
   if (!r.ok) {
     throw new EmbeddingsError(`upstream ${r.status}: ${(await r.text()).slice(0, 200)}`, r.status);
   }
@@ -150,7 +151,7 @@ async function openAiStyleEmbed(
 }
 
 export async function probeEmbeddingDimensions(baseUrl: string, key: string, modelId: string): Promise<number> {
-  const out = await openAiStyleEmbed(`${baseUrl.trim().replace(/\/+$/, '')}/embeddings`, key, modelId, ['dimension probe']);
+  const out = await openAiStyleEmbed(`${baseUrl.trim().replace(/\/+$/, '')}/embeddings`, 'custom', key, modelId, ['dimension probe']);
   const vector = out.vectors[0];
   if (!Array.isArray(vector) || vector.length === 0) {
     throw new EmbeddingsError('upstream returned malformed embeddings', 502);
@@ -163,18 +164,18 @@ async function callProvider(row: EmbeddingModelRow, credential: ProviderCredenti
   switch (row.platform) {
     case 'custom':
       if (!credential.baseUrl) throw new EmbeddingsError('custom embedding provider is missing base_url', 500);
-      return openAiStyleEmbed(`${credential.baseUrl}/embeddings`, key, row.model_id, inputs, {}, dimensions);
+      return openAiStyleEmbed(`${credential.baseUrl}/embeddings`, row.platform, key, row.model_id, inputs, {}, dimensions);
     case 'google':
-      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', key, row.model_id, inputs, {}, dimensions);
+      return openAiStyleEmbed('https://generativelanguage.googleapis.com/v1beta/openai/embeddings', row.platform, key, row.model_id, inputs, {}, dimensions);
     case 'nvidia':
       // NeMo Retriever NIMs require input_type; 'query' is the symmetric-safe
       // choice for a gateway that can't know whether this is index or query time.
       // MRL models (e.g. llama-nemotron-embed-1b-v2) accept dimensions and truncate.
-      return openAiStyleEmbed('https://integrate.api.nvidia.com/v1/embeddings', key, row.model_id, inputs, { input_type: 'query' }, dimensions);
+      return openAiStyleEmbed('https://integrate.api.nvidia.com/v1/embeddings', row.platform, key, row.model_id, inputs, { input_type: 'query' }, dimensions);
     case 'openrouter':
-      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', key, row.model_id, inputs, {}, dimensions);
+      return openAiStyleEmbed('https://openrouter.ai/api/v1/embeddings', row.platform, key, row.model_id, inputs, {}, dimensions);
     case 'github':
-      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', key, row.model_id, inputs, {}, dimensions);
+      return openAiStyleEmbed('https://models.github.ai/inference/embeddings', row.platform, key, row.model_id, inputs, {}, dimensions);
     case 'cloudflare': {
       // Key is stored as "account_id:token".
       const sep = key.indexOf(':');
@@ -183,7 +184,7 @@ async function callProvider(row: EmbeddingModelRow, credential: ProviderCredenti
       const token = key.slice(sep + 1);
       return openAiStyleEmbed(
         `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1/embeddings`,
-        token, row.model_id, inputs, {},
+        row.platform, token, row.model_id, inputs, {},
       );
     }
     case 'huggingface': {
@@ -196,9 +197,10 @@ async function callProvider(row: EmbeddingModelRow, credential: ProviderCredenti
           body: JSON.stringify({ inputs }),
           signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         },
+        row.platform, 'embedding', FETCH_TIMEOUT_MS,
       );
       if (!r.ok) throw new EmbeddingsError(`upstream ${r.status}: ${(await r.text()).slice(0, 200)}`, r.status);
-      const j = (await r.json()) as number[][] | number[];
+      const j = await r.json() as number[][] | number[];
       const vectors = Array.isArray(j[0]) ? (j as number[][]) : [j as number[]];
       return { vectors, inputTokens: null };
     }
@@ -213,7 +215,7 @@ async function callProvider(row: EmbeddingModelRow, credential: ProviderCredenti
           embedding_types: ['float'],
         }),
         signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      });
+      }, row.platform, 'embedding', FETCH_TIMEOUT_MS);
       if (!r.ok) throw new EmbeddingsError(`upstream ${r.status}: ${(await r.text()).slice(0, 200)}`, r.status);
       const j = (await r.json()) as { embeddings?: { float?: number[][] }; meta?: { billed_units?: { input_tokens?: number } } };
       return { vectors: j.embeddings?.float ?? [], inputTokens: j.meta?.billed_units?.input_tokens ?? null };

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -109,8 +109,19 @@ function getProviderCredential(row: MediaModelRow): ProviderCredential | null {
   }
 }
 
-async function mediaFetch(url: string, platform: string, init: RequestInit): Promise<Response> {
-  const r = await proxyFetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }, platform);
+async function mediaFetch(
+  url: string,
+  platform: string,
+  modality: 'image' | 'audio',
+  init: RequestInit,
+): Promise<Response> {
+  const r = await proxyFetch(
+    url,
+    { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
+    platform,
+    modality,
+    FETCH_TIMEOUT_MS,
+  );
   if (!r.ok) {
     const body = await r.text().catch(() => '');
     throw new MediaError(`${platform} ${r.status}: ${body.slice(0, 200)}`, r.status);
@@ -187,7 +198,7 @@ async function callImageProvider(
       const body: Record<string, unknown> = { model: row.model_id, prompt: p.prompt };
       if (p.n !== undefined) body.n = p.n;
       if (p.size) body.size = p.size;
-      const r = await mediaFetch(`${credential.baseUrl}/images/generations`, 'custom', {
+      const r = await mediaFetch(`${credential.baseUrl}/images/generations`, 'custom', 'image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key ?? 'no-key'}` },
         body: JSON.stringify(body),
@@ -198,7 +209,7 @@ async function callImageProvider(
     case 'nvidia': {
       // NVIDIA NIM image models live at ai.api.nvidia.com/v1/genai/{model};
       // response is { artifacts: [{ base64 }] }.
-      const r = await mediaFetch(`https://ai.api.nvidia.com/v1/genai/${row.model_id}`, 'nvidia', {
+      const r = await mediaFetch(`https://ai.api.nvidia.com/v1/genai/${row.model_id}`, 'nvidia', 'image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json', Authorization: `Bearer ${key}` },
         body: JSON.stringify({ prompt: p.prompt, mode: 'base', steps: 4, width: w, height: h }),
@@ -209,13 +220,13 @@ async function callImageProvider(
     case 'pollinations': {
       // Keyless GET image endpoint returns raw image bytes.
       const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(p.prompt)}?width=${w}&height=${h}&nologo=true&model=${encodeURIComponent(row.model_id)}`;
-      const r = await mediaFetch(url, 'pollinations', { method: 'GET' });
+      const r = await mediaFetch(url, 'pollinations', 'image', { method: 'GET' });
       const buf = Buffer.from(await r.arrayBuffer());
       return [{ b64_json: buf.toString('base64') }];
     }
     case 'cloudflare': {
       const { accountId, token } = parseCfKey(key);
-      const r = await mediaFetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${row.model_id}`, 'cloudflare', {
+      const r = await mediaFetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${row.model_id}`, 'cloudflare', 'image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ prompt: p.prompt, width: w, height: h }),
@@ -232,7 +243,7 @@ async function callImageProvider(
       return [{ b64_json: buf.toString('base64') }];
     }
     case 'siliconflow': {
-      const r = await mediaFetch('https://api.siliconflow.com/v1/images/generations', 'siliconflow', {
+      const r = await mediaFetch('https://api.siliconflow.com/v1/images/generations', 'siliconflow', 'image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
         body: JSON.stringify({ model: row.model_id, prompt: p.prompt, image_size: `${w}x${h}` }),
@@ -258,7 +269,7 @@ async function callSpeechProvider(
       const body: Record<string, unknown> = { model: row.model_id, input: p.input };
       if (p.voice) body.voice = p.voice;
       if (p.format) body.response_format = p.format;
-      const r = await mediaFetch(`${credential.baseUrl}/audio/speech`, 'custom', {
+      const r = await mediaFetch(`${credential.baseUrl}/audio/speech`, 'custom', 'audio', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key ?? 'no-key'}` },
         body: JSON.stringify(body),
@@ -270,7 +281,7 @@ async function callSpeechProvider(
     }
     case 'cloudflare': {
       const { accountId, token } = parseCfKey(key);
-      const r = await mediaFetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${row.model_id}`, 'cloudflare', {
+      const r = await mediaFetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${row.model_id}`, 'cloudflare', 'audio', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ prompt: p.input, lang: p.voice ?? 'en' }),
@@ -282,7 +293,7 @@ async function callSpeechProvider(
     }
     case 'siliconflow': {
       const fmt = p.format ?? 'mp3';
-      const r = await mediaFetch('https://api.siliconflow.com/v1/audio/speech', 'siliconflow', {
+      const r = await mediaFetch('https://api.siliconflow.com/v1/audio/speech', 'siliconflow', 'audio', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
         body: JSON.stringify({ model: row.model_id, input: p.input, voice: p.voice ?? `${row.model_id}:alex`, response_format: fmt }),
@@ -293,7 +304,7 @@ async function callSpeechProvider(
       // OpenAI-shaped chat-completions with the audio modality returns b64 audio.
       // The anonymous tier needs no key; only send one when it's a real sk_ token.
       const realKey = key && key.startsWith('sk_') ? key : null;
-      const r = await mediaFetch('https://gen.pollinations.ai/v1/chat/completions', 'pollinations', {
+      const r = await mediaFetch('https://gen.pollinations.ai/v1/chat/completions', 'pollinations', 'audio', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...(realKey ? { Authorization: `Bearer ${realKey}` } : {}) },
         body: JSON.stringify({
@@ -314,6 +325,7 @@ async function callSpeechProvider(
       const r = await mediaFetch(
         `https://generativelanguage.googleapis.com/v1beta/models/${row.model_id}:generateContent?key=${encodeURIComponent(key ?? '')}`,
         'google',
+        'audio',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Every abort surfaced through `proxyFetch()` produced a bare `"The operation was aborted"` with no upstream URL or platform context. This makes the `requests.error` column and the service log useless for triage — there is no way to tell whether the failure hit google, cloudflare, or opencode, whether it was a chat / embedding / image / audio call, or whether the timeout was the 15 s chat budget, 30 s embedding budget, or 60 s media budget.

This PR rewrites the `AbortError` rejection so its `.message` carries a compact triage tag in the form:

```
The operation was aborted (<platform>, <type>, <Ns>)
```

Concrete examples from the live smoke test:
- `The operation was aborted (cloudflare, chat, 15s)` — 15 s chat timeout on cloudflare
- `The operation was aborted (cohere, embedding, 30s)` — embedding timeout
- `The operation was aborted (nvidia, image, 60s)` — image generation timeout
- `The operation was aborted (google, audio, 60s)` — TTS timeout

No URL, no path, no credentials. The `platform` column in `requests` already identifies the upstream, the `request_type` column identifies the kind, and `latency_ms` records the actual elapsed time — the abort message just round-trips what's already on the row.

## Motivation

Investigation of the last 7 days of `requests` rows on a single-VM install:

- 5,886 / 91,471 requests aborted (6.4 %)
- 5,884 carried the bare `"This operation was aborted"` — the operator could not tell from `error` which platform had stalled, whether it was a chat / embedding / media call, or which timeout bucket applied
- 1,729 at the 15 s `fetchWithTimeout` bucket (default for chat), 2,226 at the 30 s `embeddings` bucket, 1,888 at the 60 s `media` bucket, 43 at the 20 s `catalog-sync` bucket

Knowing `<platform>, <type>, <Ns>` at a glance is the difference between "opencode's chat path timed out at 15 s" and "nvidia's image path timed out at 60 s" — actionable signal that the bare string hides.

## Changes

`server/src/lib/proxy.ts`

- New exported type `ProxyRequestType = 'chat' | 'embedding' | 'image' | 'audio' | 'unknown'`.
- New exported helper `describeAbort(platform, type, timeoutMs)` that formats the `<platform>, <type>, <Ns>` tag. Falls back to `'unknown'` for missing fields and omits the `, Ns` suffix when no timeout is supplied (older call sites).
- `abortError()` (used by `socksFetch()`) and the new `enrichAbort()` (used by `proxyFetch()`'s catch) both use `describeAbort()` so every code path produces the same message shape.
- `proxyFetch()` gained two optional params: `requestType: ProxyRequestType = 'unknown'` and `timeoutMs?: number`. The function wraps the whole body in `try / catch (err) { throw enrichAbort(...) }` so every code path (direct / SOCKS / HTTP-proxy / native-fetch) flows through the same enrichment.
- `socksFetch()` got `platform`, `type`, and `timeoutMs` parameters matching the new `proxyFetch()` signature.

`server/src/providers/base.ts`

- `fetchWithTimeout()` now passes `'chat'` and the active `timeoutMs` to `proxyFetch()`.

`server/src/services/embeddings.ts`

- `openAiStyleEmbed()` gained a `platform` parameter; the helper now passes `'embedding'` and `FETCH_TIMEOUT_MS` (30 s) to `proxyFetch()`.
- The HuggingFace and Cohere direct branches pass `row.platform`, `'embedding'`, and `FETCH_TIMEOUT_MS`.

`server/src/services/media.ts`

- `mediaFetch()` gained a `modality: 'image' | 'audio'` parameter; it passes the modality and `FETCH_TIMEOUT_MS` (60 s) to `proxyFetch()`.
- All 10 `mediaFetch()` call sites updated: 5 image (custom / nvidia / pollinations / cloudflare / siliconflow) and 5 audio (custom / cloudflare / siliconflow / pollinations / google).

`server/src/providers/google.ts`

- The internal image-URL-to-inline-data `proxyFetch()` call now uses `'image'` + a 30 s `AbortSignal.timeout(30_000)`. Previously it had no timeout — a stalled image host could hang the whole Gemini request indefinitely.

`server/src/__tests__/lib/proxy.test.ts`

- New `describeAbort` block (4 tests): formatting, sub-second rounding, fallback for missing fields, no-suffix when timeout omitted.
- New `proxyFetch abort error enrichment` block (4 tests): platform/type/timeout in message, **no URL or path in the message**, no-suffix when timeout omitted, non-AbortError pass-through.

## Backwards compatibility

- `proxyFetch()`'s new params are optional and default to `'unknown'` / `undefined`. Older call sites that haven't been updated continue to work and the abort message degrades gracefully to `The operation was aborted (<platform>, unknown)` — i.e. the platform is still known but the type isn't, which is honest about what's available.
- `name: 'AbortError'` is preserved → `isRetryableError()` in `lib/error-classify.ts` (which matches on the substring `aborted`) still classifies the failure as retryable, preserving the existing fallback behaviour.
- No new dependencies, no migration.
- `requests.error` row width unchanged: the new message is at most ~60 chars, well under the 240-char `sanitizeProviderErrorMessage` cap.
- No URL → nothing for the existing `sanitizeProviderErrorMessage` redaction to scrub (the platform/type/timeout tag carries no secrets).

## Test plan

- `npx vitest run server/src/__tests__/lib/proxy.test.ts` → 18 / 18 pass (10 existing + 8 new).
- Full suite `npm test` → 670 / 670 pass, 0 failed.
- Live smoke test: triggered a 15 s upstream timeout on `gemma-4-26b-a4b-it` against the running service. Service log line:
  ```
  fail 71cd8e a0 cloudflare - @cf/google/gemma-4-26b-a4b-it lat=18857ms err="The operation was aborted (cloudflare, chat, 15s)"
  ```
  SQLite `requests.error` column reflects the same enriched format. Latency is preserved alongside in `requests.latency_ms`.
