### PR TITLE
fix(custom): tool-capable custom models + provider label in models list (#470, #469)

### DIFF
--- a/client/src/components/keys/custom-provider-section.tsx
+++ b/client/src/components/keys/custom-provider-section.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { FieldError } from '@/components/ui/field-error'
 import { isHttpUrl } from '@/lib/validate'
@@ -33,6 +34,10 @@ export function CustomProviderSection({ onAdded }: { onAdded?: () => void } = {}
   const [displayName, setDisplayName] = useState('')
   const [family, setFamily] = useState('')
   const [apiKey, setApiKey] = useState('')
+  // Chat models default tools on (modern OpenAI-compatible servers all emit tool
+  // calls) and vision off; declare them here or flip them later per model. (#470)
+  const [supportsTools, setSupportsTools] = useState(true)
+  const [supportsVision, setSupportsVision] = useState(false)
 
   const models = customType === 'chat' ? parseModelList(model) : [model.trim()].filter(Boolean)
   const multiple = customType === 'chat' && models.length > 1
@@ -66,6 +71,8 @@ export function CustomProviderSection({ onAdded }: { onAdded?: () => void } = {}
       setModel('')
       setDisplayName('')
       setFamily('')
+      setSupportsTools(true)
+      setSupportsVision(false)
       if (onAdded) {
         toast.success(t('keys.modelAdded'))
         onAdded()
@@ -94,6 +101,8 @@ export function CustomProviderSection({ onAdded }: { onAdded?: () => void } = {}
           models,
           displayName: !multiple ? (displayName || undefined) : undefined,
           apiKey: apiKey || undefined,
+          supportsTools,
+          supportsVision,
         },
       })
       return
@@ -184,6 +193,21 @@ export function CustomProviderSection({ onAdded }: { onAdded?: () => void } = {}
               placeholder={embeddingsData?.families?.[0]?.family ?? t('keys.customFamilyPlaceholder')}
               className="w-[190px] font-mono text-xs"
             />
+          </div>
+        )}
+        {customType === 'chat' && (
+          <div className="space-y-1.5">
+            <Label className="text-xs">{t('keys.customCapabilities')}</Label>
+            <div className="flex h-9 items-center gap-4">
+              <label className="flex items-center gap-1.5 text-xs">
+                <Switch size="sm" checked={supportsTools} onCheckedChange={setSupportsTools} />
+                <span>{t('models.tools')}</span>
+              </label>
+              <label className="flex items-center gap-1.5 text-xs">
+                <Switch size="sm" checked={supportsVision} onCheckedChange={setSupportsVision} />
+                <span>{t('models.vision')}</span>
+              </label>
+            </div>
           </div>
         )}
         <div className="space-y-1.5">

--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -11,6 +11,7 @@ import {
   formatContext,
   groupMaxContext,
   groupQuotaBadge,
+  providerLabel,
   type ModelGroupRow,
   type Row,
 } from '@/lib/routing'
@@ -93,7 +94,7 @@ export function RowContent({
       <td className="py-2 pr-3 align-middle">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="font-medium text-sm">{row.displayName}</span>
-          <span className="text-xs text-muted-foreground">{row.platform}</span>
+          <span className="text-xs text-muted-foreground">{providerLabel(row)}</span>
           {row.supportsVision && (
             <span
               title={t('models.visionTitle')}
@@ -185,8 +186,8 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup }: {
           <Link to={`/models/chat/${detailId}`} aria-label={t('models.viewProviders')} onClick={e => e.stopPropagation()} className="flex items-center gap-2 flex-wrap text-left min-w-0">
             <span className="font-medium text-sm">{group.label}</span>
             {solo
-              ? <span className="text-xs text-muted-foreground">{group.members[0].platform}</span>
-              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => m.platform).join(', ') })}>
+              ? <span className="text-xs text-muted-foreground">{providerLabel(group.members[0])}</span>
+              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => providerLabel(m)).join(', ') })}>
                   <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: group.members.length })}</span>
                 </Tooltip>}
             {quota && (

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -263,6 +263,7 @@
     "customFamily": "Family",
     "customFamilyPlaceholder": "defaults to model id",
     "customApiKey": "API key",
+    "customCapabilities": "Capabilities",
     "addModel": "Add model",
     "modelAdded": "Model added",
     "addModels": "Add {count} models",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -224,6 +224,7 @@
     "customDisplayNamePerModel": "por modelo",
     "customDisplayNameOptional": "opcional",
     "customApiKey": "Clave API",
+    "customCapabilities": "Capacidades",
     "addModel": "Añadir modelo",
     "modelAdded": "Modelo añadido",
     "addModels": "Añadir {count} modelos",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -224,6 +224,7 @@
     "customDisplayNamePerModel": "par modèle",
     "customDisplayNameOptional": "facultatif",
     "customApiKey": "Clé API",
+    "customCapabilities": "Capacités",
     "addModel": "Ajouter un modèle",
     "modelAdded": "Modèle ajouté",
     "addModels": "Ajouter {count} modèles",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -224,6 +224,7 @@
     "customDisplayNamePerModel": "per-modello",
     "customDisplayNameOptional": "opzionale",
     "customApiKey": "Chiave API",
+    "customCapabilities": "Funzionalità",
     "addModel": "Aggiungi modello",
     "modelAdded": "Modello aggiunto",
     "addModels": "Aggiungi {count} modelli",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -224,6 +224,7 @@
     "customDisplayNamePerModel": "por modelo",
     "customDisplayNameOptional": "opcional",
     "customApiKey": "Chave de API",
+    "customCapabilities": "Recursos",
     "addModel": "Adicionar modelo",
     "modelAdded": "Modelo adicionado",
     "addModels": "Adicionar {count} modelos",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -224,6 +224,7 @@
     "customDisplayNamePerModel": "按模型命名",
     "customDisplayNameOptional": "可选",
     "customApiKey": "API 密钥",
+    "customCapabilities": "能力",
     "addModel": "添加模型",
     "modelAdded": "模型已添加",
     "addModels": "添加 {count} 个模型",

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -69,6 +69,15 @@ export interface TokenUsageData {
   models: { displayName: string; platform: string; modelId?: string; budget: number; used?: number }[]
 }
 
+// Custom endpoints all share the generic 'custom' platform id, so show the
+// user's key label ("Ollama box") instead so the models list names the actual
+// provider. Falls back to the platform for catalog models (and unlabeled custom
+// keys, whose label defaults to "Custom"). (#469)
+export function providerLabel(row: { platform: string; source?: 'catalog' | 'custom'; keyLabel?: string | null }): string {
+  if (row.source === 'custom' && row.keyLabel && row.keyLabel.trim()) return row.keyLabel
+  return row.platform
+}
+
 export function formatTokens(n: number): string {
   if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -16,6 +16,7 @@ import { ModelsTabs } from '@/components/models-tabs'
 import { ModelTableHead, RowContent } from '@/components/model-table'
 import {
   groupQuotaBadge,
+  providerLabel,
   type FallbackEntry,
   type RoutingData,
   type Row,
@@ -182,7 +183,7 @@ export default function ModelDetailPage() {
               <div className="space-y-1.5">
                 {members.map(m => (
                   <div key={m.modelDbId} className="flex items-center gap-2 text-xs">
-                    <span className="w-28 shrink-0 text-muted-foreground">{m.platform}</span>
+                    <span className="w-28 shrink-0 text-muted-foreground">{providerLabel(m)}</span>
                     <code className="min-w-0 flex-1 truncate font-mono text-[11px]">{m.modelId}</code>
                     <Tooltip text={t('models.copyModelName')}>
                       <CopyButton text={m.modelId} label={t('models.copyModelName')} className="border-0 bg-transparent" />
@@ -261,7 +262,7 @@ function ProviderSettingsRow({
   return (
     <div className="rounded-xl border bg-background/60 p-3">
       <div className="mb-3 flex flex-wrap items-center gap-2">
-        <span className="text-xs font-medium">{model.platform}</span>
+        <span className="text-xs font-medium">{providerLabel(model)}</span>
         <code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">{model.modelId}</code>
         <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{sourceLabel}</span>
         {model.hasOverrides && (

--- a/server/src/__tests__/db/migrate/custom-model-tool-support.test.ts
+++ b/server/src/__tests__/db/migrate/custom-model-tool-support.test.ts
@@ -1,0 +1,73 @@
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it } from 'vitest';
+import { up, down } from '../../../db/migrations/20260706_000002_custom_model_tool_support.js';
+
+// A minimal stand-in for the models table so the data-only migration can be
+// exercised without the full catalog seed.
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE models (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      platform TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      supports_tools INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  const insert = db.prepare('INSERT INTO models (platform, model_id, supports_tools) VALUES (?, ?, ?)');
+  insert.run('custom', 'qwen3:4b', 0);          // the stuck-at-zero case (#470)
+  insert.run('custom', 'llama3:8b', 1);          // already tool-capable
+  insert.run('groq', 'llama-3.3-70b', 0);        // a catalog row that must NOT change
+  return db;
+}
+
+function toolsByModel(db: Database.Database): Record<string, number> {
+  const rows = db.prepare('SELECT model_id, supports_tools FROM models').all() as { model_id: string; supports_tools: number }[];
+  return Object.fromEntries(rows.map(r => [r.model_id, r.supports_tools]));
+}
+
+const dbs: Database.Database[] = [];
+afterEach(() => {
+  for (const db of dbs.splice(0)) db.close();
+});
+
+describe('custom_model_tool_support migration (#470)', () => {
+  it('flips every custom model to tool-capable and leaves catalog rows alone', () => {
+    const db = makeDb();
+    dbs.push(db);
+
+    up(db);
+
+    expect(toolsByModel(db)).toEqual({
+      'qwen3:4b': 1,
+      'llama3:8b': 1,
+      'llama-3.3-70b': 0, // catalog row untouched
+    });
+  });
+
+  it('is idempotent — a second up() produces the identical result', () => {
+    const db = makeDb();
+    dbs.push(db);
+
+    up(db);
+    const once = toolsByModel(db);
+    up(db);
+    const twice = toolsByModel(db);
+
+    expect(twice).toEqual(once);
+  });
+
+  it('down() reverses the backfill for custom rows only', () => {
+    const db = makeDb();
+    dbs.push(db);
+
+    up(db);
+    down(db);
+
+    expect(toolsByModel(db)).toEqual({
+      'qwen3:4b': 0,
+      'llama3:8b': 0,
+      'llama-3.3-70b': 0,
+    });
+  });
+});

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -10,6 +10,7 @@ const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state.ts';
 const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
+const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
 
 interface SchemaRow {
   type: string;
@@ -66,6 +67,7 @@ describe('migration round trip', () => {
         REQUEST_AGGREGATES_FILENAME,
         GITHUB_GPT41_CONTEXT_FILENAME,
         REQUEST_CLIENT_INFO_FILENAME,
+        CUSTOM_MODEL_TOOL_SUPPORT_FILENAME,
       ]);
     } finally {
       db.close();
@@ -78,6 +80,15 @@ describe('migration round trip', () => {
     try {
       await runMigrations(db, 'up');
       expect(getPendingMigrationNames(db)).toEqual([]);
+
+      // The catalog seed has no custom models, so the custom-model tool-support
+      // backfill only alters state once a user endpoint exists. Seed one (in its
+      // post-migration state, tools = 1) so the round trip actually exercises
+      // that migration's down (tools -> 0) and up (tools -> 1).
+      db.prepare(`
+        INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, supports_tools, supports_vision, enabled)
+        VALUES ('custom', 'roundtrip-custom', 'Roundtrip Custom', 50, 50, 1, 0, 1)
+      `).run();
 
       const fullState = snapshotAppState(db);
       await runDownToBaseline(db);

--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -357,4 +357,86 @@ describe('Custom Provider Endpoints', () => {
       expect(status).toBe(400);
     });
   });
+
+  // #470: custom models used to register with supports_tools = 0, so agentic
+  // clients that send `tools` matched zero of them and hit a false "all models
+  // exhausted" error. Registration now defaults tools on, vision off.
+  describe('capability defaults (#470)', () => {
+    beforeAll(() => {
+      const db = getDb();
+      db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
+      db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
+      db.prepare("DELETE FROM api_keys WHERE platform = 'custom'").run();
+    });
+
+    function toolsVision(modelId: string) {
+      return getDb()
+        .prepare("SELECT supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ?")
+        .get(modelId) as { supports_tools: number; supports_vision: number };
+    }
+
+    it('defaults a new custom model to tools on, vision off', async () => {
+      const { status, body } = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5001/v1',
+        model: 'defaults-model',
+      });
+      expect(status).toBe(201);
+      expect(toolsVision('defaults-model')).toEqual({ supports_tools: 1, supports_vision: 0 });
+      // Echoed back to the client so the UI can render the capability badges.
+      expect(body.supportsTools).toBe(true);
+      expect(body.supportsVision).toBe(false);
+    });
+
+    it('honors submit-level supportsTools / supportsVision flags', async () => {
+      const { status } = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5002/v1',
+        model: 'vision-no-tools',
+        supportsTools: false,
+        supportsVision: true,
+      });
+      expect(status).toBe(201);
+      expect(toolsVision('vision-no-tools')).toEqual({ supports_tools: 0, supports_vision: 1 });
+    });
+
+    it('honors per-entry flags in the models array and per-model defaults', async () => {
+      const { status } = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5003/v1',
+        models: [
+          { model: 'entry-vision', supportsVision: true },
+          'entry-default',
+        ],
+      });
+      expect(status).toBe(201);
+      expect(toolsVision('entry-vision')).toEqual({ supports_tools: 1, supports_vision: 1 });
+      expect(toolsVision('entry-default')).toEqual({ supports_tools: 1, supports_vision: 0 });
+    });
+
+    it('preserves a stored capability when re-registration omits the flag', async () => {
+      await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5004/v1',
+        model: 'preserve-model',
+        supportsTools: false,
+      });
+      expect(toolsVision('preserve-model')).toEqual({ supports_tools: 0, supports_vision: 0 });
+
+      // Re-submit the same endpoint/model without capability flags — the earlier
+      // tools = 0 the user chose must survive, not snap back to the default.
+      const { status } = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5004/v1',
+        model: 'preserve-model',
+        displayName: 'Renamed',
+      });
+      expect(status).toBe(201);
+      expect(toolsVision('preserve-model')).toEqual({ supports_tools: 0, supports_vision: 0 });
+    });
+
+    it('rejects a non-boolean capability flag', async () => {
+      const { status } = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:5005/v1',
+        model: 'bad-flag',
+        supportsTools: 'yes',
+      });
+      expect(status).toBe(400);
+    });
+  });
 });

--- a/server/src/__tests__/routes/models-management.test.ts
+++ b/server/src/__tests__/routes/models-management.test.ts
@@ -78,6 +78,31 @@ describe('Model management API', () => {
     expect(item.fallbackEnabled).toBe(false);
   });
 
+  it('patches a custom model capability directly, without recording a catalog override', async () => {
+    // Custom models are not catalog-managed, so their capability edits are
+    // written straight to the row (no model_overrides entry to survive syncs).
+    const reg = await request(app, 'POST', '/api/keys/custom', {
+      baseUrl: 'http://127.0.0.1:6100/v1',
+      model: 'cap-edit-model',
+    });
+    expect(reg.status).toBe(201);
+    const modelDbId = reg.body.modelDbId as number;
+
+    const { status, body } = await request(app, 'PATCH', `/api/models/${modelDbId}`, {
+      supportsVision: true,
+      supportsTools: false,
+    });
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+
+    const row = getDb().prepare('SELECT supports_vision, supports_tools FROM models WHERE id = ?')
+      .get(modelDbId) as { supports_vision: number; supports_tools: number };
+    expect(row).toEqual({ supports_vision: 1, supports_tools: 0 });
+
+    const override = getDb().prepare("SELECT 1 FROM model_overrides WHERE platform = 'custom' AND model_id = 'cap-edit-model'").get();
+    expect(override).toBeUndefined();
+  });
+
   it('deletes a catalog model with a tombstone', async () => {
     const target = getDb().prepare(`
       SELECT id, platform, model_id FROM models

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -5,6 +5,7 @@ import * as catalogModelState from '../migrations/20260627_000002_catalog_model_
 import * as requestAggregates from '../migrations/20260628_120000_request_aggregates.js';
 import * as githubGpt41Context from '../migrations/20260630_000001_github_gpt41_context.js';
 import * as requestClientInfo from '../migrations/20260706_000001_request_client_info.js';
+import * as customModelToolSupport from '../migrations/20260706_000002_custom_model_tool_support.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -22,6 +23,7 @@ export const CATALOG_MODEL_STATE_FILENAME = '20260627_000002_catalog_model_state
 export const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 export const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 export const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
+export const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -30,4 +32,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: REQUEST_AGGREGATES_FILENAME, module: requestAggregates },
   { filename: GITHUB_GPT41_CONTEXT_FILENAME, module: githubGpt41Context },
   { filename: REQUEST_CLIENT_INFO_FILENAME, module: requestClientInfo },
+  { filename: CUSTOM_MODEL_TOOL_SUPPORT_FILENAME, module: customModelToolSupport },
 ];

--- a/server/src/db/migrations/20260706_000002_custom_model_tool_support.ts
+++ b/server/src/db/migrations/20260706_000002_custom_model_tool_support.ts
@@ -1,0 +1,22 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * Custom OpenAI-compatible providers (Ollama, vLLM, LM Studio, and friends) all
+ * speak the tool-call protocol, but early custom-model registration seeded
+ * supports_tools = 0. Agentic clients that send `tools` (Trae, Cline, and the
+ * like) then matched zero custom models and hit a false "all models exhausted"
+ * error (#470).
+ *
+ * Backfill existing custom rows to tool-capable. The trade is deliberate: a
+ * wrong tools = 1 only surfaces a recoverable upstream error the user can turn
+ * off with the per-model toggle, whereas tools = 0 hides the model from
+ * tool-bearing requests with no recourse. New registrations default to
+ * tools = 1 in the route handler, so this only touches rows created earlier.
+ */
+export function up(db: Database.Database): void {
+  db.prepare("UPDATE models SET supports_tools = 1 WHERE platform = 'custom'").run();
+}
+
+export function down(db: Database.Database): void {
+  db.prepare("UPDATE models SET supports_tools = 0 WHERE platform = 'custom'").run();
+}

--- a/server/src/db/migrations/20260706_000002_custom_model_tool_support.ts
+++ b/server/src/db/migrations/20260706_000002_custom_model_tool_support.ts
@@ -1,4 +1,4 @@
-import type Database from 'better-sqlite3';
+import type { Db } from '../types.js';
 
 /**
  * Custom OpenAI-compatible providers (Ollama, vLLM, LM Studio, and friends) all
@@ -13,10 +13,10 @@ import type Database from 'better-sqlite3';
  * tool-bearing requests with no recourse. New registrations default to
  * tools = 1 in the route handler, so this only touches rows created earlier.
  */
-export function up(db: Database.Database): void {
+export function up(db: Db): void {
   db.prepare("UPDATE models SET supports_tools = 1 WHERE platform = 'custom'").run();
 }
 
-export function down(db: Database.Database): void {
+export function down(db: Db): void {
   db.prepare("UPDATE models SET supports_tools = 0 WHERE platform = 'custom'").run();
 }

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -365,9 +365,19 @@ keysRouter.post('/', (req: Request, res: Response) => {
 // A model can be given as a bare id ("qwen3:4b") or as {model, displayName}.
 // `model`/`displayName` (singular) stay supported for older clients; `models`
 // (plural) lets one submit bind several model ids to the same endpoint. (#281)
+// A custom model can declare its capabilities at registration. `supportsTools`
+// defaults to 1 (modern OpenAI-compatible servers — Ollama, vLLM, LM Studio —
+// all emit tool calls), `supportsVision` defaults to 0 unless declared. Leaving
+// a flag unset keeps the DB default on insert and preserves the stored value on
+// re-registration, so a capability the user later toggled isn't clobbered. (#470)
 const modelEntrySchema = z.union([
   z.string().min(1),
-  z.object({ model: z.string().min(1), displayName: z.string().optional() }),
+  z.object({
+    model: z.string().min(1),
+    displayName: z.string().optional(),
+    supportsTools: z.boolean().optional(),
+    supportsVision: z.boolean().optional(),
+  }),
 ]);
 const customProviderSchema = z.object({
   baseUrl: z.string().url('baseUrl must be a valid URL'),
@@ -376,6 +386,10 @@ const customProviderSchema = z.object({
   displayName: z.string().optional(),
   apiKey: z.string().optional(),
   label: z.string().optional(),
+  // Top-level defaults applied to every model in this submit; a per-entry flag
+  // (object form) overrides them for that one model.
+  supportsTools: z.boolean().optional(),
+  supportsVision: z.boolean().optional(),
 }).refine(
   d => (d.model && d.model.trim().length > 0) || (d.models && d.models.length > 0),
   { message: 'model or models is required' },
@@ -405,19 +419,27 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
 
   // Flatten singular + plural inputs into one list, dedupe by model id, drop
   // blanks. The singular `displayName` only applies to a lone `model` (it can't
-  // sensibly fan out across many ids).
-  const entries: { modelId: string; displayName: string }[] = [];
+  // sensibly fan out across many ids). Capability flags resolve per-entry first,
+  // then fall back to the submit-level defaults, then to undefined (DB default).
+  const topTools = parsed.data.supportsTools;
+  const topVision = parsed.data.supportsVision;
+  const entries: { modelId: string; displayName: string; supportsTools?: boolean; supportsVision?: boolean }[] = [];
   const seen = new Set<string>();
-  const addEntry = (rawId: string, rawDisplay?: string) => {
+  const addEntry = (rawId: string, rawDisplay?: string, tools?: boolean, vision?: boolean) => {
     const modelId = rawId.trim();
     if (!modelId || seen.has(modelId)) return;
     seen.add(modelId);
-    entries.push({ modelId, displayName: (rawDisplay?.trim() || modelId) });
+    entries.push({
+      modelId,
+      displayName: (rawDisplay?.trim() || modelId),
+      supportsTools: tools ?? topTools,
+      supportsVision: vision ?? topVision,
+    });
   };
   if (parsed.data.model?.trim()) addEntry(parsed.data.model, parsed.data.displayName);
   for (const m of parsed.data.models ?? []) {
     if (typeof m === 'string') addEntry(m);
-    else addEntry(m.model, m.displayName);
+    else addEntry(m.model, m.displayName, m.supportsTools, m.supportsVision);
   }
 
   if (entries.length === 0) {
@@ -462,22 +484,34 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
       storedKeyForMask = keyToStore;
     }
 
-    const registered: { modelDbId: number; model: string; displayName: string }[] = [];
-    for (const { modelId, displayName } of entries) {
+    const registered: { modelDbId: number; model: string; displayName: string; supportsTools: boolean; supportsVision: boolean }[] = [];
+    for (const { modelId, displayName, supportsTools, supportsVision } of entries) {
       // Register each model bound to THIS endpoint's key. Custom models carry no
       // rate limits and sort last in the intelligence preset (size_label tier).
       // Re-registering an existing model id re-binds it (model ids are unique
       // per platform, so one id can't live on two endpoints at once).
+      // Capability flags: an unset flag binds NULL so COALESCE picks the insert
+      // default (tools 1, vision 0) on a new row and preserves the existing
+      // value on re-registration. (#470)
+      const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
+      const visionParam = supportsVision === undefined ? null : (supportsVision ? 1 : 0);
       db.prepare(`
         INSERT INTO models
           (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
-           rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, key_id)
-        VALUES ('custom', ?, ?, 50, 50, 'Custom', NULL, NULL, NULL, NULL, '', NULL, 1, ?)
+           rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, key_id,
+           supports_tools, supports_vision)
+        VALUES ('custom', @modelId, @displayName, 50, 50, 'Custom', NULL, NULL, NULL, NULL, '', NULL, 1, @keyId,
+           COALESCE(@tools, 1), COALESCE(@vision, 0))
         ON CONFLICT(platform, model_id)
-        DO UPDATE SET display_name = excluded.display_name, key_id = excluded.key_id, enabled = 1
-      `).run(modelId, displayName, keyId);
+        DO UPDATE SET
+          display_name = excluded.display_name,
+          key_id = excluded.key_id,
+          enabled = 1,
+          supports_tools = COALESCE(@tools, supports_tools),
+          supports_vision = COALESCE(@vision, supports_vision)
+      `).run({ modelId, displayName, keyId, tools: toolsParam, vision: visionParam });
 
-      const modelRow = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number };
+      const modelRow = db.prepare("SELECT id, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number; supports_tools: number; supports_vision: number };
 
       // Append to the fallback chain if not already present.
       const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
@@ -486,7 +520,13 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
         db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(modelRow.id, max.m + 1);
       }
 
-      registered.push({ modelDbId: modelRow.id, model: modelId, displayName });
+      registered.push({
+        modelDbId: modelRow.id,
+        model: modelId,
+        displayName,
+        supportsTools: modelRow.supports_tools === 1,
+        supportsVision: modelRow.supports_vision === 1,
+      });
     }
 
     return { keyId, registered, storedKeyForMask };
@@ -504,6 +544,8 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
     baseUrl,
     model: first.model,
     displayName: first.displayName,
+    supportsTools: first.supportsTools,
+    supportsVision: first.supportsVision,
     models: registered,
     maskedKey: maskKey(storedKeyForMask),
   });


### PR DESCRIPTION
Two fixes for custom OpenAI-compatible providers, both halves of recent user reports:

**Custom models were invisible to agentic clients (#470).** Registration seeded supports_tools=0, and the router filters on supports_tools whenever a client sends tools, so editors like Trae or Cline matched zero custom models and got a false "All models exhausted" 429. Now: new custom chat models default to tools on / vision off, registration accepts supportsTools/supportsVision per model or per submit, and a one-time migration backfills existing custom rows to tool-capable. The trade is deliberate: a wrong tools-on surfaces a recoverable upstream error the user can toggle off, while tools-off hides the model with no recourse. Re-registration preserves any value the user set by hand (COALESCE on NULL params).

**Models list showed 'custom' instead of your endpoint's name (#469).** The Models table, model detail page, and provider list now show the key's label (e.g. "Ollama box") for custom models. Key label editing and per-model display-name/capability editing already existed on the detail page; the missing piece was the list label.

Capability toggles were also added to the custom chat add form (tools pre-checked), with strings in all six locales.

Tests: registration defaults, per-entry and submit-level flags, re-registration preservation, migration effect + idempotency + down, and a guard that custom-model capability PATCHes write directly without creating model_overrides rows. Server suite 77 files / 794 tests green, tsc clean, client build green.
