### PR TITLE
Adopt community fixes: Docker proxy undici, configurable provider timeouts, NIM DEGRADED 400

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,23 @@ PORT=3001
 # set to 0 to disable the cap. Example — cap OpenRouter at 50 requests/day:
 # PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50
 
+# Per-provider chat HTTP timeout in milliseconds, named
+# PROVIDER_TIMEOUT_<PLATFORM> (platform name upper-cased). Overrides the
+# built-in default for that provider (60s for most OpenAI-compatible platforms,
+# 90s NVIDIA, 120s Ollama Cloud / AI Horde / custom providers, 60s Google as
+# registered). Set to 0 to disable the timeout entirely. Read at startup.
+# Example — give NVIDIA NIM's slow reasoning models 5 minutes:
+# PROVIDER_TIMEOUT_NVIDIA=300000
+
+# Mid-stream inactivity timeout for streaming responses, in milliseconds
+# (default: 90000). If an SSE stream goes this long without a single byte, the
+# gateway gives up on it (before any output reached the client this fails over
+# to the next candidate; after output was sent the stream ends with an error
+# frame). Providers that queue heavily on their free tiers can pause longer
+# than 90s mid-stream — raise this if streamed responses stop early. Set to 0
+# to disable the stall watchdog entirely.
+# PROVIDER_STREAM_STALL_TIMEOUT_MS=90000
+
 # Wall-clock budget for provider failover, in milliseconds (default: 45000).
 # A request that keeps failing over stops STARTING new attempts once this much
 # time has passed and returns the exhaustion error instead (the first attempt

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ ENV PORT=3001
 
 COPY --from=build --chown=node:node /app/package.json /app/package-lock.json ./
 COPY --from=build --chown=node:node /app/node_modules ./node_modules
+# npm nests some production packages under the workspace instead of hoisting
+# them (undici lives at server/node_modules/undici). Skipping this copy shipped
+# images where the HTTP(S) proxy dispatcher failed to load and every request
+# silently went direct — issue #550.
+COPY --from=build --chown=node:node /app/server/node_modules ./server/node_modules
 COPY --from=build --chown=node:node /app/shared ./shared
 COPY --from=build --chown=node:node /app/server/package.json ./server/package.json
 COPY --from=build --chown=node:node /app/server/dist ./server/dist

--- a/README.md
+++ b/README.md
@@ -847,6 +847,11 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full migration CLI and workflow
 <a href="https://github.com/RobinHoodO"><img src="https://images.weserv.nl/?url=github.com/RobinHoodO.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@RobinHoodO" /></a>
 <a href="https://github.com/hmm183"><img src="https://images.weserv.nl/?url=github.com/hmm183.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@hmm183" /></a>
 <a href="https://github.com/duemilionidieuro-bot"><img src="https://images.weserv.nl/?url=github.com/duemilionidieuro-bot.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@duemilionidieuro-bot" /></a>
+<a href="https://github.com/cagedbird043"><img src="https://images.weserv.nl/?url=github.com/cagedbird043.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@cagedbird043" /></a>
+<a href="https://github.com/jasnoorgill"><img src="https://images.weserv.nl/?url=github.com/jasnoorgill.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@jasnoorgill" /></a>
+<a href="https://github.com/Joey9024"><img src="https://images.weserv.nl/?url=github.com/Joey9024.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Joey9024" /></a>
+<a href="https://github.com/AskingConical"><img src="https://images.weserv.nl/?url=github.com/AskingConical.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@AskingConical" /></a>
+<a href="https://github.com/ProAlit"><img src="https://images.weserv.nl/?url=github.com/ProAlit.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@ProAlit" /></a>
 <a href="https://github.com/hjhhoni"><img src="https://images.weserv.nl/?url=github.com/hjhhoni.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@hjhhoni" /></a>
 <a href="https://github.com/immanuelsavio"><img src="https://images.weserv.nl/?url=github.com/immanuelsavio.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@immanuelsavio" /></a>
 <a href="https://github.com/Slyker"><img src="https://images.weserv.nl/?url=github.com/Slyker.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@Slyker" /></a>

--- a/server/src/__tests__/lib/degraded-error.test.ts
+++ b/server/src/__tests__/lib/degraded-error.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+// Issue #522: NVIDIA NIM reports a temporarily-degraded hosted deployment as
+// `400 {"detail":"Function id '...': DEGRADED function cannot be invoked"}`.
+// That is provider health, not request shape — it must stay retryable, must
+// NOT classify as provider_bad_request, and an exhausted chain must render a
+// 503, never a client-blaming 400 invalid_request_error.
+
+vi.mock('../../services/health.js', () => ({ checkKeyHealth: vi.fn() }));
+
+import { initDb } from '../../db/index.js';
+import {
+  isProviderBadRequestError,
+  isProviderDegradedError,
+  isRetryableError,
+} from '../../lib/error-classify.js';
+import { classifyAttemptError, exhaustedRetryError } from '../../lib/fallback-loop.js';
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = '0'.repeat(64);
+  initDb(':memory:');
+});
+
+function nimDegraded400(): Error & { status?: number } {
+  const err = new Error(
+    "NVIDIA NIM API error 400: Function id 'abc-123': DEGRADED function cannot be invoked",
+  ) as Error & { status?: number };
+  err.status = 400;
+  return err;
+}
+
+function plainBadRequest400(): Error & { status?: number } {
+  const err = new Error('Groq API error 400: max_tokens must be a positive integer') as Error & { status?: number };
+  err.status = 400;
+  return err;
+}
+
+describe('isProviderDegradedError', () => {
+  it('matches the NIM DEGRADED-function 400 shape', () => {
+    expect(isProviderDegradedError(nimDegraded400())).toBe(true);
+  });
+
+  it('does not match an ordinary provider 400', () => {
+    expect(isProviderDegradedError(plainBadRequest400())).toBe(false);
+  });
+});
+
+describe('degraded 400 classification', () => {
+  it('stays retryable so the failover chain continues', () => {
+    expect(isRetryableError(nimDegraded400())).toBe(true);
+  });
+
+  it('is excluded from provider_bad_request', () => {
+    expect(isProviderBadRequestError(nimDegraded400())).toBe(false);
+    expect(isProviderBadRequestError(plainBadRequest400())).toBe(true);
+  });
+
+  it('shows up as upstream_error in the attempt trail', () => {
+    expect(classifyAttemptError(nimDegraded400())).toBe('upstream_error');
+    expect(classifyAttemptError(plainBadRequest400())).toBe('provider_bad_request');
+  });
+});
+
+describe('exhaustedRetryError on a degraded last error', () => {
+  it('renders 503 service_unavailable instead of 400 invalid_request_error', () => {
+    const body = exhaustedRetryError(nimDegraded400(), 3);
+    expect(body.status).toBe(503);
+    expect(body.type).toBe('service_unavailable');
+    expect(body.kind).toBe('unavailable');
+    expect(body.message).toContain('degraded');
+  });
+
+  it('still renders 400 invalid_request_error for a genuine whole-chain bad request', () => {
+    const body = exhaustedRetryError(plainBadRequest400(), 3);
+    expect(body.status).toBe(400);
+    expect(body.type).toBe('invalid_request_error');
+  });
+});

--- a/server/src/__tests__/lib/provider-timeout.test.ts
+++ b/server/src/__tests__/lib/provider-timeout.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_STREAM_STALL_TIMEOUT_MS,
+  providerTimeoutEnvName,
+  providerTimeoutMs,
+  resetTimeoutWarnings,
+  streamStallTimeoutMs,
+} from '../../lib/provider-timeout.js';
+
+// Per-provider timeout overrides (issue #547, reworked from PR #509).
+
+afterEach(() => {
+  delete process.env.PROVIDER_TIMEOUT_NVIDIA;
+  delete process.env.PROVIDER_TIMEOUT_GROQ;
+  delete process.env.PROVIDER_STREAM_STALL_TIMEOUT_MS;
+  resetTimeoutWarnings();
+  vi.restoreAllMocks();
+});
+
+describe('providerTimeoutEnvName', () => {
+  it('upper-cases the platform', () => {
+    expect(providerTimeoutEnvName('nvidia')).toBe('PROVIDER_TIMEOUT_NVIDIA');
+    expect(providerTimeoutEnvName('aihorde')).toBe('PROVIDER_TIMEOUT_AIHORDE');
+  });
+});
+
+describe('providerTimeoutMs', () => {
+  it('returns the built-in default when the env var is unset', () => {
+    expect(providerTimeoutMs('nvidia', 90_000)).toBe(90_000);
+  });
+
+  it('lets the env override win over the default', () => {
+    process.env.PROVIDER_TIMEOUT_NVIDIA = '300000';
+    expect(providerTimeoutMs('nvidia', 90_000)).toBe(300_000);
+  });
+
+  it('accepts 0 as "no timeout"', () => {
+    process.env.PROVIDER_TIMEOUT_NVIDIA = '0';
+    expect(providerTimeoutMs('nvidia', 90_000)).toBe(0);
+  });
+
+  it('ignores negative, fractional, and non-numeric values (warns once, keeps default)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const bad of ['-1', '1.5', 'ninety', '']) {
+      process.env.PROVIDER_TIMEOUT_NVIDIA = bad;
+      expect(providerTimeoutMs('nvidia', 90_000)).toBe(90_000);
+    }
+    // '' is treated as unset (no warning); the three malformed values share one
+    // env name, so the warn-once gate fires exactly once.
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns on sub-second values that would abort nearly every request, but honors them', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.PROVIDER_TIMEOUT_GROQ = '500';
+    expect(providerTimeoutMs('groq', 60_000)).toBe(500);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('streamStallTimeoutMs', () => {
+  it('defaults to 90s', () => {
+    expect(streamStallTimeoutMs()).toBe(DEFAULT_STREAM_STALL_TIMEOUT_MS);
+  });
+
+  it('honors PROVIDER_STREAM_STALL_TIMEOUT_MS, including 0 to disable the watchdog', () => {
+    process.env.PROVIDER_STREAM_STALL_TIMEOUT_MS = '240000';
+    expect(streamStallTimeoutMs()).toBe(240_000);
+    process.env.PROVIDER_STREAM_STALL_TIMEOUT_MS = '0';
+    expect(streamStallTimeoutMs()).toBe(0);
+  });
+});

--- a/server/src/lib/env-drift.ts
+++ b/server/src/lib/env-drift.ts
@@ -22,6 +22,7 @@ const KNOWN_UNDOCUMENTED_ENV = new Set([
 
 const KNOWN_UNDOCUMENTED_PATTERNS = [
   /^PROVIDER_DAILY_REQUEST_CAP_[A-Z0-9_]+$/,
+  /^PROVIDER_TIMEOUT_[A-Z0-9_]+$/,
 ];
 
 export interface EnvDriftReport {

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -28,6 +28,11 @@ export function isRetryableError(err: any): boolean {
     || msg.includes('econnrefused') || msg.includes('econnreset')
     || msg.includes('fetch failed')    // undici transport error (proxy down, DNS, TLS, etc.)
     || msg.includes('503') || msg.includes('unavailable')
+    // Provider marks the hosted deployment itself as sick (NVIDIA NIM's
+    // "DEGRADED function cannot be invoked" arrives as a 400, #522). The
+    // 'api error 400' rule below already catches the NIM shape; this keeps
+    // degraded conditions retryable even when a provider words it differently.
+    || msg.includes('degraded')
     || msg.includes('500') || msg.includes('internal server error')
     // 413: this model's payload limit is too small for the request, but another
     // provider in the fallback chain may have a larger limit. Same reasoning as 503.
@@ -134,10 +139,22 @@ export function isDailyQuotaExhaustedError(err: any): boolean {
   return /allocation|quota|limit|exhaust|used up/.test(msg);
 }
 
+// A provider-side "this hosted model is temporarily degraded" condition dressed
+// up as a 400. Observed live on NVIDIA NIM (issue #522): a degraded function
+// returns `400 {"detail":"Function id '...': DEGRADED function cannot be
+// invoked"}` — the request is fine; the deployment is sick. Must NOT classify
+// as a provider bad-request: exhausting on it would render a client-blaming
+// 400 invalid_request_error for what is capacity/health, not request shape.
+export function isProviderDegradedError(err: any): boolean {
+  const msg = (err?.message ?? '').toLowerCase();
+  return msg.includes('degraded');
+}
+
 // Provider-side 400s are retryable because another provider may accept the same
 // request shape. If every routed provider rejects it, however, the client should
 // see an invalid-request error rather than a misleading rate-limit exhaustion.
 export function isProviderBadRequestError(err: any): boolean {
+  if (isProviderDegradedError(err)) return false;
   const status = typeof err?.status === 'number' ? err.status : 0;
   const msg = (err?.message ?? '').toLowerCase();
   if (status === 400) return msg.includes('api error 400');

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -35,6 +35,7 @@ import {
   isModelNotFoundError,
   isModelAccessForbiddenError,
   isProviderBadRequestError,
+  isProviderDegradedError,
 } from './error-classify.js';
 import { sanitizeProviderErrorMessage } from './error-redaction.js';
 import { checkKeyHealth } from '../services/health.js';
@@ -247,6 +248,9 @@ export function classifyAttemptError(err: any): AttemptErrorClass {
   if (isDailyQuotaExhaustedError(err)) return 'daily_quota_exhausted';
   if (isModelNotFoundError(err)) return 'model_not_found';
   if (isModelAccessForbiddenError(err)) return 'forbidden';
+  // A DEGRADED-function 400 (NVIDIA NIM, #522) is provider health, not request
+  // shape — keep it out of provider_bad_request so the trail reads honestly.
+  if (isProviderDegradedError(err)) return 'upstream_error';
   if (isProviderBadRequestError(err)) return 'provider_bad_request';
   const msg = (err?.message ?? '').toLowerCase();
   if (msg.includes('empty completion')) return 'empty_completion';
@@ -341,6 +345,19 @@ export function exhaustedRetryError(lastError: any, maxRetries?: number, ctx?: E
       message: `All ${attempts.length} attempted provider key(s) failed authentication${budgetNote}. ` +
         'The configured upstream API key(s) look invalid or expired; they are being revalidated now and will be marked invalid automatically. ' +
         `Check the provider keys in the dashboard.${trail} Last error: ${safeLastError}`,
+    };
+  }
+
+  // A chain that died on a DEGRADED-function 400 (NVIDIA NIM, #522) is a
+  // provider-capacity outage, not a bad request: render 503 so clients retry
+  // later instead of "fixing" a request that was never broken.
+  if (isProviderDegradedError(lastError)) {
+    return {
+      kind: 'unavailable',
+      status: 503,
+      type: 'service_unavailable',
+      message: `The routed provider reported the model's hosted deployment as temporarily degraded${budgetNote}. ` +
+        `This is a provider-side condition; retry later or route to another provider.${trail} Last error: ${safeLastError}`,
     };
   }
 

--- a/server/src/lib/provider-timeout.ts
+++ b/server/src/lib/provider-timeout.ts
@@ -1,0 +1,59 @@
+// Per-provider HTTP timeout overrides (issue #547, reworked from PR #509).
+//
+// PROVIDER_TIMEOUT_<PLATFORM>=<milliseconds> overrides the platform's built-in
+// chat timeout (e.g. PROVIDER_TIMEOUT_NVIDIA=300000). 0 disables the timeout
+// entirely. Values are read when the provider is constructed — for the built-in
+// platforms that means process start, so a change requires a restart.
+//
+// PROVIDER_STREAM_STALL_TIMEOUT_MS is the streaming counterpart for the
+// mid-stream inactivity watchdog (issue #553): how long an SSE stream may go
+// without a single byte before the gateway gives up on it. It is global, not
+// per-platform: a stall looks the same everywhere, and the per-platform knob
+// above already covers the slow-first-byte case.
+
+const warned = new Set<string>();
+
+function warnOnce(name: string, message: string): void {
+  if (warned.has(name)) return;
+  warned.add(name);
+  console.warn(message);
+}
+
+function parseTimeoutEnv(name: string, defaultMs: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return defaultMs;
+  const parsed = Number(raw.trim());
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    warnOnce(name, `[config] Ignoring ${name}="${raw}": expected a non-negative integer of milliseconds (0 disables the timeout). Using the default ${defaultMs}ms.`);
+    return defaultMs;
+  }
+  if (parsed > 0 && parsed < 1000) {
+    warnOnce(name, `[config] ${name}=${parsed}ms is under a second; nearly every request to this provider will abort. Was this meant to be seconds?`);
+  }
+  return parsed;
+}
+
+export function providerTimeoutEnvName(platform: string): string {
+  return `PROVIDER_TIMEOUT_${platform.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`;
+}
+
+/** Effective chat timeout for a platform: the PROVIDER_TIMEOUT_<PLATFORM> env
+ * override when set and valid, else the built-in default. Returns 0 to mean
+ * "no timeout" — callers must skip their abort timer for 0, never schedule
+ * setTimeout(0). */
+export function providerTimeoutMs(platform: string, defaultMs: number): number {
+  return parseTimeoutEnv(providerTimeoutEnvName(platform), defaultMs);
+}
+
+export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 90_000;
+
+/** Effective mid-stream inactivity timeout (PROVIDER_STREAM_STALL_TIMEOUT_MS,
+ * default 90s, 0 disables). Resolved per call so tests can vary the env. */
+export function streamStallTimeoutMs(): number {
+  return parseTimeoutEnv('PROVIDER_STREAM_STALL_TIMEOUT_MS', DEFAULT_STREAM_STALL_TIMEOUT_MS);
+}
+
+/** Test hook: forget which malformed values have already been warned about. */
+export function resetTimeoutWarnings(): void {
+  warned.clear();
+}

--- a/server/src/providers/aihorde.ts
+++ b/server/src/providers/aihorde.ts
@@ -7,6 +7,7 @@ import type {
 } from '@freellmapi/shared/types.js';
 import { BaseProvider, providerHttpError, type CompletionOptions } from './base.js';
 import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+import { providerTimeoutMs } from '../lib/provider-timeout.js';
 
 /**
  * AI Horde — free, community-powered inference served by volunteer workers and
@@ -41,7 +42,8 @@ import { recordQuotaObservationsFromResponse, type QuotaObservationContext } fro
 const ANON_KEY = '0000000000';
 const MIN_MAX_TOKENS = 16;
 const DEFAULT_MAX_TOKENS = 512;
-const HORDE_TIMEOUT_MS = 120000;
+// PROVIDER_TIMEOUT_AIHORDE overrides (#547).
+const HORDE_TIMEOUT_MS = providerTimeoutMs('aihorde', 120000);
 
 /** Rough token estimate (~4 chars/token) used only to fill usage when the proxy
  * returns kudos instead of token counts. Good enough for analytics, never

--- a/server/src/providers/base.ts
+++ b/server/src/providers/base.ts
@@ -9,6 +9,7 @@ import type {
 import type { QuotaObservationContext } from '../services/provider-quota.js';
 import type { ExtendedSamplingOptions } from '../lib/sampling-params.js';
 import { proxyFetch } from '../lib/proxy.js';
+import { providerTimeoutMs, streamStallTimeoutMs } from '../lib/provider-timeout.js';
 
 /** A provider HTTP error carrying the upstream status and, when the response
  *  included a Retry-After header, the parsed delay so the router can bench the
@@ -88,8 +89,15 @@ export abstract class BaseProvider {
   protected async fetchWithTimeout(
     url: string,
     init: RequestInit,
-    timeoutMs = 15000,
+    // Adapters that don't pass a timeout inherit the platform's env override
+    // (PROVIDER_TIMEOUT_<PLATFORM>, issue #547) over the historical 15s.
+    timeoutMs = providerTimeoutMs(this.platform, 15000),
   ): Promise<Response> {
+    // timeoutMs <= 0 means "no timeout" (PROVIDER_TIMEOUT_<PLATFORM>=0).
+    // setTimeout(abort, 0) would abort every request on the next macrotask.
+    if (timeoutMs <= 0) {
+      return proxyFetch(url, init, this.platform, 'chat', timeoutMs);
+    }
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
@@ -123,7 +131,12 @@ export abstract class BaseProvider {
    */
   protected async *readSseStream(
     res: Response,
-    inactivityTimeoutMs = 90000,
+    // The 90s default was hardcoded and silently truncated slow streams — the
+    // gateway ended them with an error frame plus a clean [DONE] that OpenAI
+    // SDK clients swallow, so responses "just stopped" (issue #553). Operators
+    // proxying slow free tiers can now raise it (or 0 to disable) via
+    // PROVIDER_STREAM_STALL_TIMEOUT_MS.
+    inactivityTimeoutMs = streamStallTimeoutMs(),
   ): AsyncGenerator<ChatCompletionChunk> {
     const reader = res.body?.getReader();
     if (!reader) throw new Error('No response body');
@@ -135,15 +148,17 @@ export abstract class BaseProvider {
     try {
       while (true) {
         let timer: ReturnType<typeof setTimeout> | undefined;
-        const result = await Promise.race([
-          reader.read(),
-          new Promise<never>((_, reject) => {
-            timer = setTimeout(
-              () => reject(new Error(`${this.name} stream stalled: no data for ${inactivityTimeoutMs}ms (timeout)`)),
-              inactivityTimeoutMs,
-            );
-          }),
-        ]).finally(() => clearTimeout(timer));
+        const result = inactivityTimeoutMs <= 0
+          ? await reader.read()
+          : await Promise.race([
+              reader.read(),
+              new Promise<never>((_, reject) => {
+                timer = setTimeout(
+                  () => reject(new Error(`${this.name} stream stalled: no data for ${inactivityTimeoutMs}ms (timeout)`)),
+                  inactivityTimeoutMs,
+                );
+              }),
+            ]).finally(() => clearTimeout(timer));
 
         const { done, value } = result;
         if (done) break;

--- a/server/src/providers/cloudflare.ts
+++ b/server/src/providers/cloudflare.ts
@@ -7,6 +7,7 @@ import { BaseProvider, providerHttpError, type CompletionOptions } from './base.
 import { extendedBodyParams } from '../lib/sampling-params.js';
 import { contentToString } from '../lib/content.js';
 import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+import { providerTimeoutMs } from '../lib/provider-timeout.js';
 
 /**
  * Cloudflare Workers AI provider.
@@ -17,7 +18,8 @@ import { recordQuotaObservationsFromResponse, type QuotaObservationContext } fro
 // Workers AI hosts reasoning models (@cf/zai-org/glm-4.7-flash) that spend
 // well over the 15s fetch default before the first byte (live sweep
 // 2026-07-11: repeated 15s aborts). Matches zhipu/agnes/ollama bumps.
-const CHAT_TIMEOUT_MS = 60_000;
+// PROVIDER_TIMEOUT_CLOUDFLARE overrides (#547).
+const CHAT_TIMEOUT_MS = providerTimeoutMs('cloudflare', 60_000);
 
 export class CloudflareProvider extends BaseProvider {
   readonly platform = 'cloudflare' as const;

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -11,6 +11,7 @@ import { BaseProvider, providerHttpError, type CompletionOptions } from './base.
 import { contentToString } from '../lib/content.js';
 import { proxyFetch } from '../lib/proxy.js';
 import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+import { providerTimeoutMs } from '../lib/provider-timeout.js';
 
 const API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
@@ -535,7 +536,8 @@ export class GoogleProvider extends BaseProvider {
 
   constructor(opts: GoogleProviderOptions = {}) {
     super();
-    this.timeoutMs = opts.timeoutMs ?? 15000;
+    // PROVIDER_TIMEOUT_GOOGLE wins over the registration default (#547).
+    this.timeoutMs = providerTimeoutMs('google', opts.timeoutMs ?? 15000);
   }
 
   async chatCompletion(

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -10,6 +10,7 @@ import { extendedBodyParams } from '../lib/sampling-params.js';
 import { rescueInlineToolCalls } from '../lib/tool-call-rescue.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+import { providerTimeoutMs } from '../lib/provider-timeout.js';
 
 /**
  * Generic provider for platforms that use an OpenAI-compatible API.
@@ -47,7 +48,8 @@ export class OpenAICompatProvider extends BaseProvider {
     this.baseUrl = opts.baseUrl;
     this.extraHeaders = opts.extraHeaders ?? {};
     this.validateUrl = opts.validateUrl;
-    this.timeoutMs = opts.timeoutMs ?? 60_000;
+    // PROVIDER_TIMEOUT_<PLATFORM> wins over the registration default (#547).
+    this.timeoutMs = providerTimeoutMs(opts.platform, opts.timeoutMs ?? 60_000);
     this.keyless = opts.keyless ?? false;
     this.forceSingleToolCall = opts.forceSingleToolCall ?? false;
   }
@@ -84,6 +86,19 @@ export class OpenAICompatProvider extends BaseProvider {
       type: 'function' as const,
       function: { name: c.name, arguments: repairToolArguments(c.arguments, schemas.get(c.name)) },
     }));
+  }
+
+  /** Extract the useful text from an upstream error body. Most providers put it
+   * at error.message, but NVIDIA NIM answers RFC7807-style ({"title": ...,
+   * "detail": "Function id '...': DEGRADED function cannot be invoked"}) — the
+   * old error.message-only read collapsed that to "Bad Request", so neither the
+   * logs nor the error classifier could ever see the DEGRADED marker (#522). */
+  private upstreamErrorText(errBody: unknown, res: Response): string {
+    const e = errBody as { error?: { message?: unknown }; detail?: unknown; title?: unknown };
+    if (typeof e?.error?.message === 'string' && e.error.message) return e.error.message;
+    if (typeof e?.detail === 'string' && e.detail) return e.detail;
+    if (typeof e?.title === 'string' && e.title) return e.title;
+    return res.statusText;
   }
 
   /** Keyless providers (Kilo's anonymous free tier) must send NO Authorization
@@ -187,7 +202,7 @@ export class OpenAICompatProvider extends BaseProvider {
         out._routed_via = { platform: this.platform, model: modelId };
         return out;
       }
-      throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `${this.name} API error ${res.status}: ${this.upstreamErrorText(err, res)}`);
     }
 
     let data: ChatCompletionResponse;
@@ -295,7 +310,7 @@ export class OpenAICompatProvider extends BaseProvider {
         yield { ...base, choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] };
         return;
       }
-      throw providerHttpError(res, `${this.name} API error ${res.status}: ${(err as any).error?.message ?? res.statusText}`);
+      throw providerHttpError(res, `${this.name} API error ${res.status}: ${this.upstreamErrorText(err, res)}`);
     }
 
     yield* this.readSseStream(res);


### PR DESCRIPTION
Adopts and lands four community-reported issues/PRs, verified against main first:

- **#550** (@Joey9024): the runtime Docker stage never copied `server/node_modules`, where npm nests `undici` — so the HTTP(S) proxy dispatcher failed its lazy import and every request silently went direct while the dashboard showed the proxy active. Verified by reproducing the `npm ci` layout; one COPY line fixes it.
- **#547** (@AskingConical) / rework of **#509** (@jasnoorgill): `PROVIDER_TIMEOUT_<PLATFORM>` now overrides any platform's hardcoded chat timeout; 0 disables the timeout safely (no `setTimeout(abort, 0)` footgun). All platforms are covered, defaults match current main.
- **#553 streaming half** (@ProAlit): the hardcoded 90s mid-stream inactivity watchdog that silently truncated slow streams is now configurable via `PROVIDER_STREAM_STALL_TIMEOUT_MS` (0 disables).
- **#522**: NIM's RFC7807 `detail` field now surfaces in error messages, and a DEGRADED-function 400 classifies as provider capacity — retryable, `upstream_error` in the trail, 503 on exhaustion instead of a client-blaming 400.

Tests: full server suite green (104 files, 1058 tests), plus new suites for the timeout resolver and the degraded classification. README credits added for all five contributors.

Fixes #550. Fixes #547. Fixes #522.
