### PR TITLE
UI: collapse Router pressure by default (with memory) + split analytics stat cards into two rows

### DIFF
--- a/client/src/components/penalty-inspector.tsx
+++ b/client/src/components/penalty-inspector.tsx
@@ -1,7 +1,21 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { AlertTriangle, Clock3, Gauge } from 'lucide-react'
+import { AlertTriangle, ChevronDown, Clock3, Gauge } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
+
+// Collapse state persists so a returning user keeps their last choice; a fresh
+// install (no stored value) defaults to collapsed to keep the routing page calm.
+const COLLAPSED_KEY = 'freellmapi.penaltyInspector.collapsed'
+
+function readCollapsed(): boolean {
+  try {
+    const stored = localStorage.getItem(COLLAPSED_KEY)
+    return stored === null ? true : stored === '1'
+  } catch {
+    return true
+  }
+}
 
 type InspectorReason = 'penalty' | 'cooldown' | 'recent_errors'
 
@@ -68,6 +82,7 @@ function penaltyClass(value: number): string {
 
 export function PenaltyInspector() {
   const { t } = useI18n()
+  const [collapsed, setCollapsed] = useState<boolean>(readCollapsed)
   const { data } = useQuery<PenaltyInspectorData>({
     queryKey: ['fallback', 'penalty-inspector'],
     queryFn: () => apiFetch('/api/fallback/penalty-inspector'),
@@ -77,9 +92,23 @@ export function PenaltyInspector() {
   const rows = data?.rows ?? []
   if (rows.length === 0) return null
 
+  function toggle() {
+    setCollapsed(prev => {
+      const next = !prev
+      try { localStorage.setItem(COLLAPSED_KEY, next ? '1' : '0') } catch { /* ignore */ }
+      return next
+    })
+  }
+
   return (
     <section className="rounded-lg border bg-card">
-      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-3">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? t('common.show') : t('common.hide')}
+        className={`flex w-full flex-wrap items-center justify-between gap-2 px-4 py-3 text-left ${collapsed ? '' : 'border-b'}`}
+      >
         <div className="flex items-center gap-2">
           <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
           <div>
@@ -89,11 +118,15 @@ export function PenaltyInspector() {
             </p>
           </div>
         </div>
-        <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground tabular-nums">
-          {t('penaltyInspector.rowCount', { count: rows.length })}
-        </span>
-      </div>
+        <div className="flex items-center gap-2">
+          <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground tabular-nums">
+            {t('penaltyInspector.rowCount', { count: rows.length })}
+          </span>
+          <ChevronDown className={`size-4 text-muted-foreground transition-transform ${collapsed ? '-rotate-90' : ''}`} />
+        </div>
+      </button>
 
+      {!collapsed && (
       <div className="divide-y">
         {rows.map(row => (
           <div key={`${row.platform}:${row.modelId}:${row.modelDbId ?? 'missing'}`} className="grid gap-3 px-4 py-3 lg:grid-cols-[minmax(14rem,1.2fr)_minmax(10rem,0.8fr)_minmax(14rem,1.3fr)]">
@@ -165,6 +198,7 @@ export function PenaltyInspector() {
           </div>
         ))}
       </div>
+      )}
     </section>
   )
 }

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -298,7 +298,7 @@ export default function AnalyticsPage() {
 
       <div className="space-y-6">
         {/* Summary stats */}
-        <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8 gap-3">
+        <div className="grid grid-cols-2 md:grid-cols-4 xl:grid-cols-4 gap-3">
           {summaryLoading ? (
             Array.from({ length: 8 }).map((_, i) => <Skeleton key={i} className="h-[74px] rounded-3xl" />)
           ) : (


### PR DESCRIPTION
Two small dashboard-client UI tweaks.

## Change 1 — Router pressure collapsed by default, with memory
`client/src/components/penalty-inspector.tsx` (the "Router pressure" section on the Models/routing page).

**Before:** always rendered fully expanded whenever there was any routing pressure; the full row list took over the top of the page on every visit.

**After:**
- Starts **collapsed by default** on a fresh install (no stored value).
- Clicking the header toggles it, using a chevron that matches the keys-page collapsible provider groups exactly (`ChevronDown` with `transition-transform` / `-rotate-90` when collapsed, `aria-expanded`, and the existing `common.show` / `common.hide` strings for the aria-label).
- The open/collapsed state **persists in `localStorage`** so a returning user gets their last state back.
- While collapsed, the header keeps showing the existing **"{count} active"** badge so there's a visible hint that something is inside; the section still renders nothing at all when there is no pressure (unchanged).

The 5s poll stays enabled (unconditional) — the count badge and the "render nothing when empty" behavior both depend on the query result, so gating it while collapsed would have removed the badge and the empty-state, which the design wants to keep. That query-gating was called out as an optional nice-to-have, so it was intentionally skipped.

## Change 2 — Analytics stat cards in two rows
`client/src/pages/AnalyticsPage.tsx` top stat cards (Requests / Success / tokens / latency / p95 / TTFT / savings).

**Before:** one long row on wide screens (`grid grid-cols-2 md:grid-cols-4 xl:grid-cols-8`).

**After:** two rows on desktop by halving the widest breakpoint's column count — `xl:grid-cols-8` → `xl:grid-cols-4`. Card order is unchanged and the existing narrow-screen stacking (`grid-cols-2` / `md:grid-cols-4`) is preserved.

## i18n
No new user-visible strings. Reused existing `common.show` / `common.hide` (aria-label) and `penaltyInspector.rowCount` ("{count} active"), so all 6 locales are already covered.

## Verification
- `npm run build -w client` (runs `tsc -b && vite build`): passes.
- `npx tsc --noEmit -p tsconfig.app.json`: clean.
- `eslint` on both touched files: clean.
- No client test script exists; no server files touched, so server suite not run.