### PR TITLE
Pin GitHub Actions runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Test & build (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -86,7 +86,7 @@ jobs:
   merge:
     name: Merge manifest and push
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build]
     steps:
       - name: Download digests


### PR DESCRIPTION
## Summary
- Pin CI from ubuntu-latest to ubuntu-24.04
- Pin Docker amd64 and manifest jobs from ubuntu-latest to ubuntu-24.04

## Why
The failed main workflows did not fail in tests or builds. GitHub annotated the cancelled jobs with: "The job was not acquired by Runner of type hosted even after multiple attempts." The failed jobs all used ubuntu-latest, while the explicit ubuntu-24.04-arm Docker leg completed successfully.

## Validation
- Workflow-only change
- Replaces all remaining ubuntu-latest labels in .github/workflows
