### PR TITLE
README: remove broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,10 +908,6 @@ Removed since the April 2026 review: Hugging Face, Moonshot, and MiniMax direct 
 
 **This project is for personal experimentation and learning, not production.** Free tiers exist so developers can prototype against them; they aren't a stable, supported inference substrate and shouldn't be treated as one. If you build something real on top of FreeLLMAPI, swap in a paid API before you ship. Your relationship with each upstream provider is governed by the terms you accepted when you created your account — those terms still apply when the traffic is proxied through this project, and you're responsible for complying with them.
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/chart?repos=tashfeenahmed/freellmapi&type=date&legend=top-left)](https://www.star-history.com/?repos=tashfeenahmed%2Ffreellmapi&type=date&legend=top-left)
-
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
The star-history.com chart embed is broken, so the section now renders as a dead image. Removed; markdown only.
