### PR TITLE
docs(readme): add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRoute
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
 [![Docker image](https://img.shields.io/badge/ghcr.io-freellmapi-2496ED?logo=docker&logoColor=white)](https://github.com/tashfeenahmed/freellmapi/pkgs/container/freellmapi)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tashfeenahmed/freellmapi)
 
 **[freellmapi.co](https://freellmapi.co)** · browse all 161 free models on the live catalog
 


### PR DESCRIPTION
Add a badge for DeepWiki to the README, for 
more frequent updates to that wiki, and to allow
others to more easily onboard to the codebase.

An up-to-date DeepWiki also makes DeepWiki's
MCP server more useful for work on this codebase.