### PR TITLE
Add NaraRouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ And the free-tier landscape shifts weekly: providers launch models, retire them,
 </tr>
 <tr>
 <td align="center"><a href="https://endpoints.ai.cloud.ovh.net"><b>OVH AI Endpoints</b><br/>Qwen3.5 397B · GPT-OSS · Llama 3.3 (anon ok)</a></td>
+<td align="center"><a href="https://router.bynara.id"><b>NaraRouter</b><br/>Mistral Large · Mistral Medium · Tencent Hy3</a></td>
 <td align="center"><a href="https://aihorde.net"><b>AI Horde</b><br/>Community Llama · Gemma · Cydonia (anon ok, slow)</a></td>
 <td align="center"></td>
 <td align="center"></td>

--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -49,6 +49,7 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'routeway', label: 'Routeway (free key)', url: 'https://routeway.ai' },
   { value: 'bazaarlink', label: 'BazaarLink (free key)', url: 'https://bazaarlink.ai' },
   { value: 'ainative', label: 'AINative Studio (free key)', url: 'https://ainative.studio' },
+  { value: 'nara', label: 'NaraRouter (free key)', url: 'https://router.bynara.id' },
   { value: 'aihorde', label: 'AI Horde (no key needed, slow)', url: 'https://aihorde.net/register', keyless: true },
 ]
 

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -163,6 +163,7 @@ export const platformColors: Record<string, string> = {
   routeway:    '#14b8a6',
   bazaarlink:  '#e11d48',
   ainative:    '#22c55e',
+  nara:         '#2563eb',
   aihorde:     '#dc2626',
 }
 

--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -37,11 +37,13 @@ describe('key parser', () => {
   it('detects current provider prefixes', () => {
     expect(detectPlatform('GOOGLE_')).toBe('google');
     expect(detectPlatform('OLLAMA_CLOUD_')).toBe('ollama');
+    expect(detectPlatform('NARAROUTER_')).toBe('nara');
     expect(detectPlatform('SAMBANOVA_')).toBeNull();
   });
 
   it('parses Hermes/OpenCode auth.json provider names', () => {
     expect(AUTH_JSON_PROVIDER_MAP['ollama-cloud']).toBe('ollama');
+    expect(AUTH_JSON_PROVIDER_MAP['bynara']).toBe('nara');
     const result = parseAuthJson(JSON.stringify({
       credential_pool: {
         gemini: [{ id: '1', label: 'Gemini', auth_type: 'api_key', access_token: 'AIza-test' }],

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -384,6 +384,7 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'github',     name: 'GitHub Models', baseUrl: 'https://models.github.ai/inference' },
     { platform: 'zhipu',      name: 'Zhipu AI',      baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
     { platform: 'opencode',   name: 'OpenCode Zen',  baseUrl: 'https://opencode.ai/zen/v1' },
+    { platform: 'nara',       name: 'NaraRouter',    baseUrl: 'https://router.bynara.id/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -54,7 +54,7 @@ function mockUpstream(script: Array<{ body: string; status?: number }>) {
     const urlStr = typeof url === 'string' ? url : url.toString();
     // Only intercept provider upstreams; the test's own localhost request
     // and anything else goes through.
-    if (!/api\.groq\.com|openrouter\.ai|api\.cohere|generativelanguage|integrate\.api\.nvidia|api\.cerebras|api\.mistral|router\.huggingface|api\.cloudflare|models\.github|open\.bigmodel|api\.llm7|api\.kilo|text\.pollinations|ollama\.com|opencode\.ai/.test(urlStr)) {
+    if (!/api\.groq\.com|openrouter\.ai|api\.cohere|generativelanguage|integrate\.api\.nvidia|api\.cerebras|api\.mistral|router\.huggingface|api\.cloudflare|models\.github|open\.bigmodel|api\.llm7|api\.kilo|text\.pollinations|ollama\.com|opencode\.ai|router\.bynara\.id/.test(urlStr)) {
       return origFetch(url as any, init);
     }
     const reqBody = JSON.parse(String((init as RequestInit).body));

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -32,6 +32,9 @@ export const PREFIX_MAP: Record<string, string> = {
   ROUTEWAY_: 'routeway',
   BAZAARLINK_: 'bazaarlink',
   AINATIVE_: 'ainative',
+  NARA_: 'nara',
+  NARAROUTER_: 'nara',
+  BYNARA_: 'nara',
   AIHORDE_: 'aihorde',
 };
 
@@ -45,6 +48,9 @@ export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
   nvidia: 'nvidia',
   'opencode-zen': 'opencode',
   opencode: 'opencode',
+  nara: 'nara',
+  bynara: 'nara',
+  'nara-router': 'nara',
 };
 
 export function detectPlatform(prefix: string): string | null {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -273,6 +273,18 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.ainative.studio/api/v1',
 }));
 
+// NaraRouter — OpenAI-compatible aggregator (router.bynara.id/v1). Free plan
+// requires a no-card API key plus Telegram channel/link verification. Live
+// probed 2026-07-09: `mistral-large`, `mistral-medium-3-5`, and `tencent-hy3`
+// answered 200 with a zero-balance account; the rest of /v1/models was
+// credit- or plan-gated. Catalog rows live in the Oracle catalog (premium now,
+// free after the 30-day model-age gate).
+register(new OpenAICompatProvider({
+  platform: 'nara',
+  name: 'NaraRouter',
+  baseUrl: 'https://router.bynara.id/v1',
+}));
+
 // AI Horde — free, community-powered inference (volunteer workers) via an
 // OpenAI-compatible proxy. Dedicated AIHordeProvider (not OpenAICompatProvider)
 // because the proxy is queue-based and diverges from the OpenAI contract:

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -19,7 +19,7 @@ const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
-  'routeway', 'bazaarlink', 'ainative', 'aihorde', 'custom',
+  'routeway', 'bazaarlink', 'ainative', 'nara', 'aihorde', 'custom',
 ] as const;
 
 const ALLOWED_IMPORT_EXTENSIONS = new Set(['.env', '.json', '.jsonc', '.md', '.txt', '.csv']);

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -136,11 +136,12 @@ function inferPoolForPlatform(platform: Platform, modelId?: string | null): stri
   if (platform === 'routeway') return 'routeway::free';
   if (platform === 'bazaarlink') return 'bazaarlink::free';
   if (platform === 'ainative') return 'ainative::account';
+  if (platform === 'nara') return 'nara::free';
   return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aihorde'].includes(platform);
+  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'nara', 'aihorde'].includes(platform);
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -85,6 +85,10 @@ export type Platform =
   // ~10M tokens/month free allocation (no card); quota unverified. Key from
   // ainative.studio.
   | 'ainative'
+  // NaraRouter — OpenAI-compatible aggregator. Free account key from
+  // router.bynara.id after Telegram channel/link verification; free-plan routes
+  // reset daily and are catalog-managed (premium now, free after 30 days).
+  | 'nara'
   // AI Horde — free, community-powered inference (volunteer workers) via an
   // OpenAI-compatible proxy (https://oai.aihorde.net/v1). Queue-based, so calls
   // can take tens of seconds; no tool support; usage is reported as kudos, not


### PR DESCRIPTION
## Summary

Adds NaraRouter as a first-class OpenAI-compatible provider in the self-hosted router.

## Changes

- Registers `nara` against `https://router.bynara.id/v1`
- Adds `nara` to platform typing, key management allowlists, key import detection, quota pooling, UI provider list, and provider colors
- Updates provider test fixtures and README provider table

## Validation

- `npm run test -w server -- src/__tests__/providers/openai-compat.test.ts src/__tests__/lib/key-parser.test.ts`
- `npm run build`
- `npm run test -w server`

## Notes

NaraRouter free-plan smoke tests passed for `mistral-large`, `mistral-medium-3-5`, and `tencent-hy3`. Other returned model IDs were credit- or plan-gated and are intentionally excluded from the catalog change.
