### PR TITLE
fix(embeddings,media): enable multi-key load balancing via random selection

### DIFF
--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -87,7 +87,7 @@ function getProviderCredential(row: EmbeddingModelRow): ProviderCredential | nul
   if (row.platform === 'custom') return null;
 
   const keyRow = getDb().prepare(
-    "SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id LIMIT 1",
+    "SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY RANDOM() LIMIT 1",
   ).get(row.platform) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
   if (!keyRow) return null;
   try {

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -95,7 +95,7 @@ function getProviderCredential(row: MediaModelRow): ProviderCredential | null {
   if (row.platform === 'custom') return null;
 
   const keyRow = getDb()
-    .prepare("SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id LIMIT 1")
+    .prepare("SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY RANDOM() LIMIT 1")
     .get(row.platform) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
   if (!keyRow) return null;
   try {


### PR DESCRIPTION
### Summary

Previously, `getProviderCredential()` in both `embeddings.ts` and `media.ts` queried `api_keys` using `ORDER BY id LIMIT 1`. This hardcoded single-key selection, ignoring additional active keys configured for the same platform. As a result, embedding and media requests would hit rate limits (429) on the first key while other valid keys for the same provider sat idle.

### Changes

- Updated the query in `server/src/services/embeddings.ts` to `ORDER BY RANDOM() LIMIT 1`.
- Updated the query in `server/src/services/media.ts` to `ORDER BY RANDOM() LIMIT 1`.

This enables multi-key load balancing across all active keys for embedding and media requests.