### PR TITLE
fix(google): strip x-* schema extensions for Gemini

### DIFF
--- a/server/src/__tests__/providers/google-schema.test.ts
+++ b/server/src/__tests__/providers/google-schema.test.ts
@@ -208,4 +208,68 @@ describe('sanitizeForGemini', () => {
       },
     });
   });
+
+  it('strips x-* vendor extension keys recursively', () => {
+    const input = {
+      type: 'object',
+      'x-root-note': 'ignored by Gemini',
+      properties: {
+        font: {
+          type: 'string',
+          enum: ['INTER', 'LEXEND'],
+          'x-google-enum-descriptions': ['Inter.', 'Lexend.'],
+        },
+        nested: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+              'x-provider-hint': 'local-only',
+            },
+          },
+        },
+      },
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: {
+        font: {
+          type: 'string',
+          enum: ['INTER', 'LEXEND'],
+        },
+        nested: {
+          type: 'object',
+          properties: {
+            mode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('preserves real property names that start with x-', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        'x-user-id': {
+          type: 'string',
+          description: 'A real tool argument name, not a schema extension',
+          'x-google-note': 'strip this schema metadata',
+        },
+      },
+      required: ['x-user-id'],
+    };
+    expect(sanitizeForGemini(input)).toEqual({
+      type: 'object',
+      properties: {
+        'x-user-id': {
+          type: 'string',
+          description: 'A real tool argument name, not a schema extension',
+        },
+      },
+      required: ['x-user-id'],
+    });
+  });
 });

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -131,15 +131,25 @@ const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   'deprecated',
 ]);
 
+const VENDOR_EXTENSION_SCHEMA_KEY = /^x-/i;
+
 export function sanitizeForGemini(schema: unknown): unknown {
+  return sanitizeForGeminiSchema(schema, false);
+}
+
+function sanitizeForGeminiSchema(schema: unknown, insidePropertiesMap: boolean): unknown {
   if (Array.isArray(schema)) {
-    return schema.map(sanitizeForGemini);
+    return schema.map(s => sanitizeForGeminiSchema(s, false));
   }
   if (schema && typeof schema === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
-      if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(k)) continue;
-      out[k] = sanitizeForGemini(v);
+      if (insidePropertiesMap) {
+        out[k] = sanitizeForGeminiSchema(v, false);
+        continue;
+      }
+      if (GEMINI_UNSUPPORTED_SCHEMA_KEYS.has(k) || VENDOR_EXTENSION_SCHEMA_KEY.test(k)) continue;
+      out[k] = sanitizeForGeminiSchema(v, k === 'properties');
     }
     return out;
   }


### PR DESCRIPTION
## Summary

Fixes #417.

Gemini rejects vendor extension fields such as `x-google-enum-descriptions` inside tool parameter schemas with an `Unknown name` 400. The existing sanitizer removed a denylist of unsupported JSON Schema keywords, but let `x-*` extension keys through.

This PR:

- strips `x-*` vendor extension keys while sanitizing Gemini tool schemas
- keeps real tool argument names such as `properties[x-user-id]` intact
- adds regression coverage for both the reported `x-google-enum-descriptions` shape and the property-name edge case

## Validation

- `npm run test -w server -- google-schema`
- `npm test`
- `npm run build`