### PR TITLE
Add SEA-LION provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **One OpenAI-compatible endpoint. 28 free LLM providers. 339 free model endpoints. ~4 billion tokens per month.**
 
-Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, OVH AI Endpoints, OpenCode Zen, AI Horde, NaraRouter, Aion Labs, Requesty, NavyAI, Agnes AI, Reka, SiliconFlow, Routeway, BazaarLink, and AINative Studio, plus custom OpenAI-compatible chat, embedding, image, and audio endpoints, behind a single `/v1` API. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
+Aggregate the free tiers from Google, Groq, Cerebras, NVIDIA, Mistral, OpenRouter, GitHub Models, Cohere, Cloudflare, HuggingFace, Z.ai (Zhipu), Ollama, Kilo, Pollinations, LLM7, OVH AI Endpoints, OpenCode Zen, AI Horde, NaraRouter, Aion Labs, Requesty, NavyAI, Agnes AI, Reka, SiliconFlow, Routeway, BazaarLink, AINative Studio, and SEA-LION, plus custom OpenAI-compatible chat, embedding, image, and audio endpoints, behind a single `/v1` API. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
 [![CI](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml/badge.svg)](https://github.com/tashfeenahmed/freellmapi/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/tashfeenahmed/freellmapi?style=flat&logo=github&color=yellow)](https://github.com/tashfeenahmed/freellmapi/stargazers)
@@ -97,6 +97,9 @@ And the free-tier landscape shifts weekly: providers launch models, retire them,
 <td align="center"><a href="https://routeway.ai"><b>Routeway</b><br/>Router free tier</a></td>
 <td align="center"><a href="https://bazaarlink.ai"><b>BazaarLink</b><br/>Auto free router</a></td>
 <td align="center"><a href="https://ainative.studio"><b>AINative Studio</b><br/>Qwen · DeepSeek · Llama</a></td>
+</tr>
+<tr>
+<td align="center"><a href="https://sea-lion.ai"><b>SEA-LION</b><br/>SEA-multilingual (key, no card)</a></td>
 </tr>
 </table>
 

--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -53,6 +53,7 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'requesty', label: 'Requesty (free key)', url: 'https://www.requesty.ai' },
   { value: 'navy', label: 'NavyAI (free key)', url: 'https://api.navy' },
   { value: 'nara', label: 'NaraRouter (free key)', url: 'https://router.bynara.id' },
+  { value: 'sealion', label: 'SEA-LION (free key)', url: 'https://sea-lion.ai' },
   { value: 'aihorde', label: 'AI Horde (no key needed, slow)', url: 'https://aihorde.net/register', keyless: true },
 ]
 

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -167,6 +167,7 @@ export const platformColors: Record<string, string> = {
   requesty:    '#10b981',
   navy:         '#1d4ed8',
   nara:         '#2563eb',
+  sealion:     '#0ea5e9',
   aihorde:     '#dc2626',
 }
 

--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -41,6 +41,7 @@ describe('key parser', () => {
     expect(detectPlatform('AIONLABS_')).toBe('aion');
     expect(detectPlatform('REQUESTY_')).toBe('requesty');
     expect(detectPlatform('NAVYAI_')).toBe('navy');
+    expect(detectPlatform('SEALION_')).toBe('sealion');
     expect(detectPlatform('SAMBANOVA_')).toBeNull();
   });
 
@@ -50,6 +51,7 @@ describe('key parser', () => {
     expect(AUTH_JSON_PROVIDER_MAP['aion-labs']).toBe('aion');
     expect(AUTH_JSON_PROVIDER_MAP['requesty']).toBe('requesty');
     expect(AUTH_JSON_PROVIDER_MAP['api-navy']).toBe('navy');
+    expect(AUTH_JSON_PROVIDER_MAP['sea-lion']).toBe('sealion');
     const result = parseAuthJson(JSON.stringify({
       credential_pool: {
         gemini: [{ id: '1', label: 'Gemini', auth_type: 'api_key', access_token: 'AIza-test' }],

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -500,6 +500,7 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'requesty',   name: 'Requesty',      baseUrl: 'https://router.requesty.ai/v1' },
     { platform: 'navy',       name: 'NavyAI',        baseUrl: 'https://api.navy/v1' },
     { platform: 'nara',       name: 'NaraRouter',    baseUrl: 'https://router.bynara.id/v1' },
+    { platform: 'sealion',    name: 'SEA-LION',      baseUrl: 'https://api.sea-lion.ai/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -42,6 +42,8 @@ export const PREFIX_MAP: Record<string, string> = {
   NARA_: 'nara',
   NARAROUTER_: 'nara',
   BYNARA_: 'nara',
+  SEALION_: 'sealion',
+  SEA_LION_: 'sealion',
   AIHORDE_: 'aihorde',
 };
 
@@ -65,6 +67,8 @@ export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
   nara: 'nara',
   bynara: 'nara',
   'nara-router': 'nara',
+  sealion: 'sealion',
+  'sea-lion': 'sealion',
 };
 
 export function detectPlatform(prefix: string): string | null {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -326,6 +326,16 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://router.bynara.id/v1',
 }));
 
+// SEA-LION (AI Singapore) — OpenAI-compatible first-party API (api.sea-lion.ai/v1).
+// Free key from sea-lion.ai (Google sign-in, no card, no region wall); recurring
+// free tier at 10 RPM. Catalog rows live in the Oracle catalog (premium now, free
+// after the 30-day model-age gate).
+register(new OpenAICompatProvider({
+  platform: 'sealion',
+  name: 'SEA-LION',
+  baseUrl: 'https://api.sea-lion.ai/v1',
+}));
+
 // AI Horde — free, community-powered inference (volunteer workers) via an
 // OpenAI-compatible proxy. Dedicated AIHordeProvider (not OpenAICompatProvider)
 // because the proxy is queue-based and diverges from the OpenAI contract:

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -20,7 +20,7 @@ const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
-  'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'aihorde', 'custom',
+  'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'aihorde', 'custom',
 ] as const;
 
 const ALLOWED_IMPORT_EXTENSIONS = new Set(['.env', '.json', '.jsonc', '.md', '.txt', '.csv']);

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -140,11 +140,12 @@ function inferPoolForPlatform(platform: Platform, modelId?: string | null): stri
   if (platform === 'requesty') return 'requesty::free';
   if (platform === 'navy') return 'navy::free';
   if (platform === 'nara') return 'nara::free';
+  if (platform === 'sealion') return 'sealion::free';
   return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'aihorde'].includes(platform);
+  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'aihorde'].includes(platform);
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -98,6 +98,10 @@ export type Platform =
   // router.bynara.id after Telegram channel/link verification; free-plan routes
   // reset daily and are catalog-managed (premium now, free after 30 days).
   | 'nara'
+  // SEA-LION (AI Singapore) — OpenAI-compatible first-party API. Free key
+  // (Google sign-in, no card, no region wall) at 10 RPM; catalog rows live in
+  // the Oracle catalog (premium now, free after 30 days).
+  | 'sealion'
   // AI Horde — free, community-powered inference (volunteer workers) via an
   // OpenAI-compatible proxy (https://oai.aihorde.net/v1). Queue-based, so calls
   // can take tens of seconds; no tool support; usage is reported as kudos, not


### PR DESCRIPTION
Add SEA-LION (AI Singapore) as an OpenAI-compatible provider (api.sea-lion.ai/v1). Free key, no card, 10 RPM. Model rows ship via the live catalog.