### PR TITLE
Fallback polish: client-disconnect abort + X-Fallback-Trail header

### DIFF
--- a/server/src/__tests__/lib/fallback-loop.test.ts
+++ b/server/src/__tests__/lib/fallback-loop.test.ts
@@ -414,3 +414,46 @@ describe('runFallbackLoop: circuit-breaker guardrail (max_consecutive_upstream_f
     expect(onExhausted).not.toHaveBeenCalled();
   });
 });
+
+describe('runFallbackLoop: client disconnect + attempt log', () => {
+  const retryable = () => Object.assign(new Error('429 Too Many Requests'), { status: 429 });
+
+  it('stops starting retries once the client is gone, without rendering exhaustion', async () => {
+    const onExhausted = vi.fn();
+    let gone = false;
+    const dispatch = vi.fn(async () => { gone = true; throw retryable(); });
+
+    await runFallbackLoop(hooksSkeleton({
+      maxRetries: 20,
+      clientGone: () => gone,
+      dispatch,
+      onExhausted,
+    }));
+
+    expect(dispatch).toHaveBeenCalledTimes(1); // first attempt ran, no retry started
+    expect(onExhausted).not.toHaveBeenCalled(); // nothing to render to a dead socket
+  });
+
+  it('a connected client is unaffected (clientGone false)', async () => {
+    const onExhausted = vi.fn();
+    const dispatch = vi.fn(async () => { throw retryable(); });
+    await runFallbackLoop(hooksSkeleton({ maxRetries: 3, clientGone: () => false, dispatch, onExhausted }));
+    expect(dispatch).toHaveBeenCalledTimes(3);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+  });
+
+  it('records failed attempts into the caller-supplied attemptLog', async () => {
+    const attemptLog: AttemptRecord[] = [];
+    let calls = 0;
+    const dispatch = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) throw retryable();
+      return 'done' as const;
+    });
+
+    await runFallbackLoop(hooksSkeleton({ maxRetries: 20, attemptLog, dispatch }));
+
+    expect(attemptLog).toHaveLength(2); // the two failures, not the success
+    expect(attemptLog[0].errorClass).toBe('rate_limited');
+  });
+});

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -262,6 +262,30 @@ export function formatAttemptTrail(attempts: AttemptRecord[]): string {
   return shown.join('; ') + (extra > 0 ? `; +${extra} more` : '');
 }
 
+/**
+ * Set the failover diagnostics headers every surface stamps on its responses:
+ * X-Fallback-Attempts (how many hops failed before this response) and
+ * X-Fallback-Trail (what each hop was and why it failed). Until now the trail
+ * only reached clients inside exhaustion error MESSAGES — a request that
+ * eventually succeeded gave no hint that it burned five hops first, which is
+ * exactly the case an operator wants to notice. Control characters are
+ * scrubbed so a hostile model id can't inject header lines.
+ */
+export function setFallbackHeaders(
+  res: { setHeader(name: string, value: string): void },
+  failedAttempts: number,
+  trail: AttemptRecord[] | undefined,
+): void {
+  if (failedAttempts > 0) res.setHeader('X-Fallback-Attempts', String(failedAttempts));
+  if (trail && trail.length > 0) {
+    const value = trail
+      .slice(0, TRAIL_MAX_SHOWN)
+      .map(a => `${a.platform}/${a.modelId} key${a.keyOrdinal}=${a.errorClass}`)
+      .join('; ') + (trail.length > TRAIL_MAX_SHOWN ? `; +${trail.length - TRAIL_MAX_SHOWN} more` : '');
+    res.setHeader('X-Fallback-Trail', value.replace(/[^\t\x20-\x7e]/g, '?'));
+  }
+}
+
 export interface ExhaustionBody {
   status: number;
   type: string;
@@ -378,6 +402,16 @@ export interface FallbackHooks {
   // Circuit-breaker threshold override, mostly for tests. Defaults to
   // getMaxConsecutiveUpstreamFails() (setting → env → 0 = disabled).
   breakerLimit?: number;
+  // When provided, the loop records every failed attempt into THIS array (it
+  // is the same array used for exhaustion bodies), so the surface can stamp
+  // X-Fallback-Trail on successful responses too.
+  attemptLog?: AttemptRecord[];
+  // Returns true once the client has hung up. Checked before STARTING each
+  // retry: a chain nobody is waiting for must not keep burning provider
+  // quota. The in-flight attempt still completes (same boundary as the
+  // wall-clock budget); stream pumps additionally stop reading upstream on
+  // disconnect, which cancels the upstream request via reader.cancel().
+  clientGone?: () => boolean;
   // Skip state; recordRetryableFailure / recordAuthFailure (called by the loop)
   // mutate it, and the surface's route() reads it to exclude failed keys/models.
   state: FallbackState;
@@ -432,7 +466,7 @@ export async function runFallbackLoop(hooks: FallbackHooks): Promise<void> {
   const maxRetries = hooks.maxRetries ?? FALLBACK_MAX_RETRIES;
   const budgetMs = hooks.timeBudgetMs ?? getFallbackTimeBudgetMs();
   const startedAt = Date.now();
-  const attempts: AttemptRecord[] = [];
+  const attempts: AttemptRecord[] = hooks.attemptLog ?? [];
   const keyOrdinals = new Map<string, number>();
   const keyOrdinal = (route: RouteResult): number => {
     const key = `${route.platform}:${route.keyId}`;
@@ -462,6 +496,14 @@ export async function runFallbackLoop(hooks: FallbackHooks): Promise<void> {
   };
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
+    // Client disconnect: nobody is waiting for this chain anymore, so stop
+    // burning provider quota on retries. Nothing to render — the socket is
+    // gone — so return without calling any exhaustion hook.
+    if (attempt > 0 && hooks.clientGone?.()) {
+      console.log(`[FallbackLoop] client disconnected — stopping failover after ${attempts.length} failed attempt(s)`);
+      return;
+    }
+
     // Wall-clock budget: refuse to START another retry once spent. The first
     // attempt always runs; a slow attempt is never aborted mid-flight (that is
     // the TODO(fallback-v2) hedging work), it just becomes the last one.

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -17,7 +17,7 @@ import { rescueInlineToolCalls, startsWithDialectMarker, couldBecomeDialectMarke
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 import { logRequest } from '../lib/request-log.js';
 import { extractApiToken, timingSafeStringEqual, getStickyModel, setStickyModel } from './proxy.js';
-import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, type ExhaustionBody } from '../lib/fallback-loop.js';
+import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, type ExhaustionBody, setFallbackHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { resolveAnthropicModel } from '../services/anthropic-map.js';
 import { buildModelListing } from '../services/model-listing.js';
@@ -413,16 +413,21 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
   // when every provider rejected the request, not always a 429), and applies the
   // inline tool-call dialect rescue that the OpenAI/Responses surfaces carry.
   const state = newFallbackState();
+  const attemptLog: AttemptRecord[] = [];
+  let clientGone = false;
+  res.on('close', () => { if (!res.writableEnded) clientGone = true; });
 
   await runFallbackLoop({
     maxRetries: MAX_RETRIES,
     state,
+    attemptLog,
+    clientGone: () => clientGone,
     route: () => routeRequest(estimatedTotal, state.skipKeys.size > 0 ? state.skipKeys : undefined, preferredModel, hasImage, wantsTools, state.skipModels.size > 0 ? state.skipModels : undefined),
     dispatch: async (route, attempt) => {
       if (stream) {
         try {
           await streamCompletion(res, route, messages, completionOptions, {
-            start, attempt, requestedModel, estimatedInputTokens, tools, pinnedModelId,
+            start, attempt, attemptLog, clientGone: () => clientGone, requestedModel, estimatedInputTokens, tools, pinnedModelId,
             sessionId, pinned: resolved.pinned,
           });
           return 'done';
@@ -500,7 +505,7 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
       };
 
       res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null, null, pinnedModelId);
       res.json(anthropicResponse);
       return 'done';
@@ -509,19 +514,19 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
       logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, sanitizeProviderErrorMessage(err.message), null, pinnedModelId);
     },
     onFatal: (route, err, attempt) => {
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       sendError(res, 502, 'api_error', `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`);
     },
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {
       if (exhaustion) {
-        if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+        setFallbackHeaders(res, info.attempts.length, info.attempts);
         sendError(res, exhaustion.status, anthropicErrorType(exhaustion), exhaustion.message);
       } else {
         sendError(res, routeErr?.status ?? 503, 'api_error', routeErr?.message ?? 'No model available to route this request');
       }
     },
     onExhausted: (exhaustion, info) => {
-      if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+      setFallbackHeaders(res, info.attempts.length, info.attempts);
       sendError(res, exhaustion.status, anthropicErrorType(exhaustion), exhaustion.message);
     },
   });
@@ -535,6 +540,8 @@ class StreamAlreadyStarted extends Error {}
 interface StreamCtx {
   start: number;
   attempt: number;
+  attemptLog: AttemptRecord[];
+  clientGone: () => boolean;
   requestedModel: string;
   estimatedInputTokens: number;
   tools?: ChatToolDefinition[];
@@ -582,7 +589,7 @@ async function streamCompletion(
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-    if (ctx.attempt > 0) res.setHeader('X-Fallback-Attempts', String(ctx.attempt));
+    setFallbackHeaders(res, ctx.attempt, ctx.attemptLog);
     writeSse(res, 'message_start', {
       type: 'message_start',
       message: {
@@ -610,6 +617,7 @@ async function streamCompletion(
     const gen = route.provider.streamChatCompletion(route.apiKey, messages, route.modelId, options);
 
     for await (const chunk of gen) {
+      if (ctx.clientGone()) break; // client hung up: stop pulling; reader.cancel() aborts upstream
       const anyChunk = chunk as Record<string, any>;
 
       // In-band provider error frame (e.g. Groq emits {"error":…} inside a 200

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -17,7 +17,7 @@ import { isFusionModel, runFusion, fusionConfigSchema, FusionError, FUSION_MODEL
 import { isRetryableError, isPaymentRequiredError, isModelNotFoundError, isModelAccessForbiddenError } from '../lib/error-classify.js';
 import { logRequest } from '../lib/request-log.js';
 import { parseCacheDirective, cacheActive, isCacheableTemperature, computeCacheKey, getCachedResponse, storeCachedResponse } from '../services/cache.js';
-import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, exhaustedRetryError } from '../lib/fallback-loop.js';
+import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, exhaustedRetryError, setFallbackHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { samplingParamSchemaFields, pickSamplingParams, supportedParametersForPlatforms } from '../lib/sampling-params.js';
 import { enforceJsonContent } from '../lib/structured-output.js';
@@ -724,6 +724,9 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
 
   const pinnedModelId = requestedModel && !isAutoModel(requestedModel) ? requestedModel : null;
   const state = newFallbackState();
+  const attemptLog: AttemptRecord[] = [];
+  let clientGone = false;
+  res.on('close', () => { if (!res.writableEnded) clientGone = true; });
 
   // Legacy /completions is a thin adapter over the shared fallback loop
   // (lib/fallback-loop.ts): the cooldown/skip/penalty/exhaustion machinery is
@@ -731,6 +734,8 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
   await runFallbackLoop({
     maxRetries: MAX_RETRIES,
     state,
+    attemptLog,
+    clientGone: () => clientGone,
     route: () => routeRequest(
       estimatedTotal,
       state.skipKeys.size > 0 ? state.skipKeys : undefined,
@@ -765,7 +770,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
           res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-          if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+          setFallbackHeaders(res, attempt, attemptLog);
           headerSent = true;
           for (const frame of buffered) res.write(`data: ${JSON.stringify(frame)}\n\n`);
           buffered.length = 0;
@@ -781,6 +786,9 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
           );
 
           for await (const chunk of gen) {
+      if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+          if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+            if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
             const text = streamChunkText(chunk);
             if (text.length > 0) sawText = true;
             const finish = (chunk as any)?.choices?.[0]?.finish_reason;
@@ -873,7 +881,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
       recordUpstreamSuccess(route, totalTokens);
 
       res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       res.json({
         id: completionIdFromChat(result.id),
         object: 'text_completion',
@@ -916,7 +924,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
       logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, null, pinnedModelId);
     },
     onFatal: (route, err, attempt) => {
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       res.status(502).json({
         error: {
           message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`,
@@ -926,7 +934,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
     },
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {
       if (exhaustion) {
-        if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+        setFallbackHeaders(res, info.attempts.length, info.attempts);
         res.status(exhaustion.status).json({ error: { message: exhaustion.message, type: exhaustion.type } });
       } else {
         const disposition: string[] = Array.isArray(routeErr.diagnostics) ? routeErr.diagnostics : [];
@@ -939,7 +947,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
       }
     },
     onExhausted: (exhaustion, info) => {
-      if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+      setFallbackHeaders(res, info.attempts.length, info.attempts);
       res.status(exhaustion.status).json({ error: { message: exhaustion.message, type: exhaustion.type } });
     },
   });
@@ -1407,10 +1415,15 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // context-handoff injection, group/unified-chain routing, and the OpenAI
   // stream turn-integrity framing.
   const state = newFallbackState();
+  const attemptLog: AttemptRecord[] = [];
+  let clientGone = false;
+  res.on('close', () => { if (!res.writableEnded) clientGone = true; });
 
   await runFallbackLoop({
     maxRetries: MAX_RETRIES,
     state,
+    attemptLog,
+    clientGone: () => clientGone,
     route: () => {
       // When a handoff could fire this turn, pad the token estimate so the router's
       // context-window and TPM checks account for the extra system message overhead.
@@ -1483,7 +1496,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
           res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-          if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+          setFallbackHeaders(res, attempt, attemptLog);
           headerSent = true;
           for (const p of preamble) res.write(`data: ${JSON.stringify(p)}\n\n`);
           preamble.length = 0;
@@ -1505,6 +1518,9 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           );
 
           for await (const chunk of gen) {
+      if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+          if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+            if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
             const anyChunk = chunk as Record<string, any>;
 
             // In-band upstream error frame (observed live: Groq emits
@@ -1786,7 +1802,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         if (handoffMode !== 'off' && sessionKey) recordSuccessfulModel({ sessionKey, modelKey });
 
         res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-        if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+        setFallbackHeaders(res, attempt, attemptLog);
         // Repair double-encoded tool arguments against the request's tool
         // schemas (e.g. GLM emitting an array parameter as a JSON string),
         // so strict clients don't reject the call. Schema-gated — a true
@@ -1849,7 +1865,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     },
     onFatal: (route, err, attempt) => {
       // Non-retryable error (bare 4xx, etc.): don't retry.
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       res.status(502).json({
         error: {
           message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`,
@@ -1860,7 +1876,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {
       // No more models available.
       if (exhaustion) {
-        if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+        setFallbackHeaders(res, info.attempts.length, info.attempts);
         res.status(exhaustion.status).json({ error: { message: exhaustion.message, type: exhaustion.type } });
       } else {
         // Synchronous exhaustion: the router rejected every candidate before any
@@ -1877,7 +1893,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       }
     },
     onExhausted: (exhaustion, info) => {
-      if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+      setFallbackHeaders(res, info.attempts.length, info.attempts);
       res.status(exhaustion.status).json({ error: { message: exhaustion.message, type: exhaustion.type } });
     },
   });

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -23,7 +23,7 @@ import {
   traceRouteEvent,
   logRequest,
 } from './proxy.js';
-import { runFallbackLoop, newFallbackState, recordUpstreamSuccess } from '../lib/fallback-loop.js';
+import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, setFallbackHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { samplingParamSchemaFields, pickSamplingParams, type ResponseFormat } from '../lib/sampling-params.js';
 import { enforceJsonContent } from '../lib/structured-output.js';
@@ -406,6 +406,9 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
 
   const responseId = newId('resp');
   const state = newFallbackState();
+  const attemptLog: AttemptRecord[] = [];
+  let clientGone = false;
+  res.on('close', () => { if (!res.writableEnded) clientGone = true; });
 
   // Stream bookkeeping (used only when stream === true). `streamStarted` is the
   // commit flag: true once the response.created/in_progress skeleton has left,
@@ -422,6 +425,8 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   await runFallbackLoop({
     maxRetries: MAX_RETRIES,
     state,
+    attemptLog,
+    clientGone: () => clientGone,
     route: () => routeRequest(estimatedTotal, state.skipKeys.size > 0 ? state.skipKeys : undefined, preferredModel, false, wantsTools, state.skipModels.size > 0 ? state.skipModels : undefined, undefined, completionOpts.response_format !== undefined),
     dispatch: async (route, attempt) => {
       traceRouteEvent('Responses', {
@@ -460,7 +465,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
           res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-          if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+          setFallbackHeaders(res, attempt, attemptLog);
           const skeleton = {
             id: responseId, object: 'response', created_at: nowUnix(),
             status: 'in_progress', model: route.modelId, output: [], output_text: '',
@@ -498,6 +503,9 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           );
 
           for await (const chunk of gen) {
+      if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+          if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
+            if (clientGone) break; // client hung up: stop pulling; reader.cancel() aborts upstream
             // In-band upstream error frame ({"error":...} inside a 200 SSE
             // stream — observed live from Groq). Throwing hands it to the catch
             // below: pre-commit it fails over, post-commit it surfaces
@@ -751,7 +759,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       setStickyModel(messages, route.modelDbId, sessionIdHeader);
 
       res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       res.json(buildResponseObject({
         id: responseId, model: route.modelId, text, toolCalls,
         promptTokens, completionTokens,
@@ -785,7 +793,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
     },
     onFatal: (route, err, attempt) => {
-      if (attempt > 0) res.setHeader('X-Fallback-Attempts', String(attempt));
+      setFallbackHeaders(res, attempt, attemptLog);
       res.status(502).json({ error: { message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`, type: 'provider_error' } });
     },
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {
@@ -796,7 +804,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         sse('response.failed', { response: { id: responseId, object: 'response', status: 'failed', error: { message, type } } });
         res.end();
       } else {
-        if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+        setFallbackHeaders(res, info.attempts.length, info.attempts);
         res.status(status).json({ error: { message, type } });
       }
     },
@@ -807,7 +815,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         sse('response.failed', { response: { id: responseId, object: 'response', status: 'failed', error: { message: exhaustion.message, type: exhaustion.type } } });
         res.end();
       } else {
-        if (info.attempts.length > 0) res.setHeader('X-Fallback-Attempts', String(info.attempts.length));
+        setFallbackHeaders(res, info.attempts.length, info.attempts);
         res.status(exhaustion.status).json({ error: { message: exhaustion.message, type: exhaustion.type } });
       }
     },


### PR DESCRIPTION
Item 6 of the gap-audit queue.

## Client-disconnect abort (quota saver)

A caller that hung up used to keep the failover chain grinding through up to 20 candidates, burning free-tier quota nobody would receive. Now:
- every surface flips a `clientGone` flag on the response `close` event (gated on `writableEnded` so normal completions don't trip it);
- the shared loop refuses to **start** another retry once the client is gone — in-flight attempts still complete (same boundary as the wall-clock budget), and nothing is rendered to the dead socket;
- the four stream pumps stop pulling upstream on disconnect, and `reader.cancel()` in the shared SSE reader cancels the upstream request itself — so the tail of a long generation is saved too, not just the retries.

## X-Fallback-Trail (Vercel `modelAttempts` / Cloudflare `cf-aig-step` equivalent)

The per-attempt trail (#484) only reached clients inside exhaustion **error** messages; a request that eventually succeeded gave no hint it burned five hops first. All fourteen header sites now go through one `setFallbackHeaders` helper: `X-Fallback-Attempts` plus a compact `X-Fallback-Trail: groq/llama-3.3 key1=rate_limited; google/gemini-2.5 key1=timeout` (capped at 10 entries, control characters scrubbed so a hostile model id can't inject headers) on success, fatal, and exhaustion paths alike.

## Testing
- 986 passed (99 files): new loop cases for disconnect-stop (first attempt runs, no retry starts, no exhaustion render), connected-client control, and attemptLog capture. `tsc` clean.
- Live: `curl --max-time 1` against a deliberately slow provider logs `[FallbackLoop] client disconnected — stopping failover after 1 failed attempt(s)` instead of continuing the chain.
- The trail header's multi-hop shape gets its realistic exercise in the demo-box validation pass (real providers, real failovers).
