### PR TITLE
feat(analytics): sticky range + sortable per-model table columns

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -124,6 +124,26 @@ function shortUserAgent(ua: string | null): string {
   return first.length > 32 ? first.slice(0, 32) + '…' : first
 }
 
+const TIME_RANGES: readonly TimeRange[] = ['24h', '7d', '30d', '90d']
+const STORAGE_KEY = 'freellmapi.analytics.range'
+const DEFAULT_RANGE: TimeRange = '7d'
+
+// Read the previously-selected range from localStorage. Invalid or missing
+// values fall back to the 7d default so a corrupted entry never bricks the
+// page; SSR-safety follows the same try/catch shape as `lib/api.ts`.
+function loadStoredRange(): TimeRange {
+  if (typeof window === 'undefined') return DEFAULT_RANGE
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored && (TIME_RANGES as readonly string[]).includes(stored)) {
+      return stored as TimeRange
+    }
+  } catch {
+    /* localStorage unavailable (private mode, etc.) — use default */
+  }
+  return DEFAULT_RANGE
+}
+
 function formatTokens(n?: number): string {
   if (!n) return '0'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -174,7 +194,20 @@ const chartVars = `
 
 export default function AnalyticsPage() {
   const { t } = useI18n()
-  const [range, setRange] = useState<TimeRange>('7d')
+  const [range, setRange] = useState<TimeRange>(loadStoredRange)
+
+  // Remember the last-selected range across page reloads / new sessions so
+  // the user lands back on the window they were inspecting. Same
+  // localStorage shape as `theme` and `freellmapi.locale`.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(STORAGE_KEY, range)
+    } catch {
+      /* ignore — storage quota / private mode */
+    }
+  }, [range])
+
   // Capture "now" once at mount so the savings extrapolation below stays a pure
   // render (calling Date.now() during render is impure and non-deterministic).
   const [now] = useState(() => Date.now())

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -144,6 +145,64 @@ function loadStoredRange(): TimeRange {
   return DEFAULT_RANGE
 }
 
+// Per-model table sort state. The `pinned` column is intentionally NOT
+// sortable — it renders "—" for zero-pinned rows and the unsortable `0`/`>0`
+// distinction would confuse the indicator. 3-state cycle per column:
+// null → asc → desc → null. Switching to a new column resets to asc.
+type SortColumn = 'model' | 'provider' | 'requests' | 'success' | 'latency' | 'inTokens' | 'outTokens' | 'saved'
+type SortDirection = 'asc' | 'desc'
+type SortState = { column: SortColumn; direction: SortDirection } | null
+
+const SORT_COLUMNS: readonly SortColumn[] = [
+  'model', 'provider', 'requests', 'success', 'latency', 'inTokens', 'outTokens', 'saved',
+]
+const SORT_STORAGE_KEY = 'freellmapi.analytics.byModelSort'
+
+function loadStoredSort(): SortState {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(SORT_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { column?: unknown; direction?: unknown }
+    if (
+      typeof parsed.column === 'string' &&
+      (SORT_COLUMNS as readonly string[]).includes(parsed.column) &&
+      (parsed.direction === 'asc' || parsed.direction === 'desc')
+    ) {
+      return { column: parsed.column as SortColumn, direction: parsed.direction }
+    }
+  } catch {
+    /* corrupted JSON or storage unavailable — fall through to null */
+  }
+  return null
+}
+
+// Numeric accessor for a sortable column. Returns null for values the API
+// didn't include so they sort to the bottom on asc and top on desc.
+function sortValue(row: any, col: SortColumn): number | string | null {
+  switch (col) {
+    case 'model': return row.displayName ?? null
+    case 'provider': return row.platform ?? null
+    case 'requests': return row.requests ?? null
+    case 'success': return row.successRate ?? null
+    case 'latency': return row.avgLatencyMs ?? null
+    case 'inTokens': return row.totalInputTokens ?? null
+    case 'outTokens': return row.totalOutputTokens ?? null
+    case 'saved': return row.estimatedCost ?? null
+  }
+}
+
+function compareRows(a: any, b: any, col: SortColumn): number {
+  const av = sortValue(a, col)
+  const bv = sortValue(b, col)
+  // Nulls always last regardless of direction (Excel/Sheets convention).
+  if (av === null && bv === null) return 0
+  if (av === null) return 1
+  if (bv === null) return -1
+  if (typeof av === 'number' && typeof bv === 'number') return av - bv
+  return String(av).localeCompare(String(bv))
+}
+
 function formatTokens(n?: number): string {
   if (!n) return '0'
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
@@ -192,6 +251,55 @@ const chartVars = `
 .dark .analytics-viz { --series-a: #3987e5; --series-b: #199e70; }
 `
 
+// Sortable header cell. Renders the label + a state-aware indicator:
+// unsorted → ChevronsUpDown (faded), asc → ArrowUp, desc → ArrowDown.
+// Right-aligned columns flip the indicator order so it sits to the LEFT
+// of the label, keeping the label closest to the data.
+function SortableHeader({
+  column,
+  label,
+  align,
+  extraClass,
+  sort,
+  onClick,
+}: {
+  column: SortColumn
+  label: string
+  align: 'left' | 'right'
+  extraClass?: string
+  sort: SortState
+  onClick: (col: SortColumn) => void
+}) {
+  const active = sort?.column === column
+  const direction = active ? sort.direction : null
+  const indicator = direction === 'asc'
+    ? <ArrowUp className="size-3 shrink-0" />
+    : direction === 'desc'
+    ? <ArrowDown className="size-3 shrink-0" />
+    : <ChevronsUpDown className="size-3 shrink-0 opacity-40" />
+  const alignClass = align === 'right' ? 'text-right' : ''
+  const headClass = [alignClass, extraClass].filter(Boolean).join(' ')
+  return (
+    <TableHead className={headClass || undefined}>
+      <button
+        type="button"
+        onClick={() => onClick(column)}
+        aria-label={label}
+        aria-sort={direction === 'asc' ? 'ascending' : direction === 'desc' ? 'descending' : 'none'}
+        className={
+          'inline-flex items-center gap-1 ' +
+          (align === 'right' ? 'flex-row-reverse' : 'flex-row') +
+          ' cursor-pointer select-none hover:text-foreground transition-colors ' +
+          (active ? 'text-foreground' : 'text-muted-foreground')
+        }
+      >
+        <span>{label}</span>
+        {indicator}
+      </button>
+    </TableHead>
+  )
+}
+
 export default function AnalyticsPage() {
   const { t } = useI18n()
   const [range, setRange] = useState<TimeRange>(loadStoredRange)
@@ -211,6 +319,28 @@ export default function AnalyticsPage() {
   // Capture "now" once at mount so the savings extrapolation below stays a pure
   // render (calling Date.now() during render is impure and non-deterministic).
   const [now] = useState(() => Date.now())
+
+  // Per-model table sort. Cycle: null → asc → desc → null. Switching column
+  // starts at asc on the new column. Persisted so the next visit lands on
+  // the user's preferred sort.
+  const [sort, setSort] = useState<SortState>(loadStoredSort)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      if (sort === null) window.localStorage.removeItem(SORT_STORAGE_KEY)
+      else window.localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(sort))
+    } catch {
+      /* ignore */
+    }
+  }, [sort])
+
+  const onHeaderClick = (col: SortColumn) => {
+    setSort((current) => {
+      if (!current || current.column !== col) return { column: col, direction: 'asc' }
+      if (current.direction === 'asc') return { column: col, direction: 'desc' }
+      return null // third click on the same column → restore API order
+    })
+  }
 
   const { data: summary, isLoading: summaryLoading } = useQuery({
     queryKey: ['analytics', 'summary', range],
@@ -236,6 +366,21 @@ export default function AnalyticsPage() {
     queryKey: ['analytics', 'by-key', range],
     queryFn: () => apiFetch<ByKeyRow[]>(`/api/analytics/by-key?range=${range}`),
   })
+
+  // Apply the user's sort to byModel. When sort is null we render the rows
+  // in API-returned order; the API's natural ordering (requests DESC) is
+  // the right default. The sort is stable within the comparator because we
+  // fall back to insertion order for equal values (Array.prototype.sort is
+  // stable in all modern engines).
+  const sortedByModel = useMemo(() => {
+    if (!sort) return byModel
+    const copy = byModel.slice()
+    copy.sort((a, b) => {
+      const primary = compareRows(a, b, sort.column)
+      return sort.direction === 'asc' ? primary : -primary
+    })
+    return copy
+  }, [byModel, sort])
 
   const { data: errors = [] } = useQuery({
     queryKey: ['analytics', 'errors', range],
@@ -572,19 +717,19 @@ export default function AnalyticsPage() {
                   <Table>
                     <TableHeader>
                       <TableRow>
-                        <TableHead className="pl-4">{t('common.model')}</TableHead>
-                        <TableHead>{t('common.provider')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.requests')}</TableHead>
+                        <SortableHeader column="model" label={t('common.model')} align="left" extraClass="pl-4" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="provider" label={t('common.provider')} align="left" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="requests" label={t('analytics.requests')} align="right" sort={sort} onClick={onHeaderClick} />
                         <TableHead className="text-right">{t('analytics.pinned')}</TableHead>
-                        <TableHead className="text-right">{t('common.success')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.latency')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.inTokens')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.outTokens')}</TableHead>
-                        <TableHead className="text-right pr-4">{t('analytics.saved')}</TableHead>
+                        <SortableHeader column="success" label={t('common.success')} align="right" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="latency" label={t('analytics.latency')} align="right" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="inTokens" label={t('analytics.inTokens')} align="right" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="outTokens" label={t('analytics.outTokens')} align="right" sort={sort} onClick={onHeaderClick} />
+                        <SortableHeader column="saved" label={t('analytics.saved')} align="right" extraClass="pr-4" sort={sort} onClick={onHeaderClick} />
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {byModel.map((m, i) => (
+                      {sortedByModel.map((m, i) => (
                         <TableRow key={i}>
                           <TableCell className="pl-4 text-sm font-medium">{m.displayName}</TableCell>
                           <TableCell className="text-xs text-muted-foreground">{m.platform}</TableCell>


### PR DESCRIPTION
## Summary

Two small but related client-side improvements to the analytics page,
shipped together because they share infrastructure and would otherwise
conflict on the same lines of `AnalyticsPage.tsx`:

1. **Sticky time range** — the selected 24h/7d/30d/90d range now persists
   in `localStorage` so reloads and new sessions land on the user's
   last choice.
2. **Sortable per-model table** — every column in the "per-model
   breakdown" table (except `pinned`, which renders `—`) is now
   clickable to sort. 3-state cycle: `unsorted (API order) → asc → desc
   → unsorted`. Last selection persists in `localStorage` too.

Both use the same persistence shape as the existing `theme` toggle
and `freellmapi.locale` preference. Same `useState` + `useEffect`
pattern, same try/catch on every storage access.

## Why combined

Originally shipped as PR #462 (sticky range only). Adding the sort
work on top of #462's branch required a rebase that would have
re-written #462's commits — at that point the cleanest move was a
single PR covering both. The two features are thematically adjacent
(analytics-page UX) and small individually, so combining avoids
two PRs reviewing the same file.

## Rebase onto current `origin/main` (9858eee)

This is a re-submission of #463 (which was based on a stale `origin/main`
snapshot @ `9048dd6`). The analytics page changed significantly upstream
since the original PR — main now uses a `<SegmentedControl>` shared
component for the range selector, `TimeRange` widens to include `90d`,
stats load via skeletons, and several i18n keys changed. The
localStorage pattern itself is unchanged.

Two conflicts during cherry-pick, both resolved in favor of keeping
both changes:

1. `useState<TimeRange>('7d')` line — kept the PR's `loadStoredRange`
   init and added upstream's `const [now]` capture alongside it.
2. `byModel.map((m, i) => (` vs PR's `sortedByModel.map(...)` —
   took the PR's sort-applied version.

Also: added `'90d'` to the `TIME_RANGES` allowlist (the PR pre-dated
that range option; without it, a user who selected 90d would have
their sticky selection silently dropped to `'7d'` on the next reload).

## Changes

| File | Change |
|---|---|
| `client/src/pages/AnalyticsPage.tsx` | +189 / -11. Added `useMemo` to imports, `STORAGE_KEY`/`loadStoredRange`/sort types, `SortableHeader` helper component, `sort` state + persistence effect, `onHeaderClick` reducer, `sortedByModel` memoized sort, replaced 8 of 9 column headers with `<SortableHeader>` (pinned stays static), added `lucide-react` ArrowUp/ArrowDown/ChevronsUpDown imports. |

**1 file, +189 / -11 across 2 commits.**

## Sort behavior

| State | Indicator | Order |
|---|---|---|
| Unsorted | ChevronsUpDown (faded) | API-returned (requests DESC) |
| Asc | ArrowUp | A→Z / 0→9 |
| Desc | ArrowDown | Z→A / 9→0 |

- Click another column → starts at asc on the new column.
- Click the same column three times → back to API order, storage
  key removed.
- Null values sort last in both directions (Excel/Sheets convention).
- Right-aligned columns flip the indicator with `flex-row-reverse` so
  the label stays closest to the data.
- `aria-sort` attribute is set on each header button for screen readers.

`pinned` is intentionally not sortable: it renders `—` for zero-pinned
rows, and the 0/>0 distinction is meaningless to sort on.

## localStorage keys

| Key | Value | When written |
|---|---|---|
| `freellmapi.analytics.range` | `'24h'` \| `'7d'` \| `'30d'` \| `'90d'` | On range change |
| `freellmapi.analytics.byModelSort` | `{"column": "...", "direction": "asc"\|"desc"}` or absent | On sort change (removed on unsort) |

Both keys are validated against an allowlist on read so a corrupted
entry falls back to the default rather than crashing the page. Both
writes are wrapped in try/catch for SSR / private-mode safety.

## Test plan

- `cd client && npx tsc -b` — clean, 0 errors.
- `cd client && npm run build` — `✓ built in 8.72s`.
- Bundle contains both storage keys + the icon imports:
  `grep -oE 'freellmapi\.analytics\.[a-zA-Z]+' client/dist/assets/index-*.js`
  returns both `freellmapi.analytics.range` and
  `freellmapi.analytics.byModelSort`.

Manual smoke (assumes the user runs locally):
1. Open `/analytics`, click 30d. Hard-reload — opens on 30d.
2. Click any column header (e.g. "Latency") — sorts asc, indicator
   shows ↑, header text darkens.
3. Click again — sorts desc, indicator shows ↓.
4. Click a third time — back to API order, indicator faded.
5. Click a different column — starts at asc on the new column.
6. Reload — your last sort is restored.
7. Hard-reload after clicking through to unsort — the key is
   removed from localStorage, the page loads in API order.

## Compatibility

No breaking changes. Defaults are unchanged (7d range, API-natural
row order). The persistence is additive. New `localStorage` keys
are namespaced under `freellmapi.*` per the existing convention.

## Supersedes

Closes #462 (the sticky-range half of this work is included here).
This PR supersedes #463, which was the original submission based on
a stale `main` snapshot and is now CLOSED.

References operator sessions 2026-07-04 / 2026-07-07. No upstream
issue number yet — happy to file one if requested.