### PR TITLE
fix: clean up keys and model UI

### DIFF
--- a/client/src/components/models-tabs.tsx
+++ b/client/src/components/models-tabs.tsx
@@ -18,18 +18,7 @@ export function ModelsTabs() {
       <NavLink to="/models/embeddings" className={({ isActive }) => tab(isActive)}>{t('models.embeddingsTab')}</NavLink>
       <NavLink to="/models/image" className={({ isActive }) => tab(isActive)}>{t('models.imageTab')}</NavLink>
       <NavLink to="/models/audio" className={({ isActive }) => tab(isActive)}>{t('models.audioTab')}</NavLink>
-      <NavLink to="/models/fusion" className={({ isActive }) => tab(isActive)}>
-        {({ isActive }) => (
-          <>
-            {t('models.fusionTab')}
-            <span className={`rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide ${
-              isActive ? 'bg-background/20 text-background' : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-            }`}>
-              {t('models.newBadge')}
-            </span>
-          </>
-        )}
-      </NavLink>
+      <NavLink to="/models/fusion" className={({ isActive }) => tab(isActive)}>{t('models.fusionTab')}</NavLink>
     </div>
   )
 }

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -189,6 +189,7 @@
     "pageTitle": "Keys",
     "pageDescription": "Provider credentials and the unified API key your apps connect with.",
     "tabProviders": "Providers",
+    "tabQuotaSignals": "Quota signals",
     "tabApiKey": "Unified API key",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "Your unified API key",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -144,6 +144,7 @@
     "pageTitle": "Claves",
     "pageDescription": "Las credenciales de los proveedores y la clave API unificada con la que se conectan tus aplicaciones.",
     "tabProviders": "Proveedores",
+    "tabQuotaSignals": "Señales de cuota",
     "tabApiKey": "Clave de API unificada",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "Tu clave API unificada",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -144,6 +144,7 @@
     "pageTitle": "Clés",
     "pageDescription": "Les identifiants des fournisseurs et la clé API unifiée à laquelle vos applications se connectent.",
     "tabProviders": "Fournisseurs",
+    "tabQuotaSignals": "Signaux de quota",
     "tabApiKey": "Clé d'API unifiée",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "Votre clé API unifiée",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -162,6 +162,7 @@
     "pageTitle": "Chiavi",
     "pageDescription": "Credenziali dei fornitori e la chiave API unificata con cui si connettono le tue app.",
     "tabProviders": "Fornitori",
+    "tabQuotaSignals": "Segnali quota",
     "tabApiKey": "Chiave API unificata",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "La tua chiave API unificata",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -144,6 +144,7 @@
     "pageTitle": "Chaves",
     "pageDescription": "As credenciais dos provedores e a chave de API unificada à qual seus aplicativos se conectam.",
     "tabProviders": "Provedores",
+    "tabQuotaSignals": "Sinais de cota",
     "tabApiKey": "Chave de API unificada",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "Sua chave de API unificada",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -144,6 +144,7 @@
     "pageTitle": "密钥",
     "pageDescription": "各提供方的凭据，以及你的应用用来连接的统一 API 密钥。",
     "tabProviders": "提供方",
+    "tabQuotaSignals": "配额信号",
     "tabApiKey": "统一 API 密钥",
     "tabAnthropic": "Anthropic",
     "unifiedKey": "您的统一 API 密钥",

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -373,7 +373,7 @@ function TokenUsageBar({ data }: { data: TokenUsageData }) {
         <span className="text-xs text-muted-foreground tabular-nums">
           <span className="text-foreground font-medium">{formatTokens(remaining)}</span> {t('models.remaining')}
           <span className="mx-1.5">·</span>
-          {remainingPct}% {t('models.of')} {formatTokens(totalBudget)}
+          {remainingPct} {t('models.of')} {formatTokens(totalBudget)}
           {totalUsed > 0 && (
             <>
               <span className="mx-1.5">·</span>

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -849,9 +849,10 @@ function AnthropicSection() {
   )
 }
 
-type KeysTab = 'providers' | 'apiKey' | 'anthropic'
+type KeysTab = 'providers' | 'quotaSignals' | 'apiKey' | 'anthropic'
 const KEYS_TABS: { id: KeysTab; labelKey: string }[] = [
   { id: 'providers', labelKey: 'keys.tabProviders' },
+  { id: 'quotaSignals', labelKey: 'keys.tabQuotaSignals' },
   { id: 'apiKey', labelKey: 'keys.tabApiKey' },
   { id: 'anthropic', labelKey: 'keys.tabAnthropic' },
 ]
@@ -1035,7 +1036,7 @@ export default function KeysPage() {
         description={t('keys.pageDescription')}
         actions={
           <>
-            {tab === 'providers' && keys.length > 0 && (
+            {(tab === 'providers' || tab === 'quotaSignals') && keys.length > 0 && (
               <Button variant="outline" size="sm" onClick={() => checkAll.mutate()} disabled={checkAll.isPending}>
                 {checkAll.isPending ? t('keys.checking') : t('keys.checkAll')}
               </Button>
@@ -1068,10 +1069,12 @@ export default function KeysPage() {
 
         {tab === 'anthropic' && <AnthropicSection />}
 
+        {tab === 'quotaSignals' && (
+          <QuotaSignalsSection states={(healthData?.quotaStates ?? []).slice(0, 24)} />
+        )}
+
         {tab === 'providers' && (
         <>
-        <QuotaSignalsSection states={(healthData?.quotaStates ?? []).slice(0, 24)} />
-
         <ImportKeysSection />
 
         <section>


### PR DESCRIPTION
## What changed
- Removed the duplicate percent sign from the model usage summary.
- Removed the New badge from the Fusion models tab.
- Moved quota signals into their own tab on the Keys page, with localized tab labels.

## Why
The deployed UI showed `%%` in the usage card, the Fusion tab no longer needs the launch badge, and quota signal details should not crowd the provider-key management view.

## Validation
- `npm run build -w client`