### PR TITLE
test: add unit coverage for inferQuotaPoolKey

### DIFF
--- a/server/src/__tests__/services/provider-quota.test.ts
+++ b/server/src/__tests__/services/provider-quota.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { inferQuotaPoolKey } from '../../services/provider-quota.js';
+
+describe('inferQuotaPoolKey', () => {
+  it('splits openrouter into free vs account pools based on the model suffix', () => {
+    expect(inferQuotaPoolKey('openrouter', 'some-model:free')).toBe('openrouter::free');
+    expect(inferQuotaPoolKey('openrouter', 'some-model')).toBe('openrouter::account');
+    expect(inferQuotaPoolKey('openrouter', null)).toBe('openrouter::account');
+  });
+
+  it('maps known platforms to their fixed shared pool key', () => {
+    expect(inferQuotaPoolKey('google', 'gemini-pro')).toBe('google::project');
+    expect(inferQuotaPoolKey('groq', null)).toBe('groq::account');
+    expect(inferQuotaPoolKey('cerebras', null)).toBe('cerebras::shared');
+    expect(inferQuotaPoolKey('huggingface', null)).toBe('huggingface::router');
+  });
+
+  it('falls back to platform::modelId for unrecognized platforms with a model', () => {
+    expect(inferQuotaPoolKey('unknown-platform' as any, 'model-x')).toBe('unknown-platform::model-x');
+  });
+
+  it('falls back to platform::account for unrecognized platforms without a model', () => {
+    expect(inferQuotaPoolKey('unknown-platform' as any, null)).toBe('unknown-platform::account');
+    expect(inferQuotaPoolKey('unknown-platform' as any, undefined)).toBe('unknown-platform::account');
+    expect(inferQuotaPoolKey('unknown-platform' as any, '  ')).toBe('unknown-platform::account');
+  });
+});


### PR DESCRIPTION
## Summary
- `inferQuotaPoolKey` in `server/src/services/provider-quota.ts` had no unit tests, despite being a pure function that maps platforms/models to quota pool keys.
- Adds tests covering the openrouter free/account split, several fixed shared-pool platforms, and the fallback behavior for unrecognized platforms (with and without a model id).

## Test plan
- [x] `npx vitest run src/__tests__/services/provider-quota.test.ts` passes (4/4)