### PR TITLE
chore: prep v0.5.0 release

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bump desktop to 0.5.0 for the v0.5.0 release installers.
