### PR TITLE
fix: sticky session map grows unbounded between prune passes

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -186,6 +186,17 @@ export function setStickyModel(messages: ChatMessage[], modelDbId: number, sessi
     for (const [k, v] of stickySessionMap) {
       if (now - v.lastUsed > STICKY_TTL_MS) stickySessionMap.delete(k);
     }
+
+    // Hard cap: if still over 1000 after pruning expired entries, evict oldest by lastUsed
+    if (stickySessionMap.size > 1000) {
+      const entries = [...stickySessionMap.entries()].sort(
+        (a, b) => a[1].lastUsed - b[1].lastUsed
+      );
+      const toEvict = stickySessionMap.size - 1000;
+      for (let i = 0; i < toEvict; i++) {
+        stickySessionMap.delete(entries[i][0]);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The sticky session map only pruned expired entries when its size exceeded 500, but had no hard cap after pruning. If all entries were fresh (under the TTL), the map could grow indefinitely — every new session added an entry, and with no eviction until 500+ expired at once, a busy proxy would accumulate thousands of stale-but-not-yet-expired entries.

Added a secondary eviction that drops the oldest entries (by \`lastUsed\` timestamp) when the map exceeds 1000 entries regardless of TTL, giving it a reasonable upper bound.