### PR TITLE
Fix: permissive json_schema upgrade needs properties:{} (Reka 503)

### DIFF
--- a/server/src/__tests__/lib/sampling-params.test.ts
+++ b/server/src/__tests__/lib/sampling-params.test.ts
@@ -114,7 +114,7 @@ describe('live-sweep policy findings (2026-07-11 demo-box validation)', () => {
   it('reka: json_object upgraded to a permissive json_schema on the wire', () => {
     const body = extendedBodyParams('reka', { response_format: { type: 'json_object' } });
     expect((body.response_format as any).type).toBe('json_schema');
-    expect((body.response_format as any).json_schema.schema).toEqual({ type: 'object' });
+    expect((body.response_format as any).json_schema.schema).toEqual({ type: 'object', properties: {}, additionalProperties: true });
   });
 
   it('reka: an explicit json_schema passes through untouched', () => {

--- a/server/src/lib/sampling-params.ts
+++ b/server/src/lib/sampling-params.ts
@@ -152,10 +152,13 @@ export const PLATFORM_PARAM_POLICIES: Record<string, PlatformParamPolicy> = {
 };
 
 // The permissive schema a json_object request is upgraded to on platforms
-// that only accept json_schema (any JSON object satisfies it).
+// that only accept json_schema (any JSON object satisfies it). The empty
+// `properties` map matters: Reka 503s on a bare {type:'object'} but accepts
+// this shape (probed live 2026-07-11); additionalProperties keeps arbitrary
+// keys legal.
 const ANY_OBJECT_SCHEMA = {
   type: 'json_schema' as const,
-  json_schema: { name: 'json_output', schema: { type: 'object' } },
+  json_schema: { name: 'json_output', schema: { type: 'object', properties: {}, additionalProperties: true } },
 };
 
 /**


### PR DESCRIPTION
Closes the last loose end from the #519 live sweep. Direct in-container probes against Reka's API isolated the 503: a bare `{type:'object'}` schema draws `503 Something wrong happened`, while `{type:'object', properties:{}, additionalProperties:true}` returns 200 (and plain + fully-specified schemas both work). The `json_object` → `json_schema` upgrade now uses the accepted shape.

Tests updated; 16/16 sampling-params cases pass; tsc clean. Will re-verify `json_object` on Reka live after the image rebuild.
