### PR TITLE
fix(server): mirror PATCH /api/models/:id fallbackEnabled toggle to active profile_models

### DIFF
--- a/server/src/routes/models.ts
+++ b/server/src/routes/models.ts
@@ -142,8 +142,25 @@ modelsRouter.patch('/:id', (req: Request, res: Response) => {
     }
 
     if (parsed.data.fallbackEnabled !== undefined) {
+      const fallbackEnabled = parsed.data.fallbackEnabled ? 1 : 0;
       db.prepare('UPDATE fallback_config SET enabled = ? WHERE model_db_id = ?')
-        .run(parsed.data.fallbackEnabled ? 1 : 0, id);
+        .run(fallbackEnabled, id);
+      // Mirror the toggle to profile_models for the currently active profile
+      // so the profile-path router (router.ts:528-545) doesn't keep routing
+      // to a model the operator just disabled. When no profile is active,
+      // fallback_config is the only chain and the sync is a no-op.
+      // See references/profile-models-vs-fallback-config.md.
+      const activeProfile = db.prepare(
+        "SELECT value FROM settings WHERE key = 'active_profile_id'"
+      ).get() as { value: string } | undefined;
+      if (activeProfile) {
+        const profileId = Number.parseInt(activeProfile.value, 10);
+        if (Number.isInteger(profileId)) {
+          db.prepare(
+            'UPDATE profile_models SET enabled = ? WHERE profile_id = ? AND model_db_id = ?'
+          ).run(fallbackEnabled, profileId, id);
+        }
+      }
     }
   });
   applyUpdate();


### PR DESCRIPTION
## Summary

The `PATCH /api/models/:id` handler with `fallbackEnabled` only writes to `fallback_config`. When `settings.active_profile_id` is set, the router reads `profile_models` exclusively (per `router.ts:528-545`), so a dashboard toggle that disabled a model via `fallback_config.enabled = 0` left its `profile_models.enabled = 1` row untouched. The profile-path router then kept routing requests to the "disabled" model.

This commit mirrors the toggle: if an active profile is set, the same `enabled` flag is written to `profile_models` in the same transaction. When no profile is active, the sync is a no-op and the existing fallback_config-only behavior is preserved.

## Motivation

On 2026-07-10, an operator disabled `groq/llama-3.1-8b-instant` from the dashboard. The `fallback_config` row flipped to `enabled=0`, but the router (which was reading `profile_models` because `active_profile_id=1`) kept picking the model. Groq's 8k context window rejected every request as `413 Request too large`, producing 210 errors over the next 24 hours before the divergence was caught by inspecting the request log.

There is no UI surface in the SPA for editing `profile_models` directly — the only frontend path that touches it is the dashboard fallback-chain editor, which writes to `fallback_config`. So every disable done via the dashboard while a profile is active is silently ineffective on the routing path that actually runs. This fix removes the footgun at the toggle site rather than adding a new UI surface.

## Changes

| File | Change |
|---|---|
| `server/src/routes/models.ts` | `PATCH /:id` handler looks up `active_profile_id` when `fallbackEnabled` is provided and, if a profile is active, also writes the same `enabled` flag to `profile_models` for that `model_db_id`, in the same transaction. Single transaction ensures atomicity. |

Diff: 1 file, +18/-1.

## Test plan

- `npm run build:server` exits 0 on `origin/main` + this commit (`f419a89` + `c3c1b74`).
- Live verification on `integration/all-my-prs` (deployed as commit `e378983`):
  - 4 historically-divergent rows (`groq/llama-3.1-8b-instant`, `cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast`, `openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free`, `openrouter/poolside/laguna-xs.2:free`) reconciled via direct SQL, so the immediate live DB is consistent.
  - Compiled JS verified to contain the new `active_profile_id` lookup (`grep -c active_profile_id server/dist/routes/models.js` → 1).
- Manual smoke test (post-deploy): toggle any model off in the dashboard, then verify with `sqlite3 data/freeapi.db "SELECT fc.enabled, pm.enabled FROM fallback_config fc LEFT JOIN profile_models pm ON pm.model_db_id=fc.model_db_id WHERE pm.profile_id=1 AND fc.model_db_id=<id>"` — both columns should match.

## Compatibility

- When no profile is active (`settings.active_profile_id` row absent), the new branch is a no-op and behavior is identical to before this commit.
- When a profile IS active, the previous behavior was that `fallbackEnabled: false` toggles had no effect on routing. After this commit, those toggles correctly disable the model in both tables. This is the intended fix — operators who had been toggling via the dashboard and observing the toggle "didn't work" will now see it take effect.

References operator session 2026-07-10. No upstream issue number yet — happy to file one if requested.