### PR TITLE
feat(custom): support multiple keys per endpoint with model-level isolation

### DIFF
--- a/client/src/components/keys/provider-list.tsx
+++ b/client/src/components/keys/provider-list.tsx
@@ -390,6 +390,16 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
                                     {k.baseUrl}
                                   </code>
                                 )}
+                                {k.platform === 'custom' && (k.models?.length ?? 0) > 1 && (
+                                  <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full" title={`${k.models!.length} models bound to this key`}>
+                                    {k.models!.length} models
+                                  </span>
+                                )}
+                                {k.platform === 'custom' && (k.models?.length ?? 0) > 1 && (
+                                  <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full" title={`${k.models!.length} models bound to this key`}>
+                                    {k.models!.length} models
+                                  </span>
+                                )}
                               </>
                             )}
                             <span className="text-xs text-muted-foreground">{statusLabelKey[status] ? t(statusLabelKey[status]) : status}</span>

--- a/client/src/components/keys/provider-list.tsx
+++ b/client/src/components/keys/provider-list.tsx
@@ -395,11 +395,6 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
                                     {k.models!.length} models
                                   </span>
                                 )}
-                                {k.platform === 'custom' && (k.models?.length ?? 0) > 1 && (
-                                  <span className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full" title={`${k.models!.length} models bound to this key`}>
-                                    {k.models!.length} models
-                                  </span>
-                                )}
                               </>
                             )}
                             <span className="text-xs text-muted-foreground">{statusLabelKey[status] ? t(statusLabelKey[status]) : status}</span>

--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -68,13 +68,15 @@ export const CUSTOM_MODEL_KIND_LABEL: Record<ApiKeyModel['kind'], string> = {
 }
 
 export function customModelDeleteKey(model: ApiKeyModel): string {
-  return `${model.kind}:${model.id}`
+  return `${model.kind}:${model.id}:${model.keyId}`
 }
 
 export function customModelDeletePath(model: ApiKeyModel): string {
-  if (model.kind === 'chat') return `/api/models/custom/${model.id}`
-  if (model.kind === 'embedding') return `/api/embeddings/custom/${model.id}`
-  return `/api/media/custom/${model.id}`
+  // Per-binding delete: removes one (model, key) association. The model survives
+  // if other keys remain bound; the key survives if other models use it.
+  if (model.kind === 'chat') return `/api/models/custom/${model.id}/keys/${model.keyId}`
+  if (model.kind === 'embedding') return `/api/embeddings/custom/${model.id}/keys/${model.keyId}`
+  return `/api/media/custom/${model.id}/keys/${model.keyId}`
 }
 
 export const statusDot: Record<string, string> = {

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -11,6 +11,7 @@ const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
 const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
+const CUSTOM_KEY_BINDINGS_FILENAME = '20260707_000000_custom_key_bindings.ts';
 
 interface SchemaRow {
   type: string;
@@ -68,6 +69,7 @@ describe('migration round trip', () => {
         GITHUB_GPT41_CONTEXT_FILENAME,
         REQUEST_CLIENT_INFO_FILENAME,
         CUSTOM_MODEL_TOOL_SUPPORT_FILENAME,
+        CUSTOM_KEY_BINDINGS_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/services/embeddings.test.ts
+++ b/server/src/__tests__/services/embeddings.test.ts
@@ -213,11 +213,13 @@ describe('embeddings service', () => {
 
     it('routes custom embeddings through the model-bound endpoint key', async () => {
       const keyId = addCustomKey('http://127.0.0.1:8181/v1', 'custom-embed-key');
-      getDb().prepare(`
+      const modelRow = getDb().prepare(`
         INSERT INTO embedding_models
           (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
         VALUES ('local-embed', 'custom', 'local-embed-v1', 'Local Embed', 3, NULL, 1, 1, '', ?)
-      `).run(keyId);
+          RETURNING id
+      `).get(keyId) as { id: number };
+      getDb().prepare('INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id) VALUES (?, ?, ?)').run('embedding', modelRow.id, keyId);
       const fetchMock = mockFetch(async () => okEmbeddingResponse(3));
 
       const result = await runEmbeddings('local-embed', ['hello']);

--- a/server/src/__tests__/services/media.test.ts
+++ b/server/src/__tests__/services/media.test.ts
@@ -23,10 +23,17 @@ function addCustomKey(baseUrl: string, raw = 'custom-media-key'): number {
 }
 
 function addMedia(platform: string, modelId: string, modality: 'image' | 'audio', priority = 1, keyId: number | null = null) {
-  getDb().prepare(`
+  const db = getDb();
+  const row = db.prepare(`
     INSERT INTO media_models (platform, model_id, display_name, modality, priority, enabled, quota_label, key_id)
     VALUES (?, ?, ?, ?, ?, 1, '', ?)
-  `).run(platform, modelId, modelId, modality, priority, keyId);
+      RETURNING id
+  `).get(platform, modelId, modelId, modality, priority, keyId) as { id: number };
+  if (platform === 'custom' && keyId != null) {
+    db.prepare('INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id) VALUES (?, ?, ?)')
+      .run(modality, row.id, keyId);
+  }
+  return row.id;
 }
 
 function jsonResponse(body: unknown) {

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -6,6 +6,7 @@ import * as requestAggregates from '../migrations/20260628_120000_request_aggreg
 import * as githubGpt41Context from '../migrations/20260630_000001_github_gpt41_context.js';
 import * as requestClientInfo from '../migrations/20260706_000001_request_client_info.js';
 import * as customModelToolSupport from '../migrations/20260706_000002_custom_model_tool_support.js';
+import * as customKeyBindings from '../migrations/20260707_000000_custom_key_bindings.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -24,6 +25,7 @@ export const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.t
 export const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 export const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
 export const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
+export const CUSTOM_KEY_BINDINGS_FILENAME = '20260707_000000_custom_key_bindings.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -33,4 +35,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: GITHUB_GPT41_CONTEXT_FILENAME, module: githubGpt41Context },
   { filename: REQUEST_CLIENT_INFO_FILENAME, module: requestClientInfo },
   { filename: CUSTOM_MODEL_TOOL_SUPPORT_FILENAME, module: customModelToolSupport },
+  { filename: CUSTOM_KEY_BINDINGS_FILENAME, module: customKeyBindings },
 ];

--- a/server/src/db/migrations/20260707_000000_custom_key_bindings.ts
+++ b/server/src/db/migrations/20260707_000000_custom_key_bindings.ts
@@ -1,0 +1,48 @@
+// Migration: custom_key_bindings junction table (model-level key isolation)
+// Created: 2026-07-07
+//
+// Adds a many-to-many table binding custom models (chat / embedding / media) to
+// the api_keys rows they may route through. Previously a custom model carried a
+// single key_id anchor and the router treated every key sharing its base_url as
+// usable — which pooled keys across all models on an endpoint and broke
+// isolation (a finance model could burn a research key's quota).
+//
+// The junction table makes "which keys can serve this model" explicit data:
+// registration writes a binding; routing reads bindings; deletion removes the
+// binding and only cascades a model/key when its last binding is gone.
+//
+// Existing models.key_id values are backfilled as their sole binding, so single
+// -key installs upgrade transparently (one binding per model == old behaviour).
+//
+// DOWN: reversible
+
+import type { Db } from '../types.js';
+
+export function up(db: Db): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS custom_key_bindings (
+      modality     TEXT NOT NULL,
+      model_db_id  INTEGER NOT NULL,
+      key_id       INTEGER NOT NULL,
+      PRIMARY KEY (modality, model_db_id, key_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_custom_key_bindings_key ON custom_key_bindings(key_id);
+
+    -- Backfill existing custom model anchors as their (sole) binding.
+    INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id)
+      SELECT 'chat', id, key_id FROM models
+       WHERE platform = 'custom' AND key_id IS NOT NULL;
+    INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id)
+      SELECT 'embedding', id, key_id FROM embedding_models
+       WHERE platform = 'custom' AND key_id IS NOT NULL;
+    INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id)
+      SELECT modality, id, key_id FROM media_models
+       WHERE platform = 'custom' AND key_id IS NOT NULL;
+  `);
+}
+
+export function down(db: Db): void {
+  db.exec(`
+    DROP TABLE IF EXISTS custom_key_bindings;
+  `);
+}

--- a/server/src/lib/custom-key-upsert.ts
+++ b/server/src/lib/custom-key-upsert.ts
@@ -1,0 +1,210 @@
+import type { Db } from '../db/types.js';
+import { encrypt, decrypt } from './crypto.js';
+
+// Custom-provider key upsert + binding helpers.
+//
+// A custom endpoint is identified by its base_url and may hold SEVERAL
+// api_keys rows (e.g. multiple free-tier accounts against the same gateway).
+// Which keys a given model may route through is recorded EXPLICITLY in the
+// custom_key_bindings junction table — a model only uses the keys it was
+// registered with, never every key on its endpoint. This keeps a finance model
+// from burning a research key's quota while still allowing one model to pool
+// several keys when the user registers it against each.
+//
+// `models/embedding_models/media_models.key_id` is kept as a display ANCHOR
+// (= MIN(key_id) from its bindings) for the legacy JOIN-based listing queries;
+// the routing source of truth is custom_key_bindings.
+
+export interface CustomKeyUpsertInput {
+  baseUrl: string;
+  apiKey?: string;
+  label?: string;
+  enabled?: boolean;
+}
+
+export interface CustomKeyUpsertResult {
+  anchorKeyId: number;
+  processedKeyId: number;
+  storedKeyForMask: string;
+  isNewKey: boolean;
+}
+
+interface ExistingKeyRow {
+  id: number;
+  encrypted_key: string;
+  iv: string;
+  auth_tag: string;
+}
+
+export function findOrInsertCustomKey(
+  db: Db,
+  input: CustomKeyUpsertInput,
+): CustomKeyUpsertResult {
+  const baseUrl = input.baseUrl;
+  const providedKey = input.apiKey?.trim() || undefined;
+  const label = input.label?.trim() || undefined;
+  const enabled = input.enabled === false ? 0 : 1;
+
+  const existing = db.prepare(
+    "SELECT id, encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'custom' AND base_url = ? ORDER BY id",
+  ).all(baseUrl) as ExistingKeyRow[];
+
+  const reEnable = (id: number) =>
+    db
+      .prepare("UPDATE api_keys SET label = COALESCE(?, label), status = 'unknown', enabled = ? WHERE id = ?")
+      .run(label ?? null, enabled, id);
+
+  if (providedKey) {
+    for (const row of existing) {
+      let matches = false;
+      try {
+        matches = decrypt(row.encrypted_key, row.iv, row.auth_tag) === providedKey;
+      } catch {
+        matches = false;
+      }
+      if (matches) {
+        reEnable(row.id);
+        return {
+          anchorKeyId: existing[0]!.id,
+          processedKeyId: row.id,
+          storedKeyForMask: providedKey,
+          isNewKey: false,
+        };
+      }
+    }
+    const { encrypted, iv, authTag } = encrypt(providedKey);
+    const r = db
+      .prepare(
+        "INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url) VALUES ('custom', ?, ?, ?, ?, 'unknown', ?, ?)",
+      )
+      .run(label ?? 'Custom', encrypted, iv, authTag, enabled, baseUrl);
+    const newId = Number(r.lastInsertRowid);
+    return {
+      anchorKeyId: existing.length > 0 ? existing[0]!.id : newId,
+      processedKeyId: newId,
+      storedKeyForMask: providedKey,
+      isNewKey: true,
+    };
+  }
+
+  if (existing.length > 0) {
+    const anchor = existing[0]!;
+    reEnable(anchor.id);
+    let storedKeyForMask = 'no-key';
+    try {
+      storedKeyForMask = decrypt(anchor.encrypted_key, anchor.iv, anchor.auth_tag);
+    } catch {
+      storedKeyForMask = 'no-key';
+    }
+    return {
+      anchorKeyId: anchor.id,
+      processedKeyId: anchor.id,
+      storedKeyForMask,
+      isNewKey: false,
+    };
+  }
+
+  const { encrypted, iv, authTag } = encrypt('no-key');
+  const r = db
+    .prepare(
+      "INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url) VALUES ('custom', ?, ?, ?, ?, 'unknown', ?, ?)",
+    )
+    .run(label ?? 'Custom', encrypted, iv, authTag, enabled, baseUrl);
+  const newId = Number(r.lastInsertRowid);
+  return {
+    anchorKeyId: newId,
+    processedKeyId: newId,
+    storedKeyForMask: 'no-key',
+    isNewKey: true,
+  };
+}
+
+export function getEndpointKeyCount(db: Db, baseUrl: string): number {
+  const row = db
+    .prepare(
+      "SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom' AND base_url = ? AND enabled = 1",
+    )
+    .get(baseUrl) as { n: number };
+  return row.n;
+}
+
+export type CustomModality = 'chat' | 'embedding' | 'image' | 'audio';
+
+export function upsertBinding(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+  keyId: number,
+): void {
+  db.prepare(
+    'INSERT OR IGNORE INTO custom_key_bindings (modality, model_db_id, key_id) VALUES (?, ?, ?)',
+  ).run(modality, modelDbId, keyId);
+  rebindAnchor(db, modality, modelDbId);
+}
+
+export function rebindAnchor(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+): void {
+  const row = db.prepare(
+    'SELECT MIN(key_id) AS k FROM custom_key_bindings WHERE modality = ? AND model_db_id = ?',
+  ).get(modality, modelDbId) as { k: number | null };
+  const table = modality === 'chat' ? 'models'
+    : modality === 'embedding' ? 'embedding_models' : 'media_models';
+  db.prepare(`UPDATE ${table} SET key_id = ? WHERE id = ? AND platform = 'custom'`)
+    .run(row.k, modelDbId);
+}
+
+export interface EndpointKeyRow {
+  id: number;
+  encrypted_key: string;
+  iv: string;
+  auth_tag: string;
+  status: string;
+  enabled: number;
+  base_url: string | null;
+}
+
+export function getModelBoundKeys(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+): EndpointKeyRow[] {
+  return db.prepare(
+    `SELECT k.id, k.encrypted_key, k.iv, k.auth_tag, k.status, k.enabled, k.base_url
+       FROM custom_key_bindings ckb
+       JOIN api_keys k ON k.id = ckb.key_id
+      WHERE ckb.modality = ? AND ckb.model_db_id = ?
+        AND k.enabled = 1 AND k.status IN ('healthy', 'unknown')
+      ORDER BY k.id`,
+  ).all(modality, modelDbId) as EndpointKeyRow[];
+}
+
+export function getModelBoundKeyIds(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+): number[] {
+  return (db.prepare(
+    'SELECT key_id FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? ORDER BY key_id',
+  ).all(modality, modelDbId) as { key_id: number }[]).map(r => r.key_id);
+}
+
+export function removeBinding(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+  keyId: number,
+): { modelHasBindings: boolean; keyHasBindings: boolean } {
+  db.prepare(
+    'DELETE FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? AND key_id = ?',
+  ).run(modality, modelDbId, keyId);
+  const modelRow = db.prepare(
+    'SELECT 1 FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? LIMIT 1',
+  ).get(modality, modelDbId);
+  const keyRow = db.prepare(
+    'SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1',
+  ).get(keyId);
+  return { modelHasBindings: Boolean(modelRow), keyHasBindings: Boolean(keyRow) };
+}

--- a/server/src/lib/custom-provider-cleanup.ts
+++ b/server/src/lib/custom-provider-cleanup.ts
@@ -1,11 +1,47 @@
 import type { Db } from '../db/types.js';
+import { getModelBoundKeyIds, type CustomModality } from './custom-key-upsert.js';
 
-export function deleteUnusedCustomEndpointKey(db: Db, keyId: number | null | undefined) {
-  if (keyId == null) return;
-  const chat = db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
-  const embeddings = db.prepare("SELECT COUNT(*) AS n FROM embedding_models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
-  const media = db.prepare("SELECT COUNT(*) AS n FROM media_models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
-  if (chat.n + embeddings.n + media.n === 0) {
-    db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+// After a custom binding (model, key) is removed, a model with no remaining
+// bindings can no longer route and a key with no remaining bindings no longer
+// serves any custom model. This helper cascades those orphans, plus the
+// fallback_config rows that referenced a deleted model.
+
+function deleteCustomModelRow(db: Db, modality: CustomModality, modelDbId: number): void {
+  db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(modelDbId);
+  const table = modality === 'chat' ? 'models'
+    : modality === 'embedding' ? 'embedding_models' : 'media_models';
+  db.prepare(`DELETE FROM ${table} WHERE id = ? AND platform = 'custom'`).run(modelDbId);
+}
+
+export function cleanupAfterBindingsRemoved(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+  formerKeyIds: number[],
+): void {
+  const stillBound = db.prepare(
+    'SELECT 1 FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? LIMIT 1',
+  ).get(modality, modelDbId);
+  if (!stillBound) {
+    deleteCustomModelRow(db, modality, modelDbId);
   }
+  for (const keyId of formerKeyIds) {
+    const keyStillUsed = db.prepare(
+      'SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1',
+    ).get(keyId);
+    if (!keyStillUsed) {
+      db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+    }
+  }
+}
+
+export function deleteCustomModelAndCleanup(
+  db: Db,
+  modality: CustomModality,
+  modelDbId: number,
+): void {
+  const keyIds = getModelBoundKeyIds(db, modality, modelDbId);
+  db.prepare('DELETE FROM custom_key_bindings WHERE modality = ? AND model_db_id = ?')
+    .run(modality, modelDbId);
+  cleanupAfterBindingsRemoved(db, modality, modelDbId, keyIds);
 }

--- a/server/src/routes/embeddings.ts
+++ b/server/src/routes/embeddings.ts
@@ -3,7 +3,8 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb, setSetting } from '../db/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
-import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
+import { deleteCustomModelAndCleanup } from '../lib/custom-provider-cleanup.js';
+import { findOrInsertCustomKey, upsertBinding, removeBinding, getModelBoundKeyIds } from '../lib/custom-key-upsert.js';
 import {
   listEmbeddingModels,
   getDefaultFamily,
@@ -136,40 +137,11 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
   }
 
   const upsert = db.transaction(() => {
-    let keyId: number;
-    let storedKeyForMask = probeKey;
-    if (existingKey) {
-      keyId = existingKey.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label),
-                 encrypted_key = ?,
-                 iv = ?,
-                 auth_tag = ?,
-                 status = 'unknown',
-                 enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, encrypted, iv, authTag, keyId);
-        storedKeyForMask = providedKey;
-      } else {
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label), status = 'unknown', enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, keyId);
-      }
-    } else {
-      const keyToStore = providedKey ?? 'no-key';
-      const { encrypted, iv, authTag } = encrypt(keyToStore);
-      const key = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(key.lastInsertRowid);
-      storedKeyForMask = keyToStore;
-    }
+    const { processedKeyId, storedKeyForMask } = findOrInsertCustomKey(db, {
+      baseUrl,
+      apiKey: providedKey,
+      label,
+    });
 
     const existingModel = db.prepare(`
       SELECT id, priority
@@ -182,6 +154,7 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
         .get(family) as { maxPriority: number }).maxPriority + 1
     );
 
+    let modelDbId: number;
     if (existingModel) {
       db.prepare(`
         UPDATE embedding_models
@@ -191,19 +164,21 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
                max_input_tokens = ?,
                priority = ?,
                enabled = 1,
-               quota_label = ?,
-               key_id = ?
+               quota_label = ?
          WHERE id = ?
-      `).run(family, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, keyId, existingModel.id);
-      return { modelDbId: existingModel.id, keyId, storedKeyForMask };
+      `).run(family, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, existingModel.id);
+      modelDbId = existingModel.id;
+    } else {
+      const model = db.prepare(`
+        INSERT INTO embedding_models
+          (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
+        VALUES (?, 'custom', ?, ?, ?, ?, ?, 1, ?, ?)
+      `).run(family, modelId, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, processedKeyId);
+      modelDbId = Number(model.lastInsertRowid);
     }
 
-    const model = db.prepare(`
-      INSERT INTO embedding_models
-        (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
-      VALUES (?, 'custom', ?, ?, ?, ?, ?, 1, ?, ?)
-    `).run(family, modelId, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, keyId);
-    return { modelDbId: Number(model.lastInsertRowid), keyId, storedKeyForMask };
+    upsertBinding(db, 'embedding', modelDbId, processedKeyId);
+    return { modelDbId, keyId: processedKeyId, storedKeyForMask };
   });
 
   const result = upsert();
@@ -266,20 +241,67 @@ embeddingsRouter.delete('/custom/:id', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const row = db.prepare("SELECT family, key_id FROM embedding_models WHERE id = ? AND platform = 'custom'").get(id) as { family: string; key_id: number | null } | undefined;
+  const row = db.prepare("SELECT family FROM embedding_models WHERE id = ? AND platform = 'custom'").get(id) as { family: string } | undefined;
   if (!row) {
     res.status(404).json({ error: { message: `Unknown custom embedding model ${id}` } });
     return;
   }
 
   const remove = db.transaction(() => {
-    db.prepare("DELETE FROM embedding_models WHERE id = ? AND platform = 'custom'").run(id);
-    deleteUnusedCustomEndpointKey(db, row.key_id);
+    deleteCustomModelAndCleanup(db, 'embedding', id);
   });
   remove();
   if (getDefaultFamily() === row.family) {
-    const replacement = db.prepare('SELECT family FROM embedding_models ORDER BY family, priority LIMIT 1').get() as { family: string } | undefined;
-    if (replacement) setSetting('embeddings_default_family', replacement.family);
+    const stillExists = db.prepare('SELECT 1 FROM embedding_models WHERE family = ? LIMIT 1').get(row.family);
+    if (!stillExists) {
+      const replacement = db.prepare('SELECT family FROM embedding_models ORDER BY family, priority LIMIT 1').get() as { family: string } | undefined;
+      if (replacement) setSetting('embeddings_default_family', replacement.family);
+    }
+  }
+  res.json({ success: true });
+});
+
+embeddingsRouter.delete('/custom/:id/keys/:keyId', (req: Request, res: Response) => {
+  const modelDbId = Number(req.params.id);
+  const keyId = Number(req.params.keyId);
+  if (!Number.isInteger(modelDbId) || !Number.isInteger(keyId)) {
+    res.status(400).json({ error: { message: 'Invalid id' } });
+    return;
+  }
+
+  const db = getDb();
+  const row = db.prepare("SELECT family FROM embedding_models WHERE id = ? AND platform = 'custom'").get(modelDbId) as { family: string } | undefined;
+  if (!row) {
+    res.status(404).json({ error: { message: `Unknown custom embedding model ${modelDbId}` } });
+    return;
+  }
+  const bound = db.prepare(
+    "SELECT 1 FROM custom_key_bindings WHERE modality = 'embedding' AND model_db_id = ? AND key_id = ?",
+  ).get(modelDbId, keyId);
+  if (!bound) {
+    res.status(404).json({ error: { message: `Key ${keyId} is not bound to custom embedding model ${modelDbId}` } });
+    return;
+  }
+
+  const remove = db.transaction(() => {
+    const formerKeyIds = getModelBoundKeyIds(db, 'embedding', modelDbId);
+    removeBinding(db, 'embedding', modelDbId, keyId);
+    const stillBound = formerKeyIds.filter(k => k !== keyId).length > 0;
+    if (!stillBound) {
+      db.prepare("DELETE FROM embedding_models WHERE id = ? AND platform = 'custom'").run(modelDbId);
+    }
+    const keyStillUsed = db.prepare('SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1').get(keyId);
+    if (!keyStillUsed) {
+      db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+    }
+  });
+  remove();
+  if (getDefaultFamily() === row.family) {
+    const stillExists = db.prepare('SELECT 1 FROM embedding_models WHERE family = ? LIMIT 1').get(row.family);
+    if (!stillExists) {
+      const replacement = db.prepare('SELECT family FROM embedding_models ORDER BY family, priority LIMIT 1').get() as { family: string } | undefined;
+      if (replacement) setSetting('embeddings_default_family', replacement.family);
+    }
   }
   res.json({ success: true });
 });

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -8,6 +8,7 @@ import { resolveProvider } from '../providers/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 import { parseKeysFromFile, stripJsoncComments, stripTrailingCommas } from '../lib/key-parser.js';
 import { assessProviderUrl } from '../lib/url-guard.js';
+import { findOrInsertCustomKey, getEndpointKeyCount, upsertBinding } from '../lib/custom-key-upsert.js';
 
 export const keysRouter = Router();
 
@@ -149,25 +150,39 @@ keysRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
   const rows = db.prepare('SELECT * FROM api_keys ORDER BY created_at DESC').all() as any[];
 
-  const customModels = [
+  // Custom models attach to a key via custom_key_bindings (the routing source of
+  // truth). Each key row only shows the models bound to IT — not every model on
+  // the endpoint — so the Keys page can offer a per-(model,key) delete and a
+  // user sees which of their accounts can reach which model.
+  const customKeyCount = new Map<string, number>();
+  for (const r of rows) {
+    if (r.platform === 'custom' && r.base_url) {
+      customKeyCount.set(r.base_url, (customKeyCount.get(r.base_url) ?? 0) + 1);
+    }
+  }
+
+  const boundModels = [
     ...db.prepare(`
-      SELECT key_id, id, 'chat' AS kind, model_id, display_name, NULL AS family
-        FROM models
-       WHERE platform = 'custom' AND key_id IS NOT NULL
+      SELECT ckb.key_id, m.id, 'chat' AS kind, m.model_id, m.display_name, NULL AS family, m.supports_tools, m.supports_vision
+        FROM custom_key_bindings ckb
+        JOIN models m ON m.id = ckb.model_db_id
+       WHERE ckb.modality = 'chat'
     `).all() as any[],
     ...db.prepare(`
-      SELECT key_id, id, 'embedding' AS kind, model_id, display_name, family
-        FROM embedding_models
-       WHERE platform = 'custom' AND key_id IS NOT NULL
+      SELECT ckb.key_id, m.id, 'embedding' AS kind, m.model_id, m.display_name, m.family, NULL AS supports_tools, NULL AS supports_vision
+        FROM custom_key_bindings ckb
+        JOIN embedding_models m ON m.id = ckb.model_db_id
+       WHERE ckb.modality = 'embedding'
     `).all() as any[],
     ...db.prepare(`
-      SELECT key_id, id, modality AS kind, model_id, display_name, NULL AS family
-        FROM media_models
-       WHERE platform = 'custom' AND key_id IS NOT NULL
+      SELECT ckb.key_id, m.id, m.modality AS kind, m.model_id, m.display_name, NULL AS family, NULL AS supports_tools, NULL AS supports_vision
+        FROM custom_key_bindings ckb
+        JOIN media_models m ON m.id = ckb.model_db_id
+       WHERE ckb.modality IN ('image', 'audio')
     `).all() as any[],
   ];
   const modelsByKeyId = new Map<number, any[]>();
-  for (const m of customModels) {
+  for (const m of boundModels) {
     const keyId = Number(m.key_id);
     if (!Number.isInteger(keyId)) continue;
     const list = modelsByKeyId.get(keyId) ?? [];
@@ -177,6 +192,9 @@ keysRouter.get('/', (_req: Request, res: Response) => {
       modelId: m.model_id,
       displayName: m.display_name,
       family: m.family ?? null,
+      supportsTools: m.supports_tools === 1,
+      supportsVision: m.supports_vision === 1,
+      keyId,
     });
     modelsByKeyId.set(keyId, list);
   }
@@ -196,18 +214,24 @@ keysRouter.get('/', (_req: Request, res: Response) => {
     } catch {
       maskedKey = '[decrypt failed]';
     }
+    const baseUrl = row.base_url ?? null;
     return {
       id: row.id,
       platform: row.platform,
       label: row.label,
       maskedKey,
-      baseUrl: row.base_url ?? null,
+      baseUrl,
       status: row.status,
       enabled: row.enabled === 1,
       keyless: resolveProvider(row.platform)?.keyless === true,
       createdAt: row.created_at,
       lastCheckedAt: row.last_checked_at,
-      models: row.platform === 'custom' ? (modelsByKeyId.get(row.id) ?? []) : undefined,
+      models: row.platform === 'custom'
+        ? (modelsByKeyId.get(row.id) ?? [])
+        : undefined,
+      endpointKeyCount: row.platform === 'custom' && baseUrl
+        ? (customKeyCount.get(baseUrl) ?? 0)
+        : undefined,
     };
   });
 
@@ -456,50 +480,21 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
 
   const db = getDb();
   const upsert = db.transaction(() => {
-    // One 'custom' key row PER ENDPOINT (matched on base_url). Re-submitting
-    // the same endpoint updates its key/label; a new base_url gets its own
-// row instead of clobbering the previous provider. (#212) Re-submitting with a
-// blank key preserves the stored key; only a provided key updates credentials.
-    const existing = db.prepare("SELECT id, encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'custom' AND base_url = ? LIMIT 1")
-      .get(baseUrl) as { id: number; encrypted_key: string; iv: string; auth_tag: string } | undefined;
-    let keyId: number;
-    let storedKeyForMask = providedKey ?? 'no-key';
-    if (existing) {
-      keyId = existing.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare("UPDATE api_keys SET label = COALESCE(?, label), encrypted_key = ?, iv = ?, auth_tag = ?, status = 'unknown', enabled = 1 WHERE id = ?")
-          .run(label ?? null, encrypted, iv, authTag, existing.id);
-        storedKeyForMask = providedKey;
-      } else {
-        try {
-          storedKeyForMask = decrypt(existing.encrypted_key, existing.iv, existing.auth_tag);
-        } catch {
-          storedKeyForMask = 'no-key';
-        }
-        db.prepare("UPDATE api_keys SET label = COALESCE(?, label), status = 'unknown', enabled = 1 WHERE id = ?")
-          .run(label ?? null, existing.id);
-      }
-    } else {
-      const keyToStore = providedKey ?? 'no-key';
-      const { encrypted, iv, authTag } = encrypt(keyToStore);
-      const r = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(r.lastInsertRowid);
-      storedKeyForMask = keyToStore;
-    }
+    // One endpoint (base_url) may hold several keys. Upsert by plaintext dedupe:
+    // a matching key is re-enabled (idempotent); a new key is inserted alongside
+    // the existing ones — never clobbering them. (#212)
+    const { processedKeyId, storedKeyForMask } = findOrInsertCustomKey(db, {
+      baseUrl,
+      apiKey: providedKey,
+      label,
+    });
 
     const registered: { modelDbId: number; model: string; displayName: string; supportsTools: boolean; supportsVision: boolean }[] = [];
     for (const { modelId, displayName, supportsTools, supportsVision } of entries) {
-      // Register each model bound to THIS endpoint's key. Custom models carry no
-      // rate limits and sort last in the intelligence preset (size_label tier).
-      // Re-registering an existing model id re-binds it (model ids are unique
-      // per platform, so one id can't live on two endpoints at once).
-      // Capability flags: an unset flag binds NULL so COALESCE picks the insert
-      // default (tools 1, vision 0) on a new row and preserves the existing
-      // value on re-registration. (#470)
+      // Upsert the model row. The (platform, model_id) uniqueness means one
+      // model id can't live on two endpoints — re-registering re-binds it to
+      // THIS endpoint. key_id is a placeholder; upsertBinding recomputes the
+      // anchor (MIN of bound keys) right after.
       const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
       const visionParam = supportsVision === undefined ? null : (supportsVision ? 1 : 0);
       db.prepare(`
@@ -512,13 +507,17 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
         ON CONFLICT(platform, model_id)
         DO UPDATE SET
           display_name = excluded.display_name,
-          key_id = excluded.key_id,
           enabled = 1,
           supports_tools = COALESCE(@tools, supports_tools),
           supports_vision = COALESCE(@vision, supports_vision)
-      `).run({ modelId, displayName, keyId, tools: toolsParam, vision: visionParam });
+      `).run({ modelId, displayName, keyId: processedKeyId, tools: toolsParam, vision: visionParam });
 
       const modelRow = db.prepare("SELECT id, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number; supports_tools: number; supports_vision: number };
+
+      // Record the (model, key) binding — the routing source of truth. Idempotent
+      // on the PK: re-registering the same model+key is a no-op; a new key adds
+      // a binding so the model pools both keys.
+      upsertBinding(db, 'chat', modelRow.id, processedKeyId);
 
       // Append to the fallback chain if not already present.
       const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
@@ -536,16 +535,15 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
       });
     }
 
-    return { keyId, registered, storedKeyForMask };
+    return { processedKeyId, registered, storedKeyForMask };
   });
 
-  const { keyId, registered, storedKeyForMask } = upsert();
-  // `model`/`displayName`/`modelDbId` echo the first model for older clients;
-  // `models` carries the full set registered in this call.
+  const { processedKeyId, registered, storedKeyForMask } = upsert();
+  const endpointKeyCount = getEndpointKeyCount(db, baseUrl);
   const first = registered[0]!;
   res.status(201).json({
     success: true,
-    keyId,
+    keyId: processedKeyId,
     modelDbId: first.modelDbId,
     platform: 'custom',
     baseUrl,
@@ -555,6 +553,7 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
     supportsVision: first.supportsVision,
     models: registered,
     maskedKey: maskKey(storedKeyForMask),
+    endpointKeyCount,
   });
 });
 
@@ -726,24 +725,49 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   }
 
   const remove = db.transaction(() => {
-    db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
-    // Custom models exist only because POST /custom registered them alongside
-    // their endpoint key (#117) — they can't route without it. Cascade away
-    // the models bound to THIS endpoint (#212); other custom providers keep
-    // theirs. Legacy rows (key_id NULL) are swept once no custom keys remain,
-    // so they never linger in the fallback chain forever (#189).
+    // Custom key: remove all its bindings, then cascade any model that lost its
+    // last binding. The key row itself is deleted last. (#212)
     if (row.platform === 'custom') {
       const defaultEmbedding = db.prepare("SELECT value FROM settings WHERE key = 'embeddings_default_family'").get() as { value: string } | undefined;
-      db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom' AND key_id = ?)").run(id);
-      db.prepare("DELETE FROM models WHERE platform = 'custom' AND key_id = ?").run(id);
-      db.prepare("DELETE FROM embedding_models WHERE platform = 'custom' AND key_id = ?").run(id);
-      db.prepare("DELETE FROM media_models WHERE platform = 'custom' AND key_id = ?").run(id);
-      const remaining = db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom'").get() as { n: number };
-      if (remaining.n === 0) {
+
+      const affected = db.prepare(
+        'SELECT modality, model_db_id FROM custom_key_bindings WHERE key_id = ?',
+      ).all(id) as { modality: string; model_db_id: number }[];
+
+      db.prepare('DELETE FROM custom_key_bindings WHERE key_id = ?').run(id);
+
+      for (const { modality, model_db_id } of affected) {
+        const m = modality as 'chat' | 'embedding' | 'image' | 'audio';
+        const stillBound = db.prepare(
+          'SELECT 1 FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? LIMIT 1',
+        ).get(m, model_db_id);
+        if (!stillBound) {
+          if (m === 'chat') {
+            db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(model_db_id);
+            db.prepare("DELETE FROM models WHERE id = ? AND platform = 'custom'").run(model_db_id);
+          } else if (m === 'embedding') {
+            db.prepare("DELETE FROM embedding_models WHERE id = ? AND platform = 'custom'").run(model_db_id);
+          } else {
+            db.prepare("DELETE FROM media_models WHERE id = ? AND platform = 'custom'").run(model_db_id);
+          }
+        } else {
+          const anchor = db.prepare(
+            'SELECT MIN(key_id) AS k FROM custom_key_bindings WHERE modality = ? AND model_db_id = ?',
+          ).get(m, model_db_id) as { k: number };
+          const table = m === 'chat' ? 'models' : m === 'embedding' ? 'embedding_models' : 'media_models';
+          db.prepare(`UPDATE ${table} SET key_id = ? WHERE id = ?`).run(anchor.k, model_db_id);
+        }
+      }
+
+      db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
+
+      const anyCustom = db.prepare("SELECT 1 FROM api_keys WHERE platform = 'custom' LIMIT 1").get();
+      if (!anyCustom) {
         db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
         db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
         db.prepare("DELETE FROM embedding_models WHERE platform = 'custom'").run();
         db.prepare("DELETE FROM media_models WHERE platform = 'custom'").run();
+        db.prepare('DELETE FROM custom_key_bindings').run();
       }
       if (defaultEmbedding) {
         const stillExists = db.prepare('SELECT 1 FROM embedding_models WHERE family = ? LIMIT 1').get(defaultEmbedding.value);
@@ -754,6 +778,8 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
           }
         }
       }
+    } else {
+      db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
     }
   });
   remove();

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -3,7 +3,8 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
-import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
+import { deleteCustomModelAndCleanup } from '../lib/custom-provider-cleanup.js';
+import { findOrInsertCustomKey, upsertBinding, removeBinding, getModelBoundKeyIds, type CustomModality } from '../lib/custom-key-upsert.js';
 import { listAllMediaModels } from '../services/media.js';
 
 export const mediaRouter = Router();
@@ -71,49 +72,11 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
   const quotaLabel = parsed.data.quotaLabel?.trim() || 'custom endpoint';
 
   const upsert = db.transaction(() => {
-    const existingKey = db.prepare(`
-      SELECT id, encrypted_key, iv, auth_tag
-        FROM api_keys
-       WHERE platform = 'custom' AND base_url = ?
-       LIMIT 1
-    `).get(baseUrl) as { id: number; encrypted_key: string; iv: string; auth_tag: string } | undefined;
-    let keyId: number;
-    let storedKeyForMask = providedKey ?? 'no-key';
-    if (existingKey) {
-      keyId = existingKey.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label),
-                 encrypted_key = ?,
-                 iv = ?,
-                 auth_tag = ?,
-                 status = 'unknown',
-                 enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, encrypted, iv, authTag, keyId);
-        storedKeyForMask = providedKey;
-      } else {
-        try {
-          storedKeyForMask = decrypt(existingKey.encrypted_key, existingKey.iv, existingKey.auth_tag);
-        } catch {
-          storedKeyForMask = 'no-key';
-        }
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label), status = 'unknown', enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, keyId);
-      }
-    } else {
-      const { encrypted, iv, authTag } = encrypt(providedKey ?? 'no-key');
-      const key = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(key.lastInsertRowid);
-    }
+    const { processedKeyId, storedKeyForMask } = findOrInsertCustomKey(db, {
+      baseUrl,
+      apiKey: providedKey,
+      label,
+    });
 
     const existingModel = db.prepare(`
       SELECT id, modality, priority
@@ -126,6 +89,7 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
       : (db.prepare('SELECT COALESCE(MAX(priority), 0) AS maxPriority FROM media_models WHERE modality = ?')
         .get(parsed.data.modality) as { maxPriority: number }).maxPriority + 1;
 
+    let modelDbId: number;
     if (existingModel) {
       db.prepare(`
         UPDATE media_models
@@ -133,19 +97,21 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
                modality = ?,
                priority = ?,
                enabled = 1,
-               quota_label = ?,
-               key_id = ?
+               quota_label = ?
          WHERE id = ?
-      `).run(displayName, parsed.data.modality, priority, quotaLabel, keyId, existingModel.id);
-      return { modelDbId: existingModel.id, keyId, storedKeyForMask };
+      `).run(displayName, parsed.data.modality, priority, quotaLabel, existingModel.id);
+      modelDbId = existingModel.id;
+    } else {
+      const model = db.prepare(`
+        INSERT INTO media_models
+          (platform, model_id, display_name, modality, priority, enabled, quota_label, key_id)
+        VALUES ('custom', ?, ?, ?, ?, 1, ?, ?)
+      `).run(modelId, displayName, parsed.data.modality, priority, quotaLabel, processedKeyId);
+      modelDbId = Number(model.lastInsertRowid);
     }
 
-    const model = db.prepare(`
-      INSERT INTO media_models
-        (platform, model_id, display_name, modality, priority, enabled, quota_label, key_id)
-      VALUES ('custom', ?, ?, ?, ?, 1, ?, ?)
-    `).run(modelId, displayName, parsed.data.modality, priority, quotaLabel, keyId);
-    return { modelDbId: Number(model.lastInsertRowid), keyId, storedKeyForMask };
+    upsertBinding(db, parsed.data.modality as CustomModality, modelDbId, processedKeyId);
+    return { modelDbId, keyId: processedKeyId, storedKeyForMask };
   });
 
   const result = upsert();
@@ -191,14 +157,91 @@ mediaRouter.delete('/custom/:id', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const row = db.prepare("SELECT key_id FROM media_models WHERE id = ? AND platform = 'custom'").get(id) as { key_id: number | null } | undefined;
+  const row = db.prepare("SELECT modality FROM media_models WHERE id = ? AND platform = 'custom'").get(id) as { modality: 'image' | 'audio' } | undefined;
   if (!row) {
     res.status(404).json({ error: { message: `Unknown custom media model ${id}` } });
     return;
   }
   const remove = db.transaction(() => {
-    db.prepare("DELETE FROM media_models WHERE id = ? AND platform = 'custom'").run(id);
-    deleteUnusedCustomEndpointKey(db, row.key_id);
+    deleteCustomModelAndCleanup(db, row.modality as CustomModality, id);
+  });
+  remove();
+  res.json({ success: true });
+});
+
+mediaRouter.delete('/custom/:id/keys/:keyId', (req: Request, res: Response) => {
+  const modelDbId = Number(req.params.id);
+  const keyId = Number(req.params.keyId);
+  if (!Number.isInteger(modelDbId) || !Number.isInteger(keyId)) {
+    res.status(400).json({ error: { message: 'Invalid id' } });
+    return;
+  }
+
+  const db = getDb();
+  const row = db.prepare("SELECT modality FROM media_models WHERE id = ? AND platform = 'custom'").get(modelDbId) as { modality: 'image' | 'audio' } | undefined;
+  if (!row) {
+    res.status(404).json({ error: { message: `Unknown custom media model ${modelDbId}` } });
+    return;
+  }
+  const modality = row.modality as CustomModality;
+  const bound = db.prepare(
+    'SELECT 1 FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? AND key_id = ?',
+  ).get(modality, modelDbId, keyId);
+  if (!bound) {
+    res.status(404).json({ error: { message: `Key ${keyId} is not bound to custom media model ${modelDbId}` } });
+    return;
+  }
+
+  const remove = db.transaction(() => {
+    const formerKeyIds = getModelBoundKeyIds(db, modality, modelDbId);
+    removeBinding(db, modality, modelDbId, keyId);
+    const stillBound = formerKeyIds.filter(k => k !== keyId).length > 0;
+    if (!stillBound) {
+      db.prepare("DELETE FROM media_models WHERE id = ? AND platform = 'custom'").run(modelDbId);
+    }
+    const keyStillUsed = db.prepare('SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1').get(keyId);
+    if (!keyStillUsed) {
+      db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+    }
+  });
+  remove();
+  res.json({ success: true });
+});
+
+mediaRouter.delete('/custom/:id/keys/:keyId', (req: Request, res: Response) => {
+  const modelDbId = Number(req.params.id);
+  const keyId = Number(req.params.keyId);
+  if (!Number.isInteger(modelDbId) || !Number.isInteger(keyId)) {
+    res.status(400).json({ error: { message: 'Invalid id' } });
+    return;
+  }
+
+  const db = getDb();
+  const row = db.prepare("SELECT modality FROM media_models WHERE id = ? AND platform = 'custom'").get(modelDbId) as { modality: 'image' | 'audio' } | undefined;
+  if (!row) {
+    res.status(404).json({ error: { message: `Unknown custom media model ${modelDbId}` } });
+    return;
+  }
+  const modality = row.modality as CustomModality;
+  const bound = db.prepare(
+    'SELECT 1 FROM custom_key_bindings WHERE modality = ? AND model_db_id = ? AND key_id = ?',
+  ).get(modality, modelDbId, keyId);
+  if (!bound) {
+    res.status(404).json({ error: { message: `Key ${keyId} is not bound to custom media model ${modelDbId}` } });
+    return;
+  }
+
+  const remove = db.transaction(() => {
+    const formerKeyIds = getModelBoundKeyIds(db, modality, modelDbId);
+    removeBinding(db, modality, modelDbId, keyId);
+    const stillBound = formerKeyIds.filter(k => k !== keyId).length > 0;
+    if (!stillBound) {
+      db.prepare("DELETE FROM media_models WHERE id = ? AND platform = 'custom'").run(modelDbId);
+    }
+    const keyStillUsed = db.prepare('SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1').get(keyId);
+    if (!keyStillUsed) {
+      db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+    }
   });
   remove();
   res.json({ success: true });

--- a/server/src/routes/models.ts
+++ b/server/src/routes/models.ts
@@ -3,7 +3,8 @@ import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
 import { hasProvider } from '../providers/index.js';
-import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
+import { deleteCustomModelAndCleanup } from '../lib/custom-provider-cleanup.js';
+import { removeBinding, getModelBoundKeyIds } from '../lib/custom-key-upsert.js';
 import {
   isCatalogManagedModel,
   recordCatalogModelTombstone,
@@ -72,16 +73,53 @@ modelsRouter.delete('/custom/:id', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const row = db.prepare("SELECT id, key_id FROM models WHERE id = ? AND platform = 'custom'").get(id) as { id: number; key_id: number | null } | undefined;
+  const row = db.prepare("SELECT id FROM models WHERE id = ? AND platform = 'custom'").get(id) as { id: number } | undefined;
   if (!row) {
     res.status(404).json({ error: { message: `Unknown custom model ${id}` } });
     return;
   }
 
   const remove = db.transaction(() => {
-    db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(id);
-    db.prepare("DELETE FROM models WHERE id = ? AND platform = 'custom'").run(id);
-    deleteUnusedCustomEndpointKey(db, row.key_id);
+    deleteCustomModelAndCleanup(db, 'chat', id);
+  });
+  remove();
+  res.json({ success: true });
+});
+
+modelsRouter.delete('/custom/:id/keys/:keyId', (req: Request, res: Response) => {
+  const modelDbId = Number(req.params.id);
+  const keyId = Number(req.params.keyId);
+  if (!Number.isInteger(modelDbId) || !Number.isInteger(keyId)) {
+    res.status(400).json({ error: { message: 'Invalid id' } });
+    return;
+  }
+
+  const db = getDb();
+  const row = db.prepare("SELECT id FROM models WHERE id = ? AND platform = 'custom'").get(modelDbId) as { id: number } | undefined;
+  if (!row) {
+    res.status(404).json({ error: { message: `Unknown custom model ${modelDbId}` } });
+    return;
+  }
+  const bound = db.prepare(
+    "SELECT 1 FROM custom_key_bindings WHERE modality = 'chat' AND model_db_id = ? AND key_id = ?",
+  ).get(modelDbId, keyId);
+  if (!bound) {
+    res.status(404).json({ error: { message: `Key ${keyId} is not bound to custom model ${modelDbId}` } });
+    return;
+  }
+
+  const remove = db.transaction(() => {
+    const formerKeyIds = getModelBoundKeyIds(db, 'chat', modelDbId);
+    removeBinding(db, 'chat', modelDbId, keyId);
+    const stillBound = formerKeyIds.filter(k => k !== keyId).length > 0;
+    if (!stillBound) {
+      db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(modelDbId);
+      db.prepare("DELETE FROM models WHERE id = ? AND platform = 'custom'").run(modelDbId);
+    }
+    const keyStillUsed = db.prepare('SELECT 1 FROM custom_key_bindings WHERE key_id = ? LIMIT 1').get(keyId);
+    if (!keyStillUsed) {
+      db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+    }
   });
   remove();
   res.json({ success: true });
@@ -169,9 +207,12 @@ modelsRouter.delete('/:id', (req: Request, res: Response) => {
     if (isCatalogManagedModel(row)) {
       recordCatalogModelTombstone(db, 'chat', row.platform, row.model_id);
     }
-    db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(id);
-    db.prepare('DELETE FROM models WHERE id = ?').run(id);
-    if (row.platform === 'custom') deleteUnusedCustomEndpointKey(db, row.key_id);
+    if (row.platform === 'custom') {
+      deleteCustomModelAndCleanup(db, 'chat', id);
+    } else {
+      db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(id);
+      db.prepare('DELETE FROM models WHERE id = ?').run(id);
+    }
   });
   remove();
 

--- a/server/src/services/declarative-config.ts
+++ b/server/src/services/declarative-config.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { Db } from '../db/types.js';
 import { getDb } from '../db/index.js';
 import { encrypt } from '../lib/crypto.js';
+import { findOrInsertCustomKey, upsertBinding } from '../lib/custom-key-upsert.js';
 import { resolveProvider } from '../providers/index.js';
 import { setCustomWeights, setRoutingStrategy } from './router.js';
 import {
@@ -191,12 +192,10 @@ function ensureFallbackRow(db: Db, modelDbId: number, enabled = true, updateExis
 }
 
 function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSchema>): number {
-  const keyId = upsertApiKey(db, {
-    platform: 'custom',
-    key: input.apiKey,
-    label: input.label,
+  const { processedKeyId: keyId } = findOrInsertCustomKey(db, {
     baseUrl: input.baseUrl,
-    enabled: true,
+    apiKey: input.apiKey,
+    label: input.label,
   });
   let registered = 0;
   for (const entry of input.models) {
@@ -217,7 +216,6 @@ function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSche
         context_window = excluded.context_window,
         supports_vision = excluded.supports_vision,
         supports_tools = excluded.supports_tools,
-        key_id = excluded.key_id,
         enabled = 1
     `).run(
       model.modelId,
@@ -232,6 +230,7 @@ function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSche
       keyId,
     );
     const row = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = ?").get(model.modelId) as { id: number };
+    upsertBinding(db, 'chat', row.id, keyId);
     ensureFallbackRow(db, row.id, model.fallbackEnabled !== false);
     registered++;
   }

--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -69,36 +69,45 @@ interface ProviderCredential {
   baseUrl: string | null;
 }
 
-function getProviderCredential(row: EmbeddingModelRow): ProviderCredential | null {
+function getProviderCredentials(row: EmbeddingModelRow): ProviderCredential[] {
+  const db = getDb();
   if (row.key_id != null) {
-    const keyRow = getDb().prepare(
-      "SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE id = ? AND enabled = 1 AND status IN ('healthy', 'unknown') LIMIT 1",
-    ).get(row.key_id) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
-    if (!keyRow) return null;
-    try {
-      return {
-        id: keyRow.id,
-        key: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
-        baseUrl: keyRow.base_url?.trim().replace(/\/+$/, '') ?? null,
-      };
-    } catch {
-      return null;
+    // Custom endpoint: a model routes ONLY through its bound keys
+    // (custom_key_bindings), not every key on the endpoint.
+    const keyRows = db.prepare(
+      `SELECT k.id, k.encrypted_key, k.iv, k.auth_tag, k.base_url
+         FROM custom_key_bindings ckb
+         JOIN api_keys k ON k.id = ckb.key_id
+        WHERE ckb.modality = 'embedding' AND ckb.model_db_id = ?
+          AND k.enabled = 1 AND k.status IN ('healthy', 'unknown')
+        ORDER BY k.id`,
+    ).all(row.id) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null }[];
+    const creds: ProviderCredential[] = [];
+    for (const kr of keyRows) {
+      try {
+        creds.push({
+          id: kr.id,
+          key: decrypt(kr.encrypted_key, kr.iv, kr.auth_tag),
+          baseUrl: kr.base_url?.trim().replace(/\/+$/, '') ?? null,
+        });
+      } catch { /* skip undecryptable key */ }
     }
+    return creds;
   }
-  if (row.platform === 'custom') return null;
+  if (row.platform === 'custom') return [];
 
-  const keyRow = getDb().prepare(
-    "SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY RANDOM() LIMIT 1",
+  const keyRow = db.prepare(
+    "SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id LIMIT 1",
   ).get(row.platform) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
-  if (!keyRow) return null;
+  if (!keyRow) return [];
   try {
-    return {
+    return [{
       id: keyRow.id,
       key: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
       baseUrl: keyRow.base_url?.trim().replace(/\/+$/, '') ?? null,
-    };
+    }];
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -271,30 +280,33 @@ export async function runEmbeddings(model: string | undefined, inputs: string[],
 
   let lastError: EmbeddingsError | null = null;
   for (const row of chain) {
-    const credential = getProviderCredential(row);
-    if (!credential) continue; // no usable key for this provider — try the next one
-    const started = Date.now();
-    try {
-      const out = await callProvider(row, credential, inputs, dimensions);
-      if (out.vectors.length !== inputs.length || out.vectors.some(v => !Array.isArray(v) || v.length === 0)) {
-        throw new EmbeddingsError('upstream returned malformed embeddings', 502);
+    const credentials = getProviderCredentials(row);
+    if (credentials.length === 0) continue;
+    for (const credential of credentials) {
+      const started = Date.now();
+      try {
+        const out = await callProvider(row, credential, inputs, dimensions);
+        if (out.vectors.length !== inputs.length || out.vectors.some(v => !Array.isArray(v) || v.length === 0)) {
+          throw new EmbeddingsError('upstream returned malformed embeddings', 502);
+        }
+        const tokens = out.inputTokens ?? estimateTokens(inputs);
+        logEmbeddingRequest(row, credential.id, 'success', tokens, Date.now() - started, null);
+        return {
+          family,
+          platform: row.platform,
+          modelId: row.model_id,
+          dimensions: out.vectors[0].length,
+          vectors: out.vectors,
+          inputTokens: tokens,
+        };
+      } catch (err: any) {
+        const e = err instanceof EmbeddingsError ? err : new EmbeddingsError(String(err?.message ?? err), 502);
+        logEmbeddingRequest(row, credential.id, 'error', 0, Date.now() - started, e.message.slice(0, 300));
+        lastError = e;
+        // try the next credential (key) for this provider
       }
-      const tokens = out.inputTokens ?? estimateTokens(inputs);
-      logEmbeddingRequest(row, credential.id, 'success', tokens, Date.now() - started, null);
-      return {
-        family,
-        platform: row.platform,
-        modelId: row.model_id,
-        dimensions: out.vectors[0].length,
-        vectors: out.vectors,
-        inputTokens: tokens,
-      };
-    } catch (err: any) {
-      const e = err instanceof EmbeddingsError ? err : new EmbeddingsError(String(err?.message ?? err), 502);
-      logEmbeddingRequest(row, credential.id, 'error', 0, Date.now() - started, e.message.slice(0, 300));
-      lastError = e;
-      // fall through to the next provider in the family
     }
+    // all credentials for this provider exhausted → fall through to the next provider
   }
 
   throw new EmbeddingsError(

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -77,36 +77,46 @@ interface ProviderCredential {
   baseUrl: string | null;
 }
 
-function getProviderCredential(row: MediaModelRow): ProviderCredential | null {
+function getProviderCredentials(row: MediaModelRow): ProviderCredential[] {
+  const db = getDb();
   if (row.key_id != null) {
-    const keyRow = getDb()
-      .prepare("SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE id = ? AND enabled = 1 AND status IN ('healthy', 'unknown') LIMIT 1")
-      .get(row.key_id) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
-    if (!keyRow) return null;
-    try {
-      return {
-        id: keyRow.id,
-        key: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
-        baseUrl: keyRow.base_url?.trim().replace(/\/+$/, '') ?? null,
-      };
-    } catch {
-      return null;
+    // Custom endpoint: a model routes ONLY through its bound keys
+    // (custom_key_bindings), not every key on the endpoint. The binding
+    // modality is the media modality ('image' | 'audio').
+    const keyRows = db.prepare(
+      `SELECT k.id, k.encrypted_key, k.iv, k.auth_tag, k.base_url
+         FROM custom_key_bindings ckb
+         JOIN api_keys k ON k.id = ckb.key_id
+        WHERE ckb.modality = ? AND ckb.model_db_id = ?
+          AND k.enabled = 1 AND k.status IN ('healthy', 'unknown')
+        ORDER BY k.id`,
+    ).all(row.modality, row.id) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null }[];
+    const creds: ProviderCredential[] = [];
+    for (const kr of keyRows) {
+      try {
+        creds.push({
+          id: kr.id,
+          key: decrypt(kr.encrypted_key, kr.iv, kr.auth_tag),
+          baseUrl: kr.base_url?.trim().replace(/\/+$/, '') ?? null,
+        });
+      } catch { /* skip undecryptable key */ }
     }
+    return creds;
   }
-  if (row.platform === 'custom') return null;
+  if (row.platform === 'custom') return [];
 
-  const keyRow = getDb()
-    .prepare("SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY RANDOM() LIMIT 1")
+  const keyRow = db
+    .prepare("SELECT id, encrypted_key, iv, auth_tag, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') ORDER BY id LIMIT 1")
     .get(row.platform) as { id: number; encrypted_key: string; iv: string; auth_tag: string; base_url: string | null } | undefined;
-  if (!keyRow) return null;
+  if (!keyRow) return [];
   try {
-    return {
+    return [{
       id: keyRow.id,
       key: decrypt(keyRow.encrypted_key, keyRow.iv, keyRow.auth_tag),
       baseUrl: keyRow.base_url?.trim().replace(/\/+$/, '') ?? null,
-    };
+    }];
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -393,22 +403,24 @@ export async function runImageGeneration(model: string | undefined, params: Imag
   const chain = resolveMediaChain(model, 'image');
   let lastError: MediaError | null = null;
   for (const row of chain) {
-    const credential = KEYLESS_CAPABLE.has(row.platform)
-      ? { id: null, key: null, baseUrl: null }
-      : getProviderCredential(row);
-    if (!credential) continue; // no usable key for this provider — try the next
-    const started = Date.now();
-    try {
-      const images = await callImageProvider(row, credential, params);
-      if (!images.length || images.every(i => !i.b64_json && !i.url)) {
-        throw new MediaError('upstream returned no image', 502);
+    const credentials = KEYLESS_CAPABLE.has(row.platform)
+      ? [{ id: null, key: null, baseUrl: null }]
+      : getProviderCredentials(row);
+    if (credentials.length === 0) continue;
+    for (const credential of credentials) {
+      const started = Date.now();
+      try {
+        const images = await callImageProvider(row, credential, params);
+        if (!images.length || images.every(i => !i.b64_json && !i.url)) {
+          throw new MediaError('upstream returned no image', 502);
+        }
+        logMedia(row, credential.id, 'success', Date.now() - started, null);
+        return { platform: row.platform, modelId: row.model_id, images };
+      } catch (err: any) {
+        const e = err instanceof MediaError ? err : new MediaError(String(err?.message ?? err), 502);
+        logMedia(row, credential.id, 'error', Date.now() - started, e.message.slice(0, 300));
+        lastError = e;
       }
-      logMedia(row, credential.id, 'success', Date.now() - started, null);
-      return { platform: row.platform, modelId: row.model_id, images };
-    } catch (err: any) {
-      const e = err instanceof MediaError ? err : new MediaError(String(err?.message ?? err), 502);
-      logMedia(row, credential.id, 'error', Date.now() - started, e.message.slice(0, 300));
-      lastError = e;
     }
   }
   throw chainError('image', lastError);
@@ -419,20 +431,22 @@ export async function runSpeech(model: string | undefined, params: SpeechParams)
   const chain = resolveMediaChain(model, 'audio');
   let lastError: MediaError | null = null;
   for (const row of chain) {
-    const credential = KEYLESS_CAPABLE.has(row.platform)
-      ? { id: null, key: null, baseUrl: null }
-      : getProviderCredential(row);
-    if (!credential) continue;
-    const started = Date.now();
-    try {
-      const out = await callSpeechProvider(row, credential, params);
-      if (!out.audio.length) throw new MediaError('upstream returned no audio', 502);
-      logMedia(row, credential.id, 'success', Date.now() - started, null);
-      return { platform: row.platform, modelId: row.model_id, audio: out.audio, contentType: out.contentType };
-    } catch (err: any) {
-      const e = err instanceof MediaError ? err : new MediaError(String(err?.message ?? err), 502);
-      logMedia(row, credential.id, 'error', Date.now() - started, e.message.slice(0, 300));
-      lastError = e;
+    const credentials = KEYLESS_CAPABLE.has(row.platform)
+      ? [{ id: null, key: null, baseUrl: null }]
+      : getProviderCredentials(row);
+    if (credentials.length === 0) continue;
+    for (const credential of credentials) {
+      const started = Date.now();
+      try {
+        const out = await callSpeechProvider(row, credential, params);
+        if (!out.audio.length) throw new MediaError('upstream returned no audio', 502);
+        logMedia(row, credential.id, 'success', Date.now() - started, null);
+        return { platform: row.platform, modelId: row.model_id, audio: out.audio, contentType: out.contentType };
+      } catch (err: any) {
+        const e = err instanceof MediaError ? err : new MediaError(String(err?.message ?? err), 502);
+        logMedia(row, credential.id, 'error', Date.now() - started, e.message.slice(0, 300));
+        lastError = e;
+      }
     }
   }
   throw chainError('audio', lastError);

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -661,9 +661,27 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   }
   const provider = getProvider(entry.platform as Platform)!;
 
-  const keys = db.prepare(
-    "SELECT * FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')"
-  ).all(entry.platform) as KeyRow[];
+  // Custom models route ONLY across the keys explicitly bound to them in
+  // custom_key_bindings — not every key on the endpoint. This keeps a finance
+  // model from burning a research key's quota while still letting one model
+  // pool several keys when the user registers it against each. (#212)
+  let keys: KeyRow[];
+  let rrKey: string;
+  if (entry.platform === 'custom' && entry.key_id != null) {
+    keys = db.prepare(
+      `SELECT k.* FROM custom_key_bindings ckb
+         JOIN api_keys k ON k.id = ckb.key_id
+        WHERE ckb.modality = 'chat' AND ckb.model_db_id = ?
+          AND k.enabled = 1 AND k.status IN ('healthy', 'unknown')
+        ORDER BY k.id`,
+    ).all(entry.model_db_id) as KeyRow[];
+    rrKey = `custom:${entry.model_db_id}`;
+  } else {
+    keys = db.prepare(
+      "SELECT * FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')",
+    ).all(entry.platform) as KeyRow[];
+    rrKey = `${entry.platform}:${entry.model_id}`;
+  }
   if (keys.length === 0) {
     diag?.push(`${label}: no enabled+healthy key for platform`);
     return null;
@@ -681,16 +699,11 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
     tpd: entry.tpd_limit,
   };
 
-  const rrKey = `${entry.platform}:${entry.model_id}`;
   let idx = roundRobinIndex.get(rrKey) ?? 0;
 
   for (let attempt = 0; attempt < keys.length; attempt++) {
     const key = keys[idx % keys.length];
     idx++;
-
-    // A custom model belongs to exactly one endpoint (#212); legacy rows
-    // (key_id NULL) keep the old any-key match.
-    if (entry.platform === 'custom' && entry.key_id != null && key.id !== entry.key_id) { note('custom-key-mismatch'); continue; }
 
     const skipId = `${entry.platform}:${entry.model_id}:${key.id}`;
     if (skipKeys?.has(skipId)) { note('already-failed-this-request'); continue; }
@@ -771,9 +784,14 @@ export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, ski
 
   for (const k of keys) {
     if (k.id === excludingKeyId) continue;
-    // A custom model binds to exactly one endpoint key (#212); a sibling custom
-    // key cannot serve it, so it doesn't count as an alternative.
-    if (m.platform === 'custom' && m.key_id != null && k.id !== m.key_id) continue;
+    // A custom model routes only through its bound keys (custom_key_bindings);
+    // a sibling custom key NOT bound to this model cannot serve it.
+    if (m.platform === 'custom' && m.key_id != null) {
+      const bound = db.prepare(
+        "SELECT 1 FROM custom_key_bindings WHERE modality = 'chat' AND model_db_id = ? AND key_id = ? LIMIT 1",
+      ).get(modelDbId, k.id);
+      if (!bound) continue;
+    }
     if (skipKeys?.has(`${m.platform}:${m.model_id}:${k.id}`)) continue;
     if (isOnCooldown(m.platform, m.model_id, k.id)) continue;
     if (!canUseProvider(m.platform, k.id)) continue;
@@ -899,12 +917,27 @@ export function getOrderedFusionChain(): FusionCandidate[] {
     const arr = keysByPlatform.get(k.platform);
     if (arr) arr.push(k.id); else keysByPlatform.set(k.platform, [k.id]);
   }
+  // Custom models are servable when any of their BOUND keys (not just any key
+  // on the endpoint) is available — the binding table is the source of truth.
+  const customBoundKeyIds = new Map<string, Set<number>>();
+  for (const e of chain) {
+    if (e.platform !== 'custom' || e.model_db_id == null) continue;
+    const key = `chat:${e.model_db_id}`;
+    if (customBoundKeyIds.has(key)) continue;
+    const rows = db.prepare(
+      "SELECT key_id FROM custom_key_bindings WHERE modality = 'chat' AND model_db_id = ?",
+    ).all(e.model_db_id) as { key_id: number }[];
+    customBoundKeyIds.set(key, new Set(rows.map(r => r.key_id)));
+  }
   const servable = chain.filter(e => {
     const keyIds = keysByPlatform.get(e.platform);
     if (!keyIds) return false;
     const limits = { rpm: e.rpm_limit, rpd: e.rpd_limit, tpm: e.tpm_limit, tpd: e.tpd_limit };
+    const allowed = e.platform === 'custom' && e.model_db_id != null
+      ? (customBoundKeyIds.get(`chat:${e.model_db_id}`) ?? new Set<number>())
+      : null;
     return keyIds.some(kid =>
-      (e.key_id == null || kid === e.key_id) &&
+      (allowed === null || allowed.has(kid)) &&
       !isOnCooldown(e.platform, e.model_id, kid) &&
       canUseProvider(e.platform, kid) &&
       canMakeRequest(e.platform, e.model_id, kid, limits),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -151,6 +151,9 @@ export interface ApiKeyModel {
   modelId: string;
   displayName: string;
   family?: string | null;
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+  keyId: number;
 }
 
 export interface ApiKey {
@@ -165,6 +168,7 @@ export interface ApiKey {
   createdAt: string;
   lastCheckedAt: string | null;
   models?: ApiKeyModel[];
+  endpointKeyCount?: number;
 }
 
 export interface ApiKeyCreate {


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers now support **multiple API keys per `base_url`** with **model-level key isolation**: each model routes ONLY through the keys it was explicitly registered against, never every key on its endpoint. This enables pooling several free-tier accounts behind one model (round-robin + failover) AND keeps a finance model from burning a research key's quota when both live on the same gateway.

The earlier single-key behaviour (re-submitting a `base_url` overwrote the stored key) is replaced by an explicit many-to-many `custom_key_bindings` table. Existing single-key configurations upgrade transparently via a backfill migration.

## Design

### New migration: `custom_key_bindings` junction table

```sql
CREATE TABLE custom_key_bindings (
  modality     TEXT NOT NULL,        -- 'chat' | 'embedding' | 'image' | 'audio'
  model_db_id  INTEGER NOT NULL,     -- models.id / embedding_models.id / media_models.id
  key_id       INTEGER NOT NULL,     -- api_keys.id
  PRIMARY KEY (modality, model_db_id, key_id)
);
CREATE INDEX idx_custom_key_bindings_key ON custom_key_bindings(key_id);
```

- One table covers all four modalities; `modality` discriminates which model table `model_db_id` refers to.
- Existing `models/embedding_models/media_models.key_id` is **kept** as a display anchor (= `MIN(key_id)` from its bindings). The **routing source of truth** is `custom_key_bindings`.
- The migration **backfills** every existing custom model's `key_id` as its sole binding. Reversible (down drops the table).

### Registration (POST /custom x3)

1. `findOrInsertCustomKey(base_url, apiKey)` -> `processedKeyId` (plaintext-deduped key row)
2. Upsert model row (`ON CONFLICT(platform, model_id) DO UPDATE`)
3. `upsertBinding(modality, modelDbId, processedKeyId)` -- `INSERT OR IGNORE` into the junction table (idempotent on PK), then refresh the model's anchor key_id to `MIN(key_id)` over its bindings

| Scenario | Bindings | Routing |
|---|---|---|
| `finance-model` + key-A | `(chat, finance, A)` | only key-A (isolation) |
| `research-model` + key-B | `(chat, research, B)` | only key-B (isolation) |
| `qwen3` + key-A, then `qwen3` + key-B | `(chat, qwen3, A), (chat, qwen3, B)` | round-robin A/B (pooling) |
| `qwen3` + key-A repeated | still `(chat, qwen3, A)` (PK dedup) | idempotent |

### Routing

`selectKeyForModel` (router), `getProviderCredentials` (embeddings), `getProviderCredentials` (media), `getOrderedFusionChain`, and `hasOtherUsableKey` all query `custom_key_bindings` joined to `api_keys` for the specific model -- only bound keys are considered for round-robin / failover.

### Deletion (binding-level)

New per-binding delete routes (the Keys page calls these when a user removes one account's access to a model):

- `DELETE /api/models/custom/:modelId/keys/:keyId`
- `DELETE /api/embeddings/custom/:modelId/keys/:keyId`
- `DELETE /api/media/custom/:modelId/keys/:keyId`

Behaviour: remove the `(model, key)` binding. If the model has no remaining bindings -> delete the model + fallback entry. If the key has no remaining bindings -> delete the key row.

The existing whole-model delete routes (`DELETE /api/models/custom/:id` etc.) and the generic `DELETE /api/models/:id` route through `deleteCustomModelAndCleanup` (removes all bindings + model + orphan keys). `DELETE /api/keys/:id` removes all of that key's bindings and cascades models that lost their last binding.

## Core behavior changes

| Scenario | Before (upstream) | After |
|---|---|---|
| Same `base_url` + different `apiKey` | Overwrites (`UPDATE encrypted_key`) | Both keys coexist (plaintext dedup, no overwrite) |
| Same model + multiple keys | Only the anchor key used (`key.id !== entry.key_id` hard filter) | Round-robins all bound keys (queries `custom_key_bindings`) |
| Different models + different keys (same endpoint) | Shares all endpoint keys | Each model uses only its own bound keys (isolation) |
| Delete a model | Deletes single row by `key_id` | Removes bindings; model cascaded only when no bindings remain |
| Delete a key | Cascades by `base_url` | Cascades by bindings; only models that lost their last binding are deleted |
| Keys page badge | "N keys" (endpoint-level, misleading) | "N models" (per-key, accurate) |
| Delete granularity | Whole-model delete only | New per-(model, key) binding-level delete |

## Changes

### New files

- **`server/src/db/migrations/20260707_000000_custom_key_bindings.ts`** -- junction table + backfill (reversible).

### Shared lib

- **`server/src/lib/custom-key-upsert.ts`** (new) -- `findOrInsertCustomKey` (plaintext-deduped multi-key upsert), `upsertBinding`, `rebindAnchor`, `getModelBoundKeys`, `getModelBoundKeyIds`, `removeBinding`, `getEndpointKeyCount`, `CustomModality` type.
- **`server/src/lib/custom-provider-cleanup.ts`** -- rewritten: `deleteUnusedCustomEndpointKey` replaced with `cleanupAfterBindingsRemoved` and `deleteCustomModelAndCleanup` (binding-scoped).

### Routes

- **`server/src/routes/keys.ts`** -- `POST /custom` writes a binding per model; `GET /` attaches models to a key row via the bindings joined to that key (each key shows only ITS bound models, plus `endpointKeyCount`); `DELETE /:id` removes the key's bindings and cascades models that lost their last binding.
- **`server/src/routes/embeddings.ts`** -- `POST /custom` writes a binding; `DELETE /custom/:id` uses `deleteCustomModelAndCleanup`; new `DELETE /custom/:id/keys/:keyId` (per-binding).
- **`server/src/routes/media.ts`** -- same as embeddings (image + audio).
- **`server/src/routes/models.ts`** -- `DELETE /custom/:id` uses `deleteCustomModelAndCleanup`; new `DELETE /custom/:id/keys/:keyId` (per-binding); generic `DELETE /:id` routes custom models through `deleteCustomModelAndCleanup`.

### Services

- **`server/src/services/router.ts`** -- `selectKeyForModel` custom branch queries `custom_key_bindings` for the model's bound keys; `hasOtherUsableKey` custom branch checks bindings instead of `key_id` equality; `getOrderedFusionChain` builds a per-model allowed-key set from bindings.
- **`server/src/services/embeddings.ts`** -- `getProviderCredentials` (plural) returns all bound keys; `runEmbeddings` iterates credentials (inner key failover).
- **`server/src/services/media.ts`** -- same multi-key failover for `runImageGeneration` and `runSpeech`.
- **`server/src/services/declarative-config.ts`** -- `registerCustomProvider` upserts a binding per model (idempotent on boot via PK).

### Shared types + client

- **`shared/types.ts`** -- `ApiKeyModel.keyId: number`; `ApiKey.endpointKeyCount?: number`.
- **`client/src/components/keys/shared.tsx`** -- `customModelDeletePath` targets `/custom/:modelId/keys/:keyId`; `customModelDeleteKey` includes `keyId`.
- **`client/src/components/keys/provider-list.tsx`** -- badge shows per-key "N models" (not endpoint-level "N keys").

### Migration registration

- **`server/src/db/migrate/defaults.ts`** -- registered the new migration in `DEFAULT_MIGRATIONS`.
- **`server/src/__tests__/db/migrate/roundtrip.test.ts`** -- added the new filename to the applied-migrations expectation.

## Test record

All 916 server tests pass (`npm test`); `npm run build` (server `tsc` + client `tsc -b && vite build`) passes.

Existing tests adapted: `embeddings.test.ts` and `media.test.ts` test helpers now write bindings when inserting custom models. `roundtrip.test.ts` updated with the new migration filename.

## Verification

```bash
npm test          # 916 passed
npm run build     # server tsc + client build OK
```

## Effect shown
<img width="1141" height="282" alt="ScreenShot_2026-07-07_115247_585" src="https://github.com/user-attachments/assets/a9f0d2c1-8fd6-4a30-83f6-118378c84b4e" />
