### PR TITLE
docs(readme): desktop credentials + data location (#430, #408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,36 @@ npm run desktop:dist:win    # Windows → "desktop/dist-electron/FreeLLMAPI Setu
 > ("More info" → "Run anyway"); the macOS build launches without Gatekeeper prompts.
 > Full instructions in [desktop/README.md](./desktop/README.md).
 
+### Credentials and where your data lives
+
+The desktop app has **no username or password to set up**. Unlike the server
+(which gates its dashboard behind an email + password account), the desktop
+build signs the dashboard in automatically with a hidden local account, so
+you're never prompted for credentials and never need one.
+
+The only credential you need is your **unified API key** — the
+`freellmapi-…` token your OpenAI/Anthropic client points at. Get it from:
+
+- the tray popover — click the tray icon, then **Copy Key**, or
+- the dashboard **Keys** page header (tray → **Open Dashboard**).
+
+You do not need to open or edit `freeapi.db` by hand.
+
+Your settings and data live in one folder per OS (copy it to migrate to
+another machine or into a container):
+
+| OS | Location |
+|----|----------|
+| Windows | `%APPDATA%\FreeLLMAPI\` (e.g. `C:\Users\<you>\AppData\Roaming\FreeLLMAPI\`) |
+| macOS | `~/Library/Application Support/FreeLLMAPI/` |
+| Linux | `~/.config/FreeLLMAPI/` |
+
+That folder holds `freeapi.db` (all keys, models, settings, encrypted at rest)
+and `config.json` (window/theme/port/LAN preferences). Copy both to move an
+install. For the server (non-desktop) deployment, the equivalent state is the
+`.env` file and the SQLite DB at `server/data/freeapi.db` (or wherever
+`FREEAPI_DB_PATH` points).
+
 ## Languages
 
 The dashboard and the desktop tray ship in 6 languages. The UI auto-detects your


### PR DESCRIPTION
## Summary

Closes #430, closes #408.

Two Windows desktop users hit the same documentation gap:
- **#430**: hunted for a username/password for the `.exe` and tried to hand-edit `freeapi.db` with SQL. There is no such credential — the desktop app auto-signs-in with a hidden local account. What they needed was the unified API key.
- **#408**: wanted to know where config lives to migrate across machines / into Docker.

## Change

New **Credentials and where your data lives** subsection under Desktop app:
- The desktop build has no login to set up (auto-authenticated); the only credential you need is the unified API key, available from the tray popover **Copy Key** button (verified the button exists in `desktop/renderer/popover.html`) and the dashboard Keys page.
- Per-OS table of the data folder (`%APPDATA%\FreeLLMAPI`, `~/Library/Application Support/FreeLLMAPI`, `~/.config/FreeLLMAPI`) holding `freeapi.db` + `config.json`, plus the server-mode equivalent.

Docs-only.
