### PR TITLE
fix: /v1/responses model routing — respect explicit model, sticky, auto priority

### DIFF
--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -9,8 +9,9 @@ import type {
   ChatToolChoice,
   Platform,
 } from '@freellmapi/shared/types.js';
-import { routeRequest, hasEnabledToolsModel, routingReserveTokens, type RouteResult } from '../services/router.js';
-import { getUnifiedApiKey } from '../db/index.js';
+import { routeRequest, hasEnabledToolsModel, routingReserveTokens, resolveModelGroupCandidates, type RouteResult, type ChainRow } from '../services/router.js';
+import { getDb, getUnifiedApiKey } from '../db/index.js';
+import { isUnifyEnabled, getModelGroups, resolveRequestedIdToMembers } from '../services/model-groups.js';
 import { contentToString } from '../lib/content.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 import { rescueInlineToolCalls, startsWithDialectMarker, couldBecomeDialectMarker, containsDialectMarker } from '../lib/tool-call-rescue.js';
@@ -31,6 +32,14 @@ import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
 import { inferQuotaPoolKey, type QuotaObservationContext } from '../services/provider-quota.js';
 
 export const responsesRouter = Router();
+
+const AUTO_MODEL_ID = 'auto';
+
+function isAutoModel(modelId: string | undefined): boolean {
+  if (!modelId) return true;
+  const lower = modelId.toLowerCase();
+  return lower === AUTO_MODEL_ID || lower.startsWith(`${AUTO_MODEL_ID}:`);
+}
 
 // ─────────────────────────────────────────────────────────────────────────
 // OpenAI Responses API shim (POST /v1/responses).
@@ -384,8 +393,55 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
   // Optional client-managed session affinity (mirrors /chat/completions).
   const rawSessionId = req.headers['x-session-id'];
   const sessionIdHeader = Array.isArray(rawSessionId) ? rawSessionId[0] : rawSessionId;
-  const preferredModel = getStickyModel(messages, sessionIdHeader);
   const requestedModelLabel = reqData.model ?? 'auto';
+
+  // Explicit `model` field pins routing. If the catalog has no enabled row
+  // matching the requested id, return 400 — silently auto-routing to a
+  // different model would be surprising to Responses API clients.
+  // Priority: explicit model > sticky session > auto routing.
+  let preferredModel: number | undefined;
+  let groupChain: ChainRow[] | undefined;
+
+  if (isAutoModel(requestedModelLabel)) {
+    preferredModel = getStickyModel(messages, sessionIdHeader);
+  } else {
+    const db = getDb();
+    const members = isUnifyEnabled() ? resolveRequestedIdToMembers(requestedModelLabel, getModelGroups()) : null;
+    if (members && members.length > 0) {
+      groupChain = resolveModelGroupCandidates(members);
+      if (groupChain.length === 0) {
+        const placeholders = members.map(() => '?').join(',');
+        const anyEnabled = db.prepare(`SELECT 1 FROM models WHERE id IN (${placeholders}) AND enabled = 1 LIMIT 1`).get(...members);
+        const reason = anyEnabled ? 'has no providers with an enabled key' : 'is disabled';
+        res.status(400).json({
+          error: {
+            message: `Model '${requestedModelLabel}' ${reason}. Use 'auto' (or omit the 'model' field) to auto-route, or call /v1/models for the available list.`,
+            type: 'invalid_request_error',
+            code: 'model_not_found',
+          },
+        });
+        return;
+      }
+      const sticky = getStickyModel(messages, sessionIdHeader, requestedModelLabel);
+      preferredModel = (sticky != null && groupChain.some(r => r.model_db_id === sticky)) ? sticky : undefined;
+    } else {
+      const enabled = db.prepare('SELECT id FROM models WHERE model_id = ? AND enabled = 1').get(requestedModelLabel) as { id: number } | undefined;
+      if (enabled) {
+        preferredModel = enabled.id;
+      } else {
+        const disabled = db.prepare('SELECT id FROM models WHERE model_id = ?').get(requestedModelLabel) as { id: number } | undefined;
+        const reason = disabled ? 'is disabled' : 'is not in the catalog';
+        res.status(400).json({
+          error: {
+            message: `Model '${requestedModelLabel}' ${reason}. Use 'auto' (or omit the 'model' field) to auto-route, or call /v1/models for the available list.`,
+            type: 'invalid_request_error',
+            code: 'model_not_found',
+          },
+        });
+        return;
+      }
+    }
+  }
 
   // Tool-bearing requests (the normal case for Codex/agent clients on this
   // endpoint) must stay on models that emit structured tool_calls. Make the
@@ -427,7 +483,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
     state,
     attemptLog,
     clientGone: () => clientGone,
-    route: () => routeRequest(estimatedTotal, state.skipKeys.size > 0 ? state.skipKeys : undefined, preferredModel, false, wantsTools, state.skipModels.size > 0 ? state.skipModels : undefined, undefined, completionOpts.response_format !== undefined),
+    route: () => routeRequest(estimatedTotal, state.skipKeys.size > 0 ? state.skipKeys : undefined, preferredModel, false, wantsTools, state.skipModels.size > 0 ? state.skipModels : undefined, groupChain, completionOpts.response_format !== undefined),
     dispatch: async (route, attempt) => {
       traceRouteEvent('Responses', {
         event: attempt === 0 ? 'start' : 'next',


### PR DESCRIPTION
https://github.com/tashfeenahmed/freellmapi/issues/577
## Problem

The `/v1/responses` endpoint ignores the client's `model` field entirely. While `/v1/chat/completions` resolves the requested model name to a database ID and pins routing accordingly, the Responses endpoint only uses session sticky (`getStickyModel`) — and on the first request in a session (no sticky history), every request silently falls through to auto routing regardless of what `model` was specified.

This means:
- Codex and other Responses-API clients cannot select a specific model — the `model` field is a no-op
- Unify group routing is never used on this endpoint
- Disabled or non-existent models return a 200 with an auto-routed answer instead of a 400 error
- Session sticky on the first request always defaults to auto

## Fix

Port the model resolution logic from `/v1/chat/completions` (`proxy.ts:1378–1427`) into `responses.ts`, applying the same priority chain:

1. **Explicit model** → resolve via Unify group or single-row pin → `preferredModel` db\_id
2. **Sticky session** → fallback when no explicit model (scoped to model group when pinned)
3. **Auto routing** → last resort when no model specified or `"auto"` requested

Also passes the resolved `groupChain` to `routeRequest()` (previously hardcoded `undefined`) so Unify groups work correctly.

## Changes

- `server/src/routes/responses.ts` — add `isAutoModel()`, model resolution block, and `groupChain` passthrough (+60/−4)

## Testing

Verified with `gemma-4-31b-it` and `gemma-4-26b-it` via:
- `POST /v1/responses` with `model` set → correctly routes to the named model
- `POST /v1/chat/completions` with `model` set → unchanged behavior
- `model: "auto"` or omitted → auto routing still works as before
- All existing tests pass (`vitest run` — 1058/1058)