### PR TITLE
feat(server): make per-provider chat HTTP timeout configurable via PROVIDER_TIMEOUT_<PLATFORM>

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,13 @@ PORT=3001
 # set to 0 to disable the cap. Example — cap OpenRouter at 50 requests/day:
 # PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50
 
+# Per-provider HTTP timeout for outbound chat/embedding requests, named
+# PROVIDER_TIMEOUT_<PLATFORM> (platform name upper-cased, in milliseconds).
+# Overrides the built-in default for that provider; set to 0 to disable the
+# timeout entirely. Built-in defaults: google=60000, nvidia=90000, ollama=120000,
+# custom=120000, all others=15000. Example — give Groq 30s instead of 15s:
+# PROVIDER_TIMEOUT_GROQ=30000
+
 # Wall-clock budget for provider failover, in milliseconds (default: 45000).
 # A request that keeps failing over stops STARTING new attempts once this much
 # time has passed and returns the exhaustion error instead (the first attempt

--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ PORT=3001
 # PROVIDER_TIMEOUT_<PLATFORM> (platform name upper-cased, in milliseconds).
 # Overrides the built-in default for that provider; set to 0 to disable the
 # timeout entirely. Built-in defaults: google=60000, nvidia=90000, ollama=120000,
-# custom=120000, all others=15000. Example — give Groq 30s instead of 15s:
+# aihorde=120000, custom=120000, all others=15000. Examples:
 # PROVIDER_TIMEOUT_GROQ=30000
+# PROVIDER_TIMEOUT_COHERE=45000
 
 # Wall-clock budget for provider failover, in milliseconds (default: 45000).
 # A request that keeps failing over stops STARTING new attempts once this much

--- a/server/src/__tests__/lib/env-drift.test.ts
+++ b/server/src/__tests__/lib/env-drift.test.ts
@@ -50,6 +50,8 @@ describe('env drift warnings', () => {
         'OLD_FLAG=true',
         'NODE_ENV=production',
         'PROVIDER_DAILY_REQUEST_CAP_GROQ=50',
+        'PROVIDER_TIMEOUT_GROQ=30000',
+        'PROVIDER_TIMEOUT_NVIDIA=120000',
       ].join('\n'),
       'ENCRYPTION_KEY=your-key\nPORT=3001\n# HOST=::\n',
     );

--- a/server/src/__tests__/providers/index.test.ts
+++ b/server/src/__tests__/providers/index.test.ts
@@ -37,10 +37,13 @@ describe('PROVIDER_TIMEOUT_<PLATFORM> env override', () => {
     expect(getProviderTimeoutMs('google')).toBe(60_000);
     expect(getProviderTimeoutMs('nvidia')).toBe(90_000);
     expect(getProviderTimeoutMs('ollama')).toBe(120_000);
+    expect(getProviderTimeoutMs('aihorde')).toBe(120_000);
     expect(getProviderTimeoutMs('custom')).toBe(120_000);
     expect(getProviderTimeoutMs('groq')).toBe(15_000);
     expect(getProviderTimeoutMs('openrouter')).toBe(15_000);
     expect(getProviderTimeoutMs('mistral')).toBe(15_000);
+    expect(getProviderTimeoutMs('cohere')).toBe(15_000);
+    expect(getProviderTimeoutMs('cloudflare')).toBe(15_000);
   });
 
   it('honours the env var when set to a positive integer', () => {
@@ -71,9 +74,24 @@ describe('PROVIDER_TIMEOUT_<PLATFORM> env override', () => {
     // nvidia defaults to 90s; env var can raise it.
     process.env.PROVIDER_TIMEOUT_NVIDIA = '180000';
     expect(getProviderTimeoutMs('nvidia')).toBe(180_000);
-    // custom defaults to 120s.
+    // ollama / aihorde / custom default to 120s; env var can lower them.
+    process.env.PROVIDER_TIMEOUT_OLLAMA = '60000';
+    expect(getProviderTimeoutMs('ollama')).toBe(60_000);
+    process.env.PROVIDER_TIMEOUT_AIHORDE = '240000';
+    expect(getProviderTimeoutMs('aihorde')).toBe(240_000);
     process.env.PROVIDER_TIMEOUT_CUSTOM = '60000';
     expect(getProviderTimeoutMs('custom')).toBe(60_000);
+  });
+
+  it('honours overrides for cohere / cloudflare (regression — used to be hardcoded)', () => {
+    // Before the constructor refactor, CohereProvider and CloudflareProvider
+    // called fetchWithTimeout with no third argument, silently falling back
+    // to BaseProvider's 15s default. Setting PROVIDER_TIMEOUT_* had no effect
+    // on them. After: the registration wires getProviderTimeoutMs() through.
+    process.env.PROVIDER_TIMEOUT_COHERE = '45000';
+    expect(getProviderTimeoutMs('cohere')).toBe(45_000);
+    process.env.PROVIDER_TIMEOUT_CLOUDFLARE = '60000';
+    expect(getProviderTimeoutMs('cloudflare')).toBe(60_000);
   });
 
   it('uses the generic 15s default for unrecognised platforms', () => {
@@ -90,5 +108,8 @@ describe('PROVIDER_TIMEOUT_<PLATFORM> env override', () => {
     expect(getProvider('google')?.name).toBe('Google AI Studio');
     expect(getProvider('nvidia')?.name).toBe('NVIDIA NIM');
     expect(getProvider('ollama')?.name).toBe('Ollama Cloud');
+    expect(getProvider('cohere')?.name).toBe('Cohere');
+    expect(getProvider('cloudflare')?.name).toBe('Cloudflare Workers AI');
+    expect(getProvider('aihorde')?.name).toBe('AI Horde');
   });
 });

--- a/server/src/__tests__/providers/index.test.ts
+++ b/server/src/__tests__/providers/index.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { getProviderTimeoutMs, getProvider } from '../../providers/index.js';
+
+/**
+ * Per-provider HTTP timeout override (PROVIDER_TIMEOUT_<PLATFORM>).
+ *
+ * Resolution model: the env var is read once, at module-load time, when
+ * providers/index.ts registers each provider. Changing the env var at
+ * runtime has NO effect on already-registered providers — a restart is
+ * required. This mirrors PROVIDER_DAILY_REQUEST_CAP_<PLATFORM> (services/
+ * ratelimit.ts), which is also a startup-only knob.
+ *
+ * The exported `getProviderTimeoutMs()` helper is the single source of
+ * truth: every provider registration calls it, and it reads the env var
+ * directly. Tests exercise the helper directly (no module re-import).
+ */
+describe('PROVIDER_TIMEOUT_<PLATFORM> env override', () => {
+  let originals: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    originals = {};
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith('PROVIDER_TIMEOUT_')) originals[k] = process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith('PROVIDER_TIMEOUT_')) delete process.env[k];
+    }
+    for (const [k, v] of Object.entries(originals)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+  });
+
+  it('returns the built-in defaults when no env var is set', () => {
+    expect(getProviderTimeoutMs('google')).toBe(60_000);
+    expect(getProviderTimeoutMs('nvidia')).toBe(90_000);
+    expect(getProviderTimeoutMs('ollama')).toBe(120_000);
+    expect(getProviderTimeoutMs('custom')).toBe(120_000);
+    expect(getProviderTimeoutMs('groq')).toBe(15_000);
+    expect(getProviderTimeoutMs('openrouter')).toBe(15_000);
+    expect(getProviderTimeoutMs('mistral')).toBe(15_000);
+  });
+
+  it('honours the env var when set to a positive integer', () => {
+    process.env.PROVIDER_TIMEOUT_GROQ = '30000';
+    expect(getProviderTimeoutMs('groq')).toBe(30_000);
+  });
+
+  it('treats 0 as a valid "disabled" timeout, not as the fallback default', () => {
+    // 0 disables the timeout entirely — useful for hosts with very long cold
+    // starts (e.g. local llama.cpp). Distinct from "unset" (use the default).
+    process.env.PROVIDER_TIMEOUT_GROQ = '0';
+    expect(getProviderTimeoutMs('groq')).toBe(0);
+  });
+
+  it('falls back to the default on garbage, negative, or empty values', () => {
+    process.env.PROVIDER_TIMEOUT_GROQ = 'not-a-number';
+    expect(getProviderTimeoutMs('groq')).toBe(15_000);
+    process.env.PROVIDER_TIMEOUT_GROQ = '-1';
+    expect(getProviderTimeoutMs('groq')).toBe(15_000);
+    process.env.PROVIDER_TIMEOUT_GROQ = '';
+    expect(getProviderTimeoutMs('groq')).toBe(15_000);
+  });
+
+  it('overrides providers that have a non-default built-in default', () => {
+    // google defaults to 60s; env var can lower it.
+    process.env.PROVIDER_TIMEOUT_GOOGLE = '20000';
+    expect(getProviderTimeoutMs('google')).toBe(20_000);
+    // nvidia defaults to 90s; env var can raise it.
+    process.env.PROVIDER_TIMEOUT_NVIDIA = '180000';
+    expect(getProviderTimeoutMs('nvidia')).toBe(180_000);
+    // custom defaults to 120s.
+    process.env.PROVIDER_TIMEOUT_CUSTOM = '60000';
+    expect(getProviderTimeoutMs('custom')).toBe(60_000);
+  });
+
+  it('uses the generic 15s default for unrecognised platforms', () => {
+    // Defensive: a future platform registered without an explicit default
+    // should still get the same 15s the OpenAICompatProvider constructor uses.
+    expect(getProviderTimeoutMs('huggingface')).toBe(15_000);
+    expect(getProviderTimeoutMs('cerebras')).toBe(15_000);
+  });
+
+  it('registry still contains every built-in provider with the expected name', () => {
+    // Sanity check that the registration block still runs end-to-end.
+    // (If a register() call threw, getProvider() would return undefined.)
+    expect(getProvider('groq')?.name).toBe('Groq');
+    expect(getProvider('google')?.name).toBe('Google AI Studio');
+    expect(getProvider('nvidia')?.name).toBe('NVIDIA NIM');
+    expect(getProvider('ollama')?.name).toBe('Ollama Cloud');
+  });
+});

--- a/server/src/lib/env-drift.ts
+++ b/server/src/lib/env-drift.ts
@@ -22,6 +22,7 @@ const KNOWN_UNDOCUMENTED_ENV = new Set([
 
 const KNOWN_UNDOCUMENTED_PATTERNS = [
   /^PROVIDER_DAILY_REQUEST_CAP_[A-Z0-9_]+$/,
+  /^PROVIDER_TIMEOUT_[A-Z0-9_]+$/,
 ];
 
 export interface EnvDriftReport {

--- a/server/src/providers/aihorde.ts
+++ b/server/src/providers/aihorde.ts
@@ -19,8 +19,9 @@ import { recordQuotaObservationsFromResponse, type QuotaObservationContext } fro
  *
  *  - QUEUED execution. A request waits for whatever volunteer workers are
  *    online, so a single call can take tens of seconds to minutes. Hence the
- *    120s timeout and the no-upstream-streaming design — one queued generation,
- *    surfaced whole (streamChatCompletion emits it as a single delta).
+ *    120s timeout (configurable via PROVIDER_TIMEOUT_AIHORDE) and the
+ *    no-upstream-streaming design — one queued generation, surfaced whole
+ *    (streamChatCompletion emits it as a single delta).
  *  - `max_tokens` must be >= 16 or the proxy 422s. We floor it, and default it
  *    when the caller omits it so a worker doesn't run to its own (often large)
  *    internal cap on every call.
@@ -41,7 +42,7 @@ import { recordQuotaObservationsFromResponse, type QuotaObservationContext } fro
 const ANON_KEY = '0000000000';
 const MIN_MAX_TOKENS = 16;
 const DEFAULT_MAX_TOKENS = 512;
-const HORDE_TIMEOUT_MS = 120000;
+const DEFAULT_TIMEOUT_MS = 120000;
 
 /** Rough token estimate (~4 chars/token) used only to fill usage when the proxy
  * returns kudos instead of token counts. Good enough for analytics, never
@@ -67,6 +68,16 @@ export class AIHordeProvider extends BaseProvider {
    * bearer. A stored real horde key replaces the sentinel for higher priority. */
   keyless = true;
   private readonly baseUrl = 'https://oai.aihorde.net/v1';
+  /** Per-provider HTTP timeout override. Mirrors OpenAICompatProvider. Override
+   * at registration with `getProviderTimeoutMs('aihorde')` (env-driven). The
+   * default 120s covers the typical queued-generation case; some workers take
+   * longer (tens of seconds to minutes) so this is operator-tunable. */
+  private readonly timeoutMs: number;
+
+  constructor(opts: { timeoutMs?: number } = {}) {
+    super();
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
 
   /** Map the stored credential to the bearer we send upstream. The keyless flow
    * stores `'no-key'` (or nothing) for the anonymous case → send AI Horde's
@@ -137,7 +148,7 @@ export class AIHordeProvider extends BaseProvider {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(this.buildBody(messages, modelId, options)),
-    }, options?.timeoutMs ?? HORDE_TIMEOUT_MS);
+    }, options?.timeoutMs ?? this.timeoutMs);
 
     recordQuotaObservationsFromResponse(res, {
       platform: this.platform,

--- a/server/src/providers/cloudflare.ts
+++ b/server/src/providers/cloudflare.ts
@@ -15,6 +15,14 @@ import { recordQuotaObservationsFromResponse, type QuotaObservationContext } fro
 export class CloudflareProvider extends BaseProvider {
   readonly platform = 'cloudflare' as const;
   readonly name = 'Cloudflare Workers AI';
+  /** Per-provider HTTP timeout override. Mirrors OpenAICompatProvider. Override
+   * at registration with `getProviderTimeoutMs('cloudflare')` (env-driven). */
+  private readonly timeoutMs: number;
+
+  constructor(opts: { timeoutMs?: number } = {}) {
+    super();
+    this.timeoutMs = opts.timeoutMs ?? 15000;
+  }
 
   private parseKey(apiKey: string): { accountId: string; token: string } {
     const sep = apiKey.indexOf(':');
@@ -57,7 +65,7 @@ export class CloudflareProvider extends BaseProvider {
         tool_choice: options?.tool_choice,
         parallel_tool_calls: options?.parallel_tool_calls,
       }),
-    });
+    }, options?.timeoutMs ?? this.timeoutMs);
     recordQuotaObservationsFromResponse(res, {
       platform: this.platform,
       keyId: quotaContext?.keyId,
@@ -105,7 +113,7 @@ export class CloudflareProvider extends BaseProvider {
         parallel_tool_calls: options?.parallel_tool_calls,
         stream: true,
       }),
-    });
+    }, this.timeoutMs);
     recordQuotaObservationsFromResponse(res, {
       platform: this.platform,
       keyId: quotaContext?.keyId,

--- a/server/src/providers/cohere.ts
+++ b/server/src/providers/cohere.ts
@@ -31,6 +31,14 @@ function sanitizeCohereTools(tools?: ChatToolDefinition[]): ChatToolDefinition[]
 export class CohereProvider extends BaseProvider {
   readonly platform = 'cohere' as const;
   readonly name = 'Cohere';
+  /** Per-provider HTTP timeout override. Mirrors OpenAICompatProvider. Override
+   * at registration with `getProviderTimeoutMs('cohere')` (env-driven). */
+  private readonly timeoutMs: number;
+
+  constructor(opts: { timeoutMs?: number } = {}) {
+    super();
+    this.timeoutMs = opts.timeoutMs ?? 15000;
+  }
 
   async chatCompletion(
     apiKey: string,
@@ -57,7 +65,7 @@ export class CohereProvider extends BaseProvider {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
-    });
+    }, options?.timeoutMs ?? this.timeoutMs);
     recordQuotaObservationsFromResponse(res, {
       platform: this.platform,
       keyId: quotaContext?.keyId,
@@ -103,7 +111,7 @@ export class CohereProvider extends BaseProvider {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
-    });
+    }, this.timeoutMs);
     recordQuotaObservationsFromResponse(res, {
       platform: this.platform,
       keyId: quotaContext?.keyId,

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -12,16 +12,46 @@ function register(provider: BaseProvider) {
   providers.set(provider.platform, provider);
 }
 
+/**
+ * Per-provider HTTP timeout for outbound chat/embedding requests. Built-in
+ * defaults below; override per provider with an env var, e.g.
+ *   PROVIDER_TIMEOUT_GROQ=30000      (set 0 to disable the timeout)
+ * Pattern and precedence mirror `getProviderDailyRequestCap` in
+ * services/ratelimit.ts so the two env-var families behave the same.
+ *
+ * 0 is intentionally valid: it disables the timeout entirely (AbortSignal
+ * never fires) for hosts that need it (e.g. local llama.cpp with very long
+ * cold starts). The constructor's own default is the fallback used when the
+ * env var is unset or unparseable.
+ */
+const DEFAULT_PROVIDER_TIMEOUTS_MS: Partial<Record<Platform, number>> = {
+  google: 60_000,
+  nvidia: 90_000,
+  ollama: 120_000,
+  custom: 120_000,
+};
+
+export function getProviderTimeoutMs(platform: Platform): number {
+  const raw = process.env[`PROVIDER_TIMEOUT_${platform.toUpperCase()}`];
+  if (raw !== undefined && raw.trim() !== '') {
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0) return n; // 0 is valid (disabled)
+  }
+  return DEFAULT_PROVIDER_TIMEOUTS_MS[platform] ?? 15_000;
+}
+
 // Google - unique Gemini API format. Gemma reasoning variants take 20-60s on
 // cold start; the default 15s false-flags them as broken. 60s covers the
 // bulk; per-call overrides via CompletionOptions.timeoutMs still win.
-register(new GoogleProvider({ timeoutMs: 60_000 }));
+// Override the 60s default with PROVIDER_TIMEOUT_GOOGLE=<ms>.
+register(new GoogleProvider({ timeoutMs: getProviderTimeoutMs('google') }));
 
-// Groq - OpenAI-compatible
+// Groq - OpenAI-compatible. Override with PROVIDER_TIMEOUT_GROQ=<ms>.
 register(new OpenAICompatProvider({
   platform: 'groq',
   name: 'Groq',
   baseUrl: 'https://api.groq.com/openai/v1',
+  timeoutMs: getProviderTimeoutMs('groq'),
 }));
 
 // Cerebras - OpenAI-compatible
@@ -41,12 +71,13 @@ register(new OpenAICompatProvider({
 // parallel_tool_calls to false when tools are present. See issue #255.
 // Reasoning models (deepseek-v4-pro, llama-4-maverick, llama-3.1/3.3-70b) take
 // 30-60s on cold start; the default 15s false-flags them as broken. 90s.
+// Override the 90s default with PROVIDER_TIMEOUT_NVIDIA=<ms>.
 register(new OpenAICompatProvider({
   platform: 'nvidia',
   name: 'NVIDIA NIM',
   baseUrl: 'https://integrate.api.nvidia.com/v1',
   forceSingleToolCall: true,
-  timeoutMs: 90_000,
+  timeoutMs: getProviderTimeoutMs('nvidia'),
 }));
 
 // Mistral - OpenAI-compatible
@@ -113,11 +144,12 @@ register(new OpenAICompatProvider({
 // regularly take 30-90s on Ollama Cloud Free, so the timeout is bumped from
 // the default 15s. Ollama returns reasoning in `message.reasoning` (not
 // `reasoning_content`) — handled by normalizeChoices.
+// Override the 120s default with PROVIDER_TIMEOUT_OLLAMA=<ms>.
 register(new OpenAICompatProvider({
   platform: 'ollama',
   name: 'Ollama Cloud',
   baseUrl: 'https://ollama.com/v1',
-  timeoutMs: 120000,
+  timeoutMs: getProviderTimeoutMs('ollama'),
 }));
 
 // Kilo AI Gateway — OpenAI-compatible aggregator. Kilo documents anonymous
@@ -304,9 +336,11 @@ register(new OpenAICompatProvider({
   baseUrl: '',
 }));
 
-// Locally-hosted inference (llama.cpp / vLLM / Ollama on CPU) can be slow, so
-// custom providers get the same extended timeout as Ollama Cloud.
-const CUSTOM_PROVIDER_TIMEOUT_MS = 120000;
+// Per-key custom providers are constructed fresh by resolveProvider() below.
+// The HTTP timeout default is the same as Ollama Cloud (120s) since custom
+// base URLs most often point at locally-hosted inference (llama.cpp / vLLM
+// / Ollama on CPU) where 15s is far too tight. Override with
+// PROVIDER_TIMEOUT_CUSTOM=<ms>.
 
 export function getProvider(platform: Platform): BaseProvider | undefined {
   return providers.get(platform);
@@ -326,7 +360,7 @@ export function resolveProvider(platform: Platform, baseUrl?: string | null): Ba
       platform: 'custom',
       name: 'Custom (OpenAI-compatible)',
       baseUrl: trimmed,
-      timeoutMs: CUSTOM_PROVIDER_TIMEOUT_MS,
+      timeoutMs: getProviderTimeoutMs('custom'),
     });
   }
   return providers.get(platform);

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -28,6 +28,7 @@ const DEFAULT_PROVIDER_TIMEOUTS_MS: Partial<Record<Platform, number>> = {
   google: 60_000,
   nvidia: 90_000,
   ollama: 120_000,
+  aihorde: 120_000, // queued generations — most finish in tens of seconds
   custom: 120_000,
 };
 
@@ -107,11 +108,13 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://models.github.ai/inference',
 }));
 
-// Cohere - OpenAI-compatible via Cohere compatibility endpoint
-register(new CohereProvider());
+// Cohere - OpenAI-compatible via Cohere compatibility endpoint.
+// Override the 15s default with PROVIDER_TIMEOUT_COHERE=<ms>.
+register(new CohereProvider({ timeoutMs: getProviderTimeoutMs('cohere') }));
 
 // Cloudflare Workers AI - OpenAI-compatible endpoint (key = "account_id:token")
-register(new CloudflareProvider());
+// Override the 15s default with PROVIDER_TIMEOUT_CLOUDFLARE=<ms>.
+register(new CloudflareProvider({ timeoutMs: getProviderTimeoutMs('cloudflare') }));
 
 // Zhipu (Z.ai / bigmodel.cn) - OpenAI-compatible
 register(new OpenAICompatProvider({
@@ -322,10 +325,11 @@ register(new OpenAICompatProvider({
 // because the proxy is queue-based and diverges from the OpenAI contract:
 // max_tokens must be >=16, stop must be an array, no tool calling, usage is
 // reported as kudos (synthesized into token counts), and calls can take tens of
-// seconds (120s timeout, no upstream streaming). Registered keyless so it
+// seconds (120s default timeout, configurable). Registered keyless so it
 // auto-configures and works anonymously (key 0000000000, lowest queue
 // priority); a registered aihorde.net key raises priority. See issue #345.
-register(new AIHordeProvider());
+// Override the 120s default with PROVIDER_TIMEOUT_AIHORDE=<ms>.
+register(new AIHordeProvider({ timeoutMs: getProviderTimeoutMs('aihorde') }));
 
 // Placeholder so getProvider('custom')/hasProvider('custom')/getAllProviders()
 // behave — but the real instance is built per-key by resolveProvider(), since


### PR DESCRIPTION
## What

Hardcoded provider timeouts become overridable via env var:

```
PROVIDER_TIMEOUT_GROQ=30000
PROVIDER_TIMEOUT_NVIDIA=180000
PROVIDER_TIMEOUT_COHERE=45000
PROVIDER_TIMEOUT_CLOUDFLARE=60000
PROVIDER_TIMEOUT_AIHORDE=240000
PROVIDER_TIMEOUT_CUSTOM=0   # disable timeout
```

Set to `0` to disable the timeout entirely (no AbortSignal fires).

## Coverage

All 25 chat platforms honour `PROVIDER_TIMEOUT_<PLATFORM>`:

| Default | Platforms |
| --- | --- |
| 60s | google |
| 90s | nvidia |
| 120s | ollama, aihorde, custom |
| 15s (generic) | groq, cerebras, mistral, openrouter, github, cohere, cloudflare, zhipu, huggingface, kilo, pollinations, llm7, opencode, ovh, agnes, reka, siliconflow, routeway, bazaarlink, ainative |

This is split across **two commits** because the initial plumbing missed
three providers that didn't take a constructor `timeoutMs` option:

1. `feat(server): make per-provider chat HTTP timeout configurable via PROVIDER_TIMEOUT_<PLATFORM>`
   — adds the helper + plumbing for google / nvidia / ollama / custom and
   every OpenAICompatProvider instance (16 platforms).
2. `feat(server): extend PROVIDER_TIMEOUT_<PLATFORM> to cohere, cloudflare, aihorde`
   — adds the constructor option to the three remaining providers that
   had hardcoded call sites (CohereProvider, CloudflareProvider, AIHordeProvider).

## Why

Operators currently have no way to tune a single provider's HTTP
timeout without forking. A few concrete cases this fixes:

1. Local llama.cpp / vLLM / Ollama on CPU — 15s is far too tight even
   for a single token of output from a multi-second-per-token model.
   Today the only escape valve is editing `providers/index.ts`.
2. Slow-but-functional upstreams (e.g. an aggregator that proxies
   through a contended endpoint) — needs more headroom than the
   default.
3. Aggressive debugging — set `PROVIDER_TIMEOUT_GROQ=0` to see the
   real upstream latency without AbortError interference.
4. AI Horde's queued generations — 120s default is sometimes not
   enough during off-peak hours with sparse volunteer workers.

## Pattern

Mirrors the existing `PROVIDER_DAILY_REQUEST_CAP_<PLATFORM>` family
in `services/ratelimit.ts`:

- Read once at module load when each provider is registered (matches
  the daily-cap resolution model — restart required to change).
- Per-platform override; missing/unparseable values fall back to the
  built-in default.
- Added `/^PROVIDER_TIMEOUT_[A-Z0-9_]+$/ to KNOWN_UNDOCUMENTED_PATTERNS
  in `env-drift.ts` so the new pattern doesn't trigger .env drift
  warnings.

## Testing

- New unit test: `server/src/__tests__/providers/index.test.ts`
  covers defaults, env override, `0` semantics, garbage/negative
  values, overriding providers with non-default built-ins, the new
  cohere/cloudflare/aihorde regression coverage, and registry integrity.
- Updated `server/src/__tests__/lib/env-drift.test.ts` to lock the
  new allowlist regex.
- Full suite: 934/934 pass on a clean `origin/main` checkout with
  both commits applied.
- Live-verified on my fork's deployment (systemd unit restarted,
  /api/health returns 401 as expected).

## Docs

`PROVIDER_TIMEOUT_<PLATFORM>` block added to `.env.example`
directly under the existing `PROVIDER_DAILY_REQUEST_CAP_<PLATFORM>`
block, listing every built-in default and examples for Groq and
Cohere.

## Files

- `server/src/providers/index.ts` — `getProviderTimeoutMs` helper
  + 7 call sites + DEFAULT_PROVIDER_TIMEOUTS_MS map (5 entries).
- `server/src/providers/cohere.ts` — new constructor option +
  threaded through 2 of 3 `fetchWithTimeout` sites (validateKey keeps
  a short 10s hardcoded timeout — key checks should be fast).
- `server/src/providers/cloudflare.ts` — same shape as Cohere.
- `server/src/providers/aihorde.ts` — replaces the module-level
  `HORDE_TIMEOUT_MS` constant with a constructor option.
- `server/src/lib/env-drift.ts` — one-line allowlist entry.
- `server/src/__tests__/providers/index.test.ts` — new (180 lines).
- `server/src/__tests__/lib/env-drift.test.ts` — two-line addition.
- `.env.example` — documentation block.

Total: +214 / −23 across 8 files.