### PR TITLE
feat(analytics): persist selected time range in localStorage

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -13,6 +13,26 @@ import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 import { useI18n } from '@/i18n'
 
 type TimeRange = '24h' | '7d' | '30d'
+
+const TIME_RANGES: readonly TimeRange[] = ['24h', '7d', '30d']
+const STORAGE_KEY = 'freellmapi.analytics.range'
+const DEFAULT_RANGE: TimeRange = '7d'
+
+// Read the previously-selected range from localStorage. Invalid or missing
+// values fall back to the 7d default so a corrupted entry never bricks the
+// page; SSR-safety follows the same try/catch shape as `lib/api.ts`.
+function loadStoredRange(): TimeRange {
+  if (typeof window === 'undefined') return DEFAULT_RANGE
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored && (TIME_RANGES as readonly string[]).includes(stored)) {
+      return stored as TimeRange
+    }
+  } catch {
+    /* localStorage unavailable (private mode, etc.) — use default */
+  }
+  return DEFAULT_RANGE
+}
 
 function formatTokens(n?: number): string {
   if (!n) return '0'
@@ -50,7 +70,19 @@ const primaryFill = 'var(--foreground)'
 
 export default function AnalyticsPage() {
   const { t } = useI18n()
-  const [range, setRange] = useState<TimeRange>('7d')
+  const [range, setRange] = useState<TimeRange>(loadStoredRange)
+
+  // Remember the last-selected range across page reloads / new sessions so
+  // the user lands back on the window they were inspecting. Same
+  // localStorage shape as `theme` and `freellmapi.locale`.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(STORAGE_KEY, range)
+    } catch {
+      /* ignore — storage quota / private mode */
+    }
+  }, [range])
 
   const { data: summary } = useQuery({
     queryKey: ['analytics', 'summary', range],


### PR DESCRIPTION
## Summary

Persists the selected analytics time range (24h / 7d / 30d) in `localStorage`
so the user lands back on the window they were inspecting after a reload or
new session. Same persistence pattern as the existing `theme` toggle
(`client/index.html`) and the `freellmapi.locale` preference
(`client/src/i18n/I18nProvider.tsx`).

Storage key: `freellmapi.analytics.range`. Values are validated against
`['24h', '7d', '30d']`; invalid or missing entries fall back to the existing
7d default so a corrupted entry never bricks the page. `localStorage`
access is wrapped in `try/catch` for SSR / private-mode safety (same
pattern as `client/src/lib/api.ts:18-26`).

## Motivation

The analytics page is a frequent revisit — most operators land on 7d or 30d,
not the default, and a hard reload (or new browser session) always snapped
them back to 7d. Small but persistent annoyance; the existing `theme` and
`freellmapi.locale` patterns show the project already considers
client-level preferences worth persisting, so this is consistent with the
project's UX conventions.

## Changes

| File | Change |
|---|---|
| `client/src/pages/AnalyticsPage.tsx` | Added `useEffect` import; `useState<TimeRange>('7d')` → `useState<TimeRange>(loadStoredRange)`; new `useEffect` to persist `range` on change; added `STORAGE_KEY`, `TIME_RANGES`, `DEFAULT_RANGE` constants and `loadStoredRange()` helper. |

**1 file, +34 / -2.** No new dependencies. No server changes. No new
migrations. No i18n changes (the tab labels use existing
`analytics.range24h` / `range7d` / `range30d` keys).

## Test plan

- `npx tsc -b` in `client/` — clean, 0 errors.
- `npx tsc -b` in `server/` — 9 errors in `server/src/routes/keys.ts` from
  upstream's `multer` typing bug (PR #438, pre-existing on `origin/main`
  at `340f414`). **Not introduced by this PR** — same errors reproduce on
  a clean `git checkout origin/main`.
- `npx vitest run` in `server/` — 524/524 passing, 0 failures, 0 regressions.
- Live verification: deployed on `integration/all-my-prs @ f81f781`; the
  rebuilt client bundle (`dist/assets/index-DJVe5VdN.js`) contains the new
  storage key string and the read+set localStorage calls. Restarted
  service, `MainPID=860700` running.

Manual smoke:
1. Open `/analytics`, click 30d.
2. Hard-reload — page opens on 30d (previously: 7d).
3. Open DevTools → Application → Local Storage → key
   `freellmapi.analytics.range` is `30d`.
4. Click 24h, reload — opens on 24h, storage now `24h`.
5. Clear the key manually + reload — falls back to 7d.

## Compatibility

No breaking changes. The default is unchanged (7d). The persistence is
additive — users who never visit the page see no different behaviour. The
`localStorage` key is namespaced (`freellmapi.*`) per the existing
convention.

References operator session 2026-07-04. No upstream issue number yet —
happy to file one if requested.
