### PR TITLE
perf: gzip dashboard bundle and cache hashed assets immutably

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,7 +1246,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1263,7 +1262,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1280,7 +1278,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1297,7 +1294,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1314,7 +1310,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1331,7 +1326,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1348,7 +1342,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1365,7 +1358,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1382,7 +1374,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1399,7 +1390,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1416,7 +1406,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1433,7 +1422,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,7 +1438,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1467,7 +1454,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1484,7 +1470,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1501,7 +1486,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1518,7 +1502,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1535,7 +1518,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1552,7 +1534,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1569,7 +1550,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1586,7 +1566,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1603,7 +1582,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1620,7 +1598,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1637,7 +1614,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1654,7 +1630,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1671,7 +1646,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3350,6 +3324,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4251,7 +4236,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.31",
@@ -4285,22 +4271,22 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -4401,11 +4387,11 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      },
-      "optional": true
+      }
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4742,6 +4728,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -5083,6 +5123,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -5091,8 +5132,7 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "optional": true
+      }
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -5123,10 +5163,10 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5933,10 +5973,10 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
@@ -6383,10 +6423,10 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
-      },
-      "optional": true
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -7170,7 +7210,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8978,13 +9019,13 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "optional": true
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -9201,26 +9242,26 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
       "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=10"
-      },
-      "optional": true
+      }
     },
     "node_modules/node-abi/node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      },
-      "optional": true
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -9335,6 +9376,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9738,6 +9788,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -9757,8 +9808,7 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "optional": true
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -9835,11 +9885,11 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      },
-      "optional": true
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -9915,6 +9965,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -9923,18 +9974,17 @@
       },
       "bin": {
         "rc": "cli.js"
-      },
-      "optional": true
+      }
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/react": {
       "version": "19.2.6",
@@ -10741,12 +10791,12 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      },
-      "optional": true
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -11089,19 +11139,20 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^2.1.4"
-      },
-      "optional": true
+      }
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -11111,8 +11162,7 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "optional": true
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -11328,13 +11378,13 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
       "engines": {
         "node": "*"
-      },
-      "optional": true
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -13239,6 +13289,7 @@
       "version": "0.2.1",
       "dependencies": {
         "@freellmapi/shared": "*",
+        "compression": "^1.8.0",
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.44.2",
@@ -13251,6 +13302,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
+        "@types/compression": "^1.7.5",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.2",
         "@types/multer": "^2.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@freellmapi/shared": "*",
+    "compression": "^1.8.0",
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.44.2",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
+    "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.2",
     "@types/multer": "^2.1.0",

--- a/server/src/__tests__/routes/static-assets-caching.test.ts
+++ b/server/src/__tests__/routes/static-assets-caching.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Server } from 'node:http';
+import { createApp } from '../../app.js';
+import { initDb } from '../../db/index.js';
+
+// Raw node:http (not global fetch): undici transparently decompresses gzip and
+// hides Content-Encoding, which would make the compression assertions below
+// meaningless. node:http leaves the response bytes and headers untouched.
+function get(
+  port: number,
+  pathname: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path: pathname, method: 'GET', headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c as Buffer));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks),
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// Vite emits content-hashed chunks (JS/CSS/fonts) under assets/. Fixtures are
+// padded past compression's 1 KB threshold so gzip actually engages.
+const BIG_JS = '// hashed bundle fixture\n' + 'export const chunk = 1;\n'.repeat(200);
+const BIG_CSS = '/* hashed styles fixture */\n' + '.cls { color: #123456; }\n'.repeat(200);
+
+describe('static SPA: gzip compression + asset cache headers', () => {
+  let tmpDir: string;
+  let server: Server;
+  let port: number;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'freeapi-static-cache-'));
+    fs.mkdirSync(path.join(tmpDir, 'assets'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'index.html'),
+      '<!doctype html><title>cache-fixture</title><script src="/assets/index-Ab3dE5fg.js"></script>',
+    );
+    fs.writeFileSync(path.join(tmpDir, 'assets', 'index-Ab3dE5fg.js'), BIG_JS);
+    fs.writeFileSync(path.join(tmpDir, 'assets', 'index-Zz9Yx8w0.css'), BIG_CSS);
+    // A non-index hashed chunk — guards against only special-casing index-*.
+    fs.writeFileSync(path.join(tmpDir, 'assets', 'vendor-Q1w2E3r4.js'), BIG_JS);
+
+    process.env.CLIENT_DIST = tmpDir;
+    server = createApp().listen(0);
+    port = (server.address() as { port: number }).port;
+  });
+
+  afterAll(() => {
+    server.close();
+    delete process.env.CLIENT_DIST;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('gzips a static asset when the client accepts gzip', async () => {
+    const res = await get(port, '/assets/index-Ab3dE5fg.js', { 'Accept-Encoding': 'gzip' });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+  });
+
+  it('serves hashed assets with a long-lived immutable Cache-Control', async () => {
+    for (const asset of [
+      '/assets/index-Ab3dE5fg.js',
+      '/assets/index-Zz9Yx8w0.css',
+      '/assets/vendor-Q1w2E3r4.js', // not index-* — all hashed chunks covered
+    ]) {
+      const res = await get(port, asset);
+      expect(res.status, asset).toBe(200);
+      expect(res.headers['cache-control'], asset).toBe(
+        'public, max-age=31536000, immutable',
+      );
+    }
+  });
+
+  it('does NOT mark index.html immutable so deploys propagate', async () => {
+    const res = await get(port, '/index.html');
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control'] ?? '').not.toContain('immutable');
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('serves SPA deep links with the same no-cache policy as index.html', async () => {
+    const res = await get(port, '/analytics');
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('does NOT gzip API responses (SSE/proxy responses stay untouched)', async () => {
+    // /v1/openapi.json is large (>1 KB) JSON served by an API router mounted
+    // before the compression middleware — proof the middleware never wraps it.
+    const res = await get(port, '/v1/openapi.json', { 'Accept-Encoding': 'gzip' });
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBeGreaterThan(1024);
+    expect(res.headers['content-encoding']).toBeUndefined();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import compression from 'compression';
 import cors from 'cors';
 import helmet from 'helmet';
 import path from 'path';
@@ -34,6 +35,19 @@ const DEFAULT_DASHBOARD_ORIGINS = [
   'http://127.0.0.1:5173',
   'http://[::1]:5173',
 ];
+
+// A build asset is safe to cache forever+immutable when its URL is
+// content-addressed. Vite parks every hashed chunk (JS, CSS, fonts, images)
+// under assets/, so that directory is the reliable signal; the -<hash>.<ext>
+// suffix is a belt-and-braces fallback for any hashed file emitted elsewhere.
+// index.html and other unhashed entries deliberately fall through to no-cache.
+const HASHED_ASSET_RE = /-[A-Za-z0-9_-]{6,}\.[A-Za-z0-9]+$/;
+function isImmutableAsset(filePath: string): boolean {
+  return (
+    filePath.includes(`${path.sep}assets${path.sep}`) ||
+    HASHED_ASSET_RE.test(path.basename(filePath))
+  );
+}
 
 export function createApp(config?: Config) {
   const cfg = config ?? loadConfig();
@@ -127,14 +141,39 @@ export function createApp(config?: Config) {
     const clientDist = cfg.clientDist
       ? path.resolve(cfg.clientDist)
       : path.resolve(__dirname, '../../client/dist');
-    app.use(express.static(clientDist));
+    // Gzip the dashboard bundle (1+ MB uncompressed). Mounted HERE — after
+    // every API/proxy router and the error handler — so it only wraps the
+    // static-file / SPA-fallback responses below it. The /v1 and /api handlers
+    // end their responses upstream and never fall through to this middleware,
+    // so nothing (crucially the /v1/chat/completions SSE streams) gets buffered
+    // or re-encoded by compression.
+    app.use(compression());
+    app.use(express.static(clientDist, {
+      // Vite emits content-hashed build assets under assets/ (index-<hash>.js,
+      // chunk-<hash>.js, *.css, fonts…). The URL changes whenever the bytes do,
+      // so cache them for a year and mark them immutable. index.html and other
+      // unhashed root entries must stay revalidated (no-cache) so a redeploy
+      // propagates the new asset URLs immediately.
+      setHeaders(res, filePath) {
+        res.setHeader(
+          'Cache-Control',
+          isImmutableAsset(filePath)
+            ? 'public, max-age=31536000, immutable'
+            : 'no-cache',
+        );
+      },
+    }));
     // SPA fallback — serve index.html for non-API routes
     app.use((req, res, next) => {
       if (req.path.startsWith('/api/') || req.path.startsWith('/v1/')) {
         next();
         return;
       }
-      res.sendFile(path.join(clientDist, 'index.html'));
+      // Same no-cache policy as the statically-served index.html: SPA deep
+      // links must revalidate so a redeploy propagates new asset URLs.
+      res.sendFile(path.join(clientDist, 'index.html'), {
+        headers: { 'Cache-Control': 'no-cache' },
+      });
     });
   }
 


### PR DESCRIPTION
Adopts the one salvageable improvement from #546 (thanks @wangzhenhui1992), re-implemented cleanly.

**Problem:** the dashboard bundle (1.4 MB JS) was served uncompressed with no cache headers, so every visit re-downloaded everything.

**Change:**
- `compression()` mounted after all API/proxy routers in `app.ts` — only static-file and SPA-fallback responses are wrapped. `/v1/chat/completions` SSE streams and API JSON structurally never pass through the middleware (verified by test and live curl).
- Vite's content-hashed `assets/` files are served with `Cache-Control: public, max-age=31536000, immutable` (covers all hashed chunks — JS, CSS, fonts, images — not just `index-*`).
- `index.html` and SPA deep links (e.g. `/analytics`) get `no-cache` so redeploys propagate immediately.

**Result:** main JS bundle over the wire 1390 KB → 411 KB (−70%); repeat visits hit the browser cache entirely.

**Testing:** new 5-test suite (gzip on assets, immutable header on hashed chunks incl. non-index chunks, `index.html` non-immutable, SPA deep-link no-cache, API responses uncompressed); full server suite 1,083 tests green; `tsc --noEmit` clean; verified live against a production client build with curl.
