### PR TITLE
fix: correct GitHub context and usage display

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -79,6 +79,7 @@
     "newBadge": "New",
     "monthlyTokenBudget": "Monthly token budget",
     "remaining": "remaining",
+    "used": "used",
     "of": "of",
     "showAllModels": "Show all {count} models",
     "showLess": "Show less",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -79,6 +79,7 @@
     "newBadge": "Nuevo",
     "monthlyTokenBudget": "Presupuesto mensual de tokens",
     "remaining": "restante",
+    "used": "usados",
     "of": "de",
     "showAllModels": "Mostrar los {count} modelos",
     "showLess": "Mostrar menos",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -79,6 +79,7 @@
     "newBadge": "Nouveau",
     "monthlyTokenBudget": "Budget mensuel de tokens",
     "remaining": "restant",
+    "used": "utilisés",
     "of": "sur",
     "showAllModels": "Afficher les {count} modèles",
     "showLess": "Afficher moins",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -79,6 +79,7 @@
     "newBadge": "Nuovo",
     "monthlyTokenBudget": "Budget mensile di token",
     "remaining": "rimanenti",
+    "used": "usati",
     "of": "di",
     "showAllModels": "Mostra tutti i {count} modelli",
     "showLess": "Mostra meno",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -79,6 +79,7 @@
     "newBadge": "Novo",
     "monthlyTokenBudget": "Orçamento mensal de tokens",
     "remaining": "restante",
+    "used": "usados",
     "of": "de",
     "showAllModels": "Mostrar os {count} modelos",
     "showLess": "Mostrar menos",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -79,6 +79,7 @@
     "newBadge": "新",
     "monthlyTokenBudget": "每月令牌额度",
     "remaining": "剩余",
+    "used": "已用",
     "of": "共",
     "showAllModels": "显示全部 {count} 个模型",
     "showLess": "收起",

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -218,6 +218,17 @@ export function formatTokens(n: number): string {
   return String(n)
 }
 
+function formatPercent(value: number): string {
+  const pct = Math.max(0, Math.min(100, value * 100))
+  if (pct > 0 && pct < 0.1) return '<0.1%'
+  if (pct > 99.9 && pct < 100) {
+    const floored = Math.floor(pct * 100) / 100
+    return `${floored.toFixed(2).replace(/0+$/, '').replace(/\.$/, '')}%`
+  }
+  const digits = pct < 10 ? 1 : 0
+  return `${pct.toFixed(digits).replace(/\.0$/, '')}%`
+}
+
 // Compact context-window label (whole-number K/M, base 1000): 8000 → "8K",
 // 128000 → "128K", 1_000_000 → "1M". Used by the catalog context badge/filter.
 function formatContext(n: number): string {
@@ -278,7 +289,7 @@ export function groupQuotaBadge(
 interface TokenUsageData {
   totalBudget: number
   totalUsed: number
-  models: { displayName: string; platform: string; budget: number }[]
+  models: { displayName: string; platform: string; modelId?: string; budget: number; used?: number }[]
 }
 
 const platformColors: Record<string, string> = {
@@ -325,7 +336,7 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
   const { t } = useI18n()
   const { totalBudget, totalUsed, models } = data
   const remaining = Math.max(0, totalBudget - totalUsed)
-  const remainingPct = totalBudget > 0 ? Math.round((remaining / totalBudget) * 100) : 0
+  const remainingPct = totalBudget > 0 ? formatPercent(remaining / totalBudget) : '0%'
 
   // Collapse the per-model legend to a few rows; the chevron reveals the rest.
   // The toggle only appears when the legend actually overflows the collapsed
@@ -343,12 +354,17 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
     return () => ro.disconnect()
   }, [models.length])
 
-  const modelsWithWidth = models.map(m => ({
-    ...m,
-    remainingTokens: totalBudget > 0 ? (m.budget / totalBudget) * remaining : 0,
-    widthPct: totalBudget > 0 ? (m.budget / totalBudget) * (remaining / totalBudget) * 100 : 0,
-  }))
-  const usedPct = totalBudget > 0 ? (totalUsed / totalBudget) * 100 : 0
+  const modelsWithWidth = models.map(m => {
+    const usedTokens = m.used ?? 0
+    const remainingTokens = Math.max(0, m.budget - usedTokens)
+    return {
+      ...m,
+      usedTokens,
+      remainingTokens,
+      widthPct: totalBudget > 0 ? (remainingTokens / totalBudget) * 100 : 0,
+    }
+  })
+  const usedPct = totalBudget > 0 ? Math.min(100, (totalUsed / totalBudget) * 100) : 0
 
   return (
     <section className="rounded-3xl border bg-card p-5">
@@ -358,6 +374,12 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
           <span className="text-foreground font-medium">{formatTokens(remaining)}</span> {t('models.remaining')}
           <span className="mx-1.5">·</span>
           {remainingPct}% {t('models.of')} {formatTokens(totalBudget)}
+          {totalUsed > 0 && (
+            <>
+              <span className="mx-1.5">·</span>
+              <span className="text-foreground font-medium">{formatTokens(totalUsed)}</span> {t('models.used')}
+            </>
+          )}
         </span>
       </div>
 
@@ -365,7 +387,7 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
         {modelsWithWidth.map((m, i) => (
           <div
             key={i}
-            title={`${m.displayName} (${m.platform}): ${formatTokens(m.remainingTokens)} remaining`}
+            title={`${m.displayName} (${m.platform}): ${formatTokens(m.remainingTokens)} ${t('models.remaining')}, ${formatTokens(m.usedTokens)} ${t('models.used')}`}
             style={{
               width: `${m.widthPct}%`,
               backgroundColor: platformColors[m.platform] ?? '#94a3b8',

--- a/server/src/__tests__/db/idempotency.test.ts
+++ b/server/src/__tests__/db/idempotency.test.ts
@@ -193,6 +193,18 @@ describe('Migration idempotency', () => {
     ]);
   });
 
+  it('caps GitHub GPT-4.1 at the routable free-tier context window (#426)', () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    const db = initDb(':memory:');
+
+    const row = db.prepare(`
+      SELECT context_window FROM models
+       WHERE platform = 'github' AND model_id = 'openai/gpt-4.1'
+    `).get() as { context_window: number };
+
+    expect(row.context_window).toBe(8000);
+  });
+
   it('V14: cerebras deprecation disables qwen-3-235b and llama3.1-8b but keeps gpt-oss-120b enabled', () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     const db = initDb(':memory:');

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -8,6 +8,7 @@ const LEGACY_BASELINE_FILENAME = '20260101_000000_legacy_baseline.ts';
 const CUSTOM_PROVIDER_MODALITIES_FILENAME = '20260627_000001_custom_provider_modalities.ts';
 const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state.ts';
 const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
+const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 
 interface SchemaRow {
   type: string;
@@ -62,6 +63,7 @@ describe('migration round trip', () => {
         CUSTOM_PROVIDER_MODALITIES_FILENAME,
         CATALOG_MODEL_STATE_FILENAME,
         REQUEST_AGGREGATES_FILENAME,
+        GITHUB_GPT41_CONTEXT_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/fallback.test.ts
+++ b/server/src/__tests__/routes/fallback.test.ts
@@ -63,6 +63,47 @@ describe('Fallback API', () => {
     expect(first).toHaveProperty('contextWindow');
   });
 
+  it('GET /api/fallback/token-usage reports per-model chat usage for configured platforms', async () => {
+    const db = getDb();
+    const target = db.prepare(`
+      SELECT id, platform, model_id FROM models
+       WHERE platform = 'github' AND model_id = 'openai/gpt-4.1'
+    `).get() as { id: number; platform: string; model_id: string };
+    const other = db.prepare(`
+      SELECT platform, model_id FROM models
+       WHERE platform <> ?
+       LIMIT 1
+    `).get(target.platform) as { platform: string; model_id: string };
+    const secret = encrypt('usage-test-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, 'usage', ?, ?, ?, 'healthy', 1)
+    `).run(target.platform, secret.encrypted, secret.iv, secret.authTag);
+    db.prepare(`
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
+      VALUES (?, ?, NULL, 'success', 123, 45, 10, NULL, 'chat')
+    `).run(target.platform, target.model_id);
+    db.prepare(`
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
+      VALUES (?, ?, NULL, 'success', 1000, 1000, 10, NULL, 'chat')
+    `).run(other.platform, other.model_id);
+    db.prepare(`
+      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
+      VALUES (?, ?, NULL, 'success', 500, 500, 10, NULL, 'embedding')
+    `).run(target.platform, target.model_id);
+
+    const { status, body } = await request(app, 'GET', '/api/fallback/token-usage');
+
+    expect(status).toBe(200);
+    expect(body.totalUsed).toBe(168);
+    const model = body.models.find((m: any) => m.modelDbId === target.id);
+    expect(model).toMatchObject({
+      platform: target.platform,
+      modelId: target.model_id,
+      used: 168,
+    });
+  });
+
   // Regression: GET /routing must always carry customWeights, even before the
   // user has saved any — the dashboard's custom-weight sliders dereference it
   // and a missing field white-screened the Fallback page.

--- a/server/src/__tests__/services/catalog-sync.test.ts
+++ b/server/src/__tests__/services/catalog-sync.test.ts
@@ -93,6 +93,20 @@ describe('applyCatalog', () => {
     expect(fb).toBeTruthy();
   });
 
+  it('caps GitHub GPT-4.1 catalog context at the routable free-tier limit (#426)', () => {
+    const models = existingAsCatalogModels();
+    const target = models.find((m) => m.platform === 'github' && m.modelId === 'openai/gpt-4.1');
+    expect(target).toBeDefined();
+    target!.contextWindow = 128000;
+
+    applyCatalog(getDb(), catalogOf(models));
+
+    const row = getDb()
+      .prepare("SELECT context_window FROM models WHERE platform = 'github' AND model_id = 'openai/gpt-4.1'")
+      .get() as { context_window: number };
+    expect(row.context_window).toBe(8000);
+  });
+
   it('updates metadata in place and respects the enabled policy', () => {
     const models = existingAsCatalogModels();
     const target = models.find((m) => m.modelId === 'brand-new-model')!;

--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -136,6 +136,42 @@ describe('Router', () => {
     expect(large.modelDbId).not.toBe(baseline.modelDbId);
   });
 
+  it('skips GitHub GPT-4.1 above its free-tier 8K request cap (#426)', () => {
+    const db = getDb();
+    const githubKey = encrypt('test-github-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('github', 'github', githubKey.encrypted, githubKey.iv, githubKey.authTag, 'healthy', 1);
+    const groqKey = encrypt('test-groq-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'groq', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
+
+    const github = db.prepare(`
+      SELECT id, context_window FROM models
+       WHERE platform = 'github' AND model_id = 'openai/gpt-4.1'
+    `).get() as { id: number; context_window: number };
+    const groq = db.prepare(`
+      SELECT id FROM models
+       WHERE platform = 'groq' AND context_window > 9000
+       LIMIT 1
+    `).get() as { id: number };
+
+    db.prepare('UPDATE fallback_config SET priority = 1000, enabled = 1').run();
+    db.prepare('UPDATE fallback_config SET priority = 1 WHERE model_db_id = ?').run(github.id);
+    db.prepare('UPDATE fallback_config SET priority = 2 WHERE model_db_id = ?').run(groq.id);
+    db.prepare(`
+      UPDATE models SET tpm_limit = NULL, tpd_limit = NULL
+       WHERE id IN (?, ?)
+    `).run(github.id, groq.id);
+
+    expect(github.context_window).toBe(8000);
+    expect(routeRequest(7000).modelDbId).toBe(github.id);
+    expect(routeRequest(9000).modelDbId).toBe(groq.id);
+  });
+
   it('still routes a model with an unknown (null) context window (#167)', () => {
     const db = getDb();
     const groqKey = encrypt('test-groq-key');

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -3,6 +3,7 @@ import * as legacyBaseline from '../migrations/20260101_000000_legacy_baseline.j
 import * as customProviderModalities from '../migrations/20260627_000001_custom_provider_modalities.js';
 import * as catalogModelState from '../migrations/20260627_000002_catalog_model_state.js';
 import * as requestAggregates from '../migrations/20260628_120000_request_aggregates.js';
+import * as githubGpt41Context from '../migrations/20260630_000001_github_gpt41_context.js';
 
 export interface MigrationModule {
   up(db: Database.Database): void;
@@ -18,10 +19,12 @@ export const LEGACY_BASELINE_FILENAME = '20260101_000000_legacy_baseline.ts';
 export const CUSTOM_PROVIDER_MODALITIES_FILENAME = '20260627_000001_custom_provider_modalities.ts';
 export const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state.ts';
 export const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
+export const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
   { filename: CUSTOM_PROVIDER_MODALITIES_FILENAME, module: customProviderModalities },
   { filename: CATALOG_MODEL_STATE_FILENAME, module: catalogModelState },
   { filename: REQUEST_AGGREGATES_FILENAME, module: requestAggregates },
+  { filename: GITHUB_GPT41_CONTEXT_FILENAME, module: githubGpt41Context },
 ];

--- a/server/src/db/migrations/20260101_000000_legacy_baseline.ts
+++ b/server/src/db/migrations/20260101_000000_legacy_baseline.ts
@@ -641,7 +641,7 @@ function migrateModelsV4(db: Database.Database) {
     ['mistral',    'mistral-medium-latest',                  'Mistral Medium 3.5',            14, 8,  'Large',    2, null, 500000, null, '~50-100M', 131072],
 
     // GitHub Models — Low-tier category (15 RPM / 150 RPD, 8K in / 4K out per call)
-    ['github',     'openai/gpt-4.1',                         'GPT-4.1 (GitHub)',              20, 7,  'Large',    10, 50,  null, null, '~9M', 128000],
+    ['github',     'openai/gpt-4.1',                         'GPT-4.1 (GitHub)',              20, 7,  'Large',    10, 50,  null, null, '~9M', 8000],
 
     // Cohere — shared 1000 calls/mo trial pool, 20 RPM Chat
     ['cohere',     'command-a-03-2025',                      'Command-A (03-2025)',           27, 11, 'Large',    20, 33,  null, null, '~1-2M', 131072],
@@ -2292,4 +2292,3 @@ function migrateProfilesInit(db: Database.Database) {
     `).run();
   }
 }
-

--- a/server/src/db/migrations/20260630_000001_github_gpt41_context.ts
+++ b/server/src/db/migrations/20260630_000001_github_gpt41_context.ts
@@ -1,0 +1,24 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * GitHub Models' free GPT-4.1 endpoint rejects requests above the low-tier
+ * per-call input cap even though the upstream model can support a larger
+ * context elsewhere. Keep the local catalog aligned with the routable limit.
+ */
+export function up(db: Database.Database): void {
+  db.prepare(`
+    UPDATE models
+       SET context_window = 8000
+     WHERE platform = 'github'
+       AND model_id = 'openai/gpt-4.1'
+  `).run();
+}
+
+export function down(db: Database.Database): void {
+  db.prepare(`
+    UPDATE models
+       SET context_window = 128000
+     WHERE platform = 'github'
+       AND model_id = 'openai/gpt-4.1'
+  `).run();
+}

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -286,13 +286,24 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
   }
 
   // Build per-model breakdown (only platforms with keys), preserving enabled state
+  const usageRows = db.prepare(`
+    SELECT platform, model_id, COALESCE(SUM(input_tokens + output_tokens), 0) AS used
+    FROM requests
+    WHERE created_at >= datetime('now', 'start of month')
+      AND request_type = 'chat'
+    GROUP BY platform, model_id
+  `).all() as { platform: string; model_id: string; used: number }[];
+  const usageByModel = new Map(usageRows.map(r => [`${r.platform}:${r.model_id}`, r.used]));
+
   const modelBudgets = rawModels
     .filter(m => platformSet.has(m.platform))
     .map(m => ({
       modelDbId: m.model_db_id,
       displayName: m.display_name,
       platform: m.platform,
+      modelId: m.model_id,
       budget: parseBudget(m.monthly_token_budget),
+      used: usageByModel.get(`${m.platform}:${m.model_id}`) ?? 0,
       enabled: m.enabled === 1,
       rpmLimit: m.rpm_limit,
       rpdLimit: m.rpd_limit,
@@ -302,19 +313,11 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
 
   // Total budget counts all models (both enabled and disabled — they contribute to the pool)
   const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0);
-
-  // Tokens used this month
-  const usage = db.prepare(`
-    SELECT
-      COALESCE(SUM(input_tokens + output_tokens), 0) as total_used
-    FROM requests
-    WHERE created_at >= datetime('now', 'start of month')
-      AND request_type = 'chat'
-  `).get() as { total_used: number };
+  const totalUsed = modelBudgets.reduce((s, m) => s + m.used, 0);
 
   res.json({
     totalBudget,
-    totalUsed: usage.total_used,
+    totalUsed,
     models: modelBudgets,
   });
 });

--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -146,6 +146,11 @@ function isCatalog(value: unknown): value is Catalog {
   );
 }
 
+function routableContextWindow(platform: string, modelId: string, contextWindow: number | null): number | null {
+  if (platform === 'github' && modelId === 'openai/gpt-4.1') return 8000;
+  return contextWindow;
+}
+
 /**
  * Apply a verified catalog to the local DB inside one transaction.
  *
@@ -248,7 +253,7 @@ export function applyCatalog(db: DatabaseType.Database, catalog: Catalog): NonNu
         tpm: m.limits.tpm,
         tpd: m.limits.tpd,
         monthlyTokenBudget: m.monthlyTokenBudget,
-        contextWindow: m.contextWindow,
+        contextWindow: routableContextWindow(m.platform, m.modelId, m.contextWindow),
         supportsVision: m.supportsVision ? 1 : 0,
         supportsTools: m.supportsTools ? 1 : 0,
       };


### PR DESCRIPTION
## Summary

- cap GitHub Models `openai/gpt-4.1` at the routable 8K free-tier context window in both bundled migrations and catalog sync
- add an upgrade migration so existing installs get corrected
- make the Models page monthly budget card use per-model local chat usage instead of spreading one aggregate across all models
- show explicit used tokens and avoid rounding small usage back to `100%` remaining

## Root cause

GitHub GPT-4.1 was cataloged as 128K context even though the GitHub Models free route rejects larger requests with 413. The migration-only fix was not enough because cached catalog reapply could restore the bad 128K value, so the catalog application path now clamps that model too.

The usage card previously only received a single total monthly usage number. The UI distributed that total proportionally across model budgets and rounded the remaining percentage to a whole number, which made real local usage appear unchanged for large aggregate budgets.

## Credits

- Reported #426 by @NirvanaCh7
- Reported #427 by @1029734570

## Validation

- `npm run test -w server -- catalog-sync router idempotency fallback migrate/roundtrip`
- `npm run build -w server`
- `npm run build -w client`
- `git diff --check`
