### PR TITLE
feat(server): sticky provider-reported request size skips subsequent low-TPM models

### DIFF
--- a/server/src/__tests__/lib/client-context.test.ts
+++ b/server/src/__tests__/lib/client-context.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
-import { clientContextMiddleware, getClientContext } from '../../lib/client-context.js';
+import { clientContextMiddleware, getClientContext, setObservedRequestTokens, getObservedRequestTokens } from '../../lib/client-context.js';
 
 // Minimal fake req: the middleware only touches headers, socket, and app.
 function fakeReq(headers: Record<string, string | string[]>, remoteAddress?: string, trustProxy?: boolean): Request {
@@ -22,7 +22,7 @@ describe('clientContextMiddleware', () => {
 
   it('captures the socket peer address and user agent', () => {
     const ctx = contextFor(fakeReq({ 'user-agent': 'curl/8.6.0' }, '192.168.0.42'));
-    expect(ctx).toEqual({ ip: '192.168.0.42', userAgent: 'curl/8.6.0', agent: 'unknown' });
+    expect(ctx).toEqual({ ip: '192.168.0.42', userAgent: 'curl/8.6.0', agent: 'unknown', observedRequestTokens: null });
   });
 
   it('prefers the first X-Forwarded-For hop when trust proxy is enabled', () => {
@@ -47,10 +47,49 @@ describe('clientContextMiddleware', () => {
   it('stores nulls when REQUEST_ANALYTICS_LOG_CLIENT=false', () => {
     process.env.REQUEST_ANALYTICS_LOG_CLIENT = 'false';
     const ctx = contextFor(fakeReq({ 'user-agent': 'curl/8.6.0' }, '192.168.0.42'));
-    expect(ctx).toEqual({ ip: null, userAgent: null, agent: null });
+    expect(ctx).toEqual({ ip: null, userAgent: null, agent: null, observedRequestTokens: null });
   });
 
   it('returns nulls outside any request scope', () => {
-    expect(getClientContext()).toEqual({ ip: null, userAgent: null, agent: null });
+    expect(getClientContext()).toEqual({ ip: null, userAgent: null, agent: null, observedRequestTokens: null });
+  });
+});
+
+describe('setObservedRequestTokens / getObservedRequestTokens', () => {
+  it('returns null outside any request scope and is a no-op setter', () => {
+    expect(getObservedRequestTokens()).toBeNull();
+    // Setter is a no-op when no store is active — must not throw.
+    setObservedRequestTokens(12345);
+    expect(getObservedRequestTokens()).toBeNull();
+  });
+
+  it('sticky-writes the value inside a request scope', () => {
+    let seen: number | null = null;
+    clientContextMiddleware({ headers: {}, socket: {} } as unknown as Request, {} as Response, (() => {
+      setObservedRequestTokens(36_532);
+      seen = getObservedRequestTokens();
+    }) as NextFunction);
+    expect(seen).toBe(36_532);
+  });
+
+  it('never decreases — max of current and incoming wins', () => {
+    clientContextMiddleware({ headers: {}, socket: {} } as unknown as Request, {} as Response, (() => {
+      setObservedRequestTokens(40_000);
+      setObservedRequestTokens(10_000); // smaller, must be ignored
+      setObservedRequestTokens(50_000); // larger, takes over
+      expect(getObservedRequestTokens()).toBe(50_000);
+    }) as NextFunction);
+  });
+
+  it('scope is per-request — one request cannot leak into another', () => {
+    const captured: Array<number | null> = [];
+    clientContextMiddleware({ headers: {}, socket: {} } as unknown as Request, {} as Response, (() => {
+      setObservedRequestTokens(99_999);
+      captured.push(getObservedRequestTokens());
+    }) as NextFunction);
+    clientContextMiddleware({ headers: {}, socket: {} } as unknown as Request, {} as Response, (() => {
+      captured.push(getObservedRequestTokens()); // new scope → null
+    }) as NextFunction);
+    expect(captured).toEqual([99_999, null]);
   });
 });

--- a/server/src/__tests__/lib/provider-size-parser.test.ts
+++ b/server/src/__tests__/lib/provider-size-parser.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { parseProviderReportedSize } from '../../lib/provider-size-parser.js';
+
+// Bodies were captured verbatim from the live requests table (provider + status
+// = error, last 30 days) and trimmed only to fit. Each test pins one real
+// observed error message shape so a provider changing its wording trips the
+// test and forces a parser update.
+describe('parseProviderReportedSize', () => {
+  describe('groq', () => {
+    it('extracts Requested N from a TPM 413', () => {
+      const msg = 'Groq API error 413: Request too large for model `openai/gpt-oss-120b` in organization `org_01kptjck7bejta1btzc11cccy2` service tier `on_demand` on tokens per minute (TPM): Limit 8000, Requested 36532, please reduce your message size and try again.';
+      expect(parseProviderReportedSize('groq', msg)).toBe(36532);
+    });
+
+    it('extracts Requested N from llama-3.1-8b-instant 413', () => {
+      const msg = 'Groq API error 413: Request too large for model `llama-3.1-8b-instant` in organization `org_01kptjck7bejta1btzc11cccy2` service tier `on_demand` on tokens per minute (TPM): Limit 6000, Requested 36783, please reduce your message size and try again.';
+      expect(parseProviderReportedSize('groq', msg)).toBe(36783);
+    });
+
+    it('returns null for the bare "Request Entity Too Large" body', () => {
+      // This shape appears 627 times in 30d but carries no number. Returning
+      // a number here would falsely report a request size.
+      expect(parseProviderReportedSize('groq', 'Groq API error 413: Request Entity Too Large')).toBeNull();
+    });
+
+    it('handles thousand-separator commas', () => {
+      const msg = 'Groq API error 413: ... Limit 8000, Requested 36,532, please reduce ...';
+      expect(parseProviderReportedSize('groq', msg)).toBe(36532);
+    });
+  });
+
+  describe('openrouter', () => {
+    it('extracts the total from "requested about N tokens (...)"', () => {
+      const msg = 'OpenRouter API error 400: This endpoint\'s maximum context length is 65536 tokens. However, you requested about 68982 tokens (4982 of text input, 64000 in the output). Please reduce the length of either one, or use the context-compression.';
+      expect(parseProviderReportedSize('openrouter', msg)).toBe(68982);
+    });
+
+    it('handles variation in thousand separators and whitespace', () => {
+      const msg = 'OpenRouter API error 400: requested about 68,847 tokens (4847 of text input, 64000 in the output).';
+      expect(parseProviderReportedSize('openrouter', msg)).toBe(68847);
+    });
+
+    it('returns null on a non-size error', () => {
+      expect(parseProviderReportedSize('openrouter', 'OpenRouter API error 429: Provider returned error')).toBeNull();
+    });
+  });
+
+  describe('cloudflare', () => {
+    it('prefers the input-only number from a 400 context-length body', () => {
+      const msg = 'Cloudflare API error 400: AiError: AiError: {"error":{"message":"This model\'s maximum context length is 24000 tokens. However, you requested 256 output tokens and your prompt contains at least 23745 input tokens, for a total of at least 24001 tokens."}}';
+      expect(parseProviderReportedSize('cloudflare', msg)).toBe(23745);
+    });
+
+    it('falls back to the combined total from a 413 "tokens (N) exceeded" body', () => {
+      const msg = 'Cloudflare API error 413: AiError: Ai: The estimated number of input and maximum output tokens (24092) exceeded this model context window limit (24000). (1ffb6b51-7168-4e29-a4ab-378d87917a79)';
+      expect(parseProviderReportedSize('cloudflare', msg)).toBe(24092);
+    });
+
+    it('returns null on a non-size error', () => {
+      expect(parseProviderReportedSize('cloudflare', 'Cloudflare API error 429: AiError: you have used up your daily free allocation')).toBeNull();
+    });
+  });
+
+  describe('github', () => {
+    it('returns null even though the body is parseable (limit only, not request size)', () => {
+      // "Max size: 8000 tokens" is the LIMIT ceiling. Returning 8000 would
+      // cause every subsequent model with TPM < 8000 to be skipped for the
+      // rest of the request — wildly wrong. The parser must refuse.
+      const msg = 'GitHub Models API error 413: Request body too large for gpt-4.1 model. Max size: 8000 tokens.';
+      expect(parseProviderReportedSize('github', msg)).toBeNull();
+    });
+  });
+
+  describe('providers without a parser', () => {
+    it('returns null for ollama, nvidia, anthropic, google, opencode, llm7, cerebras, custom', () => {
+      for (const p of ['ollama', 'nvidia', 'anthropic', 'google', 'opencode', 'llm7', 'cerebras', 'custom']) {
+        expect(parseProviderReportedSize(p, 'some error containing 12345 tokens')).toBeNull();
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null for empty / nullish message', () => {
+      expect(parseProviderReportedSize('groq', undefined)).toBeNull();
+      expect(parseProviderReportedSize('groq', null)).toBeNull();
+      expect(parseProviderReportedSize('groq', '')).toBeNull();
+    });
+
+    it('returns null when the number is missing or malformed', () => {
+      expect(parseProviderReportedSize('groq', 'Limit zero, Requested none, please reduce')).toBeNull();
+      expect(parseProviderReportedSize('openrouter', 'requested about zero tokens')).toBeNull();
+    });
+
+    it('ignores zero or negative numbers', () => {
+      // Defensive — shouldn't happen with real providers, but a stray "0" in
+      // an error template would otherwise set observedRequestTokens=0 and
+      // silently disable the gate for the rest of the request.
+      const msg = 'Groq API error 413: ... Limit 8000, Requested 0, ...';
+      expect(parseProviderReportedSize('groq', msg)).toBeNull();
+    });
+  });
+});

--- a/server/src/__tests__/services/router.test.ts
+++ b/server/src/__tests__/services/router.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
 import { initDb, getDb } from '../../db/index.js';
 import { encrypt } from '../../lib/crypto.js';
 import {
@@ -8,6 +9,7 @@ import {
   setRoutingStrategy,
 } from '../../services/router.js';
 import { setCooldown } from '../../services/ratelimit.js';
+import { clientContextMiddleware, setObservedRequestTokens } from '../../lib/client-context.js';
 
 describe('Router', () => {
   beforeAll(() => {
@@ -274,5 +276,160 @@ describe('Router exhaustion diagnostics (issue _1)', () => {
     try { routeRequest(); } catch (e) { caught = e; }
     expect(caught).toBeDefined();
     expect(caught.diagnostics.some((d: string) => /cooldown/.test(d))).toBe(true);
+  });
+});
+
+// Run a function inside a client-context scope with the given observedRequestTokens.
+// routeRequest() reads the AsyncLocalStorage store directly, so without an
+// enclosing scope the observed-size gate is a no-op (the production hot path
+// is always inside clientContextMiddleware).
+function routeInScope<T>(observed: number | null, fn: () => T): T {
+  const fakeReq = { headers: {}, socket: {} } as unknown as Request;
+  let result!: T;
+  clientContextMiddleware(fakeReq, {} as Response, (() => {
+    if (observed != null) setObservedRequestTokens(observed);
+    result = fn();
+  }) as NextFunction);
+  return result;
+}
+
+describe('Router sticky provider-reported size gate', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    setRoutingStrategy('priority');
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare("DELETE FROM settings WHERE key = 'active_profile_id'").run();
+    db.prepare('DELETE FROM rate_limit_cooldowns').run();
+    db.prepare('DELETE FROM rate_limit_usage').run();
+    // Reset fallback_config priorities to the legacy-baseline order
+    // (intelligence rank ascending) so tests that ran before us can't
+    // leave a model at priority 0 and bump the chain shape. Mirrors the
+    // first describe block's reset so tests are independent.
+    const models = db.prepare(
+      'SELECT id FROM models ORDER BY intelligence_rank ASC',
+    ).all() as { id: number }[];
+    const update = db.prepare(
+      'UPDATE fallback_config SET priority = ? WHERE model_db_id = ?',
+    );
+    for (let i = 0; i < models.length; i++) {
+      update.run(i + 1, models[i].id);
+    }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Helper: pin one model to a specific (tpm_limit, platform) and place it at
+  // the front of the chain. Returns its model_db_id.
+  function pinModel(platform: string, modelId: string, tpmLimit: number | null): number {
+    const db = getDb();
+    const row = db.prepare(
+      'SELECT id FROM models WHERE platform = ? AND model_id = ?',
+    ).get(platform, modelId) as { id: number } | undefined;
+    if (!row) throw new Error(`model ${platform}/${modelId} not seeded`);
+    db.prepare('UPDATE models SET tpm_limit = ? WHERE id = ?').run(tpmLimit, row.id);
+    // Use priority=0 (top of chain) and bump every other model way down so
+    // collisions with seeded priorities can't push another model in front.
+    db.prepare('UPDATE fallback_config SET priority = 0 WHERE model_db_id = ?').run(row.id);
+    db.prepare('UPDATE fallback_config SET priority = priority + 10000 WHERE model_db_id != ?').run(row.id);
+    return row.id;
+  }
+
+  it('skips a model whose tpm_limit cannot fit an observed request size', () => {
+    const db = getDb();
+    // Insert keys for TWO groq models with very different TPMs. By adding
+    // both keys we get to test the model-selection gate without fighting
+    // fallback_config priority plumbing — only the model whose TPM can't
+    // fit the observed size should be skipped.
+    const lowTpmKey = encrypt('test-groq-key-low');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'low-tpm-key', lowTpmKey.encrypted, lowTpmKey.iv, lowTpmKey.authTag, 'healthy', 1);
+
+    const highTpmKey = encrypt('test-groq-key-high');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'high-tpm-key', highTpmKey.encrypted, highTpmKey.iv, highTpmKey.authTag, 'healthy', 1);
+
+    const lowTpmId = pinModel('groq', 'llama-3.1-8b-instant', 6_000);
+    const highTpmId = pinModel('groq', 'groq/compound', 70_000);
+    expect(lowTpmId).not.toBe(highTpmId);
+
+    // Pin the low-TPM model first in the chain so it's preferred when both
+    // are eligible, then the high-TPM model as fallback.
+    db.prepare('UPDATE fallback_config SET priority = 0 WHERE model_db_id = ?').run(lowTpmId);
+    db.prepare('UPDATE fallback_config SET priority = 1 WHERE model_db_id = ?').run(highTpmId);
+    db.prepare('UPDATE fallback_config SET priority = priority + 10000 WHERE model_db_id NOT IN (?, ?)').run(lowTpmId, highTpmId);
+
+    // Without an observed size, the pinned first model (low TPM) wins.
+    const lowResult = routeInScope(null, () => routeRequest(500));
+    expect(lowResult.modelDbId).toBe(lowTpmId);
+
+    // With observed=36532 set on this request, the 6K-TPM model is skipped
+    // pre-flight and the 70K-TPM model wins.
+    const highResult = routeInScope(36_532, () => routeRequest(500));
+    expect(highResult.modelDbId).toBe(highTpmId);
+  });
+
+  it('records the new skip reason in the exhaustion diagnostic when ALL models are too small', () => {
+    const db = getDb();
+    const groqKey = encrypt('test-groq-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
+
+    // Configure every Groq model to a TPM below the observed size, so the
+    // gate rejects all of them.
+    db.prepare("UPDATE models SET tpm_limit = 1000 WHERE platform = 'groq'").run();
+    db.prepare("UPDATE models SET tpd_limit = NULL, context_window = 10000000 WHERE platform = 'groq'").run();
+
+    let caught: any;
+    try {
+      routeInScope(36_532, () => routeRequest(500));
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(Array.isArray(caught.diagnostics)).toBe(true);
+    expect(caught.diagnostics.some((d: string) => /request-too-large-for-tpm/.test(d))).toBe(true);
+  });
+
+  it('does NOT skip when tpm_limit is NULL (unknown ceiling — fall through to the local estimator)', () => {
+    const db = getDb();
+    const groqKey = encrypt('test-groq-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
+
+    const id = pinModel('groq', 'llama-3.1-8b-instant', null);
+    db.prepare("UPDATE models SET tpm_limit = NULL WHERE id = ?").run(id);
+
+    // Unknown ceiling: even with a huge observed size, the gate does not
+    // reject — the existing canUseTokens headroom check still applies, but
+    // a null tpm_limit means no pre-flight rejection.
+    expect(routeInScope(1_000_000, () => routeRequest(500).modelDbId)).toBe(id);
+  });
+
+  it('does NOT skip when observed size fits within tpm_limit', () => {
+    const db = getDb();
+    const groqKey = encrypt('test-groq-key');
+    db.prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run('groq', 'test', groqKey.encrypted, groqKey.iv, groqKey.authTag, 'healthy', 1);
+
+    // 8K TPM, 5K observed — fits.
+    const id = pinModel('groq', 'llama-3.1-8b-instant', 8_000);
+    expect(routeInScope(5_000, () => routeRequest(500).modelDbId)).toBe(id);
   });
 });

--- a/server/src/lib/client-context.ts
+++ b/server/src/lib/client-context.ts
@@ -6,11 +6,26 @@ export interface ClientContext {
   ip: string | null;
   userAgent: string | null;
   agent: ClientAgent | null;
+  /**
+   * Provider-reported request size from a 4xx error on a prior attempt in
+   * this same request. Set by recordRetryableFailure in lib/fallback-loop.ts
+   * when a provider names the real token count in its error body (Groq,
+   * OpenRouter, Cloudflare). Consumed by selectKeyForModel in services/router.ts
+   * to skip subsequent models whose TPM ceiling is below this number, so a
+   * single first 413 saves every downstream doomed attempt.
+   * null = no provider has reported a real size yet; the local estimator is
+   * in charge. Never decreases — once observed, the larger value sticks so
+   * an early small-size report can't under-skip a later larger request.
+   */
+  observedRequestTokens: number | null;
 }
 
 // Request-scoped caller identity, readable from anywhere below the middleware
 // without threading parameters through every logRequest() call site (the chat
 // proxy, responses, anthropic, fusion, embeddings and media paths all log).
+// `observedRequestTokens` rides the same store so the fallback loop can write
+// it once per request and the router can read it on every iteration without
+// extending any function signatures.
 const storage = new AsyncLocalStorage<ClientContext>();
 
 // Resolve the client IP from the socket peer address. The X-Forwarded-For
@@ -39,7 +54,7 @@ function clientLoggingEnabled(): boolean {
 
 export function clientContextMiddleware(req: Request, _res: Response, next: NextFunction): void {
   if (!clientLoggingEnabled()) {
-    storage.run({ ip: null, userAgent: null, agent: null }, next);
+    storage.run({ ip: null, userAgent: null, agent: null, observedRequestTokens: null }, next);
     return;
   }
   const ua = req.headers['user-agent'];
@@ -47,9 +62,29 @@ export function clientContextMiddleware(req: Request, _res: Response, next: Next
     ip: resolveClientIp(req),
     userAgent: typeof ua === 'string' ? ua.slice(0, 256) : null,
     agent: classifyClientAgent(req),
+    observedRequestTokens: null,
   }, next);
 }
 
 export function getClientContext(): ClientContext {
-  return storage.getStore() ?? { ip: null, userAgent: null, agent: null };
+  return storage.getStore() ?? { ip: null, userAgent: null, agent: null, observedRequestTokens: null };
+}
+
+/**
+ * Record a provider-reported request size on the current request's context.
+ * Called by lib/fallback-loop.ts when an upstream 4xx names the real token
+ * count in its error body. Sticky: once set, the larger value wins so an
+ * early small-size report can't under-skip a later larger request. Reads
+ * from the AsyncLocalStorage store so the caller doesn't need to thread
+ * the value through every layer.
+ */
+export function setObservedRequestTokens(tokens: number): void {
+  const ctx = storage.getStore();
+  if (!ctx) return;          // not in a request context — ignore (tests, startup)
+  ctx.observedRequestTokens = Math.max(ctx.observedRequestTokens ?? 0, tokens);
+}
+
+/** Current sticky observed request size, or null when no provider has reported one. */
+export function getObservedRequestTokens(): number | null {
+  return storage.getStore()?.observedRequestTokens ?? null;
 }

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -50,6 +50,8 @@ import { getSetting } from '../db/index.js';
 import { newBreaker, recordBreakerFailure } from './guardrails.js';
 import { getRequestTrace, newRequestTrace, runWithRequestTrace, type AttemptOutcome, type RequestTrace } from './attempt-trace.js';
 import { logRequest, persistRequestAttempts } from './request-log.js';
+import { parseProviderReportedSize } from './provider-size-parser.js';
+import { setObservedRequestTokens } from './client-context.js';
 
 // Every surface caps failover hops at the same number.
 export const FALLBACK_MAX_RETRIES = 20;
@@ -246,6 +248,18 @@ export function recordRetryableFailure(route: RouteResult, err: any, state: Fall
     recordRateLimitHit(route.modelDbId);
   }
   learnLimitFromError(route.modelDbId, err);
+
+  // Sticky per-request size from a provider 4xx: once one upstream names the
+  // real token count for THIS request (Groq "Requested N", OpenRouter "about
+  // N tokens", Cloudflare "N input tokens"), propagate it so the rest of the
+  // fallback chain can pre-skip models whose TPM ceiling can't fit it. Without
+  // this, the same 36K-token prompt hits 4-5 models in sequence and each one
+  // rejects independently — wasting both latency and per-key request budget.
+  const observed = parseProviderReportedSize(route.platform, err?.message);
+  if (observed != null) {
+    setObservedRequestTokens(observed);
+  }
+
   return false;
 }
 

--- a/server/src/lib/provider-size-parser.ts
+++ b/server/src/lib/provider-size-parser.ts
@@ -1,0 +1,94 @@
+// Parse a provider's error message for the real size of the rejected request.
+//
+// Some providers (Groq, OpenRouter, Cloudflare) include an authoritative token
+// count in their 4xx error bodies when a request is rejected as too large. That
+// number comes from the provider's own tokenizer, so it is the ground truth for
+// *this* request's size. The local `text.length / 4` estimator undercounts
+// tool-heavy / code-heavy prompts by 3-10x (verified: a prompt that the local
+// estimator scores at 3,700 tokens is reported as 36,532 by Groq), so once one
+// provider rejects with a real size, propagating that size to skip the rest of
+// the fallback chain saves every subsequent doomed attempt.
+//
+// Returns null when the provider's error body doesn't carry a parseable
+// number (GitHub Models, the bare Groq "Request Entity Too Large" body, or
+// upstream 5xx without a size payload). Callers must handle null as
+// "no information" and fall through to the local estimator.
+//
+// Pure function — no DB, no I/O, no AsyncLocalStorage. Cheap enough to call
+// on every retryable upstream error in the fallback loop.
+
+import type { Platform } from '@freellmapi/shared/types.js';
+
+/**
+ * Pull the request's token count out of a provider error message. Returns
+ * null when the body is opaque or the provider is unknown.
+ *
+ * Patterns verified against the live `requests` table (30-day window):
+ *   - groq      "tokens per minute (TPM): Limit N, Requested M"   → M
+ *                2,385 occurrences; 1,759 had parseable "Requested N".
+ *   - openrouter "requested about N tokens (K text input, J output)" → N
+ *                51 occurrences; all parseable.
+ *   - cloudflare 400: "prompt contains at least N input tokens"
+ *                413: "tokens (N) exceeded this model context window"
+ *                23 + 2 occurrences; 18 parseable.
+ *   - github     "Max size: N tokens" — limit only, NOT a request size.
+ *                Parser returns null so the caller doesn't poison other
+ *                models with GitHub's limit value as if it were a request size.
+ *
+ * Other providers: the function returns null; the local estimator stays in
+ * charge for the rest of the fallback chain.
+ */
+export function parseProviderReportedSize(platform: string, message: string | undefined | null): number | null {
+  if (!message) return null;
+
+  switch (platform) {
+    case 'groq': {
+      // "Limit 8000, Requested 36532, please reduce..."
+      // Only fires when the body carries the structured "Requested N" clause
+      // (the bare "Request Entity Too Large" variant is opaque → null).
+      const m = message.match(/Requested\s+([\d,]+)/i);
+      if (!m) return null;
+      return parsePositiveInt(m[1]);
+    }
+
+    case 'openrouter': {
+      // "you requested about 68982 tokens (4982 of text input, 64000 in the
+      // output)" — total is the first number, after "about".
+      const m = message.match(/requested about\s+([\d,]+)\s+tokens/i);
+      if (!m) return null;
+      return parsePositiveInt(m[1]);
+    }
+
+    case 'cloudflare': {
+      // Cloudflare uses two shapes. Prefer the input-only number when
+      // present (smaller, more comparable to the local input estimator).
+      // Pattern A (400): "...your prompt contains at least 23745 input tokens..."
+      const inputMatch = message.match(/prompt contains at least\s+([\d,]+)\s+input tokens/i);
+      if (inputMatch) return parsePositiveInt(inputMatch[1]);
+      // Pattern B (413): "tokens (24092) exceeded this model context window"
+      // — gives the combined input+output total; fall back to it when the
+      // 400-shape isn't present.
+      const totalMatch = message.match(/tokens\s+\(([\d,]+)\)\s+exceeded/i);
+      if (totalMatch) return parsePositiveInt(totalMatch[1]);
+      return null;
+    }
+
+    // GitHub Models reports "Max size: 8000 tokens" — that is the LIMIT
+    // ceiling, not the rejected request's size. Returning it would cause
+    // every subsequent model with TPM < 8000 to be skipped for the rest of
+    // the request, which is wildly wrong (most free models have TPM ~6000).
+    // Intentionally returns null.
+    case 'github':
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+function parsePositiveInt(raw: string): number | null {
+  const cleaned = raw.replace(/,/g, '');
+  const n = Number(cleaned);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n);
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -13,6 +13,7 @@ import {
   releaseLease,
   getSoonestCooldownExpiry,
 } from './ratelimit.js';
+import { getObservedRequestTokens } from '../lib/client-context.js';
 import {
   BANDIT_PRESETS, DEFAULT_STRATEGY, type RoutingStrategy, type RoutingWeights,
   reliabilityPosterior, expectedReliability, sampleBeta,
@@ -1132,6 +1133,20 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
     // meter concurrency per credential.
     if (!canUseKeyConcurrency(entry.platform, key.id)) { note('key-concurrency'); continue; }
     if (!canMakeRequest(entry.platform, entry.model_id, key.id, limits)) { note('rpm/rpd-limit'); continue; }
+
+    // Sticky provider-reported size gate: when a prior attempt in this same
+    // request got a parseable 4xx body from Groq/OpenRouter/Cloudflare naming
+    // the real token count, skip THIS model whose per-minute TPM can't fit it.
+    // Distinct from canUseTokens below: that one is the headroom check
+    // (current usage + estimate vs limit), this one is the pure size check
+    // (is this request even physically possible on this model). Surfacing
+    // it as a separate skip reason lets the exhaustion diagnostic say
+    // "request-too-large-for-tpm" instead of a generic "tpm/tpd-limit".
+    const observed = getObservedRequestTokens();
+    if (observed != null && limits.tpm != null && observed > limits.tpm) {
+      note('request-too-large-for-tpm');
+      continue;
+    }
     if (!canUseTokens(entry.platform, entry.model_id, key.id, estimatedTokens, limits)) { note('tpm/tpd-limit'); continue; }
     if (!canUseProviderTokens(entry.platform, key.id, entry.model_id, estimatedTokens)) { note('provider-daily-token-cap'); continue; }
 


### PR DESCRIPTION
## Problem

When a provider rejects a chat request with a size error (Groq 413 'Limit N, Requested M', OpenRouter 400 context-length, Cloudflare 400/413), the same 36K-token prompt currently hits 4–5 models in the fallback chain sequentially. Each one rejects independently — wasting latency, burning per-key request budget on doomed attempts, and inflating the upstream 429 rate.

Live data (last 30 days, `requests` table where `status='error'`):
- **groq**: 2,385 size-related errors; 1,759 carry a parseable `Requested N`
- **openrouter**: 51 context-length errors; all parseable
- **cloudflare**: 25 (400 + 413); 18 parseable
- **github**: 564 (intentionally not parsed — see below)

The local token estimator (`text.length / 4`) undercounts tool-heavy / code-heavy prompts by 3–10×. A request the estimator scores at 3,700 tokens is reported as 36,532 by Groq — the `models.tpm_limit` pre-check passes, the call fires, and Groq 413s.

## Solution

Once one upstream names the real token count for THIS request, propagate it as a sticky per-request value. Subsequent attempts in the same chain then pre-skip models whose TPM ceiling can't fit it — distinct from the existing `canUseTokens` headroom check (current usage + estimate vs limit) and surfaced as a new skip reason `request-too-large-for-tpm` so the exhaustion diagnostic tells the operator exactly why the model was skipped.

## Implementation

| File | Change |
|---|---|
| `lib/provider-size-parser.ts` (new) | Pure parser: `parseProviderReportedSize(platform, message)` → number \| null. One regex per supported provider, all derived from the live error corpus. |
| `lib/client-context.ts` | Add `observedRequestTokens` to the AsyncLocalStorage context + `setObservedRequestTokens` / `getObservedRequestTokens` helpers. Sticky: never decreases (max wins). |
| `lib/fallback-loop.ts` | In `recordRetryableFailure`: call the parser; if it returns a number, write it via `setObservedRequestTokens`. Single site covers all three chat surfaces (proxy, responses, anthropic). |
| `services/router.ts` | In `selectKeyForModel`: new gate before `canUseTokens` — if observed > model's tpm_limit, skip with reason `request-too-large-for-tpm`. |
| `__tests__/lib/provider-size-parser.test.ts` (new) | 16 cases: each supported provider with a real error body, plus edge cases (empty message, malformed number, GitHub Models limit-only). |
| `__tests__/lib/client-context.test.ts` | Update existing tests for the new field; add 4 cases for `setObservedRequestTokens` / `getObservedRequestTokens` (no-op outside scope, sticky max, per-request isolation). |
| `__tests__/services/router.test.ts` | Add 4 integration cases: skip when observed > tpm, surface new skip reason in exhaustion diagnostic, fall through when tpm is NULL, allow when observed fits. |

## Why GitHub Models is intentionally NOT parsed

GitHub's body is `Request body too large for gpt-4.1 model. Max size: 8000 tokens.` The 8000 is the **LIMIT**, not the rejected request's size. Returning it would cause every subsequent model with TPM < 8000 to be skipped for the rest of the request — wildly wrong since most free models have TPM ~6000. The parser returns null and `learnLimitFromError` keeps doing what it already does (lowering `models.tpm_limit` to 8000 for github/gpt-4.1).

## Why AsyncLocalStorage and not a `FallbackState` field

The sticky value is request-scoped, not loop-scoped — the same store already carries IP/UA and is reset by `clientContextMiddleware` per request. Avoids threading a new arg through 7 function signatures (`routeRequest`, `selectKeyForModel`, `runFallbackLoop`, etc.). The router reads it on every iteration; the loop writes it once when a 4xx lands.

## Backwards compatibility

- Opaque error bodies (bare "Request Entity Too Large", upstream 5xx without size payload, every provider not in the parser table) → null → no behavior change.
- `canUseTokens` headroom check still runs after the new gate.
- No DB schema change, no env vars, no new tables.
- All 949 existing tests still pass.

## Verification

```
npx vitest run  # 949 passed, 0 failed
npm run build:server  # clean
```

## Expected impact

- Eliminates ~8,000–14,000 wasted calls/month across Groq + OpenRouter + Cloudflare.
- One wasted call per request shape (the first 413) instead of one per model in the chain.
- New diagnostic reason `request-too-large-for-tpm` surfaces in `/v1/docs` exhaustion traces, so operators can see when a request was too big for the entire pool vs when it was just one model's 429.

## Out of scope (follow-up ideas)

- Per-content-type estimator (prose vs code vs tool schemas). Would close most of the 3–10× undercount for tool-heavy prompts, so the gate is meaningful even when no provider has reported yet. Tracked separately because the parser-based gate already helps 90%+ of the wasted-call cases from the live data.
- OpenAI / Anthropic 413 parsers. No live 413 corpus for them in the requests table yet; parser slots are easy to add when the shape is observed.