### PR TITLE
fix(catalog-sync): add enabled to model overrides map to prevent undefined SQL column crash

### DIFF
--- a/server/src/services/declarative-config.ts
+++ b/server/src/services/declarative-config.ts
@@ -302,6 +302,7 @@ function upsertModel(db: Database.Database, input: z.infer<typeof modelSchema>):
     contextWindow: 'context_window',
     supportsVision: 'supports_vision',
     supportsTools: 'supports_tools',
+    enabled: 'enabled',
   };
   for (const key of Object.keys(patch) as Array<keyof ModelOverridePatch>) {
     assignments.push(`${columnMap[key]} = ?`);

--- a/server/src/services/model-state.ts
+++ b/server/src/services/model-state.ts
@@ -15,6 +15,7 @@ export interface ModelOverridePatch {
   contextWindow?: number | null;
   supportsVision?: boolean;
   supportsTools?: boolean;
+  enabled?: boolean;
 }
 
 type StoredOverrides = Partial<ModelOverridePatch>;
@@ -32,6 +33,7 @@ const OVERRIDE_COLUMNS: Record<keyof ModelOverridePatch, string> = {
   contextWindow: 'context_window',
   supportsVision: 'supports_vision',
   supportsTools: 'supports_tools',
+  enabled: 'enabled',
 };
 
 function parseOverrides(raw: string | undefined): StoredOverrides {
@@ -45,7 +47,7 @@ function parseOverrides(raw: string | undefined): StoredOverrides {
 }
 
 function toDbValue(key: keyof ModelOverridePatch, value: unknown): unknown {
-  if (key === 'supportsVision' || key === 'supportsTools') return value ? 1 : 0;
+  if (key === 'supportsVision' || key === 'supportsTools' || key === 'enabled') return value ? 1 : 0;
   return value;
 }
 
@@ -138,7 +140,7 @@ export function applyModelOverrides(
   modelId: string,
 ): boolean {
   const overrides = getModelOverrides(db, platform, modelId);
-  const keys = Object.keys(overrides) as Array<keyof ModelOverridePatch>;
+  const keys = (Object.keys(overrides) as Array<keyof ModelOverridePatch>).filter(k => k in OVERRIDE_COLUMNS);
   if (keys.length === 0) return false;
 
   const assignments: string[] = [];


### PR DESCRIPTION
### Summary

Fixes a crash during catalog sync re-application after boot (`cached catalog re-apply failed: no such column: undefined`).

### Root Cause

When a model has overrides stored in `model_overrides` (such as `{"enabled": false}`), `applyModelOverrides()` in `model-state.ts` maps each JSON key to a SQLite column using `OVERRIDE_COLUMNS`. Because `enabled` was missing from `OVERRIDE_COLUMNS`, `OVERRIDE_COLUMNS['enabled']` evaluated to `undefined`. This constructed a broken query (`UPDATE models SET undefined = ? ...`) that failed on boot.

### Changes

- Added `enabled?: boolean` to `ModelOverridePatch` and `enabled: 'enabled'` to `OVERRIDE_COLUMNS` in both `model-state.ts` and `declarative-config.ts`.
- Added boolean-to-integer conversion for `enabled` in `toDbValue()`.
- Added a defensive filter (`.filter(k => k in OVERRIDE_COLUMNS)`) in `applyModelOverrides()` to ensure unmapped keys in JSON never result in SQL column errors.