### PR TITLE
fix: 自定义 provider URL 默认限制 localhost，新增 ALLOW_REMOTE_CUSTOM_PROVIDERS…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ REQUEST_ANALYTICS_MAX_ROWS=100000
 # Vite dev dashboard. Only set this if you serve the dashboard from a
 # different host than the API (e.g. http://my-server.local).
 # DASHBOARD_ORIGINS=http://my-server.local,http://192.168.1.50
+
+# Custom providers are restricted to localhost by default to avoid turning the
+# server into a private-network request proxy. Set this only when you need a
+# remote OpenAI-compatible HTTPS endpoint.
+# ALLOW_REMOTE_CUSTOM_PROVIDERS=true

--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -48,6 +48,10 @@ describe('resolveProvider (#117)', () => {
     expect(resolveProvider('custom', '   ')).toBeUndefined();
   });
 
+  it('refuses a custom provider bound to a private remote address', () => {
+    expect(resolveProvider('custom', 'http://192.168.1.20:8080/v1')).toBeUndefined();
+  });
+
   it('returns the registered singleton for built-in platforms', () => {
     expect(resolveProvider('groq')).toBe(getProvider('groq'));
   });
@@ -66,6 +70,50 @@ describe('POST /api/keys/custom (#117)', () => {
   it('rejects an invalid base URL', async () => {
     const { status } = await post(app, '/api/keys/custom', { baseUrl: 'not-a-url', model: 'm' });
     expect(status).toBe(400);
+  });
+
+  it('rejects private-network custom endpoints by default', async () => {
+    const { status, body } = await post(app, '/api/keys/custom', {
+      baseUrl: 'http://192.168.1.20:11434/v1',
+      model: 'm',
+    });
+    expect(status).toBe(400);
+    expect(body.error.message).toMatch(/private|loopback|link-local|unspecified/i);
+  });
+
+  it('rejects non-http custom endpoint schemes', async () => {
+    const { status, body } = await post(app, '/api/keys/custom', {
+      baseUrl: 'file:///etc/passwd',
+      model: 'm',
+    });
+    expect(status).toBe(400);
+    expect(body.error.message).toMatch(/http or https/i);
+  });
+
+  it('allows remote HTTPS custom endpoints only when explicitly enabled', async () => {
+    const previous = process.env.ALLOW_REMOTE_CUSTOM_PROVIDERS;
+    process.env.ALLOW_REMOTE_CUSTOM_PROVIDERS = 'true';
+    try {
+      const { status, body } = await post(app, '/api/keys/custom', {
+        baseUrl: 'https://llm.example.com/v1/',
+        model: 'remote-model',
+      });
+      expect(status).toBe(201);
+      expect(body.baseUrl).toBe('https://llm.example.com/v1');
+    } finally {
+      const db = getDb();
+      const model = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = 'remote-model'").get() as { id: number } | undefined;
+      if (model) {
+        db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(model.id);
+        db.prepare('DELETE FROM models WHERE id = ?').run(model.id);
+      }
+      db.prepare("DELETE FROM api_keys WHERE platform = 'custom' AND base_url = 'https://llm.example.com/v1'").run();
+      if (previous === undefined) {
+        delete process.env.ALLOW_REMOTE_CUSTOM_PROVIDERS;
+      } else {
+        process.env.ALLOW_REMOTE_CUSTOM_PROVIDERS = previous;
+      }
+    }
   });
 
   it('registers a custom endpoint, model, and fallback entry', async () => {

--- a/server/src/lib/custom-provider-url.ts
+++ b/server/src/lib/custom-provider-url.ts
@@ -1,0 +1,73 @@
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+function normalizeHostname(hostname: string): string {
+  return hostname.trim().toLowerCase().replace(/^\[(.*)\]$/, '$1');
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return false;
+
+  const octets = parts.map(part => Number(part));
+  if (octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) return false;
+
+  const [a, b] = octets;
+  return a === 0
+    || a === 10
+    || a === 127
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && b === 168);
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const host = normalizeHostname(hostname);
+  return host === '::1'
+    || host.startsWith('fc')
+    || host.startsWith('fd')
+    || host.startsWith('fe80:');
+}
+
+function isLocalCustomProviderHost(hostname: string): boolean {
+  const host = normalizeHostname(hostname);
+  return LOCAL_HOSTNAMES.has(host);
+}
+
+function allowsRemoteCustomProviders(): boolean {
+  return process.env.ALLOW_REMOTE_CUSTOM_PROVIDERS === 'true';
+}
+
+export function normalizeCustomProviderBaseUrl(rawBaseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawBaseUrl.trim());
+  } catch {
+    throw new Error('baseUrl must be a valid URL');
+  }
+
+  const protocol = parsed.protocol;
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new Error('Custom provider baseUrl must use http or https');
+  }
+
+  const hostname = normalizeHostname(parsed.hostname);
+  const isLocal = isLocalCustomProviderHost(hostname);
+
+  if (isLocal) {
+    return parsed.toString().replace(/\/+$/, '');
+  }
+
+  if (isPrivateIpv4(hostname) || isPrivateIpv6(hostname)) {
+    throw new Error('Custom provider baseUrl cannot target private, loopback, link-local, or unspecified IP addresses');
+  }
+
+  if (!allowsRemoteCustomProviders()) {
+    throw new Error('Remote custom provider URLs are disabled by default. Set ALLOW_REMOTE_CUSTOM_PROVIDERS=true to allow remote HTTPS endpoints.');
+  }
+
+  if (protocol !== 'https:') {
+    throw new Error('Remote custom provider baseUrl must use https');
+  }
+
+  return parsed.toString().replace(/\/+$/, '');
+}

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -4,6 +4,7 @@ import { GoogleProvider } from './google.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
+import { normalizeCustomProviderBaseUrl } from '../lib/custom-provider-url.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -187,10 +188,16 @@ export function resolveProvider(platform: Platform, baseUrl?: string | null): Ba
   if (platform === 'custom') {
     const trimmed = baseUrl?.trim();
     if (!trimmed) return undefined;
+    let normalized: string;
+    try {
+      normalized = normalizeCustomProviderBaseUrl(trimmed);
+    } catch {
+      return undefined;
+    }
     return new OpenAICompatProvider({
       platform: 'custom',
       name: 'Custom (OpenAI-compatible)',
-      baseUrl: trimmed,
+      baseUrl: normalized,
       timeoutMs: CUSTOM_PROVIDER_TIMEOUT_MS,
     });
   }

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
+import { normalizeCustomProviderBaseUrl } from '../lib/custom-provider-url.js';
 
 export const keysRouter = Router();
 
@@ -103,7 +104,13 @@ keysRouter.post('/custom', (req: Request, res: Response) => {
     return;
   }
 
-  const baseUrl = parsed.data.baseUrl.trim().replace(/\/+$/, '');
+  let baseUrl: string;
+  try {
+    baseUrl = normalizeCustomProviderBaseUrl(parsed.data.baseUrl);
+  } catch (err: any) {
+    res.status(400).json({ error: { message: err?.message ?? 'Invalid custom provider baseUrl' } });
+    return;
+  }
   const modelId = parsed.data.model.trim();
   const displayName = (parsed.data.displayName ?? modelId).trim();
   // Local servers often need no key; keep a sentinel so there's always a bearer.


### PR DESCRIPTION
… 安全开关
## 安全加固

1. **自定义 provider URL 默认限制 localhost**
   - 新增 URL 校验，非 localhost 的 HTTPS URL 需要显式设置 `ALLOW_REMOTE_CUSTOM_PROVIDERS=true`
   - 写入 config 时和运行时解析 provider 时双重校验

2. **防止历史恶意 URL**
   - 即使之前配置了恶意 base_url，升级后也会被拦截

3. **测试验证**
   - npm run test -w server -- custom-provider: 12 passed ✅
   - npm run build -w server: 通过 ✅