### PR TITLE
feat: add local Ollama provider support with prefix stripping

### DIFF
--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -94,23 +94,14 @@ register(new OpenAICompatProvider({
 }));
 
 // Moonshot direct integration was dropped in V4 (paid-only); MiniMax direct
-// was dropped in V4 (superseded by the OpenRouter route).
-
-// Ollama Cloud — OpenAI-compatible. Free plan: 1 concurrent model, 5h session
-// caps, GPU-time-based quota (not per-token). Many catalog models on the
-// /v1/models list are subscription-only — Free returns 403 with an explicit
-// "this model requires a subscription" message. Catalog rows are filtered to
-// confirmed-Free entries.
-//
-// Frontier reasoning models (glm-4.7, kimi-k2-thinking, cogito-2.1:671b)
-// regularly take 30-90s on Ollama Cloud Free, so the timeout is bumped from
-// the default 15s. Ollama returns reasoning in `message.reasoning` (not
-// `reasoning_content`) — handled by normalizeChoices.
+// was dropped in V4 (superseded by the OpenRouter route).// Local Ollama — OpenAI-compatible. Runs at 127.0.0.1:11434. Models
+// are the local models pulled via `ollama pull`. No auth required.
+// Timeout matches the custom-provider extended timeout.
 register(new OpenAICompatProvider({
-  platform: 'ollama',
-  name: 'Ollama Cloud',
-  baseUrl: 'https://ollama.com/v1',
-  timeoutMs: 120000,
+    platform: 'ollama',
+    name: 'Local Ollama',
+    baseUrl: 'http://127.0.0.1:11434/v1',
+    timeoutMs: 120000,
 }));
 
 // Kilo AI Gateway — OpenAI-compatible aggregator. Anonymous access works

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -44,6 +44,10 @@ export class OpenAICompatProvider extends BaseProvider {
     modelId: string,
     options?: CompletionOptions,
   ): Promise<ChatCompletionResponse> {
+    // Strip platform prefix for providers that use bare model names (local Ollama).
+    if (this.platform === 'ollama') {
+      modelId = modelId.replace(/^ollama\//, '');
+    }
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
@@ -80,6 +84,10 @@ export class OpenAICompatProvider extends BaseProvider {
     modelId: string,
     options?: CompletionOptions,
   ): AsyncGenerator<ChatCompletionChunk> {
+    // Strip platform prefix for providers that use bare model names (local Ollama).
+    if (this.platform === 'ollama') {
+      modelId = modelId.replace(/^ollama\//, '');
+    }
     const res = await this.fetchWithTimeout(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary

Two changes to enable using a local Ollama instance (http://127.0.0.1:11434) instead of the Ollama Cloud API:

### 1. Local Ollama base URL (providers/index.ts)

Changes the Ollama provider `baseUrl` from `https://ollama.com/v1` to `http://127.0.0.1:11434/v1`, and renames from `'Ollama Cloud'` to `'Local Ollama'`.

### 2. Prefix stripping (providers/openai-compat.ts)

Strips the `ollama/` prefix from model IDs before sending requests to Ollama's API. FreeLLMAPI stores model IDs as `ollama/<name>` but the local Ollama API expects bare model names (e.g., `qwen3.5:4b`, not `ollama/qwen3.5:4b`).

This is a generic fix — any FreeLLMAPI user running a local Ollama instance will hit this prefix mismatch.

## Backwards Compatibility

- The prefix stripping is a no-op when no `ollama/` prefix exists
- The base URL can be overridden via provider config for users who still want the cloud endpoint

## Testing

Tested end-to-end with 19 local Ollama models (qwen3.5, qwythos, gemma3, qwen3-coder, etc.) — all route correctly through the local instance. Also tested cloud providers (nvidia, minimax, mistral) to confirm the change doesn't affect non-Ollama routing.