### PR TITLE
Param-policy tuning from the live all-provider sweep (kilo, reka)

### DIFF
--- a/server/src/__tests__/lib/sampling-params.test.ts
+++ b/server/src/__tests__/lib/sampling-params.test.ts
@@ -103,3 +103,29 @@ describe('supportedParametersFor / supportedParametersForPlatforms', () => {
     expect(supportedParametersForPlatforms(['groq'])).toEqual(supportedParametersFor('groq'));
   });
 });
+
+describe('live-sweep policy findings (2026-07-11 demo-box validation)', () => {
+  it('kilo: response_format dropped (gateway 400s on it), seed still forwarded', () => {
+    const body = extendedBodyParams('kilo', { seed: 7, response_format: { type: 'json_object' } });
+    expect(body.seed).toBe(7);
+    expect(body).not.toHaveProperty('response_format');
+  });
+
+  it('reka: json_object upgraded to a permissive json_schema on the wire', () => {
+    const body = extendedBodyParams('reka', { response_format: { type: 'json_object' } });
+    expect((body.response_format as any).type).toBe('json_schema');
+    expect((body.response_format as any).json_schema.schema).toEqual({ type: 'object' });
+  });
+
+  it('reka: an explicit json_schema passes through untouched', () => {
+    const rf = { type: 'json_schema' as const, json_schema: { name: 'x', schema: { type: 'object', properties: {} } } };
+    const body = extendedBodyParams('reka', { response_format: rf });
+    expect(body.response_format).toBe(rf);
+  });
+
+  it('kilo is skipped by structured-output routing; reka is not', async () => {
+    const { platformDropsResponseFormat } = await import('../../lib/sampling-params.js');
+    expect(platformDropsResponseFormat('kilo')).toBe(true);
+    expect(platformDropsResponseFormat('reka')).toBe(false);
+  });
+});

--- a/server/src/lib/sampling-params.ts
+++ b/server/src/lib/sampling-params.ts
@@ -111,6 +111,11 @@ export function pickSamplingParams(body: ParsedSamplingBody): ExtendedSamplingOp
 export interface PlatformParamPolicy {
   drop?: readonly ExtendedSamplingKey[];
   rename?: Readonly<Partial<Record<ExtendedSamplingKey, string>>>;
+  // The platform supports json_schema but 400s on json_object (observed live:
+  // Reka — "Unsupported response_format type: 'json_object'. Supported types
+  // are 'text' and 'json_schema'."). Upgrade json_object to a permissive
+  // json_schema on the wire instead of dropping structured output entirely.
+  jsonObjectToSchema?: boolean;
 }
 
 export const PLATFORM_PARAM_POLICIES: Record<string, PlatformParamPolicy> = {
@@ -137,6 +142,20 @@ export const PLATFORM_PARAM_POLICIES: Record<string, PlatformParamPolicy> = {
   cloudflare: { drop: ['min_p', 'logit_bias', 'logprobs', 'top_logprobs'] },
   // AI Horde builds its own payload format; none of the extended set maps.
   aihorde: { drop: [...EXTENDED_SAMPLING_KEYS] },
+  // Kilo's anonymous gateway 400s ("Provider returned error") whenever
+  // response_format is present — observed live 2026-07-11; seed passes fine.
+  // Dropping it also makes structured-output routing skip kilo entirely.
+  kilo: { drop: ['response_format'] },
+  // Reka supports json_schema but rejects json_object (live 2026-07-11);
+  // upgraded on the wire instead of dropped.
+  reka: { jsonObjectToSchema: true },
+};
+
+// The permissive schema a json_object request is upgraded to on platforms
+// that only accept json_schema (any JSON object satisfies it).
+const ANY_OBJECT_SCHEMA = {
+  type: 'json_schema' as const,
+  json_schema: { name: 'json_output', schema: { type: 'object' } },
 };
 
 /**
@@ -151,8 +170,12 @@ export function extendedBodyParams(platform: string, options: ExtendedSamplingOp
   const out: Record<string, unknown> = {};
   for (const key of EXTENDED_SAMPLING_KEYS) {
     if (dropped.has(key)) continue;
-    const value = (options as Record<string, unknown>)[key];
+    let value = (options as Record<string, unknown>)[key];
     if (value === undefined) continue;
+    if (key === 'response_format' && policy?.jsonObjectToSchema
+        && (value as { type?: string }).type === 'json_object') {
+      value = ANY_OBJECT_SCHEMA;
+    }
     out[policy?.rename?.[key] ?? key] = value;
   }
   return out;


### PR DESCRIPTION
Follow-up to #514/#516, encoding what the live sweep on the demo instance found (13 single-platform providers, one `json_object`+`seed` request each, then isolation retests):

| Platform | Finding | Fix |
|---|---|---|
| kilo | 400 "Provider returned error" whenever `response_format` is present; `seed` fine | droplist `response_format` → structured-output routing now skips kilo |
| reka | explicit 400: "Unsupported response_format type: 'json_object'. Supported types are 'text' and 'json_schema'"; `json_schema` verified working live | new `jsonObjectToSchema` policy flag upgrades `json_object` → permissive `json_schema` on the wire |

Sweep results that needed **no** change: github/nvidia/opencode/zhipu/groq/llm7 returned valid JSON directly; google + cohere first tripped the #516 format-ignore failover purely because `max_tokens: 60` starved their reasoning models (clean at 400 — the enforcement caught a real quality failure, correctly); openrouter was a transient upstream 429; agnes/cloudflare hit the 15s adapter timeout, unrelated to params.

Tests: 1002 passed (100 files), four new policy cases. After merge the demo instance gets re-pulled and kilo/reka re-verified live.
