### PR TITLE
fix(fusion): size-aware panel selection so a too-small model can't claim a slot

### DIFF
--- a/server/src/__tests__/routes/fusion.test.ts
+++ b/server/src/__tests__/routes/fusion.test.ts
@@ -395,16 +395,16 @@ describe('fusion route (/v1/chat/completions, model: "fusion")', () => {
     try {
       // Priority mode: ordering is the manual chain order, and stable.
       setRoutingStrategy('priority');
-      const p1 = getOrderedFusionChain().map(c => c.modelId);
-      const p2 = getOrderedFusionChain().map(c => c.modelId);
+      const p1 = getOrderedFusionChain(1).map(c => c.modelId);
+      const p2 = getOrderedFusionChain(1).map(c => c.modelId);
       expect(p1.length).toBeGreaterThan(0);
       expect(p2).toEqual(p1);
 
       // Bandit mode: previously Thompson-sampled (random per call); now the
       // deterministic expected-score ranking, so two calls must be identical.
       setRoutingStrategy('smartest');
-      const s1 = getOrderedFusionChain().map(c => c.modelId);
-      const s2 = getOrderedFusionChain().map(c => c.modelId);
+      const s1 = getOrderedFusionChain(1).map(c => c.modelId);
+      const s2 = getOrderedFusionChain(1).map(c => c.modelId);
       expect(s2).toEqual(s1);
 
       // The strategy actually drives the ordering: 'smartest' (intelligence)
@@ -422,7 +422,7 @@ describe('fusion route (/v1/chat/completions, model: "fusion")', () => {
     const r = await request(app, 'POST', '/api/keys', { platform: 'groq', key: 'k_groq_only', label: 'only-groq' });
     expect(r.status).toBe(201);
 
-    const candidates = getOrderedFusionChain();
+    const candidates = getOrderedFusionChain(1);
     expect(candidates.length).toBeGreaterThan(0);
     // Even though the seeded catalog has many higher-ranked models on other
     // platforms (cerebras, openrouter, opencode…), none are routable without a
@@ -436,14 +436,47 @@ describe('fusion route (/v1/chat/completions, model: "fusion")', () => {
     await request(app, 'POST', '/api/keys', { platform: 'groq', key: 'k_groq_cool', label: 'cool' });
     const keyId = (db.prepare("SELECT id FROM api_keys WHERE platform = 'groq'").get() as { id: number }).id;
 
-    const before = getOrderedFusionChain().filter(c => c.platform === 'groq');
+    const before = getOrderedFusionChain(1).filter(c => c.platform === 'groq');
     expect(before.length).toBeGreaterThan(0);
     const target = before[0]; // the top groq model under the strategy
 
     // Bench that exact model+key (as a 402/429 cooldown would), then re-check.
     setCooldown('groq', target.modelId, keyId, 60_000);
-    const after = getOrderedFusionChain();
+    const after = getOrderedFusionChain(1);
     expect(after.find(c => c.modelId === target.modelId)).toBeUndefined();
+  });
+
+  it('auto-panel excludes a model whose context window cannot hold the prompt', async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    await request(app, 'POST', '/api/keys', { platform: 'groq', key: 'k_groq_ctx', label: 'ctx' });
+
+    const target = getOrderedFusionChain(1).find(c => c.platform === 'groq');
+    expect(target).toBeDefined();
+    db.prepare('UPDATE models SET context_window = 1000 WHERE platform = ? AND model_id = ?')
+      .run('groq', target!.modelId);
+
+    // Fits: a 500-token prompt is well inside the 1000-token window.
+    expect(getOrderedFusionChain(500).find(c => c.modelId === target!.modelId)).toBeDefined();
+    // Does not fit: the model can NEVER serve this request, so it must not claim
+    // a panel slot. Before this gate it was selected anyway and failed at
+    // dispatch, reported as the misleading "no available key for model".
+    expect(getOrderedFusionChain(5000).find(c => c.modelId === target!.modelId)).toBeUndefined();
+  });
+
+  it('auto-panel treats a null context_window as unknown, not as zero', async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    await request(app, 'POST', '/api/keys', { platform: 'groq', key: 'k_groq_null', label: 'nullctx' });
+
+    const target = getOrderedFusionChain(1).find(c => c.platform === 'groq');
+    expect(target).toBeDefined();
+    db.prepare('UPDATE models SET context_window = NULL WHERE platform = ? AND model_id = ?')
+      .run('groq', target!.modelId);
+
+    // An unspecified window must never itself exclude a model, at any size:
+    // same convention the auto-router uses.
+    expect(getOrderedFusionChain(5_000_000).find(c => c.modelId === target!.modelId)).toBeDefined();
   });
 
   it('auto-panel refills failed slots from the fallback chain', async () => {

--- a/server/src/services/fusion.ts
+++ b/server/src/services/fusion.ts
@@ -419,7 +419,7 @@ export function diversifyChain(ordered: FusionCandidate[]): FusionCandidate[] {
  * both the panel and its refills span genuinely different perspectives before
  * doubling up on either axis.
  */
-function selectPanel(config: FusionConfig, requirements: { requireTools?: boolean } = {}): { panel: FusionCandidate[]; overflow: FusionCandidate[]; dropped: string[] } {
+function selectPanel(config: FusionConfig, requirements: { requireTools?: boolean; estimatedTokens: number }): { panel: FusionCandidate[]; overflow: FusionCandidate[]; dropped: string[] } {
   const maxK = panelMaxK();
 
   if (config.models && config.models.length > 0) {
@@ -440,7 +440,10 @@ function selectPanel(config: FusionConfig, requirements: { requireTools?: boolea
   }
 
   const k = Math.min(Math.max(config.k ?? panelDefaultK(), 1), maxK);
-  const ordered = getOrderedFusionChain().filter(c => !requirements.requireTools || c.supportsTools);
+  // Size-aware: the chain excludes models that cannot hold a prompt this large,
+  // so a too-small model never claims a slot it is guaranteed to fail.
+  const ordered = getOrderedFusionChain(requirements.estimatedTokens)
+    .filter(c => !requirements.requireTools || c.supportsTools);
 
   // Diversity-first ordering of the whole servable chain along provider AND
   // model family (see diversifyChain). The first K are the panel; the rest are
@@ -531,7 +534,7 @@ export async function runFusion(params: {
   const strategy = config.strategy ?? 'synthesize';
 
   const requireTools = (options.tools?.length ?? 0) > 0;
-  const { panel, overflow, dropped } = selectPanel(config, { requireTools });
+  const { panel, overflow, dropped } = selectPanel(config, { requireTools, estimatedTokens });
   if (panel.length === 0) {
     throw new FusionError(
       'fusion: no usable models for the panel. Provide `fusion.models` with enabled model ids, or enable models in the Fallback Chain.',

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -901,7 +901,7 @@ export interface FusionCandidate {
  * so the panel's auto-pick draws from the highest-scored models first and the
  * fusion layer just needs to apply provider-diversity on top.
  */
-export function getOrderedFusionChain(): FusionCandidate[] {
+export function getOrderedFusionChain(estimatedTokens: number): FusionCandidate[] {
   const db = getDb();
   const strategy = getRoutingStrategy();
   if (strategy !== 'priority') refreshStatsCache(db);
@@ -916,6 +916,13 @@ export function getOrderedFusionChain(): FusionCandidate[] {
   // currently cooled down (huggingface/Kimi-K2.6) would claim a panel slot it
   // can't fill — surfacing as "no available key" and pushing out a usable model,
   // which also makes the panel look like it's ignoring the routing strategy.
+  //
+  // The SIZE gates matter as much as the key gates: a model whose context window
+  // cannot hold the prompt can NEVER fill its slot, yet diversifyChain keeps
+  // handing it one on every request when it is its platform's only representative.
+  // That leaves one panel slot dead on arrival and reports the failure as the
+  // misleading "no available key for model". Passing a placeholder token count
+  // here made both size gates no-ops.
   const usableKeys = db.prepare(
     "SELECT id, platform FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown')"
   ).all() as { id: number; platform: string }[];
@@ -925,6 +932,9 @@ export function getOrderedFusionChain(): FusionCandidate[] {
     if (arr) arr.push(k.id); else keysByPlatform.set(k.platform, [k.id]);
   }
   const servable = chain.filter(e => {
+    // A null context_window means "unknown", not "zero": same convention the
+    // auto-router uses, so an unspecified window is never itself a reason to skip.
+    if (e.context_window != null && estimatedTokens > e.context_window) return false;
     const keyIds = keysByPlatform.get(e.platform);
     if (!keyIds) return false;
     const limits = { rpm: e.rpm_limit, rpd: e.rpd_limit, tpm: e.tpm_limit, tpd: e.tpd_limit };
@@ -933,7 +943,7 @@ export function getOrderedFusionChain(): FusionCandidate[] {
       !isOnCooldown(e.platform, e.model_id, kid) &&
       canUseProvider(e.platform, kid) &&
       canMakeRequest(e.platform, e.model_id, kid, limits) &&
-      canUseProviderTokens(e.platform, kid, e.model_id, 1),
+      canUseProviderTokens(e.platform, kid, e.model_id, estimatedTokens),
     );
   });
 


### PR DESCRIPTION
## Problem

`getOrderedFusionChain` builds the candidate pool that fusion's auto-panel picks from. It filters candidates by key health, cooldown, provider daily cap and rpm/rpd limits, but never by request **size**:

- there is no `context_window` check at all, while the normal auto-router applies one;
- `canUseProviderTokens` is called with a hardcoded `1` rather than the real estimate, which makes the token gate a no-op.

The reason is structural rather than an oversight in the predicate itself: `selectPanel`'s `requirements` parameter carried only `requireTools`, and `getOrderedFusionChain()` took no arguments, so **no size information ever reached panel selection**.

The consequence is that a model whose context window is smaller than the prompt is still selected. Because `diversifyChain` deliberately takes one model per platform before doubling up, such a model is picked on **every** request whenever it is its platform's only representative. One panel slot is therefore dead on arrival every time.

The slot then fails at dispatch, where `routePinnedModel` finally applies the real gates, and the failure surfaces as `no available key for model`. That reads as a key or quota problem, which is misleading: the model simply cannot accept a prompt that size, and no amount of waiting or extra keys will change it.

Observed on a six-provider deployment: a model whose catalog entry lists an 8192-token context window was selected for every request of roughly 11k tokens and failed every time. It burned a dispatch and forced an overflow refill, which then collapsed the panel's platform diversity, since the refill queue is diversity-blind.

## Fix

- Thread `estimatedTokens` through `selectPanel` into `getOrderedFusionChain`. It was already in scope in `runFusion`, seven lines above the callsite.
- Add the `context_window` check the auto-router already applies.
- Pass the real estimate to `canUseProviderTokens` instead of `1`.

A null `context_window` continues to mean "unknown", never "zero", matching auto-routing, so an unspecified window is never itself a reason to skip a model.

**No behavior change when every candidate fits the prompt**: same panel, same order. The only requests affected are ones where a selected model provably could not have served.

## Scope / relationship to other work

Deliberately narrow: fusion panel selection only, no routing or dashboard changes.

This does **not** touch `hasOtherUsableKey` (`router.ts:796`), which passes a literal `1` to the same helper. That one is correct as written. It asks whether a sibling *key* exists in order to decide a model-level 429 penalty, so a nominal probe is the right question. Using the real estimate there would demote an otherwise healthy model on the strength of a single oversized request, and the existing comment says as much.

Independent of #331 (family diversity), which is already merged. This is what makes that diversity actually hold under size pressure, rather than losing a slot to a model that cannot answer.

## Tests

- Two new tests in `fusion.test.ts`: a model with a 1000-token window is kept at a 500-token estimate and excluded at 5000; a `NULL` context window is never itself a reason to exclude, at any size.
- The first test was verified to **fail without the `router.ts` change** by reverting only that file and re-running, so it exercises the fix rather than passing vacuously.
- Existing `getOrderedFusionChain` callers in the suite now pass an explicit estimate. Worth noting for future signature changes: `src/__tests__` is excluded from `server/tsconfig.json`, so a stale no-arg call would have passed `undefined` at runtime without failing the typecheck.
- Full server suite green: 104 files, 1060 tests.
