### PR TITLE
Fix routing chain semantics

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -11,6 +11,7 @@ const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.ts';
 const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
 const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
+const PROFILE_CHAIN_BACKFILL_FILENAME = '20260714_000001_profile_chain_backfill.ts';
 
 interface SchemaRow {
   type: string;
@@ -68,6 +69,7 @@ describe('migration round trip', () => {
         GITHUB_GPT41_CONTEXT_FILENAME,
         REQUEST_CLIENT_INFO_FILENAME,
         CUSTOM_MODEL_TOOL_SUPPORT_FILENAME,
+        PROFILE_CHAIN_BACKFILL_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/routing-semantics.test.ts
+++ b/server/src/__tests__/routes/routing-semantics.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { encrypt } from '../../lib/crypto.js';
+import {
+  resolveModelGroupCandidates,
+  resolveRoutingChain,
+  routeRequest,
+  setRoutingStrategy,
+} from '../../services/router.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+
+let app: Express;
+let dashToken = '';
+
+async function request(method: string, path: string, body?: any) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method,
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+function activeProfileId(): number {
+  const row = getDb().prepare("SELECT value FROM settings WHERE key = 'active_profile_id'").get() as { value: string };
+  return Number(row.value);
+}
+
+function addKey(platform: string): void {
+  const secret = encrypt(`${platform}-routing-test-key`);
+  getDb().prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+    VALUES (?, 'routing-test', ?, ?, ?, 'healthy', 1)
+  `).run(platform, secret.encrypted, secret.iv, secret.authTag);
+}
+
+function addSyntheticModel(modelId: string, priority: number, enabled = true): number {
+  const db = getDb();
+  const inserted = db.prepare(`
+    INSERT INTO models (
+      platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+      rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget,
+      context_window, enabled, supports_vision, supports_tools
+    )
+    VALUES ('groq', ?, ?, ?, ?, 'Small', NULL, NULL, NULL, NULL, '~1M', 128000, 1, 0, 1)
+  `).run(modelId, `Routing Test ${modelId}`, priority, priority);
+  const id = Number(inserted.lastInsertRowid);
+  db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, ?)').run(id, priority, enabled ? 1 : 0);
+  db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, ?)')
+    .run(activeProfileId(), id, priority, enabled ? 1 : 0);
+  return id;
+}
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = '0'.repeat(64);
+  initDb(':memory:');
+  app = createApp();
+  dashToken = mintDashboardToken();
+  setRoutingStrategy('priority');
+  getDb().prepare('DELETE FROM api_keys').run();
+});
+
+describe('routing semantics', () => {
+  it('Models page fallback edits update the active profile chain the router uses', async () => {
+    addKey('groq');
+    addKey('google');
+
+    const db = getDb();
+    const groq = db.prepare(`
+      SELECT m.id
+        FROM profile_models pm
+        JOIN models m ON m.id = pm.model_db_id
+       WHERE pm.profile_id = ? AND m.platform = 'groq' AND m.enabled = 1
+       ORDER BY pm.priority
+       LIMIT 1
+    `).get(activeProfileId()) as { id: number };
+    const google = db.prepare(`
+      SELECT m.id
+        FROM profile_models pm
+        JOIN models m ON m.id = pm.model_db_id
+       WHERE pm.profile_id = ? AND m.platform = 'google' AND m.enabled = 1
+       ORDER BY pm.priority
+       LIMIT 1
+    `).get(activeProfileId()) as { id: number };
+
+    const original = await request('GET', '/api/fallback');
+    expect(original.status).toBe(200);
+    const update = original.body.map((row: any, index: number) => ({
+      modelDbId: row.modelDbId,
+      priority: row.modelDbId === groq.id ? 1 : row.modelDbId === google.id ? 2 : index + 100,
+      enabled: true,
+    }));
+    const saved = await request('PUT', '/api/fallback', update);
+    expect(saved.status).toBe(200);
+
+    const profileRow = db.prepare('SELECT priority FROM profile_models WHERE profile_id = ? AND model_db_id = ?')
+      .get(activeProfileId(), groq.id) as { priority: number };
+    expect(profileRow.priority).toBe(1);
+    expect(routeRequest(100).modelDbId).toBe(groq.id);
+  });
+
+  it('custom models added after profile seeding are appended to the active profile and auto-routable', async () => {
+    const created = await request('POST', '/api/keys/custom', {
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      model: 'profile-visible-custom-model',
+    });
+    expect(created.status).toBe(201);
+
+    const profileRow = getDb().prepare('SELECT enabled FROM profile_models WHERE profile_id = ? AND model_db_id = ?')
+      .get(activeProfileId(), created.body.modelDbId) as { enabled: number } | undefined;
+    expect(profileRow?.enabled).toBe(1);
+
+    const routed = routeRequest(100);
+    expect(routed.platform).toBe('custom');
+    expect(routed.modelId).toBe('profile-visible-custom-model');
+  });
+
+  it('auto routing skips chain-disabled models even when the chain is prefetched', () => {
+    const db = getDb();
+    db.prepare('DELETE FROM fallback_config').run();
+    db.prepare('DELETE FROM profile_models').run();
+    db.prepare('DELETE FROM models').run();
+    addKey('groq');
+
+    const disabledId = addSyntheticModel('disabled-for-auto', 1, false);
+    const enabledId = addSyntheticModel('enabled-for-auto', 2, true);
+
+    const resolved = resolveRoutingChain('auto');
+    const routed = routeRequest(100, undefined, undefined, false, false, undefined, resolved.chain);
+    expect(routed.modelDbId).toBe(enabledId);
+    expect(routed.modelDbId).not.toBe(disabledId);
+  });
+
+  it('explicit named routing can still use a model disabled only for auto routing', () => {
+    const db = getDb();
+    db.prepare('DELETE FROM fallback_config').run();
+    db.prepare('DELETE FROM profile_models').run();
+    db.prepare('DELETE FROM models').run();
+    addKey('groq');
+
+    const disabledId = addSyntheticModel('direct-only-model', 1, false);
+    addSyntheticModel('auto-model', 2, true);
+
+    const groupChain = resolveModelGroupCandidates([disabledId]);
+    expect(groupChain.map(row => row.model_db_id)).toEqual([disabledId]);
+
+    const routed = routeRequest(100, undefined, undefined, false, false, undefined, groupChain);
+    expect(routed.modelDbId).toBe(disabledId);
+    expect(routed.modelId).toBe('direct-only-model');
+  });
+});

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -6,6 +6,7 @@ import * as requestAggregates from '../migrations/20260628_120000_request_aggreg
 import * as githubGpt41Context from '../migrations/20260630_000001_github_gpt41_context.js';
 import * as requestClientInfo from '../migrations/20260706_000001_request_client_info.js';
 import * as customModelToolSupport from '../migrations/20260706_000002_custom_model_tool_support.js';
+import * as profileChainBackfill from '../migrations/20260714_000001_profile_chain_backfill.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -24,6 +25,7 @@ export const REQUEST_AGGREGATES_FILENAME = '20260628_120000_request_aggregates.t
 export const GITHUB_GPT41_CONTEXT_FILENAME = '20260630_000001_github_gpt41_context.ts';
 export const REQUEST_CLIENT_INFO_FILENAME = '20260706_000001_request_client_info.ts';
 export const CUSTOM_MODEL_TOOL_SUPPORT_FILENAME = '20260706_000002_custom_model_tool_support.ts';
+export const PROFILE_CHAIN_BACKFILL_FILENAME = '20260714_000001_profile_chain_backfill.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -33,4 +35,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: GITHUB_GPT41_CONTEXT_FILENAME, module: githubGpt41Context },
   { filename: REQUEST_CLIENT_INFO_FILENAME, module: requestClientInfo },
   { filename: CUSTOM_MODEL_TOOL_SUPPORT_FILENAME, module: customModelToolSupport },
+  { filename: PROFILE_CHAIN_BACKFILL_FILENAME, module: profileChainBackfill },
 ];

--- a/server/src/db/migrations/20260714_000001_profile_chain_backfill.ts
+++ b/server/src/db/migrations/20260714_000001_profile_chain_backfill.ts
@@ -1,0 +1,49 @@
+import type { Db } from '../types.js';
+
+const DOWNGRADE_MARKER_KEY = 'profile_chain_backfill_downgraded';
+
+/**
+ * The router prefers the active profile's `profile_models` chain, while the
+ * visible Models page historically edited `fallback_config`. New rows added by
+ * catalog sync or custom providers were therefore missing from the hidden active
+ * profile and never entered auto routing. Backfill every profile with any model
+ * rows it lacks, preserving the current fallback_config enabled flag for the
+ * initial auto-routing state.
+ */
+export function up(db: Db): void {
+  db.prepare('DELETE FROM settings WHERE key = ?').run(DOWNGRADE_MARKER_KEY);
+
+  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  if (profiles.length === 0) return;
+
+  const missing = db.prepare(`
+    SELECT m.id, f.enabled
+      FROM fallback_config f
+      JOIN models m ON m.id = f.model_db_id
+      LEFT JOIN profile_models pm ON pm.profile_id = ? AND pm.model_db_id = m.id
+     WHERE pm.id IS NULL
+     ORDER BY f.priority, m.id
+  `);
+  const maxPriority = db.prepare('SELECT COALESCE(MAX(priority), 0) AS max_priority FROM profile_models WHERE profile_id = ?');
+  const insert = db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, ?)');
+
+  for (const profile of profiles) {
+    const rows = missing.all(profile.id) as { id: number; enabled: number }[];
+    if (rows.length === 0) continue;
+    const max = maxPriority.get(profile.id) as { max_priority: number };
+    rows.forEach((row, index) => {
+      insert.run(profile.id, row.id, max.max_priority + index + 1, row.enabled);
+    });
+  }
+}
+
+export function down(db: Db): void {
+  // Removing rows on downgrade would discard user-managed profile order and
+  // enabled state. Older app versions ignore this marker, and the next upgrade
+  // removes it before re-running the backfill.
+  db.prepare(`
+    INSERT INTO settings (key, value)
+    VALUES (?, datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `).run(DOWNGRADE_MARKER_KEY);
+}

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -12,6 +12,7 @@ import { BANDIT_PRESETS, type RoutingStrategy } from '../services/scoring.js';
 import { parseBudget } from '../lib/budget.js';
 import { getModelGroups } from '../services/model-groups.js';
 import { getPenaltyInspector } from '../services/penalty-inspector.js';
+import { getActiveProfileId } from '../services/profile-models.js';
 
 export const fallbackRouter = Router();
 
@@ -63,7 +64,25 @@ fallbackRouter.put('/routing', (req: Request, res: Response) => {
 // Get fallback chain (with dynamic penalties)
 fallbackRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
-  const rows = db.prepare(`
+  const activeProfileId = getActiveProfileId(db);
+  let rows = activeProfileId == null ? [] : db.prepare(`
+    SELECT pm.model_db_id, pm.priority, pm.enabled,
+           m.platform, m.model_id, m.display_name, m.intelligence_rank,
+           m.speed_rank, m.size_label, m.rpm_limit, m.rpd_limit,
+           m.tpm_limit, m.tpd_limit, m.context_window,
+           m.monthly_token_budget, m.supports_vision, m.supports_tools,
+           m.key_id, ak.label AS key_label,
+           mo.overrides_json IS NOT NULL AS has_overrides
+    FROM profile_models pm
+    JOIN models m ON m.id = pm.model_db_id
+    LEFT JOIN api_keys ak ON ak.id = m.key_id
+    LEFT JOIN model_overrides mo ON mo.platform = m.platform AND mo.model_id = m.model_id
+    WHERE pm.profile_id = ? AND m.enabled = 1
+    ORDER BY pm.priority ASC
+  `).all(activeProfileId) as any[];
+
+  if (rows.length === 0) {
+    rows = db.prepare(`
     SELECT fc.model_db_id, fc.priority, fc.enabled,
            m.platform, m.model_id, m.display_name, m.intelligence_rank,
            m.speed_rank, m.size_label, m.rpm_limit, m.rpd_limit,
@@ -77,7 +96,8 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
     LEFT JOIN model_overrides mo ON mo.platform = m.platform AND mo.model_id = m.model_id
     WHERE m.enabled = 1
     ORDER BY fc.priority ASC
-  `).all() as any[];
+    `).all() as any[];
+  }
 
   // Count usable keys per platform — enabled AND healthy/unknown status. Unified
   // with /token-usage and the routing scorer (#456) so budget pooling is computed
@@ -160,13 +180,18 @@ fallbackRouter.put('/', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const update = db.prepare(`
-    UPDATE fallback_config SET priority = ?, enabled = ? WHERE model_db_id = ?
-  `);
+  const activeProfileId = getActiveProfileId(db);
+  const useProfile = activeProfileId != null && Boolean(
+    db.prepare('SELECT 1 FROM profile_models WHERE profile_id = ? LIMIT 1').get(activeProfileId),
+  );
+  const update = useProfile
+    ? db.prepare('UPDATE profile_models SET priority = ?, enabled = ? WHERE profile_id = ? AND model_db_id = ?')
+    : db.prepare('UPDATE fallback_config SET priority = ?, enabled = ? WHERE model_db_id = ?');
 
   const updateAll = db.transaction(() => {
     for (const entry of parsed.data) {
-      update.run(entry.priority, entry.enabled ? 1 : 0, entry.modelDbId);
+      if (useProfile) update.run(entry.priority, entry.enabled ? 1 : 0, activeProfileId, entry.modelDbId);
+      else update.run(entry.priority, entry.enabled ? 1 : 0, entry.modelDbId);
     }
   });
   updateAll();
@@ -216,6 +241,10 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
   const preset = String(req.params.preset);
   const db = getDb();
   let models: { id: number }[] = [];
+  const activeProfileId = getActiveProfileId(db);
+  const useProfile = activeProfileId != null && Boolean(
+    db.prepare('SELECT 1 FROM profile_models WHERE profile_id = ? LIMIT 1').get(activeProfileId),
+  );
 
   if (preset === 'budget') {
     const allModels = db.prepare(`SELECT id, monthly_token_budget, tpd_limit FROM models`).all() as any[];
@@ -230,10 +259,13 @@ fallbackRouter.post('/sort/:preset', (req: Request, res: Response) => {
     models = db.prepare(`SELECT m.id FROM models m ORDER BY ${orderBy}`).all() as { id: number }[];
   }
 
-  const update = db.prepare('UPDATE fallback_config SET priority = ? WHERE model_db_id = ?');
+  const update = useProfile
+    ? db.prepare('UPDATE profile_models SET priority = ? WHERE profile_id = ? AND model_db_id = ?')
+    : db.prepare('UPDATE fallback_config SET priority = ? WHERE model_db_id = ?');
   const reorder = db.transaction(() => {
     for (let i = 0; i < models.length; i++) {
-      update.run(i + 1, models[i].id);
+      if (useProfile) update.run(i + 1, activeProfileId, models[i].id);
+      else update.run(i + 1, models[i].id);
     }
   });
   reorder();

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -8,6 +8,7 @@ import { resolveProvider } from '../providers/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 import { parseKeysFromFile, stripJsoncComments, stripTrailingCommas } from '../lib/key-parser.js';
 import { assessProviderUrl } from '../lib/url-guard.js';
+import { ensureModelInProfiles } from '../services/profile-models.js';
 
 export const keysRouter = Router();
 
@@ -526,6 +527,7 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
         const max = db.prepare('SELECT COALESCE(MAX(priority), 0) AS m FROM fallback_config').get() as { m: number };
         db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(modelRow.id, max.m + 1);
       }
+      ensureModelInProfiles(db, modelRow.id);
 
       registered.push({
         modelDbId: modelRow.id,

--- a/server/src/routes/models.ts
+++ b/server/src/routes/models.ts
@@ -10,6 +10,7 @@ import {
   upsertModelOverrides,
   type ModelOverridePatch,
 } from '../services/model-state.js';
+import { getActiveProfileId } from '../services/profile-models.js';
 
 export const modelsRouter = Router();
 
@@ -142,8 +143,14 @@ modelsRouter.patch('/:id', (req: Request, res: Response) => {
     }
 
     if (parsed.data.fallbackEnabled !== undefined) {
+      const next = parsed.data.fallbackEnabled ? 1 : 0;
       db.prepare('UPDATE fallback_config SET enabled = ? WHERE model_db_id = ?')
-        .run(parsed.data.fallbackEnabled ? 1 : 0, id);
+        .run(next, id);
+      const activeProfileId = getActiveProfileId(db);
+      if (activeProfileId != null) {
+        db.prepare('UPDATE profile_models SET enabled = ? WHERE profile_id = ? AND model_db_id = ?')
+          .run(next, activeProfileId, id);
+      }
     }
   });
   applyUpdate();
@@ -181,7 +188,8 @@ modelsRouter.delete('/:id', (req: Request, res: Response) => {
 // List all models with availability info
 modelsRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
-  const models = db.prepare(`
+  const activeProfileId = getActiveProfileId(db);
+  const models = activeProfileId == null ? db.prepare(`
     SELECT m.*, fc.priority, fc.enabled as fallback_enabled,
            mo.overrides_json IS NOT NULL AS has_overrides,
            ak.label AS key_label
@@ -190,7 +198,18 @@ modelsRouter.get('/', (_req: Request, res: Response) => {
     LEFT JOIN model_overrides mo ON mo.platform = m.platform AND mo.model_id = m.model_id
     LEFT JOIN api_keys ak ON ak.id = m.key_id
     ORDER BY COALESCE(fc.priority, m.intelligence_rank) ASC
-  `).all() as any[];
+  `).all() as any[] : db.prepare(`
+    SELECT m.*, COALESCE(pm.priority, fc.priority) AS priority,
+           COALESCE(pm.enabled, fc.enabled) AS fallback_enabled,
+           mo.overrides_json IS NOT NULL AS has_overrides,
+           ak.label AS key_label
+    FROM models m
+    LEFT JOIN fallback_config fc ON fc.model_db_id = m.id
+    LEFT JOIN profile_models pm ON pm.profile_id = ? AND pm.model_db_id = m.id
+    LEFT JOIN model_overrides mo ON mo.platform = m.platform AND mo.model_id = m.model_id
+    LEFT JOIN api_keys ak ON ak.id = m.key_id
+    ORDER BY COALESCE(pm.priority, fc.priority, m.intelligence_rank) ASC
+  `).all(activeProfileId) as any[];
 
   // Count keys per platform
   const keyCounts = db.prepare(`

--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -11,6 +11,7 @@ import {
   deleteTombstonedCatalogModels,
   isCatalogModelTombstoned,
 } from './model-state.js';
+import { ensureAllModelsInProfiles } from './profile-models.js';
 
 // Generative-media modalities are routed into the separate media_models table
 // (see services/media.ts), never into the chat `models` table.
@@ -284,6 +285,7 @@ export function applyCatalog(db: Db, catalog: Catalog): NonNullable<SyncResult['
       const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
       missingFb.forEach((r, i) => addFb.run(r.id, maxPriority + 1 + i));
     }
+    ensureAllModelsInProfiles(db);
 
     // Remove catalog-managed models that the catalog no longer lists.
     const candidates = db

--- a/server/src/services/profile-models.ts
+++ b/server/src/services/profile-models.ts
@@ -1,0 +1,51 @@
+import type { Db } from '../db/types.js';
+
+export function getActiveProfileId(db: Db): number | null {
+  const setting = db.prepare("SELECT value FROM settings WHERE key = 'active_profile_id'").get() as { value: string } | undefined;
+  if (!setting) return null;
+  const profileId = parseInt(setting.value, 10);
+  if (!Number.isInteger(profileId)) return null;
+  const profile = db.prepare('SELECT id FROM profiles WHERE id = ?').get(profileId) as { id: number } | undefined;
+  return profile ? profileId : null;
+}
+
+export function ensureModelInProfiles(db: Db, modelDbId: number): void {
+  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  const fallback = db.prepare('SELECT enabled FROM fallback_config WHERE model_db_id = ?').get(modelDbId) as { enabled: number } | undefined;
+  if (!fallback) return;
+
+  const exists = db.prepare('SELECT 1 FROM profile_models WHERE profile_id = ? AND model_db_id = ?');
+  const maxPriority = db.prepare('SELECT COALESCE(MAX(priority), 0) AS max_priority FROM profile_models WHERE profile_id = ?');
+  const insert = db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, ?)');
+
+  for (const profile of profiles) {
+    if (exists.get(profile.id, modelDbId)) continue;
+    const max = maxPriority.get(profile.id) as { max_priority: number };
+    insert.run(profile.id, modelDbId, max.max_priority + 1, fallback.enabled);
+  }
+}
+
+export function ensureAllModelsInProfiles(db: Db): void {
+  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  if (profiles.length === 0) return;
+
+  const missing = db.prepare(`
+    SELECT m.id, f.enabled
+      FROM fallback_config f
+      JOIN models m ON m.id = f.model_db_id
+      LEFT JOIN profile_models pm ON pm.profile_id = ? AND pm.model_db_id = m.id
+     WHERE pm.id IS NULL
+     ORDER BY f.priority, m.id
+  `);
+  const maxPriority = db.prepare('SELECT COALESCE(MAX(priority), 0) AS max_priority FROM profile_models WHERE profile_id = ?');
+  const insert = db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, ?)');
+
+  for (const profile of profiles) {
+    const rows = missing.all(profile.id) as { id: number; enabled: number }[];
+    if (rows.length === 0) continue;
+    const max = maxPriority.get(profile.id) as { max_priority: number };
+    rows.forEach((row, index) => {
+      insert.run(profile.id, row.id, max.max_priority + index + 1, row.enabled);
+    });
+  }
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -10,6 +10,7 @@ import {
 import { parseBudget } from '../lib/budget.js';
 import { platformDropsResponseFormat } from '../lib/sampling-params.js';
 import { isUnifyEnabled, getModelGroups, resolveRequestedIdToMembers } from './model-groups.js';
+import { getActiveProfileId } from './profile-models.js';
 import type { BaseProvider } from '../providers/base.js';
 import type { Platform } from '@freellmapi/shared/types.js';
 import type { Db } from '../db/types.js';
@@ -528,9 +529,8 @@ const GLOBAL_SORT_ALIASES: Record<string, string> = {
 };
 
 function getActiveChain(db: Db): ChainRow[] {
-  const activeProfileSetting = db.prepare("SELECT value FROM settings WHERE key = 'active_profile_id'").get() as { value: string } | undefined;
-  if (activeProfileSetting) {
-    const profileId = parseInt(activeProfileSetting.value, 10);
+  const profileId = getActiveProfileId(db);
+  if (profileId != null) {
     const chain = db.prepare(`
       SELECT pm.model_db_id, pm.priority, pm.enabled,
              m.platform, m.model_id, m.display_name, m.intelligence_rank,
@@ -824,12 +824,11 @@ export function routePinnedModel(modelDbId: number, estimatedTokens = 1000, skip
 
 /**
  * Resolve a logical model group's member db ids to an ordered ChainRow[] for
- * strict group-pin routing (the "unify" feature). Each enabled member is
- * hydrated as a ChainRow carrying its REAL fallback_config.priority, then
- * ordered by the active strategy via orderChain — so 'priority' honors the
- * manual within-group order and scored strategies use live scores (priority as
- * the tiebreaker). Members disabled in the chain (fallback_config.enabled = 0)
- * are dropped.
+ * strict group-pin routing (the "unify" feature). Each catalog-enabled member
+ * is hydrated as a ChainRow carrying its active-profile/manual priority, then
+ * ordered by the active strategy via orderChain. Auto-chain enabled/disabled is
+ * intentionally ignored here because an explicit model request should still be
+ * able to use a direct model that the user removed from auto routing.
  *
  * Pass the result to routeRequest() as `prefetchedChain` and DO NOT pass a
  * `preferredModelDbId` that isn't already one of these rows — otherwise the
@@ -841,22 +840,36 @@ export function resolveModelGroupCandidates(memberDbIds: number[]): ChainRow[] {
   const strategy = getRoutingStrategy();
   if (strategy !== 'priority') refreshStatsCache(db);
 
-  const selectMember = db.prepare(`
-    SELECT m.id as model_db_id, COALESCE(fc.priority, 0) as priority,
-           COALESCE(fc.enabled, 1) as enabled,
-           m.platform, m.model_id, m.display_name, m.intelligence_rank,
-           m.size_label, m.monthly_token_budget,
-           m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit, m.supports_vision,
-           m.supports_tools, m.context_window, m.key_id
-    FROM models m
-    LEFT JOIN fallback_config fc ON fc.model_db_id = m.id
-    WHERE m.id = ? AND m.enabled = 1
-  `);
+  const activeProfileId = getActiveProfileId(db);
+  const selectMember = activeProfileId == null
+    ? db.prepare(`
+      SELECT m.id as model_db_id, COALESCE(fc.priority, 0) as priority,
+             1 as enabled,
+             m.platform, m.model_id, m.display_name, m.intelligence_rank,
+             m.size_label, m.monthly_token_budget,
+             m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit, m.supports_vision,
+             m.supports_tools, m.context_window, m.key_id
+      FROM models m
+      LEFT JOIN fallback_config fc ON fc.model_db_id = m.id
+      WHERE m.id = ? AND m.enabled = 1
+    `)
+    : db.prepare(`
+      SELECT m.id as model_db_id, COALESCE(pm.priority, fc.priority, 0) as priority,
+             1 as enabled,
+             m.platform, m.model_id, m.display_name, m.intelligence_rank,
+             m.size_label, m.monthly_token_budget,
+             m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit, m.supports_vision,
+             m.supports_tools, m.context_window, m.key_id
+      FROM models m
+      LEFT JOIN profile_models pm ON pm.profile_id = ? AND pm.model_db_id = m.id
+      LEFT JOIN fallback_config fc ON fc.model_db_id = m.id
+      WHERE m.id = ? AND m.enabled = 1
+    `);
 
   const rows: ChainRow[] = [];
   for (const id of memberDbIds) {
-    const row = selectMember.get(id) as ChainRow | undefined;
-    if (row && row.enabled) rows.push(row);
+    const row = (activeProfileId == null ? selectMember.get(id) : selectMember.get(activeProfileId, id)) as ChainRow | undefined;
+    if (row) rows.push(row);
   }
   return orderChain(rows, strategy);
 }
@@ -989,7 +1002,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   const strategy = getRoutingStrategy();
   if (strategy !== 'priority') refreshStatsCache(db);
 
-  const chain = prefetchedChain ?? getActiveChain(db).filter(e => e.enabled);
+  const chain = (prefetchedChain ?? getActiveChain(db)).filter(e => e.enabled);
 
   const sortedChain = orderChain(chain, strategy);
 
@@ -1109,16 +1122,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
   const strategy = getRoutingStrategy();
   refreshStatsCache(db);
 
-  const chain = db.prepare(`
-    SELECT fc.model_db_id, fc.priority, fc.enabled,
-           m.platform, m.model_id, m.display_name, m.intelligence_rank,
-           m.size_label, m.monthly_token_budget,
-           m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit, m.supports_vision,
-           m.supports_tools, m.context_window
-    FROM fallback_config fc
-    JOIN models m ON m.id = fc.model_db_id
-    WHERE m.enabled = 1
-  `).all() as ChainRow[];
+  const chain = getActiveChain(db);
 
   // For display we score under 'balanced' weights when in priority mode, so the
   // table still shows a meaningful ranking even with the bandit turned off.
@@ -1159,13 +1163,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
 // the generic exhaustion message when none is configured (#118, #125).
 export function hasEnabledVisionModel(): boolean {
   const db = getDb();
-  const row = db.prepare(`
-    SELECT COUNT(*) as cnt
-    FROM fallback_config fc
-    JOIN models m ON m.id = fc.model_db_id
-    WHERE fc.enabled = 1 AND m.enabled = 1 AND m.supports_vision = 1
-  `).get() as { cnt: number };
-  return row.cnt > 0;
+  return getActiveChain(db).some(entry => entry.enabled === 1 && entry.supports_vision === 1);
 }
 
 // Whether at least one tool-capable model is enabled in the fallback chain.
@@ -1173,11 +1171,5 @@ export function hasEnabledVisionModel(): boolean {
 // requests beats routing them to a model that mangles the tool call.
 export function hasEnabledToolsModel(): boolean {
   const db = getDb();
-  const row = db.prepare(`
-    SELECT COUNT(*) as cnt
-    FROM fallback_config fc
-    JOIN models m ON m.id = fc.model_db_id
-    WHERE fc.enabled = 1 AND m.enabled = 1 AND m.supports_tools = 1
-  `).get() as { cnt: number };
-  return row.cnt > 0;
+  return getActiveChain(db).some(entry => entry.enabled === 1 && entry.supports_tools === 1);
 }


### PR DESCRIPTION
## Summary
- make `/api/fallback` read/write the active profile chain so the dashboard and router use the same order
- backfill profile chains for catalog/custom models that are in `fallback_config`
- let explicit model/group requests ignore the auto-routing enabled toggle while still requiring catalog availability and usable keys
- always filter disabled chain rows during auto routing, including prefetched chains

## Tests
- `npm run test -w server -- src/__tests__/routes/routing-semantics.test.ts`
- `npm run test -w server -- src/__tests__/db/migrate/roundtrip.test.ts`
- `npm run test -w server`
- `npm run build -w server -- --pretty false`
