### PR TITLE
ci(desktop): fall back to unsigned DMG when Apple signing secrets are absent

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -130,6 +130,14 @@ jobs:
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
         run: |
           set -e
+          # Unconfigured secrets arrive as EMPTY env vars, and electron-builder
+          # treats a present-but-empty CSC_LINK as a certificate path — failing
+          # with "<dir> not a file" on any non-PR build (PR builds never hit it
+          # because electron-builder skips signing for pull requests). Drop empty
+          # signing vars so unsigned builds actually build unsigned.
+          for v in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID APPLE_KEYCHAIN APPLE_KEYCHAIN_PROFILE; do
+            if [ -z "${!v:-}" ]; then unset "$v"; fi
+          done
           # Run electron-builder with desktop/ as its own project root. Invoked
           # from the monorepo root (e.g. via `npm --prefix desktop run`), it walks
           # up, treats the repo root as the project, and on Windows pulls parent

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -65,6 +65,7 @@ jobs:
           npm --prefix desktop run stage:client
 
       - name: Validate macOS signing credentials
+        id: maccreds
         if: matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
@@ -78,9 +79,14 @@ jobs:
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
         run: |
           set -euo pipefail
+          # No signing cert at all → fall back to an unsigned DMG rather than
+          # failing the release (users bypass Gatekeeper via right-click → Open
+          # or xattr -d com.apple.quarantine). Signing cert present but broken
+          # notarization config is still a hard error — that's a misconfiguration.
           if [ -z "${CSC_LINK:-}" ]; then
-            echo "Missing MACOS_CSC_LINK secret for signed macOS release builds."
-            exit 1
+            echo "::warning::No MACOS_CSC_LINK secret — building an UNSIGNED DMG. Configure Apple Developer ID signing + notarization secrets for a Gatekeeper-clean release."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           has_api_key_creds=false
@@ -102,14 +108,16 @@ jobs:
             echo "Missing Apple notarization secrets. Provide APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER, APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID, or APPLE_KEYCHAIN_PROFILE."
             exit 1
           fi
+          echo "signed=true" >> "$GITHUB_OUTPUT"
 
       - name: Package installer
         shell: bash
         env:
           # Pull-request and manual artifact builds stay unsigned. Tagged macOS
-          # release builds must use Developer ID signing + notarization so the
-          # downloaded DMG opens without Gatekeeper's "damaged" quarantine block.
-          CSC_IDENTITY_AUTODISCOVERY: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/') && 'true' || 'false' }}
+          # release builds sign + notarize when the Apple secrets are configured
+          # (so the downloaded DMG opens without Gatekeeper's "damaged" quarantine
+          # block) and fall back to an unsigned DMG when they aren't.
+          CSC_IDENTITY_AUTODISCOVERY: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/') && steps.maccreds.outputs.signed == 'true' && 'true' || 'false' }}
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}


### PR DESCRIPTION
Tagged macOS release builds have hard-failed since the signing-credential validation landed on 2026-06-27, because the repo has no Apple secrets configured — that's why no DMG shipped after v0.4.1 (v0.5.0's tag build hit the same wall; its DMG was attached from a manual unsigned build).

- No `MACOS_CSC_LINK` at all → `::warning` + build an **unsigned** DMG (same as v0.4.1), instead of failing the release.
- Cert present but notarization creds missing → still a hard error (misconfiguration).
- `CSC_IDENTITY_AUTODISCOVERY` now keys off the validation step's `signed` output.
