### PR TITLE
feat(client): analytics search has scope chips and shared highlight

### DIFF
--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -405,7 +405,16 @@
     "recentCalls": "Recent calls",
     "clientIp": "Client IP",
     "clientAgent": "Client app",
-    "requestedModelHint": "Requested {model}, served by fallback"
+    "requestedModelHint": "Requested {model}, served by fallback",
+    "searchAriaLabel": "Filter tables",
+    "searchScopeAriaLabel": "Filter scope",
+    "searchScopeAll": "All",
+    "searchScopeModels": "Models",
+    "searchScopeCalls": "Calls",
+    "searchScopeErrors": "Errors",
+    "searchScopeKeys": "Keys",
+    "matchedCount": "{shown} of {total}",
+    "noMatches": "No matches"
   },
   "playground": {
     "title": "Playground",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -388,7 +388,16 @@
     "recentCalls": "Llamadas recientes",
     "clientIp": "IP del cliente",
     "clientAgent": "Aplicación cliente",
-    "requestedModelHint": "Se solicitó {model}, servido por respaldo"
+    "requestedModelHint": "Se solicitó {model}, servido por respaldo",
+    "searchAriaLabel": "Filtrar tablas",
+    "searchScopeAriaLabel": "Alcance del filtro",
+    "searchScopeAll": "Todo",
+    "searchScopeModels": "Modelos",
+    "searchScopeCalls": "Llamadas",
+    "searchScopeErrors": "Errores",
+    "searchScopeKeys": "Claves",
+    "matchedCount": "{shown} de {total}",
+    "noMatches": "Sin coincidencias"
   },
   "playground": {
     "title": "Entorno de pruebas",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -388,7 +388,16 @@
     "recentCalls": "Appels récents",
     "clientIp": "IP du client",
     "clientAgent": "Application cliente",
-    "requestedModelHint": "{model} demandé, servi par repli"
+    "requestedModelHint": "{model} demandé, servi par repli",
+    "searchAriaLabel": "Filtrer les tableaux",
+    "searchScopeAriaLabel": "Portée du filtre",
+    "searchScopeAll": "Tous",
+    "searchScopeModels": "Modèles",
+    "searchScopeCalls": "Appels",
+    "searchScopeErrors": "Erreurs",
+    "searchScopeKeys": "Clés",
+    "matchedCount": "{shown} sur {total}",
+    "noMatches": "Aucun résultat"
   },
   "playground": {
     "title": "Bac à sable",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -388,7 +388,16 @@
     "recentCalls": "Chiamate recenti",
     "clientIp": "IP del client",
     "clientAgent": "App client",
-    "requestedModelHint": "Richiesto {model}, servito dal fallback"
+    "requestedModelHint": "Richiesto {model}, servito dal fallback",
+    "searchAriaLabel": "Filtra tabelle",
+    "searchScopeAriaLabel": "Ambito del filtro",
+    "searchScopeAll": "Tutto",
+    "searchScopeModels": "Modelli",
+    "searchScopeCalls": "Chiamate",
+    "searchScopeErrors": "Errori",
+    "searchScopeKeys": "Chiavi",
+    "matchedCount": "{shown} di {total}",
+    "noMatches": "Nessun risultato"
   },
   "playground": {
     "title": "Playground",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -388,7 +388,16 @@
     "recentCalls": "Chamadas recentes",
     "clientIp": "IP do cliente",
     "clientAgent": "Aplicativo cliente",
-    "requestedModelHint": "Solicitado {model}, servido por fallback"
+    "requestedModelHint": "Solicitado {model}, servido por fallback",
+    "searchAriaLabel": "Filtrar tabelas",
+    "searchScopeAriaLabel": "Escopo do filtro",
+    "searchScopeAll": "Todos",
+    "searchScopeModels": "Modelos",
+    "searchScopeCalls": "Chamadas",
+    "searchScopeErrors": "Erros",
+    "searchScopeKeys": "Chaves",
+    "matchedCount": "{shown} de {total}",
+    "noMatches": "Nenhum resultado"
   },
   "playground": {
     "title": "Playground",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -388,7 +388,16 @@
     "recentCalls": "最近调用",
     "clientIp": "客户端 IP",
     "clientAgent": "客户端应用",
-    "requestedModelHint": "请求了 {model}，由回退模型提供"
+    "requestedModelHint": "请求了 {model}，由回退模型提供",
+    "searchAriaLabel": "筛选表格",
+    "searchScopeAriaLabel": "筛选范围",
+    "searchScopeAll": "全部",
+    "searchScopeModels": "模型",
+    "searchScopeCalls": "调用",
+    "searchScopeErrors": "错误",
+    "searchScopeKeys": "密钥",
+    "matchedCount": "{shown} / {total}",
+    "noMatches": "无匹配项"
   },
   "playground": {
     "title": "试玩台",

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -167,7 +167,7 @@ function Panel({
     <div
       className={cn(
         "rounded-3xl border bg-card transition-shadow duration-200",
-        highlighted && "ring-2 ring-primary/50 shadow-lg shadow-primary/10"
+        highlighted && "ring-4 ring-primary shadow-xl shadow-primary/30"
       )}
     >
       <div className="px-4 py-3 border-b flex items-center justify-between">
@@ -442,7 +442,7 @@ export default function AnalyticsPage() {
             <div
               className={cn(
                 "flex items-center gap-2 rounded-xl border bg-card px-2.5 py-1 transition-shadow duration-200",
-                anyPanelHighlighted && "ring-2 ring-primary/50 shadow-lg shadow-primary/10"
+                anyPanelHighlighted && "ring-4 ring-primary shadow-xl shadow-primary/30"
               )}
             >
               <div className="relative flex-1 min-w-0 sm:w-56">

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -1,16 +1,17 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   LineChart, Line, Legend,
 } from 'recharts'
+import { Search, X } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { PageHeader } from '@/components/page-header'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip as HoverTooltip } from '@/components/tooltip'
-import { formatSqliteUtcToLocalTime } from '@/lib/utils'
+import { cn, formatSqliteUtcToLocalTime } from '@/lib/utils'
 import { useI18n } from '@/i18n'
 
 type TimeRange = '24h' | '7d' | '30d' | '90d'
@@ -143,11 +144,39 @@ function Stat({ label, value, hint, className }: { label: string; value: string 
   return hint ? <HoverTooltip text={hint} side="bottom" className="block">{card}</HoverTooltip> : card
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+// Panel card. The same `highlighted` ring used on the toolbar (#fe1) wraps
+// the card when its data is being filtered by the search box — same
+// primary-tinted ring, same shadow, same transition duration so the input
+// row and the table pulse in sync. `countLabel` is the pre-rendered top-right
+// text (parent calls `t('analytics.matchedCount', …)` so this component stays
+// presentational and doesn't need the i18n hook in scope). Same
+// flex/justify-between keeps the title left + count right even when no
+// count is rendered, so the title doesn't shift when a filter is applied.
+function Panel({
+  title,
+  children,
+  highlighted = false,
+  countLabel,
+}: {
+  title: string
+  children: React.ReactNode
+  highlighted?: boolean
+  countLabel?: React.ReactNode
+}) {
   return (
-    <div className="rounded-3xl border bg-card">
-      <div className="px-4 py-3 border-b">
+    <div
+      className={cn(
+        "rounded-3xl border bg-card transition-shadow duration-200",
+        highlighted && "ring-2 ring-primary/50 shadow-lg shadow-primary/10"
+      )}
+    >
+      <div className="px-4 py-3 border-b flex items-center justify-between">
         <h3 className="text-sm font-medium">{title}</h3>
+        {highlighted && countLabel != null && (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {countLabel}
+          </span>
+        )}
       </div>
       <div className="p-4">{children}</div>
     </div>
@@ -172,12 +201,49 @@ const chartVars = `
 .dark .analytics-viz { --series-a: #3987e5; --series-b: #199e70; }
 `
 
+// One filter matches if the query (trimmed, lower-cased) appears anywhere in the
+// joined, lower-cased haystack. Empty query short-circuits to "match all" so
+// the underlying array stays untouched. Case-insensitive substring (not fuzzy,
+// not regex) — same shape FallbackPage uses (#343), so power users get one
+// mental model across the dashboard.
+type MatchesFn<T> = (row: T, q: string) => boolean
+function makeMatches<T>(getHaystack: (row: T) => string): MatchesFn<T> {
+  return (row, q) => {
+    if (!q) return true
+    return getHaystack(row).toLowerCase().includes(q)
+  }
+}
+
 export default function AnalyticsPage() {
   const { t } = useI18n()
   const [range, setRange] = useState<TimeRange>('7d')
   // Capture "now" once at mount so the savings extrapolation below stays a pure
   // render (calling Date.now() during render is impure and non-deterministic).
   const [now] = useState(() => Date.now())
+  // Page-wide filter. Filtered client-side over already-fetched rows so
+  // keystrokes don't re-hit the API (the useQuery keys stay range-only).
+  // NOT persisted: the search box resets to empty on every page mount, same
+  // shape as FallbackPage and ProviderList. The user is more often
+  // investigating a one-off pattern than narrowing repeatedly across visits,
+  // and persistence makes the page land in a half-filtered state from a
+  // deep link with no context.
+  //
+  // The `scope` chip selects which tables the search applies to. Default
+  // 'all' preserves the prior behavior; the other values narrow the
+  // filter to a single table so typing in the box doesn't shrink panels
+  // the user isn't looking at. Tables outside the active scope render
+  // unfiltered.
+  //
+  // The query is trimmed + lowered once at the top of the filter
+  // pipeline — passing it through unchanged means each `matches` impl
+  // stays pure, but the trim+lower happens in every render where the
+  // user typed. Cheap (4 memoized filters, total dataset < few hundred
+  // rows).
+  type SearchScope = 'all' | 'models' | 'calls' | 'errors' | 'keys'
+  const [search, setSearch] = useState<string>('')
+  const [scope, setScope] = useState<SearchScope>('all')
+  const trimmedQuery = search.trim().toLowerCase()
+  const hasQuery = trimmedQuery.length > 0
 
   const { data: summary, isLoading: summaryLoading } = useQuery({
     queryKey: ['analytics', 'summary', range],
@@ -230,6 +296,87 @@ export default function AnalyticsPage() {
     queryKey: ['analytics', 'summary', '30d'],
     queryFn: () => apiFetch<SummaryResponse>(`/api/analytics/summary?range=30d`),
   })
+  // ----- Page-wide filter ----------------------------------------------------
+  // One matches() builder per table, joined so the haystack is computed once
+  // per row in the filter pass (instead of three times via three separate
+  // predicates). For rows whose every field is a string primitive this is just
+  // template-literal concatenation. The four tables each carry slightly
+  // different searchable fields, so the haystack text is bespoke per row
+  // type. Charts are deliberately NOT filtered — they aggregate over the
+  // selected window and filtering them would misrepresent totals; the
+  // summary stat cards and time-series charts already stay unfiltered.
+  const matchesByModel = useMemo(
+    () => makeMatches<ByModelRow>((r) => `${r.displayName} ${r.platform} ${r.modelId}`),
+    []
+  )
+  const matchesByKey = useMemo(
+    () => makeMatches<ByKeyRow>((r) => `${r.label ?? ''} ${r.platform ?? ''} #${r.keyId}`),
+    []
+  )
+  const matchesRecentCall = useMemo(
+    () => makeMatches<RecentCallRow>((r) =>
+      `${r.clientIp ?? ''} ${r.clientUserAgent ?? ''} ${r.modelId} ${r.platform} ` +
+      `${r.requestedModel ?? ''} ${r.status} ${r.error ?? ''} ${r.requestType}`
+    ),
+    []
+  )
+  const matchesRecentError = useMemo(
+    () => makeMatches<RecentErrorRow>((r) => `${r.platform} ${r.modelId} ${r.error}`),
+    []
+  )
+  // Filtered versions of every list-driven surface. Each uses .filter + the
+  // `matches` helper so an empty query returns the array unmodified (no copy
+  // when there is no filter — saves an allocation per render in the common
+  // case). useMemo deps include trimmedQuery so a keystroke recomputes only
+  // what's affected; the dependencies on the source arrays keep the filter
+  // in sync with re-fetches when range changes.
+  // Per-table filtered arrays. The filter only applies when:
+  //   1. there's a non-empty query, AND
+  //   2. the active scope includes the table.
+  // A table outside the active scope renders unfiltered even with text in the
+  // box — that's the whole point of the scope chip. Empty query short-circuits
+  // to the source array (no allocation in the common no-filter case). The
+  // `highlight*` flags drive the panel ring + match-count display: a panel
+  // highlights only when it's in scope AND the filter produced ≥1 match.
+  // Zero matches in a panel = no highlight, no count, full table (the panel
+  // is a no-op for this query and renders as if there were no filter).
+  const inScope = (kind: 'models' | 'calls' | 'errors' | 'keys') =>
+    scope === 'all' || scope === kind
+  const visibleByModel = useMemo(
+    () => hasQuery && inScope('models')
+      ? byModel.filter((r) => matchesByModel(r, trimmedQuery))
+      : byModel,
+    [byModel, matchesByModel, trimmedQuery, hasQuery, scope]
+  )
+  const visibleErrors = useMemo(
+    () => hasQuery && inScope('errors')
+      ? errors.filter((r) => matchesRecentError(r, trimmedQuery))
+      : errors,
+    [errors, matchesRecentError, trimmedQuery, hasQuery, scope]
+  )
+  const visibleByKey = useMemo(
+    () => hasQuery && inScope('keys')
+      ? byKey.filter((r) => matchesByKey(r, trimmedQuery))
+      : byKey,
+    [byKey, matchesByKey, trimmedQuery, hasQuery, scope]
+  )
+  const visibleRecentCalls = useMemo(() => {
+    const rows = recentCalls?.rows
+    if (!rows) return rows
+    return hasQuery && inScope('calls')
+      ? rows.filter((r) => matchesRecentCall(r, trimmedQuery))
+      : rows
+  }, [recentCalls?.rows, matchesRecentCall, trimmedQuery, hasQuery, scope])
+  // Single source of truth for "is this panel's filter active right now?" —
+  // any of the four tables highlighting pulls the search-row container
+  // into the same highlighted state, so the input area and the filtered
+  // table read as one visual unit.
+  const highlightByModel  = hasQuery && inScope('models')  && byModel.length > 0       && visibleByModel.length > 0
+  const highlightErrors   = hasQuery && inScope('errors')  && errors.length > 0        && visibleErrors.length > 0
+  const highlightByKey    = hasQuery && inScope('keys')    && byKey.length > 0         && visibleByKey.length > 0
+  const highlightByCalls  = hasQuery && inScope('calls')   && (recentCalls?.rows?.length ?? 0) > 0 && (visibleRecentCalls?.length ?? 0) > 0
+  const anyPanelHighlighted = highlightByModel || highlightErrors || highlightByKey || highlightByCalls
+
   const actualSavings = summary?.estimatedCostSavings ?? 0
   const baseSavings = summary30?.estimatedCostSavings ?? 0
   const spanDays = (() => {
@@ -284,15 +431,85 @@ export default function AnalyticsPage() {
         title={t('analytics.title')}
         description={t('analytics.description')}
         actions={
-          <SegmentedControl
-            value={range}
-            onValueChange={setRange}
-            options={(['24h', '7d', '30d', '90d'] as TimeRange[]).map(r => ({
-              value: r,
-              label: t(r === '24h' ? 'analytics.range24h' : r === '7d' ? 'analytics.range7d' : r === '30d' ? 'analytics.range30d' : 'analytics.range90d'),
-            }))}
-            ariaLabel={t('analytics.title')}
-          />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            {/* Search row: input + scope chips, all sharing one rounded border.
+                Mirrors the FallbackPage toolbar shape (#343). When any panel
+                below is actively filtering (highlighted), the same
+                primary-tinted ring animates around this whole container so
+                the input area reads as part of the same visual unit. Same
+                shadow + transition as the table panels, so the eye groups
+                them as one. `w-56` covers ~25 chars of model/IP query. */}
+            <div
+              className={cn(
+                "flex items-center gap-2 rounded-xl border bg-card px-2.5 py-1 transition-shadow duration-200",
+                anyPanelHighlighted && "ring-2 ring-primary/50 shadow-lg shadow-primary/10"
+              )}
+            >
+              <div className="relative flex-1 min-w-0 sm:w-56">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  placeholder={t('models.searchPlaceholder')}
+                  aria-label={t('analytics.searchAriaLabel')}
+                  className="w-full bg-transparent py-1 pl-8 pr-7 text-sm outline-none"
+                />
+                {search && (
+                  <button
+                    onClick={() => setSearch('')}
+                    aria-label={t('models.clearSearch')}
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="size-4" />
+                  </button>
+                )}
+              </div>
+              {/* Scope chip strip. `role="group"` + `aria-label` so screen
+                  readers announce "Filter scope" and treat the chips as a
+                  single radiogroup. Each chip is a real <button> (not a
+                  div) so Tab + Space/Enter works. The selected chip uses
+                  the same primary tint as the panel ring, tying the
+                  "active filter" cue across the toolbar and the table. */}
+              <div
+                role="group"
+                aria-label={t('analytics.searchScopeAriaLabel')}
+                className="flex items-center gap-1 pl-2 border-l"
+              >
+                {(['all', 'models', 'calls', 'errors', 'keys'] as const).map(s => {
+                  const isActive = scope === s
+                  return (
+                    <button
+                      key={s}
+                      type="button"
+                      onClick={() => setScope(s)}
+                      aria-pressed={isActive}
+                      className={cn(
+                        "rounded-full px-2.5 py-0.5 text-xs font-medium border transition-colors",
+                        isActive
+                          ? "bg-primary text-primary-foreground border-primary"
+                          : "bg-background text-muted-foreground hover:text-foreground hover:bg-muted"
+                      )}
+                    >
+                      {t(s === 'all' ? 'analytics.searchScopeAll'
+                           : s === 'models' ? 'analytics.searchScopeModels'
+                           : s === 'calls' ? 'analytics.searchScopeCalls'
+                           : s === 'errors' ? 'analytics.searchScopeErrors'
+                           : 'analytics.searchScopeKeys')}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+            <SegmentedControl
+              value={range}
+              onValueChange={setRange}
+              options={(['24h', '7d', '30d', '90d'] as TimeRange[]).map(r => ({
+                value: r,
+                label: t(r === '24h' ? 'analytics.range24h' : r === '7d' ? 'analytics.range7d' : r === '30d' ? 'analytics.range30d' : 'analytics.range90d'),
+              }))}
+              ariaLabel={t('analytics.title')}
+            />
+          </div>
         }
       />
 
@@ -448,9 +665,15 @@ export default function AnalyticsPage() {
             )}
           </Panel>
 
-          <Panel title={t('analytics.recentErrors')}>
+          <Panel
+            title={t('analytics.recentErrors')}
+            highlighted={highlightErrors}
+            countLabel={highlightErrors ? t('analytics.matchedCount', { shown: visibleErrors.length, total: errors.length }) : undefined}
+          >
             {errors.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noErrors')}</p>
+            ) : visibleErrors.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noMatches')}</p>
             ) : (
               <div className="max-h-[240px] overflow-y-auto -mx-4">
                 <Table>
@@ -462,7 +685,7 @@ export default function AnalyticsPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {errors.slice(0, 20).map((e) => (
+                    {visibleErrors.slice(0, 20).map((e) => (
                       <TableRow key={e.id}>
                         <TableCell className="pl-4 text-xs">{e.platform}</TableCell>
                         <TableCell className="text-xs max-w-[200px] truncate">{e.error}</TableCell>
@@ -481,9 +704,15 @@ export default function AnalyticsPage() {
               user agent. All local clients share the unified key, so this is
               the only view that answers "who is hitting the router". */}
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.recentCalls')}>
+            <Panel
+              title={t('analytics.recentCalls')}
+              highlighted={highlightByCalls}
+              countLabel={highlightByCalls ? t('analytics.matchedCount', { shown: visibleRecentCalls?.length ?? 0, total: recentCalls?.rows?.length ?? 0 }) : undefined}
+            >
               {!recentCalls?.rows?.length ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
+              ) : (visibleRecentCalls?.length ?? 0) === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noMatches')}</p>
               ) : (
                 <div className="max-h-[420px] overflow-y-auto -mx-4">
                   <Table>
@@ -501,7 +730,7 @@ export default function AnalyticsPage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {recentCalls.rows.map((r) => (
+                      {(visibleRecentCalls ?? []).map((r) => (
                         <TableRow key={r.id}>
                           <TableCell className="pl-4 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
                             {formatSqliteUtcToLocalTime(r.createdAt, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit' })}
@@ -531,9 +760,15 @@ export default function AnalyticsPage() {
           </div>
 
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.perModelBreakdown')}>
+            <Panel
+              title={t('analytics.perModelBreakdown')}
+              highlighted={highlightByModel}
+              countLabel={highlightByModel ? t('analytics.matchedCount', { shown: visibleByModel.length, total: byModel.length }) : undefined}
+            >
               {byModel.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
+              ) : visibleByModel.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noMatches')}</p>
               ) : (
                 <div className="max-h-[360px] overflow-y-auto -mx-4">
                   <Table>
@@ -551,7 +786,7 @@ export default function AnalyticsPage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {byModel.map((m, i) => (
+                      {visibleByModel.map((m, i) => (
                         <TableRow key={i}>
                           <TableCell className="pl-4 text-sm font-medium">{m.displayName}</TableCell>
                           <TableCell className="text-xs text-muted-foreground">{m.platform}</TableCell>
@@ -574,37 +809,45 @@ export default function AnalyticsPage() {
           {/* Usage by key: only rendered when the endpoint returns rows. */}
           {byKey.length > 0 && (
             <div className="lg:col-span-2">
-              <Panel title={t('analytics.usageByKey')}>
-                <div className="max-h-[360px] overflow-y-auto -mx-4">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="pl-4">{t('analytics.keyColumn')}</TableHead>
-                        <TableHead>{t('common.provider')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.requests')}</TableHead>
-                        <TableHead className="text-right">{t('common.success')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.latency')}</TableHead>
-                        <TableHead className="text-right">{t('analytics.inTokens')}</TableHead>
-                        <TableHead className="text-right pr-4">{t('analytics.outTokens')}</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {byKey.map((k) => (
-                        <TableRow key={k.keyId}>
-                          <TableCell className="pl-4 text-sm font-medium">
-                            {k.label || t('analytics.keyLabelFallback', { id: k.keyId })}
-                          </TableCell>
-                          <TableCell className="text-xs text-muted-foreground">{k.platform ?? '—'}</TableCell>
-                          <TableCell className="text-right tabular-nums">{k.requests}</TableCell>
-                          <TableCell className="text-right tabular-nums">{k.successRate}%</TableCell>
-                          <TableCell className="text-right tabular-nums">{k.avgLatencyMs} ms</TableCell>
-                          <TableCell className="text-right tabular-nums">{formatTokens(k.totalInputTokens)}</TableCell>
-                          <TableCell className="text-right tabular-nums pr-4">{formatTokens(k.totalOutputTokens)}</TableCell>
+              <Panel
+                title={t('analytics.usageByKey')}
+                highlighted={highlightByKey}
+                countLabel={highlightByKey ? t('analytics.matchedCount', { shown: visibleByKey.length, total: byKey.length }) : undefined}
+              >
+                {visibleByKey.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noMatches')}</p>
+                ) : (
+                  <div className="max-h-[360px] overflow-y-auto -mx-4">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="pl-4">{t('analytics.keyColumn')}</TableHead>
+                          <TableHead>{t('common.provider')}</TableHead>
+                          <TableHead className="text-right">{t('analytics.requests')}</TableHead>
+                          <TableHead className="text-right">{t('common.success')}</TableHead>
+                          <TableHead className="text-right">{t('analytics.latency')}</TableHead>
+                          <TableHead className="text-right">{t('analytics.inTokens')}</TableHead>
+                          <TableHead className="text-right pr-4">{t('analytics.outTokens')}</TableHead>
                         </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
+                      </TableHeader>
+                      <TableBody>
+                        {visibleByKey.map((k) => (
+                          <TableRow key={k.keyId}>
+                            <TableCell className="pl-4 text-sm font-medium">
+                              {k.label || t('analytics.keyLabelFallback', { id: k.keyId })}
+                            </TableCell>
+                            <TableCell className="text-xs text-muted-foreground">{k.platform ?? '—'}</TableCell>
+                            <TableCell className="text-right tabular-nums">{k.requests}</TableCell>
+                            <TableCell className="text-right tabular-nums">{k.successRate}%</TableCell>
+                            <TableCell className="text-right tabular-nums">{k.avgLatencyMs} ms</TableCell>
+                            <TableCell className="text-right tabular-nums">{formatTokens(k.totalInputTokens)}</TableCell>
+                            <TableCell className="text-right tabular-nums pr-4">{formatTokens(k.totalOutputTokens)}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
               </Panel>
             </div>
           )}


### PR DESCRIPTION
# feat(client): analytics search has scope chips and shared highlight

## Summary

The analytics-page search box now filters the four list tables with a **scope chip** selector (All / Models / Calls / Errors / Keys) and a **shared highlight ring** on the input row + matched panel. The search is not persisted, charts and summary cards stay unfiltered.

This bundles two commits:

- `468f033` — feat(client): analytics search has scope chips and shared highlight (the feature)
- `3039d4c` — fix(client): bolder analytics search highlight (a 2-line visual tweak on top)

## Motivation

The previous state had the search box filtering every list table at once, with no way to narrow scope. A user typing an IP got four partial results lists, half of which were irrelevant for what they were inspecting. There was also no visual feedback for "which table is this filter actually affecting?" — the user had to read every panel header to know.

Two specific user pain points this fixes:

1. **Deep-link / reload surprise.** Search persisted (or didn't, depending on the table), so a deep link to `/analytics?q=gpt-4` would land in a half-filtered state with no context. Now the search resets to empty on every page mount, and the chips give an explicit "scope" for the current query.

2. **No visual grouping of "active filter".** When the search matched rows in, say, the recent-calls table only, there was no visual cue tying the input box to that table. Now the input row and the matched panel share the same primary-tinted ring + shadow + 200ms transition, so they pulse in sync and read as one visual unit.

## Changes

- **`client/src/pages/AnalyticsPage.tsx`** (+339/-56, biggest file in the diff):
  - **Imports:** `useMemo` from `react`, `Search` + `X` from `lucide-react`, `cn` from `@/lib/utils`.
  - **`makeMatches<T>(getHaystack)`** — generic helper that lower-cases a row's haystack and substring-matches the trimmed query. Empty query short-circuits to `true` so the source array stays untouched in the common no-filter case.
  - **`Panel` wrapper** — gained optional `highlighted` and `countLabel` props. Highlighted adds a `ring-2 ring-primary/50 shadow-lg shadow-primary/10` (later bumped to `ring-4 ring-primary shadow-xl shadow-primary/30` in the follow-up) and a `200ms transition-shadow`. Eight non-list panels (charts, summary, per-platform breakdowns) keep their old shape unchanged.
  - **State:** `search: string`, `scope: 'all' | 'models' | 'calls' | 'errors' | 'keys'` (default `'all'`), `trimmedQuery` (lowered + trimmed once), `hasQuery`.
  - **Per-table filters:** `matchesByModel`, `matchesByKey`, `matchesRecentCall`, `matchesRecentError` (useMemoized for stable identity). `visibleByModel`, `visibleErrors`, `visibleByKey`, `visibleRecentCalls` (filtered arrays). `highlightByModel`, `highlightErrors`, `highlightByKey`, `highlightByCalls` (each is `hasQuery && inScope(kind) && source.length > 0 && visible.length > 0`). `anyPanelHighlighted` is the OR of the four — drives the input row's ring.
  - **Toolbar UI:** the `<SegmentedControl>` (range) is wrapped in a flex row with a search-input + scope-chip strip on the left. The chip strip uses `role="group"` + `aria-label="Filter scope"` for screen readers; each chip is a real `<button>` with `aria-pressed`. Selected chip uses `bg-primary text-primary-foreground border-primary`, mirroring the panel ring's primary tint.
  - **Four list Panel invocations** wired: `recentErrors`, `recentCalls`, `perModelBreakdown`, `usageByKey`. Each got:
    - `highlighted={highlight*}`
    - `countLabel={highlight* ? t('analytics.matchedCount', { shown: visible*.length, total: source.length }) : undefined}`
    - The data source switched from `errors` / `recentCalls.rows` / `byModel` / `byKey` to the matching `visible*` array
    - A `visible*.length === 0` empty-state branch that renders `t('analytics.noMatches')` (separate from the "no data at all" branch which keeps the old copy).

- **Six i18n locale files** (`en`, `es`, `fr`, `it`, `pt-BR`, `zh-CN`): +9 keys each
  - `searchAriaLabel` (input aria-label)
  - `searchScopeAriaLabel` (chip strip group label)
  - `searchScopeAll/Models/Calls/Errors/Keys` (chip labels)
  - `matchedCount` (`"{shown} of {total}"`)
  - `noMatches` (empty-state copy)

## Test plan

- [x] `npm run build` — full build succeeds (server + client), bundle hash `index-Bxql93PJ.js` includes `"Filter scope"` (×1), `searchScope*` (×6 keys), `matchedCount` (×10 = 4 countLabel invocations + i18n key + deps), `ring-4 ring-primary` (×2 = input + Panel wrapper), `ring-2 ring-primary/50` (×0 = old style fully replaced).
- [x] `npm test` — 94 test files, **926 tests passed**.
- [x] Visual check (local integration branch, on the live service):
  - Type a query → all four list tables filter simultaneously with the "All" chip active.
  - Click "Models" chip → only the per-model table filters; recent-errors, recent-calls, usage-by-key render unfiltered.
  - Each in-scope panel with ≥1 match gets the same primary ring + shadow, and the input row's ring animates in sync.
  - Type a query with zero matches in a panel → that panel renders `t('analytics.noMatches')` (no highlight, no count); other in-scope panels with matches still highlight.
  - Reload the page → search resets to empty (NOT persisted), scope chip stays at "All" (default).
  - Charts, summary stats, and time-series panels are unaffected by the search.

## Compatibility

- **No server changes** — search is purely client-side over already-fetched rows. The `/api/analytics/*` endpoints and their response shapes are unchanged.
- **No new dependencies** — `lucide-react` and `cn` from `@/lib/utils` are already used elsewhere in the client (`EmbeddingDetailPage`, `EmbeddingsPage`, etc.).
- **i18n additive only** — nine new keys per locale. Existing translations untouched; the chips degrade gracefully if a locale ever drops a key (renders the raw key, same as the rest of the app).
- **No new public API or breaking changes to existing components.** The `Panel` signature change is backward-compatible: `highlighted` and `countLabel` are optional, default false / undefined, and the eight non-list call sites are unchanged.
- **Reuses FallbackPage's search-row shape** (per skill discipline, `cherry-pick-pr-scope-discipline`): same rounded container, same `w-56` input width, same scope-on-the-right pattern. Power users get one mental model across the dashboard.

## Out of scope (deliberate)

The integration branch (`integration/all-my-prs`) also carries:

- Per-model sortable column headers
- Recent-calls sortable column headers
- Usage-by-key sortable column headers
- Persist selected time range in localStorage
- A few smaller analytics tweaks

These are **separate features** with their own review shape. Keeping this PR focused on the search/scope-chips/highlight bundle keeps the diff reviewable (7 files, +353/-56) and lets each feature land independently upstream. Happy to ship any of those as follow-up PRs if wanted.

## Follow-up commit (3039d4c)

A 2-line visual tweak shipped as a follow-up commit on top:

- `ring-2 ring-primary/50 shadow-lg shadow-primary/10` → `ring-4 ring-primary shadow-xl shadow-primary/30`
- Applied identically to the input row and the Panel wrapper

This makes the highlight pop more obviously against the dashboard background. Keeping it as a separate commit makes the bump easy to revert if reviewers want a more subtle effect.
