### PR TITLE
fix: Remove Gemma tool-calling isolation — pass tools through to Google API  uniformly

### DIFF
--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -154,7 +154,7 @@ describe('GoogleProvider', () => {
     expect(capturedBody.contents[0].role).toBe('user');
   });
 
-  it('folds system prompts into user content and strips function tools for Gemma models (#500)', async () => {
+  it('passes through tools and system instruction for Gemma models like Gemini (#500)', async () => {
     let capturedBody: any;
     vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
       capturedBody = JSON.parse((init as any).body);
@@ -188,11 +188,10 @@ describe('GoogleProvider', () => {
       },
     );
 
-    expect(capturedBody.systemInstruction).toBeUndefined();
-    expect(capturedBody.tools).toBeUndefined();
-    expect(capturedBody.toolConfig).toBeUndefined();
-    expect(capturedBody.contents[0]).toEqual({ role: 'user', parts: [{ text: 'You are helpful' }] });
-    expect(capturedBody.contents[1]).toEqual({ role: 'user', parts: [{ text: 'Hi' }] });
+    expect(capturedBody.systemInstruction).toEqual({ parts: [{ text: 'You are helpful' }] });
+    expect(capturedBody.tools[0].functionDeclarations[0].name).toBe('get_weather');
+    expect(capturedBody.toolConfig).toBeDefined();
+    expect(capturedBody.contents[0]).toEqual({ role: 'user', parts: [{ text: 'Hi' }] });
   });
 
   it('does not expose Gemini thought parts as visible content (#539)', async () => {

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -109,52 +109,12 @@ interface GeminiResponse {
 
 type GeminiContent = { role: 'user' | 'model'; parts: GeminiPart[] };
 
-function isGemmaModel(modelId: string): boolean {
-  const normalized = modelId.toLowerCase().replace(/^models\//, '');
-  return /(?:^|[/.:])gemma[-_]/.test(normalized);
-}
-
-function optionsForModel(modelId: string, options?: CompletionOptions): CompletionOptions | undefined {
-  if (!isGemmaModel(modelId) || !options) return options;
-  const { tools: _tools, tool_choice: _toolChoice, parallel_tool_calls: _parallelToolCalls, ...rest } = options;
-  return rest;
-}
-
 function systemInstructionText(systemInstruction: { parts?: Array<{ text?: string }> } | undefined): string | null {
   const text = systemInstruction?.parts
     ?.map(part => part.text ?? '')
     .join('\n\n')
     .trim();
   return text ? text : null;
-}
-
-function contentsForModel(
-  modelId: string,
-  contents: GeminiContent[],
-  systemInstruction: { parts: Array<{ text: string }> } | undefined,
-): { contents: GeminiContent[]; systemInstruction?: { parts: Array<{ text: string }> } } {
-  if (!isGemmaModel(modelId)) return { contents, systemInstruction };
-
-  const cleaned = contents
-    .map((entry): GeminiContent | null => {
-      const parts = entry.parts.filter(part => !part.functionCall && !part.functionResponse);
-      if (parts.length === 0) return null;
-      return { ...entry, parts };
-    })
-    .filter((entry): entry is GeminiContent => entry !== null);
-  const safeContents = cleaned.length > 0
-    ? cleaned
-    : [{ role: 'user' as const, parts: [{ text: '' }] }];
-
-  const systemText = systemInstructionText(systemInstruction);
-  if (!systemText) return { contents: safeContents };
-
-  return {
-    contents: [
-      { role: 'user', parts: [{ text: systemText }] },
-      ...safeContents,
-    ],
-  };
 }
 
 function safeParseObject(raw: string): Record<string, unknown> {
@@ -548,25 +508,23 @@ export class GoogleProvider extends BaseProvider {
     quotaContext?: QuotaObservationContext,
   ): Promise<ChatCompletionResponse> {
     const translated = await toGeminiContents(messages);
-    const request = contentsForModel(modelId, translated.contents, translated.systemInstruction);
-    const modelOptions = optionsForModel(modelId, options);
 
-    const tools = toGeminiTools(modelOptions?.tools);
+    const tools = toGeminiTools(options?.tools);
     const body: Record<string, unknown> = {
-      contents: request.contents,
+      contents: translated.contents,
       generationConfig: {
-        temperature: modelOptions?.temperature,
-        maxOutputTokens: modelOptions?.max_tokens,
-        topP: modelOptions?.top_p,
-        stopSequences: toGeminiStopSequences(modelOptions?.stop),
-        ...toGeminiExtendedConfig(modelOptions),
+        temperature: options?.temperature,
+        maxOutputTokens: options?.max_tokens,
+        topP: options?.top_p,
+        stopSequences: toGeminiStopSequences(options?.stop),
+        ...toGeminiExtendedConfig(options),
       },
       tools,
       // functionCallingConfig is only valid when real function tools are present;
       // a grounding-only request (just google_search) must omit it. (#59)
-      toolConfig: hasFunctionDeclarations(tools) ? toGeminiToolConfig(modelOptions?.tool_choice) : undefined,
+      toolConfig: hasFunctionDeclarations(tools) ? toGeminiToolConfig(options?.tool_choice) : undefined,
     };
-    if (request.systemInstruction) body.systemInstruction = request.systemInstruction;
+    if (translated.systemInstruction) body.systemInstruction = translated.systemInstruction;
 
     const url = `${API_BASE}/models/${modelId}:generateContent?key=${apiKey}`;
     const res = await this.fetchWithTimeout(url, {
@@ -630,23 +588,21 @@ export class GoogleProvider extends BaseProvider {
     quotaContext?: QuotaObservationContext,
   ): AsyncGenerator<ChatCompletionChunk> {
     const translated = await toGeminiContents(messages);
-    const request = contentsForModel(modelId, translated.contents, translated.systemInstruction);
-    const modelOptions = optionsForModel(modelId, options);
 
-    const tools = toGeminiTools(modelOptions?.tools);
+    const tools = toGeminiTools(options?.tools);
     const body: Record<string, unknown> = {
-      contents: request.contents,
+      contents: translated.contents,
       generationConfig: {
-        temperature: modelOptions?.temperature,
-        maxOutputTokens: modelOptions?.max_tokens,
-        topP: modelOptions?.top_p,
-        stopSequences: toGeminiStopSequences(modelOptions?.stop),
-        ...toGeminiExtendedConfig(modelOptions),
+        temperature: options?.temperature,
+        maxOutputTokens: options?.max_tokens,
+        topP: options?.top_p,
+        stopSequences: toGeminiStopSequences(options?.stop),
+        ...toGeminiExtendedConfig(options),
       },
       tools,
-      toolConfig: hasFunctionDeclarations(tools) ? toGeminiToolConfig(modelOptions?.tool_choice) : undefined,
+      toolConfig: hasFunctionDeclarations(tools) ? toGeminiToolConfig(options?.tool_choice) : undefined,
     };
-    if (request.systemInstruction) body.systemInstruction = request.systemInstruction;
+    if (translated.systemInstruction) body.systemInstruction = translated.systemInstruction;
 
     const url = `${API_BASE}/models/${modelId}:streamGenerateContent?alt=sse&key=${apiKey}`;
     const res = await this.fetchWithTimeout(url, {


### PR DESCRIPTION
https://github.com/tashfeenahmed/freellmapi/issues/582
The Google provider contains isGemmaModel(), optionsForModel(), and contentsForModel() — introduced in #500 to work around early Gemma models' weak tool-calling support. For any model ID matching the gemma pattern, these functions strip tools/tool_choice/parallel_tool_calls from the request, filter out functionCall/functionResponse parts from history, and fold the system instruction into a user message.

However, Google's Gemini API uses the same functionDeclarations/ functionCall protocol for all models — Gemma included. The isolation was unnecessary and silently blocked tool use on Gemma even when supports_tools was explicitly enabled via the dashboard.

Remove the three helper functions. Both chatCompletion() and streamChatCompletion() now pass translated contents, systemInstruction, and options directly — same code path as Gemini.

- No behavioral change for Gemini models
- No impact on other providers (OpenAI-compat, Cloudflare, etc.)
- All 1058 existing tests pass

test:
```
$ curl -s http://127.0.0.1:8001/v1/chat/completions \
  -H "Authorization: Bearer freellmapi-*" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemma-4-31b-it",
    "messages": [{"role": "user", "content": "What is the weather in Tokyo today?"}],
    "tools": [
      {"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a given city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}},
      {"type": "function", "function": {"name": "get_time", "description": "Get the current time in a timezone", "parameters": {"type": "object", "properties": {"timezone": {"type": "string"}}, "required": ["timezone"]}}}
    ],
    "tool_choice": "auto"
  }' 2>&1 | python3 -m json.tool

{
    "id": "chatcmpl-*",
    "object": "chat.completion",
    "created": *,
    "model": "gemma-4-31b-it",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": null,
                "reasoning_content": "The user is asking for the current weather in Tokyo. I should check the available tools to see if there is one that can provide weather information. The `get_weather` tool takes a `city` as an argument and returns the current weather. This is the correct tool to use.",
                "tool_calls": [
                    {
                        "id": "*",
                        "type": "function",
                        "function": {
                            "name": "get_weather",
                            "arguments": "{\"city\":\"Tokyo\"}"
                        },
                        "thought_signature": "*"
                    }
                ]
            },
            "finish_reason": "tool_calls"
        }
    ],
    "usage": {
        "prompt_tokens": 98,
        "completion_tokens": 16,
        "total_tokens": 172
    },
    "_routed_via": {
        "platform": "google",
        "model": "gemma-4-31b-it"
    }
}


```
with system prompt
```
$ curl -s http://127.0.0.1:8001/v1/chat/completions \
  -H "Authorization: Bearer freellmapi-*" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemma-4-31b-it",
    "messages": [
      {"role": "system", "content": "You are a helpful weather assistant. Always respond in JSON format."},
      {"role": "user", "content": "What is the weather in Tokyo today?"}
    ],
    "tools": [
      {"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a given city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}
    ]
  }' 2>&1 | python3 -m json.tool

{
    "id": "chatcmpl-*",
    "object": "chat.completion",
    "created": *,
    "model": "gemma-4-31b-it",
    "choices": [
        {
            "index": 0,
            "message": {
                "role": "assistant",
                "content": null,
                "reasoning_content": "The user is asking for the weather in Tokyo. I should call the `get_weather` tool with `city='Tokyo'`.",
                "tool_calls": [
                    {
                        "id": "*",
                        "type": "function",
                        "function": {
                            "name": "get_weather",
                            "arguments": "{\"city\":\"Tokyo\"}"
                        },
                        "thought_signature": "*=="
                    }
                ]
            },
            "finish_reason": "tool_calls"
        }
    ],
    "usage": {
        "prompt_tokens": 67,
        "completion_tokens": 16,
        "total_tokens": 110
    },
    "_routed_via": {
        "platform": "google",
        "model": "gemma-4-31b-it"
    }
}
```