### PR TITLE
fix(keys): explain when a saved key has no catalog models yet (#438)

### DIFF
--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -867,6 +867,9 @@ export default function KeysPage() {
   const [label, setLabel] = useState('')
   const [editingKeyId, setEditingKeyId] = useState<number | null>(null)
   const [editingLabel, setEditingLabel] = useState('')
+  // Server-supplied notice when a key is saved for a platform with no models in
+  // the current catalog tier yet (e.g. a newly added premium provider, #438).
+  const [addNotice, setAddNotice] = useState<string | null>(null)
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
   const [confirmDeleteModelKey, setConfirmDeleteModelKey] = useState<string | null>(null)
   const [expandedKeyIds, setExpandedKeyIds] = useState<Set<number>>(new Set())
@@ -885,11 +888,12 @@ export default function KeysPage() {
 
   const addKey = useMutation({
     mutationFn: (body: { platform: string; key: string; label?: string }) =>
-      apiFetch('/api/keys', { method: 'POST', body: JSON.stringify(body) }),
-    onSuccess: () => {
+      apiFetch<{ notice?: string | null }>('/api/keys', { method: 'POST', body: JSON.stringify(body) }),
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['keys'] })
       queryClient.invalidateQueries({ queryKey: ['health'] })
       queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      setAddNotice(data?.notice ?? null)
       setPlatform('')
       setApiKey('')
       setAccountId('')
@@ -1141,6 +1145,9 @@ export default function KeysPage() {
           </form>
           {addKey.isError && (
             <p className="text-destructive text-xs mt-2">{(addKey.error as Error).message}</p>
+          )}
+          {addNotice && (
+            <p className="text-amber-600 dark:text-amber-500 text-xs mt-2" role="status">{addNotice}</p>
           )}
         </section>
 

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -103,6 +103,33 @@ describe('Keys API', () => {
     expect(body[0].platform).toBe('groq');
   });
 
+  it('POST /api/keys warns when the platform has no catalog models yet (#438)', async () => {
+    const db = getDb();
+    // Simulate the Agnes case: a registered platform whose models aren't in
+    // this install's catalog tier. Force it by disabling every agnes row (a
+    // fresh migrated DB already has zero agnes models, but be explicit).
+    db.prepare("UPDATE models SET enabled = 0 WHERE platform = 'agnes'").run();
+
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'agnes',
+      key: 'agnes_test_key_123456',
+    });
+    expect(status).toBe(201);
+    expect(body.modelsAvailable).toBe(0);
+    expect(body.notice).toBeTruthy();
+    expect(body.notice).toMatch(/no agnes models/i);
+  });
+
+  it('POST /api/keys does not warn when the platform has catalog models', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'groq',
+      key: 'gsk_test123456789',
+    });
+    expect(status).toBe(201);
+    expect(body.modelsAvailable).toBeGreaterThan(0);
+    expect(body.notice ?? null).toBeNull();
+  });
+
   it('POST /api/keys rejects invalid platform', async () => {
     const { status } = await request(app, 'POST', '/api/keys', {
       platform: 'invalid_platform',

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -117,6 +117,33 @@ function insertImportedKey(platform: (typeof PLATFORMS)[number], keyName: string
   `).run(platform, keyName, encrypted, iv, authTag);
 }
 
+// Count enabled catalog models for a platform. Used to warn when a key is
+// added for a provider that has zero models in the operator's current catalog
+// tier — the Agnes case (#438): the provider is registered and selectable, but
+// its models ship in the premium/live catalog and only appear for free-tier
+// installs once they age into the monthly catalog, so a fresh install adds the
+// key and silently sees nothing.
+function enabledModelCount(platform: string): number {
+  const db = getDb();
+  const row = db.prepare(
+    'SELECT COUNT(*) AS c FROM models WHERE platform = ? AND enabled = 1',
+  ).get(platform) as { c: number };
+  return row.c;
+}
+
+// Non-null when the just-added key has no usable models yet, so the client can
+// explain the silence instead of leaving the user staring at an empty list.
+function noModelsNotice(platform: string): string | undefined {
+  if (enabledModelCount(platform) > 0) return undefined;
+  return (
+    `Key saved, but no ${platform} models are in your current catalog yet. ` +
+    `Newer providers are published to the premium catalog first and appear ` +
+    `for free-tier installs once they age into the monthly catalog. Add a ` +
+    `Premium license key to use them now, or add ${platform} as a custom ` +
+    `OpenAI-compatible provider with its base URL.`
+  );
+}
+
 // List all keys (masked)
 keysRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
@@ -222,6 +249,8 @@ keysRouter.post('/', (req: Request, res: Response) => {
         maskedKey: maskKey(keyToStore),
         status: 'unknown',
         enabled: true,
+        modelsAvailable: enabledModelCount(platform),
+        notice: noModelsNotice(platform),
       });
       return;
     }
@@ -240,6 +269,8 @@ keysRouter.post('/', (req: Request, res: Response) => {
     maskedKey: maskKey(keyToStore),
     status: 'unknown',
     enabled: true,
+    modelsAvailable: enabledModelCount(platform),
+    notice: noModelsNotice(platform),
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses #438 ("I added Agnes AI, but it doesn't appear in the model list", two reporters).

### Root cause

Agnes models live in the **premium/live** catalog and are not yet in the **monthly/free** catalog that free-tier installs receive (they age in ~mid-July), and they aren't shipped as bundled migrations either. I confirmed a freshly migrated DB has **0** `agnes` model rows (110 models total). So the provider is registered and selectable in the add-key picker, the user saves a key — and the model list stays silently empty. Same trap for any future premium-first provider.

### Fix

`POST /api/keys` now returns:
- `modelsAvailable`: enabled catalog model count for the platform.
- `notice`: when that count is 0, a message explaining the key was saved but no models are in the current catalog tier yet, and how to use it now (Premium license key, or add the provider as a custom OpenAI-compatible endpoint).

The keys page renders the notice inline (amber `role="status"`) instead of leaving an unexplained empty list. Fully additive — existing response fields are unchanged and `notice` is `undefined` whenever models exist.

## Tests

- New cases in `keys.test.ts`: `agnes` (0 models) → `modelsAvailable: 0` + a notice matching /no agnes models/i; `groq` (has models) → `modelsAvailable > 0`, no notice.
- Full server suite 748/748; `tsc --noEmit` clean on server and client.

## Note

This is the UX safety net. The models themselves reaching free-tier users is a catalog-publishing action (promote Agnes into the monthly catalog), which is separate from this repo and left for the maintainer to do when ready.