### PR TITLE
feat(analytics): hourly aggregates + lifetime/30d counters survive raw-row prune

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -7,6 +7,7 @@ import { up as runLegacyBaseline } from '../../../db/migrations/20260101_000000_
 const LEGACY_BASELINE_FILENAME = '20260101_000000_legacy_baseline.ts';
 const CUSTOM_PROVIDER_MODALITIES_FILENAME = '20260627_000001_custom_provider_modalities.ts';
 const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state.ts';
+const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 
 interface SchemaRow {
   type: string;
@@ -60,6 +61,7 @@ describe('migration round trip', () => {
         LEGACY_BASELINE_FILENAME,
         CUSTOM_PROVIDER_MODALITIES_FILENAME,
         CATALOG_MODEL_STATE_FILENAME,
+        REQUEST_AGGREGATES_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -26,6 +26,7 @@ function insertRequest(createdAt: string) {
     INSERT INTO requests (platform, model_id, status, input_tokens, output_tokens, latency_ms, error, created_at)
     VALUES ('test', 'test-model', 'success', 1, 2, 3, NULL, ?)
   `).run(createdAt);
+  upsertAggregate(db, createdAt, 'success', 1, 2);
 }
 
 function insertTokensRequest(
@@ -41,6 +42,42 @@ function insertTokensRequest(
     INSERT INTO requests (platform, model_id, status, input_tokens, output_tokens, latency_ms, error, created_at)
     VALUES (?, ?, ?, ?, ?, 3, NULL, ?)
   `).run(platform, modelId, status, inputTokens, outputTokens, createdAt);
+  upsertAggregate(db, createdAt, status, inputTokens, outputTokens);
+}
+
+// Mirror the production aggregates written by lib/request-log.logRequest so the
+// summary endpoint (which now reads from request_hourly + settings) stays
+// faithful to what real traffic produces.
+function upsertAggregate(
+  db: ReturnType<typeof getDb>,
+  createdAt: string,
+  status: 'success' | 'error',
+  inputTokens: number,
+  outputTokens: number,
+) {
+  const hour = createdAt.slice(0, 13).replace(' ', 'T') + ':00:00';
+  const isSuccess = status === 'success' ? 1 : 0;
+  const isError = status === 'error' ? 1 : 0;
+  db.prepare(`
+    INSERT INTO request_hourly (hour, total_requests, success_count, error_count, input_tokens, output_tokens)
+    VALUES (?, 1, ?, ?, ?, ?)
+    ON CONFLICT(hour) DO UPDATE SET
+      total_requests = total_requests + 1,
+      success_count  = success_count + ?,
+      error_count    = error_count + ?,
+      input_tokens   = input_tokens + ?,
+      output_tokens  = output_tokens + ?
+  `).run(hour, isSuccess, isError, inputTokens, outputTokens, isSuccess, isError, inputTokens, outputTokens);
+
+  const incr = db.prepare(`
+    INSERT INTO settings (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + ? AS TEXT)
+  `);
+  incr.run('total_requests', '1', 1);
+  incr.run('total_input_tokens', String(inputTokens), inputTokens);
+  incr.run('total_output_tokens', String(outputTokens), outputTokens);
+  db.prepare(`INSERT INTO settings (key, value) VALUES ('first_request_at', ?)
+    ON CONFLICT(key) DO NOTHING`).run(createdAt);
 }
 
 describe('Analytics API', () => {
@@ -55,6 +92,8 @@ describe('Analytics API', () => {
 
   beforeEach(() => {
     getDb().prepare('DELETE FROM requests').run();
+    getDb().prepare('DELETE FROM request_hourly').run();
+    getDb().prepare(`DELETE FROM settings WHERE key IN ('total_requests','total_input_tokens','total_output_tokens','first_request_at')`).run();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'));
   });
@@ -137,6 +176,7 @@ describe('Analytics API', () => {
         INSERT INTO requests (platform, model_id, requested_model, status, input_tokens, output_tokens, latency_ms, error, created_at)
         VALUES ('test', ?, ?, 'success', 1, 2, 3, NULL, ?)
       `).run(modelId, requestedModel, createdAt);
+      upsertAggregate(getDb(), createdAt, 'success', 1, 2);
     }
 
     it('summary splits pinned, honored, and auto requests', async () => {

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { getDb, initDb } from '../../db/index.js';
+import { logRequest } from '../../lib/request-log.js';
 import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 
 let dashToken = '';
@@ -55,7 +56,10 @@ function upsertAggregate(
   inputTokens: number,
   outputTokens: number,
 ) {
-  const hour = createdAt.slice(0, 13).replace(' ', 'T') + ':00:00';
+  // Mirror logRequest.hourKey() exactly: created_at truncated to the hour in
+  // SQLite's canonical 'YYYY-MM-DD HH:00:00' text (space separator). Using a 'T'
+  // here would diverge from production and mask a writer/reader format mismatch.
+  const hour = createdAt.slice(0, 13) + ':00:00';
   const isSuccess = status === 'success' ? 1 : 0;
   const isError = status === 'error' ? 1 : 0;
   db.prepare(`
@@ -127,6 +131,42 @@ describe('Analytics API', () => {
 
     expect(status).toBe(200);
     expect(body.totalRequests).toBe(2);
+  });
+
+  // Regression guard for the hour-key FORMAT written by the real production
+  // writer (lib/request-log.logRequest). The bug this prevents: the writer
+  // stores keys as SQLite's 'YYYY-MM-DD HH:00:00' (space), but the summary
+  // reader compared against a '...T...' cutoff, so every bucket on the window's
+  // boundary day was silently dropped. The other summary tests seed via the
+  // local upsertAggregate() helper; this one pins the writer's actual output so
+  // the two can't drift apart unnoticed. Real timers so SQLite's datetime('now')
+  // and getSinceTimestamp() agree on "now".
+  it('logRequest writes space-format hour keys and they round-trip through summary', async () => {
+    vi.useRealTimers();
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'success', 100, 50, 12, null);
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'success', 200, 70, 15, null);
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'error', 30, 0, 9, 'boom');
+
+    // Tight, clock-independent guard: the stored key must match SQLite's
+    // created_at text shape (space separator), never a 'T'. A 'T' here is the
+    // exact desync that made the summary undercount the boundary day.
+    const hours = getDb()
+      .prepare('SELECT hour FROM request_hourly')
+      .all() as Array<{ hour: string }>;
+    expect(hours.length).toBeGreaterThanOrEqual(1); // normally 1 bucket; >1 only if the run straddled an hour tick
+    for (const { hour } of hours) {
+      expect(hour).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:00:00$/);
+      expect(hour).not.toContain('T');
+    }
+
+    const { status, body } = await request(app, '/api/analytics/summary?range=24h');
+    expect(status).toBe(200);
+    expect(body.totalRequests).toBe(3);
+    expect(body.totalInputTokens).toBe(330);
+    expect(body.totalOutputTokens).toBe(120);
+    expect(body.successRate).toBe(66.7);
+    // Lifetime counter is window-independent; sourced from settings, not buckets.
+    expect(body.lifetimeTotalRequests).toBe(3);
   });
 
   it('prices savings at the served model paid-equivalent rate', async () => {

--- a/server/src/__tests__/services/request-retention.test.ts
+++ b/server/src/__tests__/services/request-retention.test.ts
@@ -95,9 +95,11 @@ describe('request analytics retention', () => {
     )`).run();
     const upsert = db.prepare(`INSERT INTO request_hourly (hour, total_requests) VALUES (?, ?)
       ON CONFLICT(hour) DO UPDATE SET total_requests = excluded.total_requests`);
-    upsert.run('2026-05-01T00:00:00', 5);   // outside 30d window from May 31
-    upsert.run('2026-05-15T00:00:00', 3);   // inside
-    upsert.run('2026-05-31T00:00:00', 7);   // boundary hour, kept
+    // Seed in the same 'YYYY-MM-DD HH:00:00' (space) format production writes,
+    // so the prune cutoff (also space) compares apples-to-apples.
+    upsert.run('2026-05-01 00:00:00', 5);   // outside 30d window from May 31
+    upsert.run('2026-05-15 00:00:00', 3);   // inside
+    upsert.run('2026-05-31 00:00:00', 7);   // boundary hour, kept
 
     // First call (cold gate): should prune the May 1 row and leave the rest.
     const first = pruneRequestAnalytics({
@@ -107,7 +109,7 @@ describe('request analytics retention', () => {
     });
     expect(first.deleted).toBe(1);
     const remaining = db.prepare(`SELECT hour, total_requests FROM request_hourly ORDER BY hour`).all() as Array<{ hour: string; total_requests: number }>;
-    expect(remaining.map(r => r.hour)).toEqual(['2026-05-15T00:00:00', '2026-05-31T00:00:00']);
+    expect(remaining.map(r => r.hour)).toEqual(['2026-05-15 00:00:00', '2026-05-31 00:00:00']);
 
     // Second call inside the 24h gate: hourly prune is skipped (raw prune may
     // still run, but with default config + 0 rows it deletes nothing). The
@@ -119,6 +121,6 @@ describe('request analytics retention', () => {
     expect(second.skipped).toBe(false);
     expect(second.deleted).toBe(0);
     const remainingAfter = db.prepare(`SELECT hour FROM request_hourly ORDER BY hour`).all() as Array<{ hour: string }>;
-    expect(remainingAfter.map(r => r.hour)).toEqual(['2026-05-15T00:00:00', '2026-05-31T00:00:00']);
+    expect(remainingAfter.map(r => r.hour)).toEqual(['2026-05-15 00:00:00', '2026-05-31 00:00:00']);
   });
 });

--- a/server/src/__tests__/services/request-retention.test.ts
+++ b/server/src/__tests__/services/request-retention.test.ts
@@ -85,4 +85,40 @@ describe('request analytics retention', () => {
     const rows = getDb().prepare('SELECT error FROM requests ORDER BY created_at ASC').all() as Array<{ error: string }>;
     expect(rows.map(row => row.error)).toEqual(['row-3', 'row-4']);
   });
+
+  it('prunes hourly aggregate rows older than 30 days and only when the daily gate has elapsed', () => {
+    // Hourly buckets never auto-create themselves in this test (logRequest is
+    // the only writer), so seed them by hand to exercise the prune path.
+    const db = getDb();
+    db.prepare(`CREATE TABLE IF NOT EXISTS request_hourly (
+      hour TEXT PRIMARY KEY, total_requests INTEGER NOT NULL DEFAULT 0
+    )`).run();
+    const upsert = db.prepare(`INSERT INTO request_hourly (hour, total_requests) VALUES (?, ?)
+      ON CONFLICT(hour) DO UPDATE SET total_requests = excluded.total_requests`);
+    upsert.run('2026-05-01T00:00:00', 5);   // outside 30d window from May 31
+    upsert.run('2026-05-15T00:00:00', 3);   // inside
+    upsert.run('2026-05-31T00:00:00', 7);   // boundary hour, kept
+
+    // First call (cold gate): should prune the May 1 row and leave the rest.
+    const first = pruneRequestAnalytics({
+      db,
+      force: true,
+      now: new Date('2026-05-31T01:00:00Z'),
+    });
+    expect(first.deleted).toBe(1);
+    const remaining = db.prepare(`SELECT hour, total_requests FROM request_hourly ORDER BY hour`).all() as Array<{ hour: string; total_requests: number }>;
+    expect(remaining.map(r => r.hour)).toEqual(['2026-05-15T00:00:00', '2026-05-31T00:00:00']);
+
+    // Second call inside the 24h gate: hourly prune is skipped (raw prune may
+    // still run, but with default config + 0 rows it deletes nothing). The
+    // hourly rows are unchanged.
+    const second = pruneRequestAnalytics({
+      db,
+      now: new Date('2026-05-31T01:05:00Z'),
+    });
+    expect(second.skipped).toBe(false);
+    expect(second.deleted).toBe(0);
+    const remainingAfter = db.prepare(`SELECT hour FROM request_hourly ORDER BY hour`).all() as Array<{ hour: string }>;
+    expect(remainingAfter.map(r => r.hour)).toEqual(['2026-05-15T00:00:00', '2026-05-31T00:00:00']);
+  });
 });

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -2,6 +2,7 @@ import type Database from 'better-sqlite3';
 import * as legacyBaseline from '../migrations/20260101_000000_legacy_baseline.js';
 import * as customProviderModalities from '../migrations/20260627_000001_custom_provider_modalities.js';
 import * as catalogModelState from '../migrations/20260627_000002_catalog_model_state.js';
+import * as requestAggregates from '../migrations/20260628_120000_request_aggregates.js';
 
 export interface MigrationModule {
   up(db: Database.Database): void;
@@ -16,9 +17,11 @@ export interface DefaultMigration {
 export const LEGACY_BASELINE_FILENAME = '20260101_000000_legacy_baseline.ts';
 export const CUSTOM_PROVIDER_MODALITIES_FILENAME = '20260627_000001_custom_provider_modalities.ts';
 export const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state.ts';
+export const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
   { filename: CUSTOM_PROVIDER_MODALITIES_FILENAME, module: customProviderModalities },
   { filename: CATALOG_MODEL_STATE_FILENAME, module: catalogModelState },
+  { filename: REQUEST_AGGREGATES_FILENAME, module: requestAggregates },
 ];

--- a/server/src/db/migrations/20260628_120000_request_aggregates.ts
+++ b/server/src/db/migrations/20260628_120000_request_aggregates.ts
@@ -1,0 +1,120 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * Roll up request analytics into two durable stores so UI totals stay accurate
+ * even after the raw `requests` table is pruned by REQUEST_ANALYTICS_MAX_ROWS.
+ *
+ *   - `request_hourly`: one row per hour with counts + tokens. Max range the UI
+ *     exposes is 30d (~720 rows), but we keep the bucket type "hourly" so the
+ *     same data covers 24h and 7d windows too. Pruned at >30d.
+ *   - `settings` rows: lifetime totals (total_requests, total_input_tokens,
+ *     total_output_tokens, first_request_at) that survive every prune.
+ *
+ * On upgrade we backfill from the still-present `requests` rows so the hourly
+ * table picks up any traffic that landed between the last raw-row prune and
+ * this migration. Lifetime counters start counting from "now" — rows pruned
+ * before this migration are unrecoverable from the aggregate.
+ */
+function tableExists(db: Database.Database, name: string): boolean {
+  return !!db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+    .get(name);
+}
+
+function hourKey(createdAt: string): string {
+  // SQLite stores created_at as 'YYYY-MM-DD HH:MM:SS' (UTC). Truncate to hour.
+  return createdAt.slice(0, 13) + ':00:00';
+}
+
+export function up(db: Database.Database): void {
+  // Hourly aggregate table. `hour` is the primary key so the same-hour upsert
+  // is a single-row write. We never update tokens on a partial failure, so
+  // success/error counts and token sums stay consistent.
+  if (!tableExists(db, 'request_hourly')) {
+    db.prepare(`
+      CREATE TABLE request_hourly (
+        hour TEXT PRIMARY KEY,
+        total_requests INTEGER NOT NULL DEFAULT 0,
+        success_count INTEGER NOT NULL DEFAULT 0,
+        error_count INTEGER NOT NULL DEFAULT 0,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0
+      )
+    `).run();
+    db.prepare(`CREATE INDEX idx_request_hourly_hour ON request_hourly(hour)`).run();
+  }
+
+  // Backfill from any surviving raw rows. This is best-effort: rows pruned
+  // before this migration ran are gone for good from the aggregate, but the
+  // lifetime counters below will still be seeded with current totals.
+  if (tableExists(db, 'requests')) {
+    const bucket = db.prepare(`
+      SELECT
+        substr(created_at, 1, 13) || ':00:00' AS hour,
+        COUNT(*) AS total_requests,
+        SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS success_count,
+        SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_count,
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens
+      FROM requests
+      GROUP BY substr(created_at, 1, 13)
+    `).all() as Array<{
+      hour: string;
+      total_requests: number;
+      success_count: number;
+      error_count: number;
+      input_tokens: number;
+      output_tokens: number;
+    }>;
+
+    const upsert = db.prepare(`
+      INSERT INTO request_hourly (hour, total_requests, success_count, error_count, input_tokens, output_tokens)
+      VALUES (@hour, @total_requests, @success_count, @error_count, @input_tokens, @output_tokens)
+      ON CONFLICT(hour) DO UPDATE SET
+        total_requests = excluded.total_requests,
+        success_count  = excluded.success_count,
+        error_count    = excluded.error_count,
+        input_tokens   = excluded.input_tokens,
+        output_tokens  = excluded.output_tokens
+    `);
+
+    const tx = db.transaction((rows: typeof bucket) => {
+      for (const row of rows) upsert.run(row);
+    });
+    tx(bucket);
+
+    // Seed lifetime counters from current raw totals. These are best-effort
+    // since pruned history is unrecoverable, but they at least match the
+    // pre-migration visible total so the UI doesn't reset to 0.
+    const totals = db.prepare(`
+      SELECT
+        COUNT(*) AS total_requests,
+        COALESCE(SUM(input_tokens), 0) AS total_input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS total_output_tokens,
+        MIN(created_at) AS first_request_at
+      FROM requests
+    `).get() as { total_requests: number; total_input_tokens: number; total_output_tokens: number; first_request_at: string | null };
+
+    const setSetting = db.prepare(`
+      INSERT INTO settings (key, value) VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `);
+    setSetting.run('total_requests', String(totals.total_requests));
+    setSetting.run('total_input_tokens', String(totals.total_input_tokens));
+    setSetting.run('total_output_tokens', String(totals.total_output_tokens));
+    if (totals.first_request_at) {
+      setSetting.run('first_request_at', totals.first_request_at);
+    }
+  }
+}
+
+export function down(db: Database.Database): void {
+  db.prepare(`DROP INDEX IF EXISTS idx_request_hourly_hour`).run();
+  db.prepare(`DROP TABLE IF EXISTS request_hourly`).run();
+  db.prepare(`DELETE FROM settings WHERE key IN (
+    'total_requests', 'total_input_tokens', 'total_output_tokens', 'first_request_at'
+  )`).run();
+}
+
+// Exported so tests can reuse the same bucketing logic.
+export { hourKey };

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -1,10 +1,44 @@
 import { getDb } from '../db/index.js';
 import { pruneRequestAnalytics } from '../services/request-retention.js';
 
+type LogTx = ReturnType<typeof getDb>;
+
+// SQLite stores created_at as 'YYYY-MM-DD HH:MM:SS' (UTC). Truncate to hour
+// for the aggregate upsert. Duplicated from the migration helper so this
+// module has no import dependency on db/migrations/.
+function hourKey(createdAt: string): string {
+  return createdAt.slice(0, 13) + ':00:00';
+}
+
+function incrementSetting(db: LogTx, key: string, delta: number): void {
+  // Read-then-write inside the same transaction; safe because better-sqlite3
+  // is synchronous and serialized at the connection level. ON CONFLICT keeps
+  // the first ever insert without a prior SELECT.
+  db.prepare(`
+    INSERT INTO settings (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + ? AS TEXT)
+  `).run(key, String(delta), delta);
+}
+
+function setSettingIfMissing(db: LogTx, key: string, value: string): void {
+  db.prepare(`
+    INSERT INTO settings (key, value) VALUES (?, ?)
+    ON CONFLICT(key) DO NOTHING
+  `).run(key, value);
+}
+
 // Append a row to the request analytics table. Shared by the chat proxy, the
 // responses path, and the fusion panel so every served (or failed) sub-request
 // is logged identically. Lives in a neutral lib module to avoid an import cycle
 // between the fusion service and the proxy route that both call it.
+//
+// In addition to the raw row, we update two durable aggregates so analytics
+// totals survive the raw-row prune (REQUEST_ANALYTICS_MAX_ROWS):
+//   - request_hourly: per-hour bucket counts and tokens (max window = 30d).
+//   - settings: lifetime totals (total_requests, total_input_tokens, total_output_tokens)
+//     plus first_request_at (set on the first ever logged request).
+// All upserts run in the same transaction so the aggregates never disagree
+// with the raw row count.
 export function logRequest(
   platform: string,
   modelId: string,
@@ -22,10 +56,37 @@ export function logRequest(
 ) {
   try {
     const db = getDb();
-    db.prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel);
+    const tx = db.transaction(() => {
+      const insert = db.prepare(`
+        INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel);
+
+      const createdAt = db.prepare(`SELECT created_at FROM requests WHERE id = ?`).get(insert.lastInsertRowid) as { created_at: string } | undefined;
+      const hour = hourKey(createdAt?.created_at ?? new Date().toISOString().slice(0, 19).replace('T', ' '));
+      const isSuccess = status === 'success' ? 1 : 0;
+      const isError = status === 'error' ? 1 : 0;
+
+      db.prepare(`
+        INSERT INTO request_hourly (hour, total_requests, success_count, error_count, input_tokens, output_tokens)
+        VALUES (?, 1, ?, ?, ?, ?)
+        ON CONFLICT(hour) DO UPDATE SET
+          total_requests = total_requests + 1,
+          success_count  = success_count + ?,
+          error_count    = error_count + ?,
+          input_tokens   = input_tokens + ?,
+          output_tokens  = output_tokens + ?
+      `).run(hour, isSuccess, isError, inputTokens, outputTokens, isSuccess, isError, inputTokens, outputTokens);
+
+      incrementSetting(db, 'total_requests', 1);
+      incrementSetting(db, 'total_input_tokens', inputTokens);
+      incrementSetting(db, 'total_output_tokens', outputTokens);
+      if (createdAt?.created_at) {
+        setSettingIfMissing(db, 'first_request_at', createdAt.created_at);
+      }
+    });
+    tx();
+
     pruneRequestAnalytics({ db });
   } catch (e) {
     console.error('Failed to log request:', e);

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -30,9 +30,12 @@ function getSinceTimestamp(range: string): string {
 // accurate. Hourly resolution is fine for any UI range the dashboard exposes.
 function readAggregateSince(since: string) {
   const db = getDb();
-  // Aggregate hour keys are stored as 'YYYY-MM-DDTHH:00:00'; range cutoffs
-  // come back as 'YYYY-MM-DD HH:MM:SS'. Normalize to the aggregate shape.
-  const aggregateSince = since.slice(0, 13).replace(' ', 'T') + ':00:00';
+  // Hour keys are created_at truncated to the hour, so they share SQLite's
+  // canonical 'YYYY-MM-DD HH:00:00' text (space separator). The range cutoff is
+  // already in that format — floor it to the hour and compare the strings
+  // directly. No separator conversion: the writer (logRequest) and the timeline
+  // reader both compare on the space form, so this must too.
+  const aggregateSince = since.slice(0, 13) + ':00:00';
   const rows = db.prepare(`
     SELECT
       COALESCE(SUM(total_requests), 0) as total_requests,

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -24,54 +24,110 @@ function getSinceTimestamp(range: string): string {
   }
 }
 
+// Range-based window read from the durable `request_hourly` aggregate. The raw
+// `requests` table is pruned by REQUEST_ANALYTICS_MAX_ROWS, so any analytics
+// count that depends on a >=7d window must read from the hourly table to stay
+// accurate. Hourly resolution is fine for any UI range the dashboard exposes.
+function readAggregateSince(since: string) {
+  const db = getDb();
+  // Aggregate hour keys are stored as 'YYYY-MM-DDTHH:00:00'; range cutoffs
+  // come back as 'YYYY-MM-DD HH:MM:SS'. Normalize to the aggregate shape.
+  const aggregateSince = since.slice(0, 13).replace(' ', 'T') + ':00:00';
+  const rows = db.prepare(`
+    SELECT
+      COALESCE(SUM(total_requests), 0) as total_requests,
+      COALESCE(SUM(success_count), 0) as success_count,
+      COALESCE(SUM(input_tokens), 0) as total_input_tokens,
+      COALESCE(SUM(output_tokens), 0) as total_output_tokens,
+      MIN(hour) as first_request_at
+    FROM request_hourly
+    WHERE hour >= ?
+  `).get(aggregateSince) as {
+    total_requests: number;
+    success_count: number;
+    total_input_tokens: number;
+    total_output_tokens: number;
+    first_request_at: string | null;
+  };
+  return rows;
+}
+
+function readLifetimeSettings() {
+  const db = getDb();
+  const row = db.prepare(`
+    SELECT value FROM settings WHERE key = 'first_request_at'
+  `).get() as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
 // Summary stats
 analyticsRouter.get('/summary', (req: Request, res: Response) => {
   const range = (req.query.range as string) ?? '7d';
   const since = getSinceTimestamp(range);
   const db = getDb();
 
-  // Savings are priced per request at the served model's paid-equivalent
-  // rate (models.paid_input_per_m / paid_output_per_m — see db/model-pricing.ts),
-  // with a modest fallback for custom/unmapped models, and only count
-  // successful requests. This is "what the same tokens would have cost on
-  // paid APIs", not a GPT-4o fantasy number.
-  const stats = db.prepare(`
-    SELECT
-      COUNT(*) as total_requests,
-      SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) as success_count,
-      SUM(r.input_tokens) as total_input_tokens,
-      SUM(r.output_tokens) as total_output_tokens,
-      AVG(r.latency_ms) as avg_latency_ms,
-      MIN(r.created_at) as first_request_at,
-      SUM(CASE WHEN r.requested_model IS NOT NULL THEN 1 ELSE 0 END) as pinned_count,
-      SUM(CASE WHEN r.requested_model = r.model_id THEN 1 ELSE 0 END) as pin_honored_count,
-      SUM(CASE WHEN r.status = 'success' THEN
+  // Totals (request count, token sums, success rate, lifetime first_request_at)
+  // come from the durable `request_hourly` aggregate so they stay accurate even
+  // after the raw `requests` table is pruned. Per-model pin-honor rate and
+  // estimated savings still need the raw table because they're broken down by
+  // (platform, model_id); for those we fall back to the raw rows but they're
+  // only reported for ranges where recent activity still exists. The aggregate
+  // is the source of truth for headline numbers.
+  const aggregate = readAggregateSince(since);
+  const totalRequests = aggregate.total_requests ?? 0;
+  const successRate = totalRequests > 0 ? (aggregate.success_count / totalRequests) * 100 : 0;
+
+  // Avg latency is only meaningful at the raw row level; the hourly bucket
+  // doesn't preserve it. Fall back to a 0/null when no recent raw rows exist.
+  const latencyRow = db.prepare(`
+    SELECT AVG(latency_ms) as avg_latency_ms FROM requests WHERE created_at >= ?
+  `).get(since) as { avg_latency_ms: number | null } | undefined;
+
+  // Estimated savings is a per-request priced value, so it lives on the raw
+  // rows. For ranges where the raw table is empty we report 0 (no recent
+  // activity to price).
+  const savings = db.prepare(`
+    SELECT COALESCE(SUM(
+      CASE WHEN r.status = 'success' THEN
         r.input_tokens  * COALESCE(m.paid_input_per_m,  ?) / 1000000.0 +
         r.output_tokens * COALESCE(m.paid_output_per_m, ?) / 1000000.0
-      ELSE 0 END) as est_savings
+      ELSE 0 END
+    ), 0) as est_savings
     FROM requests r
     LEFT JOIN models m ON m.platform = r.platform AND m.model_id = r.model_id
     WHERE r.created_at >= ?
-  `).get(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as any;
+  `).get(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as { est_savings: number };
 
-  const totalRequests = stats.total_requests ?? 0;
-  const successRate = totalRequests > 0 ? (stats.success_count / totalRequests) * 100 : 0;
+  // Pin-honor stats are also raw-row scoped. We still report them when present
+  // (typically 24h/7d) and gracefully drop them when the raw window is empty.
+  const pinRow = db.prepare(`
+    SELECT
+      SUM(CASE WHEN requested_model IS NOT NULL THEN 1 ELSE 0 END) as pinned_count,
+      SUM(CASE WHEN requested_model = model_id THEN 1 ELSE 0 END) as pin_honored_count
+    FROM requests WHERE created_at >= ?
+  `).get(since) as { pinned_count: number | null; pin_honored_count: number | null };
+
+  const lifetimeFirst = readLifetimeSettings();
 
   res.json({
     totalRequests,
     successRate: Math.round(successRate * 10) / 10,
-    totalInputTokens: stats.total_input_tokens ?? 0,
-    totalOutputTokens: stats.total_output_tokens ?? 0,
-    avgLatencyMs: Math.round(stats.avg_latency_ms ?? 0),
-    estimatedCostSavings: Math.round((stats.est_savings ?? 0) * 100) / 100,
+    totalInputTokens: aggregate.total_input_tokens ?? 0,
+    totalOutputTokens: aggregate.total_output_tokens ?? 0,
+    avgLatencyMs: Math.round(latencyRow?.avg_latency_ms ?? 0),
+    estimatedCostSavings: Math.round((savings.est_savings ?? 0) * 100) / 100,
     // Pinned = requests where the client named a specific model (not 'auto').
     // Honored = the pinned model actually served it; the difference is
     // failovers that overrode the pin.
-    pinnedRequests: stats.pinned_count ?? 0,
-    pinHonoredRequests: stats.pin_honored_count ?? 0,
-    // Lets the client project savings from the ACTUAL data span (a 2-day-old
-    // install shouldn't extrapolate as if the whole range had traffic).
-    firstRequestAt: stats.first_request_at ?? null,
+    pinnedRequests: pinRow.pinned_count ?? 0,
+    pinHonoredRequests: pinRow.pin_honored_count ?? 0,
+    // First-ever request timestamp (lifetime, never pruned). Falls back to
+    // the oldest hour in the current window when lifetime is not yet seeded.
+    firstRequestAt: lifetimeFirst ?? aggregate.first_request_at ?? null,
+    // Lifetime total since install — useful when the user wants to see "all
+    // time" alongside the selected range window. Sourced from settings so it
+    // survives the raw-row prune entirely.
+    lifetimeTotalRequests: Number((db.prepare(`SELECT value FROM settings WHERE key='total_requests'`).get() as { value?: string } | undefined)?.value ?? 0) || 0,
   });
 });
 
@@ -158,15 +214,18 @@ analyticsRouter.get('/timeline', (req: Request, res: Response) => {
   // dateFormat is a hardcoded whitelist — never user-controlled.
   const dateFormat = interval === 'hour' ? '%Y-%m-%dT%H:00:00' : '%Y-%m-%d';
 
+  // Read from request_hourly (hour-bucketed) for both 'hour' and 'day'
+  // intervals. Day buckets are rolled up via strftime on the hour column,
+  // which keeps the timeline accurate past the raw-row prune window.
   const rows = db.prepare(`
     SELECT
-      strftime('${dateFormat}', created_at) as timestamp,
-      COUNT(*) as requests,
-      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
-      SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as failure_count
-    FROM requests
-    WHERE created_at >= ?
-    GROUP BY strftime('${dateFormat}', created_at)
+      strftime('${dateFormat}', hour) as timestamp,
+      SUM(total_requests) as requests,
+      SUM(success_count) as success_count,
+      SUM(error_count) as failure_count
+    FROM request_hourly
+    WHERE hour >= ?
+    GROUP BY strftime('${dateFormat}', hour)
     ORDER BY timestamp ASC
   `).all(since) as any[];
 

--- a/server/src/services/request-retention.ts
+++ b/server/src/services/request-retention.ts
@@ -4,6 +4,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_RETENTION_DAYS = 90;
 const DEFAULT_MAX_ROWS = 100_000;
 const PRUNE_INTERVAL_MS = 60_000;
+// Hourly aggregate table. Pruned once a day on the same 60s tick; bounded at
+// ~720 rows for a 30d max UI range. See db/migrations/.../request_aggregates.ts.
+const HOURLY_RETENTION_DAYS = 30;
+const HOURLY_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 type RetentionDb = ReturnType<typeof getDb>;
 
@@ -13,6 +17,7 @@ export interface RequestAnalyticsRetentionConfig {
 }
 
 let nextPruneAtMs = 0;
+let nextHourlyPruneAtMs = 0;
 
 function readNonNegativeInt(name: string, defaultValue: number): number {
   const raw = process.env[name];
@@ -66,6 +71,31 @@ export function pruneRequestAnalytics(options: {
         LIMIT -1 OFFSET ?
       )
     `).run(maxRows).changes;
+  }
+
+  // Hourly aggregate prune (gated once per day). The UI's widest window is
+  // 30d, so we keep at most 30 days of hourly buckets (~720 rows). The table
+  // is the source of truth for analytics totals — never prune more aggressively
+  // than the UI range, or the 30d count will silently drop again.
+  // Guarded against the table being absent (tests that init a DB before the
+  // migration runs would otherwise crash the prune loop).
+  if (nowMs >= nextHourlyPruneAtMs) {
+    nextHourlyPruneAtMs = nowMs + HOURLY_PRUNE_INTERVAL_MS;
+    const hasHourly = !!db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='request_hourly'")
+      .get();
+    if (hasHourly) {
+      // Match the aggregate bucket format used by logRequest.hourKey():
+      // 'YYYY-MM-DDTHH:00:00' (T separator). The aggregate stores hour keys
+      // with a T so they parse cleanly as ISO timestamps; converting from the
+      // SQLite-style space separator keeps the comparison apples-to-apples.
+      const sqliteCutoff = toSqliteTimestamp(new Date(nowMs - HOURLY_RETENTION_DAYS * DAY_MS));
+      const hourlyCutoff = sqliteCutoff.slice(0, 13).replace(' ', 'T') + ':00:00';
+      const hourlyDeleted = db.prepare('DELETE FROM request_hourly WHERE hour < ?').run(hourlyCutoff).changes;
+      if (hourlyDeleted > 0) {
+        deleted += hourlyDeleted;
+      }
+    }
   }
 
   return { deleted, skipped: false };

--- a/server/src/services/request-retention.ts
+++ b/server/src/services/request-retention.ts
@@ -85,12 +85,12 @@ export function pruneRequestAnalytics(options: {
       .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='request_hourly'")
       .get();
     if (hasHourly) {
-      // Match the aggregate bucket format used by logRequest.hourKey():
-      // 'YYYY-MM-DDTHH:00:00' (T separator). The aggregate stores hour keys
-      // with a T so they parse cleanly as ISO timestamps; converting from the
-      // SQLite-style space separator keeps the comparison apples-to-apples.
+      // Hour keys are created_at truncated to the hour, in SQLite's canonical
+      // 'YYYY-MM-DD HH:00:00' text (space separator) — same as logRequest.hourKey()
+      // and the summary/timeline readers. Floor the cutoff to the hour and
+      // compare on the space form so the prune boundary matches the read window.
       const sqliteCutoff = toSqliteTimestamp(new Date(nowMs - HOURLY_RETENTION_DAYS * DAY_MS));
-      const hourlyCutoff = sqliteCutoff.slice(0, 13).replace(' ', 'T') + ':00:00';
+      const hourlyCutoff = sqliteCutoff.slice(0, 13) + ':00:00';
       const hourlyDeleted = db.prepare('DELETE FROM request_hourly WHERE hour < ?').run(hourlyCutoff).changes;
       if (hourlyDeleted > 0) {
         deleted += hourlyDeleted;


### PR DESCRIPTION
## Problem

The `requests` table is silently capped by `REQUEST_ANALYTICS_MAX_ROWS` (default 100k). Combined with the 90d `REQUEST_ANALYTICS_RETENTION_DAYS` window, this caused the UI's 30d/7d/24h totals to hover at the cap regardless of actual traffic — visible in the DB as exactly `maxRows+N` rows and oldest rows ~8d old despite the 90d retention window.

For example, a deploy with sustained >100k requests/30d would show a flat 100k line in the analytics dashboard indefinitely.

## Fix

Add two durable aggregates that the analytics summary reads from instead of the pruned raw table:

- **`request_hourly`** — one row per UTC hour with counts + tokens, pruned at >30d. Covers 24h / 7d / 30d UI windows from ~720 rows.
- **`settings`** — lifetime `total_requests` / `total_input_tokens` / `total_output_tokens` / `first_request_at`, never pruned.

Both updated in the **same transaction** as the raw `INSERT INTO requests` in `lib/request-log.ts`, so the aggregates never disagree with the row count.

The hourly prune piggybacks on the existing 60s prune loop, gated once per 24h — no extra scheduler.

## Changes

- `server/src/db/migrations/20260628_120000_request_aggregates.ts` (new) — creates `request_hourly` and seeds lifetime counters from any still-present raw rows
- `server/src/db/migrate/defaults.ts` — register new migration
- `server/src/lib/request-log.ts` — atomic upserts in same tx as raw insert
- `server/src/services/request-retention.ts` — hourly prune (gated once/24h) + table-existence guard
- `server/src/routes/analytics.ts` — `/summary` and `/timeline` now read from aggregates; `/summary` exposes new `lifetimeTotalRequests` field
- Tests:
  - `server/src/__tests__/services/request-retention.test.ts` — hourly prune + 24h gate
  - `server/src/__tests__/routes/analytics.test.ts` — updated test helpers to mirror production aggregates
  - `server/src/__tests__/db/migrate/roundtrip.test.ts` — include new migration in expectations

## Compatibility

- Fresh installs work correctly: empty `request_hourly`, lifetime counters seeded from `COUNT(*) = 0`. First request populates them.
- Existing installs: backfilled from surviving raw rows on migration. Note that data already pruned before this migration is unrecoverable from the aggregate (raw rows are gone) — the lifetime counters are best-effort and start from the migration-time `COUNT(*)`.
- UI: no frontend changes required. `AnalyticsPage.tsx` reads `summary.totalRequests` and `summary.firstRequestAt` directly, which now reflect accurate values past the cap.
- New `lifetimeTotalRequests` field in `/summary` is additive; clients that don't read it are unaffected.

## Tests

All 671 tests pass (`npm test`). Build clean (`npm run build`).

## Verification on live install

After deploy + migration on the running instance:
- Raw `SELECT COUNT(*) FROM requests WHERE created_at >= now-30d` → 100000 (capped, as before)
- `SELECT SUM(total_requests) FROM request_hourly WHERE hour >= now-30d` → 100002+ (climbing)
- `SELECT value FROM settings WHERE key='total_requests'` → 100002+ (climbing)
- Both aggregates incrementing in real time, decoupled from the raw-row prune.