### PR TITLE
feat: support inline editing of custom provider endpoints, keys, model names, and model adding

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -258,6 +258,7 @@
     "checking": "Checking…",
     "editLabel": "Edit label",
     "saveLabel": "Save label",
+    "save": "Save",
     "unifiedKeyDescBefore": "Use this as your OpenAI ",
     "unifiedKeyDescAfter": "; it authenticates requests to this proxy.",
     "serverUnreachableBefore": "Can't reach the server on ",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -202,6 +202,7 @@
     "checking": "Comprobando…",
     "editLabel": "Editar etiqueta",
     "saveLabel": "Guardar etiqueta",
+    "save": "Guardar",
     "unifiedKeyDescBefore": "Úsala como tu ",
     "unifiedKeyDescAfter": " de OpenAI; autentica las solicitudes a este proxy.",
     "serverUnreachableBefore": "No se puede conectar con el servidor en ",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -202,6 +202,7 @@
     "checking": "Vérification…",
     "editLabel": "Modifier le libellé",
     "saveLabel": "Enregistrer le libellé",
+    "save": "Enregistrer",
     "unifiedKeyDescBefore": "Utilisez-la comme votre ",
     "unifiedKeyDescAfter": " OpenAI ; elle authentifie les requêtes vers ce proxy.",
     "serverUnreachableBefore": "Impossible de joindre le serveur sur ",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -220,6 +220,7 @@
     "checking": "Controllo…",
     "editLabel": "Modifica etichetta",
     "saveLabel": "Salva etichetta",
+    "save": "Salva",
     "unifiedKeyDescBefore": "Usa questa come tua chiave OpenAI ",
     "unifiedKeyDescAfter": "; autentica le richieste a questo proxy.",
     "serverUnreachableBefore": "Impossibile raggiungere il server su ",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -202,6 +202,7 @@
     "checking": "Verificando…",
     "editLabel": "Editar rótulo",
     "saveLabel": "Salvar rótulo",
+    "save": "Salvar",
     "unifiedKeyDescBefore": "Use-a como sua ",
     "unifiedKeyDescAfter": " da OpenAI; ela autentica as solicitações a este proxy.",
     "serverUnreachableBefore": "Não foi possível acessar o servidor em ",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -202,6 +202,7 @@
     "checking": "检查中…",
     "editLabel": "编辑标签",
     "saveLabel": "保存标签",
+    "save": "保存",
     "unifiedKeyDescBefore": "将其用作你的 OpenAI ",
     "unifiedKeyDescAfter": "；它用于对发往本代理的请求进行身份验证。",
     "serverUnreachableBefore": "无法连接到位于 ",

--- a/client/src/pages/KeysPage.tsx
+++ b/client/src/pages/KeysPage.tsx
@@ -867,12 +867,19 @@ export default function KeysPage() {
   const [label, setLabel] = useState('')
   const [editingKeyId, setEditingKeyId] = useState<number | null>(null)
   const [editingLabel, setEditingLabel] = useState('')
+  const [editingBaseUrl, setEditingBaseUrl] = useState('')
+  const [editingApiKey, setEditingApiKey] = useState('')
   // Server-supplied notice when a key is saved for a platform with no models in
   // the current catalog tier yet (e.g. a newly added premium provider, #438).
   const [addNotice, setAddNotice] = useState<string | null>(null)
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null)
   const [confirmDeleteModelKey, setConfirmDeleteModelKey] = useState<string | null>(null)
   const [expandedKeyIds, setExpandedKeyIds] = useState<Set<number>>(new Set())
+  const [editingModelId, setEditingModelId] = useState<number | null>(null)
+  const [editingModelName, setEditingModelName] = useState('')
+  const [newModelInput, setNewModelInput] = useState('')
+  const [newModelType, setNewModelType] = useState<'chat' | 'embedding' | 'image' | 'audio'>('chat')
+  const [addingModelToKeyId, setAddingModelToKeyId] = useState<number | null>(null)
   const editInputRef = useRef<HTMLInputElement>(null)
 
   const { data: keys = [], isLoading } = useQuery<ApiKey[]>({
@@ -921,6 +928,45 @@ export default function KeysPage() {
     },
   })
 
+  const updateCustomModel = useMutation({
+    mutationFn: ({ id, displayName }: { id: number; displayName: string }) =>
+      apiFetch(`/api/models/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ displayName }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      queryClient.invalidateQueries({ queryKey: ['models'] })
+      setEditingModelId(null)
+      setEditingModelName('')
+    },
+  })
+
+  const addCustomModel = useMutation({
+    mutationFn: ({ baseUrl, model, kind }: { baseUrl: string; model: string; kind: string }) => {
+      const path = kind === 'chat' ? '/api/keys/custom'
+        : kind === 'embedding' ? '/api/embeddings/custom'
+        : '/api/media/custom'
+      const body: Record<string, unknown> = { baseUrl, model }
+      if (kind !== 'chat' && kind !== 'embedding') body.modality = kind
+      return apiFetch(path, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+      queryClient.invalidateQueries({ queryKey: ['health'] })
+      queryClient.invalidateQueries({ queryKey: ['fallback'] })
+      queryClient.invalidateQueries({ queryKey: ['models'] })
+      queryClient.invalidateQueries({ queryKey: ['embeddings'] })
+      queryClient.invalidateQueries({ queryKey: ['media'] })
+      setNewModelInput('')
+      setAddingModelToKeyId(null)
+    },
+  })
+
   const checkAll = useMutation({
     mutationFn: () => apiFetch('/api/health/check-all', { method: 'POST' }),
     onSuccess: () => {
@@ -951,32 +997,50 @@ export default function KeysPage() {
   })
 
   const updateKey = useMutation({
-    mutationFn: ({ id, label }: { id: number; label: string }) =>
-      apiFetch(`/api/keys/${id}`, {
+    mutationFn: ({ id, label, baseUrl, apiKey }: { id: number; label?: string; baseUrl?: string; apiKey?: string }) => {
+      const body: Record<string, unknown> = {}
+      if (label !== undefined) body.label = label
+      if (baseUrl !== undefined) body.baseUrl = baseUrl
+      if (apiKey !== undefined) body.apiKey = apiKey
+      return apiFetch(`/api/keys/${id}`, {
         method: 'PATCH',
-        body: JSON.stringify({ label }),
-      }),
+        body: JSON.stringify(body),
+      })
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['keys'] })
       setEditingKeyId(null)
       setEditingLabel('')
+      setEditingBaseUrl('')
+      setEditingApiKey('')
     },
   })
 
   function startEditing(key: ApiKey) {
     setEditingKeyId(key.id)
     setEditingLabel(key.label)
+    if (key.platform === 'custom') {
+      setEditingBaseUrl(key.baseUrl ?? '')
+      setEditingApiKey('')
+    } else {
+      setEditingBaseUrl('')
+      setEditingApiKey('')
+    }
   }
 
   function cancelEditing() {
     setEditingKeyId(null)
     setEditingLabel('')
+    setEditingBaseUrl('')
+    setEditingApiKey('')
   }
 
   function saveEditing(id: number) {
-    if (editingLabel !== undefined) {
-      updateKey.mutate({ id, label: editingLabel })
-    }
+    const body: { id: number; label?: string; baseUrl?: string; apiKey?: string } = { id }
+    if (editingLabel !== undefined) body.label = editingLabel
+    if (editingBaseUrl !== undefined && editingBaseUrl) body.baseUrl = editingBaseUrl
+    if (editingApiKey !== undefined && editingApiKey) body.apiKey = editingApiKey
+    updateKey.mutate(body)
   }
 
   function toggleExpandedKey(id: number) {
@@ -1219,7 +1283,45 @@ export default function KeysPage() {
                               </Button>
                             )}
                             <code className="text-xs font-mono flex-shrink-0">{k.maskedKey}</code>
-                            {isEditing ? (
+                            {isEditing && k.platform === 'custom' ? (
+                              <div className="flex flex-wrap items-center gap-1.5">
+                                <Input
+                                  ref={editInputRef}
+                                  value={editingLabel}
+                                  onChange={e => setEditingLabel(e.target.value)}
+                                  onKeyDown={e => {
+                                    if (e.key === 'Enter') saveEditing(k.id)
+                                    if (e.key === 'Escape') cancelEditing()
+                                  }}
+                                  placeholder="标签"
+                                  className="h-6 w-[100px] text-xs"
+                                  disabled={updateKey.isPending}
+                                />
+                                <Input
+                                  value={editingBaseUrl}
+                                  onChange={e => setEditingBaseUrl(e.target.value)}
+                                  onKeyDown={e => {
+                                    if (e.key === 'Enter') saveEditing(k.id)
+                                    if (e.key === 'Escape') cancelEditing()
+                                  }}
+                                  placeholder="Base URL"
+                                  className="h-6 w-[200px] text-xs font-mono"
+                                  disabled={updateKey.isPending}
+                                />
+                                <Input
+                                  type="password"
+                                  value={editingApiKey}
+                                  onChange={e => setEditingApiKey(e.target.value)}
+                                  onKeyDown={e => {
+                                    if (e.key === 'Enter') saveEditing(k.id)
+                                    if (e.key === 'Escape') cancelEditing()
+                                  }}
+                                  placeholder="新 API Key（留空不变）"
+                                  className="h-6 w-[160px] text-xs font-mono"
+                                  disabled={updateKey.isPending}
+                                />
+                              </div>
+                            ) : isEditing ? (
                               <Input
                                 ref={editInputRef}
                                 value={editingLabel}
@@ -1249,7 +1351,11 @@ export default function KeysPage() {
                                 {formatSqliteUtcToLocalTime(lastChecked, { hour: '2-digit', minute: '2-digit' })}
                               </span>
                             )}
-                            {!isEditing && (
+                            {isEditing && k.platform === 'custom' ? (
+                              <Button variant="ghost" size="xs" onClick={() => saveEditing(k.id)} disabled={updateKey.isPending}>
+                                {t('keys.save')}
+                              </Button>
+                            ) : !isEditing && (
                               <Button variant="ghost" size="xs" onClick={() => startEditing(k)}>
                                 <Pencil className="size-3" />
                               </Button>
@@ -1280,14 +1386,48 @@ export default function KeysPage() {
                               {customModels.map(model => {
                                 const modelKey = customModelDeleteKey(model)
                                 const confirming = confirmDeleteModelKey === modelKey
+                                const isEditingModel = editingModelId === model.id
                                 return (
                                   <div key={modelKey} className="inline-flex min-w-0 items-center gap-2 rounded-md border bg-background px-2 py-1 text-[11px]">
                                     <span className="rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
                                       {t(CUSTOM_MODEL_KIND_LABEL[model.kind])}
                                     </span>
-                                    <span className="max-w-[180px] truncate font-medium" title={model.modelId}>
-                                      {model.displayName}
-                                    </span>
+                                    {isEditingModel ? (
+                                      <Input
+                                        value={editingModelName}
+                                        onChange={e => setEditingModelName(e.target.value)}
+                                        onKeyDown={e => {
+                                          if (e.key === 'Enter' && editingModelName.trim()) {
+                                            updateCustomModel.mutate({ id: model.id, displayName: editingModelName.trim() })
+                                          }
+                                          if (e.key === 'Escape') {
+                                            setEditingModelId(null)
+                                            setEditingModelName('')
+                                          }
+                                        }}
+                                        onBlur={() => {
+                                          if (editingModelName.trim() && editingModelName.trim() !== model.displayName) {
+                                            updateCustomModel.mutate({ id: model.id, displayName: editingModelName.trim() })
+                                          } else {
+                                            setEditingModelId(null)
+                                            setEditingModelName('')
+                                          }
+                                        }}
+                                        className="h-5 w-[130px] text-[11px]"
+                                        disabled={updateCustomModel.isPending}
+                                      />
+                                    ) : (
+                                      <span
+                                        className="max-w-[140px] truncate font-medium cursor-pointer hover:text-primary"
+                                        title={model.modelId}
+                                        onClick={() => {
+                                          setEditingModelId(model.id)
+                                          setEditingModelName(model.displayName)
+                                        }}
+                                      >
+                                        {model.displayName}
+                                      </span>
+                                    )}
                                     {model.family && (
                                       <code className="max-w-[160px] truncate text-muted-foreground" title={model.family}>
                                         {model.family}
@@ -1315,6 +1455,63 @@ export default function KeysPage() {
                                   </div>
                                 )
                               })}
+                              {addingModelToKeyId === k.id ? (
+                                <div className="inline-flex items-center gap-1.5">
+                                  <Select value={newModelType} onValueChange={(v) => setNewModelType(v as typeof newModelType)}>
+                                    <SelectTrigger className="h-6 w-[90px] text-xs">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="chat">{t('keys.customTypeChat')}</SelectItem>
+                                      <SelectItem value="embedding">{t('keys.customTypeEmbedding')}</SelectItem>
+                                      <SelectItem value="image">{t('keys.customTypeImage')}</SelectItem>
+                                      <SelectItem value="audio">{t('keys.customTypeAudio')}</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <Input
+                                    value={newModelInput}
+                                    onChange={e => setNewModelInput(e.target.value)}
+                                    onKeyDown={e => {
+                                      if (e.key === 'Enter' && newModelInput.trim() && k.baseUrl) {
+                                        addCustomModel.mutate({ baseUrl: k.baseUrl, model: newModelInput.trim(), kind: newModelType })
+                                      }
+                                      if (e.key === 'Escape') {
+                                        setNewModelInput('')
+                                        setAddingModelToKeyId(null)
+                                      }
+                                    }}
+                                    placeholder={t('keys.addModel')}
+                                    className="h-6 w-[140px] text-xs"
+                                    disabled={addCustomModel.isPending}
+                                  />
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="xs"
+                                    disabled={!newModelInput.trim() || addCustomModel.isPending || !k.baseUrl}
+                                    onClick={() => {
+                                      if (newModelInput.trim() && k.baseUrl) {
+                                        addCustomModel.mutate({ baseUrl: k.baseUrl, model: newModelInput.trim(), kind: newModelType })
+                                      }
+                                    }}
+                                  >
+                                    {t('keys.save')}
+                                  </Button>
+                                </div>
+                              ) : (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="xs"
+                                  onClick={() => {
+                                    setAddingModelToKeyId(k.id)
+                                    setNewModelInput('')
+                                  }}
+                                  className="h-6 text-xs"
+                                >
+                                  + {t('keys.addModel')}
+                                </Button>
+                              )}
                             </div>
                           )}
                         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,10 @@
       ],
       "devDependencies": {
         "concurrently": "^9.1.2"
+      },
+      "engines": {
+        "node": ">=20.18.0 <25.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "client": {
@@ -53,6 +57,10 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4"
+      },
+      "engines": {
+        "node": ">=20.18.0 <25.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -13199,6 +13207,10 @@
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",
         "vitest": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=20.18.0 <25.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "server/node_modules/@types/node": {

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -114,7 +114,7 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
       penalty: penalty?.penalty ?? 0,
       rateLimitHits: penalty?.count ?? 0,
       enabled: r.enabled === 1,
-      platform: r.platform,
+      platform: r.platform === 'custom' && r.key_label ? r.key_label : r.platform,
       modelId: r.model_id,
       displayName: r.display_name,
       intelligenceRank: r.intelligence_rank,

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -48,8 +48,10 @@ const addKeySchema = z.object({
 const updateKeySchema = z.object({
   enabled: z.boolean().optional(),
   label: z.string().optional(),
-}).refine(data => data.enabled !== undefined || data.label !== undefined, {
-  message: 'At least one of enabled or label must be provided',
+  baseUrl: z.string().url('baseUrl must be a valid URL').optional(),
+  apiKey: z.string().optional(),
+}).refine(data => data.enabled !== undefined || data.label !== undefined || data.baseUrl !== undefined || data.apiKey !== undefined, {
+  message: 'At least one field must be provided',
 });
 
 const importKeySchema = z.object({
@@ -618,8 +620,8 @@ keysRouter.patch('/platform/:platform', (req: Request, res: Response) => {
   res.json({ success: true, enabled, updatedKeys: result.changes });
 });
 
-// Update key (toggle enable/disable or edit label)
-keysRouter.patch('/:id', (req: Request, res: Response) => {
+// Update key (toggle enable/disable, edit label, or edit custom provider baseUrl/apiKey)
+keysRouter.patch('/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id as string, 10);
   if (isNaN(id)) {
     res.status(400).json({ error: { message: 'Invalid key ID' } });
@@ -632,7 +634,33 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     return;
   }
 
-  const { enabled, label } = parsed.data;
+  const { enabled, label, baseUrl, apiKey } = parsed.data;
+
+  const db = getDb();
+  const existing = db.prepare('SELECT id, platform FROM api_keys WHERE id = ?').get(id) as { id: number; platform: string } | undefined;
+  if (!existing) {
+    res.status(404).json({ error: { message: 'Key not found' } });
+    return;
+  }
+
+  // SSRF guard + duplicate check when updating baseUrl for custom providers
+  if (baseUrl) {
+    if (existing.platform !== 'custom') {
+      res.status(400).json({ error: { message: 'baseUrl can only be updated for custom providers' } });
+      return;
+    }
+    const verdict = await assessProviderUrl(baseUrl);
+    if (!verdict.allowed) {
+      res.status(400).json({ error: { message: `baseUrl rejected: ${verdict.reason}` } });
+      return;
+    }
+    const dupExisting = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND base_url = ? AND id != ?").get(baseUrl.trim().replace(/\/+$/, ''), id);
+    if (dupExisting) {
+      res.status(409).json({ error: { message: 'Another custom provider already uses this base URL' } });
+      return;
+    }
+  }
+
   const updates: string[] = [];
   const values: (string | number)[] = [];
 
@@ -644,10 +672,32 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     updates.push('label = ?');
     values.push(label);
   }
+  if (label !== undefined && existing.platform === 'custom' && label) {
+    // 同步更新关联模型的显示名，让模型页和试玩台显示标签
+    db.prepare(`
+      UPDATE models SET display_name = model_id || ' (' || ? || ')'
+      WHERE key_id = ? AND display_name = model_id
+    `).run(label.trim(), id);
+  }
+  if (baseUrl && existing.platform === 'custom') {
+    updates.push('base_url = ?');
+    values.push(baseUrl.trim().replace(/\/+$/, ''));
+  }
+  if (apiKey && existing.platform === 'custom') {
+    const { encrypted, iv, authTag } = encrypt(apiKey.trim());
+    updates.push('encrypted_key = ?');
+    updates.push('iv = ?');
+    updates.push('auth_tag = ?');
+    values.push(encrypted, iv, authTag);
+  }
+
+  if (updates.length === 0) {
+    res.status(400).json({ error: { message: 'No valid fields to update' } });
+    return;
+  }
 
   values.push(id);
 
-  const db = getDb();
   const result = db.prepare(`UPDATE api_keys SET ${updates.join(', ')} WHERE id = ?`).run(...values);
 
   if (result.changes === 0) {
@@ -658,5 +708,6 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
   const response: Record<string, unknown> = { success: true };
   if (enabled !== undefined) response.enabled = enabled;
   if (label !== undefined) response.label = label;
+  if (baseUrl !== undefined && existing.platform === 'custom') response.baseUrl = baseUrl;
   res.json(response);
 });


### PR DESCRIPTION
## Summary

Extends custom provider key management with inline editing capabilities.

### Backend (`server/src/routes/`)

- **`keys.ts`**: `PATCH /:id` now supports updating `baseUrl` and `apiKey` fields (with SSRF check + duplicate URL detection). When a custom key label changes, linked models' `display_name` is auto-updated.
- **`fallback.ts`**: Custom models' platform name now uses `api_keys.label` instead of hardcoded "custom", so model pages and playground show meaningful names.

### Frontend (`client/src/pages/KeysPage.tsx`)

- **Endpoint & Key inline editing**: Expanded custom key rows show Base URL and API Key inputs; save via button.
- **Model name editing**: Click a model name in expanded view to edit `display_name` inline.
- **Add model**: "+ Add model" button at bottom of expanded view with type selector (chat/embedding/image/audio).
- **Platform label display**: Model pages and playground show key label instead of "custom".

### i18n

Added `keys.save` translation key to all 6 locale files.

## Testing

- Server `tsc` passes
- Client `tsc -b && vite build` passes
- Docker build and deploy verified