### PR TITLE
feat(custom): multi-key rotation pool per endpoint

### DIFF
--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -358,3 +358,40 @@ describe('Custom Provider Endpoints', () => {
     });
   });
 });
+
+// Isolated DB so the global custom-key counts in the block above stay intact.
+describe('custom provider key rotation pool', () => {
+  let app: Express;
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare("DELETE FROM settings WHERE key = 'active_profile_id'").run();
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  it('builds a pool from extraKeys and replaces it on re-submit (primary preserved)', async () => {
+    const base = 'http://127.0.0.1:9991/v1';
+    const r1 = await post(app, '/api/keys/custom', {
+      baseUrl: base, model: 'pool-model', apiKey: 'primary', extraKeys: ['k2', 'k3', 'k2', '  ', 'primary'],
+    });
+    expect(r1.status).toBe(201);
+    expect(r1.body.poolKeys).toBe(3); // primary + 2 unique extras (dupes/blank/self dropped)
+
+    const db = getDb();
+    const count = () =>
+      (db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom' AND base_url = ?").get(base) as { n: number }).n;
+    expect(count()).toBe(3);
+
+    const primaryId = r1.body.keyId;
+    const model = db.prepare("SELECT key_id FROM models WHERE platform = 'custom' AND model_id = 'pool-model'")
+      .get() as { key_id: number };
+    expect(model.key_id).toBe(primaryId); // model stays bound to the primary key
+
+    // Re-submit with a smaller pool → extras rebuilt, primary row + binding kept.
+    const r2 = await post(app, '/api/keys/custom', { baseUrl: base, model: 'pool-model', apiKey: 'primary', extraKeys: ['only2'] });
+    expect(r2.body.poolKeys).toBe(2);
+    expect(r2.body.keyId).toBe(primaryId);
+    expect(count()).toBe(2);
+  });
+});

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -179,6 +179,9 @@ const customProviderSchema = z.object({
   models: z.array(modelEntrySchema).optional(),
   displayName: z.string().optional(),
   apiKey: z.string().optional(),
+  // Extra interchangeable keys for the SAME endpoint — the router round-robins
+  // across all of them (rotation pool). Re-submitting replaces the extra pool.
+  extraKeys: z.array(z.string()).optional(),
   label: z.string().optional(),
 }).refine(
   d => (d.model && d.model.trim().length > 0) || (d.models && d.models.length > 0),
@@ -196,6 +199,12 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
   // Local servers often need no key; keep a sentinel so there's always a bearer.
   const providedKey = parsed.data.apiKey?.trim() || undefined;
   const label = parsed.data.label?.trim() || undefined;
+  // Extra rotation-pool keys for this endpoint: trimmed, non-empty, deduped, and
+  // never a copy of the primary (it already gets its own row).
+  const primaryKey = providedKey ?? 'no-key';
+  const extraKeys = [...new Set(
+    (parsed.data.extraKeys ?? []).map(k => k.trim()).filter(k => k && k !== primaryKey)
+  )];
 
   // Flatten singular + plural inputs into one list, dedupe by model id, drop
   // blanks. The singular `displayName` only applies to a lone `model` (it can't
@@ -283,10 +292,27 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
       registered.push({ modelDbId: modelRow.id, model: modelId, displayName });
     }
 
-    return { keyId, registered, storedKeyForMask };
+    // Rebuild this endpoint's EXTRA key pool. Drop the previous extra rows (custom
+    // rows sharing this base_url that no model binds to and aren't the primary),
+    // then insert the freshly-submitted ones. The router rotates across the
+    // primary + every extra that shares this base_url.
+    db.prepare(`
+      DELETE FROM api_keys
+       WHERE platform = 'custom' AND base_url = ? AND id != ?
+         AND id NOT IN (SELECT key_id FROM models WHERE key_id IS NOT NULL)
+    `).run(baseUrl, keyId);
+    for (const extra of extraKeys) {
+      const { encrypted, iv, authTag } = encrypt(extra);
+      db.prepare(`
+        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
+        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
+      `).run(`${label ?? 'Custom'} (pool)`, encrypted, iv, authTag, baseUrl);
+    }
+
+    return { keyId, registered, storedKeyForMask, extraPool: extraKeys.length };
   });
 
-  const { keyId, registered, storedKeyForMask } = upsert();
+  const { keyId, registered, storedKeyForMask, extraPool } = upsert();
   // `model`/`displayName`/`modelDbId` echo the first model for older clients;
   // `models` carries the full set registered in this call.
   const first = registered[0]!;
@@ -300,6 +326,7 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
     displayName: first.displayName,
     models: registered,
     maskedKey: maskKey(storedKeyForMask),
+    poolKeys: 1 + extraPool,
   });
 });
 

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -583,13 +583,32 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   const rrKey = `${entry.platform}:${entry.model_id}`;
   let idx = roundRobinIndex.get(rrKey) ?? 0;
 
+  // A custom model belongs to ONE endpoint (base_url), but that endpoint may now
+  // have SEVERAL keys (a rotation pool). Resolve the model's endpoint once from
+  // its bound key_id, so the loop below can rotate across every key sharing this
+  // base_url (and still exclude keys for OTHER custom endpoints).
+  let customEndpoint: string | null = null;
+  if (entry.platform === 'custom' && entry.key_id != null) {
+    const row = db.prepare('SELECT base_url FROM api_keys WHERE id = ?')
+      .get(entry.key_id) as { base_url: string | null } | undefined;
+    customEndpoint = row?.base_url ?? null;
+  }
+
   for (let attempt = 0; attempt < keys.length; attempt++) {
     const key = keys[idx % keys.length];
     idx++;
 
-    // A custom model belongs to exactly one endpoint (#212); legacy rows
-    // (key_id NULL) keep the old any-key match.
-    if (entry.platform === 'custom' && entry.key_id != null && key.id !== entry.key_id) { note('custom-key-mismatch'); continue; }
+    // Keep a custom model on its OWN endpoint: rotate across every key sharing
+    // its base_url, but skip keys belonging to a different custom endpoint.
+    // (#212 + multi-key pool) If the endpoint base_url can't be resolved, fall
+    // back to the legacy exact-key match. Legacy rows (key_id NULL) match any.
+    if (entry.platform === 'custom' && entry.key_id != null) {
+      if (customEndpoint != null) {
+        if (key.base_url !== customEndpoint) { note('custom-key-mismatch'); continue; }
+      } else if (key.id !== entry.key_id) {
+        note('custom-key-mismatch'); continue;
+      }
+    }
 
     const skipId = `${entry.platform}:${entry.model_id}:${key.id}`;
     if (skipKeys?.has(skipId)) { note('already-failed-this-request'); continue; }


### PR DESCRIPTION
## What

Lets a single custom (OpenAI-compatible) endpoint rotate across **several interchangeable API keys**, instead of being pinned to one.

## Why

The router already round-robins across a platform's keys, but a custom model was pinned to a single key by an exact `key_id` match (#212). For self-hosted / proxied OpenAI-compatible endpoints that hand out multiple keys (rate-limit headroom, multiple accounts behind one base_url), there was no way to spread load across them.

## How

- **Routing** (`router.ts`): a custom model now matches keys by its endpoint's `base_url` rather than the exact `key_id`. Every key sharing that `base_url` joins the round-robin (cooldowns / rpm / rpd / tpm / tpd limits still applied per key); keys belonging to *other* custom endpoints stay excluded, so the #212 isolation is preserved. If the endpoint's `base_url` can't be resolved it falls back to the legacy exact-key match; legacy rows (`key_id NULL`) keep the old any-key behaviour.
- **Registration** (`keys.ts`): `POST /api/keys/custom` gains an optional `extraKeys: string[]`. The primary key still backs the model bindings; the extras form the rotation pool. Extras are trimmed, de-duped, and never a copy of the primary. Re-submitting an endpoint rebuilds its pool (primary row and its model bindings preserved). The response returns `poolKeys` = primary + extras.

## Tests

New isolated test covering pool build, dedupe (duplicate / blank / self-copy dropped), primary preservation, and pool rebuild on re-submit. Full suite green (685 passed).
