### PR TITLE
fix(i18n): free tier gets each model 30 days after launch, not on the 1st of the month

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -454,7 +454,7 @@
     "keyHint": "Your key is in your purchase email and on the post-checkout page. Lost it?",
     "recoverKey": "Recover it on the website",
     "upsellTitle": "Go live for $19 a year",
-    "upsellDescription": "New free models the moment they exist, instead of on the 1st of the month. One key, every device. Cancel anytime; the router stays free forever.",
+    "upsellDescription": "New free models the moment they exist, instead of 30 days later. One key, every device. Cancel anytime; the router stays free forever.",
     "goPremium": "Go Premium",
     "bundled": "bundled",
     "planGeneric": "Premium"

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -375,7 +375,7 @@
     "keyHint": "Tu clave está en el correo de compra y en la página posterior al pago. ¿La perdiste?",
     "recoverKey": "Recupérala en el sitio web",
     "upsellTitle": "Pásate al directo por 19 $ al año",
-    "upsellDescription": "Nuevos modelos gratuitos en cuanto existen, en lugar de esperar al día 1 del mes. Una clave, todos tus dispositivos. Cancela cuando quieras; el enrutador sigue siendo gratis para siempre.",
+    "upsellDescription": "Nuevos modelos gratuitos en cuanto existen, en lugar de 30 días después. Una clave, todos tus dispositivos. Cancela cuando quieras; el enrutador sigue siendo gratis para siempre.",
     "goPremium": "Hazte Premium",
     "bundled": "incluido",
     "planGeneric": "Premium"

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -375,7 +375,7 @@
     "keyHint": "Votre clé figure dans votre e-mail d'achat et sur la page de confirmation. Égarée ?",
     "recoverKey": "Récupérez-la sur le site web",
     "upsellTitle": "Passez en direct pour 19 $ par an",
-    "upsellDescription": "De nouveaux modèles gratuits dès leur sortie, au lieu du 1er du mois. Une seule clé, tous vos appareils. Annulable à tout moment ; le routeur reste gratuit pour toujours.",
+    "upsellDescription": "De nouveaux modèles gratuits dès leur sortie, au lieu de 30 jours plus tard. Une seule clé, tous vos appareils. Annulable à tout moment ; le routeur reste gratuit pour toujours.",
     "goPremium": "Passer à Premium",
     "bundled": "intégré",
     "planGeneric": "Premium"

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -396,7 +396,7 @@
     "keyHint": "La tua chiave è nell'email di acquisto e nella pagina post-checkout. L'hai persa?",
     "recoverKey": "Recuperala sul sito web",
     "upsellTitle": "Passa al feed live per $19 all'anno",
-    "upsellDescription": "Nuovi modelli gratuiti nel momento in cui esistono, invece che il 1° del mese. Una chiave, ogni dispositivo. Annulla quando vuoi; il router rimane gratuito per sempre.",
+    "upsellDescription": "Nuovi modelli gratuiti nel momento in cui esistono, invece che 30 giorni dopo. Una chiave, ogni dispositivo. Annulla quando vuoi; il router rimane gratuito per sempre.",
     "goPremium": "Vai a Premium",
     "bundled": "incluso",
     "planGeneric": "Premium"

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -375,7 +375,7 @@
     "keyHint": "Sua chave está no e-mail de compra e na página pós-pagamento. Perdeu?",
     "recoverKey": "Recupere-a no site",
     "upsellTitle": "Vá para o ao vivo por US$ 19 por ano",
-    "upsellDescription": "Novos modelos gratuitos no momento em que existem, em vez de no dia 1º do mês. Uma chave, todos os dispositivos. Cancele quando quiser; o roteador continua gratuito para sempre.",
+    "upsellDescription": "Novos modelos gratuitos no momento em que existem, em vez de 30 dias depois. Uma chave, todos os dispositivos. Cancele quando quiser; o roteador continua gratuito para sempre.",
     "goPremium": "Assinar o Premium",
     "bundled": "incluído",
     "planGeneric": "Premium"

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -377,7 +377,7 @@
     "keyHint": "您的密钥可在购买邮件与结账后页面找到。丢失了?",
     "recoverKey": "在官网找回",
     "upsellTitle": "升级为每年 19 美元的实时版",
-    "upsellDescription": "新免费模型上线即用，无需等待每月 1 日更新。一个密钥，所有设备。随时取消，路由器永久免费。",
+    "upsellDescription": "新免费模型上线即用，无需等待 30 天。一个密钥，所有设备。随时取消，路由器永久免费。",
     "goPremium": "升级到高级版",
     "bundled": "内置",
     "planGeneric": "Premium"

--- a/server/src/db/migrations/20260101_000000_legacy_baseline.ts
+++ b/server/src/db/migrations/20260101_000000_legacy_baseline.ts
@@ -2024,7 +2024,7 @@ function migrateEmbeddingsV1(db: Database.Database) {
  * misroute to an image model) and never pollute the chat token budget. This is
  * schema only: per the no-model-data-in-migrations rule (see migrateDbSchema),
  * the rows are maintained in the published catalog and arrive via catalog-sync
- * (premium on the live tier within ~12h, free at the monthly promote). `modality`
+ * (premium on the live tier within ~12h, free once each model is 30 days old). `modality`
  * is 'image' | 'audio'; `quota_label` mirrors the catalog's display note. The
  * request_type column (added by migrateEmbeddingsV1) tags media traffic 'image'
  * / 'audio' so it stays out of the chat budget math.

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -6,7 +6,7 @@
 // token budget. Each platform has a small adapter here; routing fails over
 // across the providers serving the same modality. The rows are maintained in the
 // published catalog and arrive via catalog-sync (premium on the live tier within
-// ~12h, free at the monthly promote) — never seeded by migrations.
+// ~12h, free once each model is 30 days old) — never seeded by migrations.
 import { getDb } from '../db/index.js';
 import { decrypt } from '../lib/crypto.js';
 import { proxyFetch } from '../lib/proxy.js';


### PR DESCRIPTION
The premium upsell copy claimed new free models arrive "on the 1st of the month". The free catalog is actually rebuilt daily, and each model becomes free 30 days after it first appears in the live catalog. This updates the upsell string in all six locales (en, zh-CN, it, fr, es, pt-BR) and two stale code comments describing the old monthly design.

No behavior change; copy and comments only.
