### PR TITLE
fix: extend NVIDIA NIM stream timeout

### DIFF
--- a/server/src/__tests__/providers/reasoning-timeouts.test.ts
+++ b/server/src/__tests__/providers/reasoning-timeouts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { resolveProvider } from '../../providers/index.js';
 import { CloudflareProvider } from '../../providers/cloudflare.js';
+import type { ChatCompletionChunk } from '@freellmapi/shared/types.js';
 
 // Regression guard for the 2026-07-11 live-sweep finding: platforms hosting
 // hidden-reasoning or buffered non-streaming models (zhipu glm-4.7-flash 41s
@@ -13,11 +14,30 @@ import { CloudflareProvider } from '../../providers/cloudflare.js';
 
 describe('reasoning-model chat timeouts', () => {
   afterEach(() => {
+    delete process.env.PROVIDER_STREAM_STALL_TIMEOUT_MS;
     vi.restoreAllMocks();
   });
 
+  function sseResponse(frames: string[]): Response {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
+        controller.close();
+      },
+    });
+    return { ok: true, body: stream, headers: new Headers() } as Response;
+  }
+
+  async function collect(gen: AsyncGenerator<ChatCompletionChunk>): Promise<ChatCompletionChunk[]> {
+    const out: ChatCompletionChunk[] = [];
+    for await (const chunk of gen) out.push(chunk);
+    return out;
+  }
+
   it.each([
     ['mistral', 60_000],
+    ['nvidia', 180_000],
     ['openrouter', 60_000],
     ['zhipu', 60_000],
     ['agnes', 60_000],
@@ -56,5 +76,33 @@ describe('reasoning-model chat timeouts', () => {
 
     expect(delays).toContain(200_000);
     expect(delays).not.toContain(15_000);
+  });
+
+  it('nvidia streams use the longer stall watchdog by default', async () => {
+    const provider = resolveProvider('nvidia');
+    expect(provider).toBeDefined();
+    const delays: number[] = [];
+    const origSetTimeout = global.setTimeout;
+    vi.spyOn(global, 'setTimeout').mockImplementation(((fn: () => void, ms?: number) => {
+      delays.push(ms ?? 0);
+      return origSetTimeout(fn, ms);
+    }) as typeof setTimeout);
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(sseResponse([
+      'data: {"id":"x","object":"chat.completion.chunk","created":1,"model":"deepseek-ai/deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n',
+      'data: {"id":"x","object":"chat.completion.chunk","created":1,"model":"deepseek-ai/deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ]));
+
+    const chunks = await collect(provider!.streamChatCompletion(
+      'nv-key',
+      [{ role: 'user', content: 'hi' }],
+      'deepseek-ai/deepseek-v4-pro',
+      { timeoutMs: 777 },
+    ));
+
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(delays).toContain(777);
+    expect(delays).toContain(180_000);
+    expect(delays).not.toContain(90_000);
   });
 });

--- a/server/src/lib/provider-timeout.ts
+++ b/server/src/lib/provider-timeout.ts
@@ -7,9 +7,8 @@
 //
 // PROVIDER_STREAM_STALL_TIMEOUT_MS is the streaming counterpart for the
 // mid-stream inactivity watchdog (issue #553): how long an SSE stream may go
-// without a single byte before the gateway gives up on it. It is global, not
-// per-platform: a stall looks the same everywhere, and the per-platform knob
-// above already covers the slow-first-byte case.
+// without a single byte before the gateway gives up on it. The env override is
+// global, while providers may pass a longer built-in default for slow streams.
 
 const warned = new Set<string>();
 
@@ -49,8 +48,8 @@ export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 90_000;
 
 /** Effective mid-stream inactivity timeout (PROVIDER_STREAM_STALL_TIMEOUT_MS,
  * default 90s, 0 disables). Resolved per call so tests can vary the env. */
-export function streamStallTimeoutMs(): number {
-  return parseTimeoutEnv('PROVIDER_STREAM_STALL_TIMEOUT_MS', DEFAULT_STREAM_STALL_TIMEOUT_MS);
+export function streamStallTimeoutMs(defaultMs = DEFAULT_STREAM_STALL_TIMEOUT_MS): number {
+  return parseTimeoutEnv('PROVIDER_STREAM_STALL_TIMEOUT_MS', defaultMs);
 }
 
 /** Test hook: forget which malformed values have already been warned about. */

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -7,6 +7,8 @@ import { CloudflareProvider } from './cloudflare.js';
 import { AIHordeProvider } from './aihorde.js';
 
 const providers = new Map<Platform, BaseProvider>();
+const NVIDIA_NIM_TIMEOUT_MS = 180_000;
+const NVIDIA_NIM_STREAM_STALL_TIMEOUT_MS = 180_000;
 
 function register(provider: BaseProvider) {
   providers.set(provider.platform, provider);
@@ -39,14 +41,15 @@ register(new OpenAICompatProvider({
 // NVIDIA NIM - OpenAI-compatible. Several NIM models reject parallel tool calls
 // ("This model only supports single tool-calls at once!"), so pin
 // parallel_tool_calls to false when tools are present. See issue #255.
-// Reasoning models (deepseek-v4-pro, llama-4-maverick, llama-3.1/3.3-70b) take
-// 30-60s on cold start; the default 15s false-flags them as broken. 90s.
+// Reasoning models (deepseek-v4-pro, llama-4-maverick, llama-3.1/3.3-70b) can
+// spend well over a minute processing large prompts before the first byte.
 register(new OpenAICompatProvider({
   platform: 'nvidia',
   name: 'NVIDIA NIM',
   baseUrl: 'https://integrate.api.nvidia.com/v1',
   forceSingleToolCall: true,
-  timeoutMs: 90_000,
+  timeoutMs: NVIDIA_NIM_TIMEOUT_MS,
+  streamStallTimeoutMs: NVIDIA_NIM_STREAM_STALL_TIMEOUT_MS,
 }));
 
 // Mistral - OpenAI-compatible

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -10,7 +10,7 @@ import { extendedBodyParams } from '../lib/sampling-params.js';
 import { rescueInlineToolCalls } from '../lib/tool-call-rescue.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
-import { providerTimeoutMs } from '../lib/provider-timeout.js';
+import { streamStallTimeoutMs, providerTimeoutMs } from '../lib/provider-timeout.js';
 
 /**
  * Generic provider for platforms that use an OpenAI-compatible API.
@@ -27,6 +27,7 @@ export class OpenAICompatProvider extends BaseProvider {
    * non-streaming responses until generation completes, and reasoning models can
    * take >15s before first byte. Default 60000. */
   private readonly timeoutMs: number;
+  private readonly streamStallTimeoutMs?: number;
   /** NVIDIA NIM models reject any request that permits parallel tool calls with
    * `400 This model only supports single tool-calls at once!`. When set, pin
    * parallel_tool_calls to false whenever tools are in play. See issue #255. */
@@ -39,6 +40,7 @@ export class OpenAICompatProvider extends BaseProvider {
     extraHeaders?: Record<string, string>;
     validateUrl?: string;
     timeoutMs?: number;
+    streamStallTimeoutMs?: number;
     keyless?: boolean;
     forceSingleToolCall?: boolean;
   }) {
@@ -50,6 +52,7 @@ export class OpenAICompatProvider extends BaseProvider {
     this.validateUrl = opts.validateUrl;
     // PROVIDER_TIMEOUT_<PLATFORM> wins over the registration default (#547).
     this.timeoutMs = providerTimeoutMs(opts.platform, opts.timeoutMs ?? 60_000);
+    this.streamStallTimeoutMs = opts.streamStallTimeoutMs;
     this.keyless = opts.keyless ?? false;
     this.forceSingleToolCall = opts.forceSingleToolCall ?? false;
   }
@@ -332,7 +335,7 @@ export class OpenAICompatProvider extends BaseProvider {
       throw providerHttpError(res, `${this.name} API error ${res.status}: ${this.upstreamErrorText(err, res)}`);
     }
 
-    yield* this.readSseStream(res);
+    yield* this.readSseStream(res, streamStallTimeoutMs(this.streamStallTimeoutMs));
   }
 
   async validateKey(apiKey: string, quotaContext?: QuotaObservationContext): Promise<KeyValidationResult> {


### PR DESCRIPTION
## Summary
- raise NVIDIA NIM's built-in request timeout from 90s to 180s
- give NVIDIA NIM streams a matching 180s inactivity watchdog while preserving `PROVIDER_STREAM_STALL_TIMEOUT_MS` as the global override
- add regression coverage for both the provider registration timeout and the actual SSE stream watchdog path

## Test verification (RED -> GREEN)
- Upstream-base RED: with only the new regression test present, `npm run test -w server -- src/__tests__/providers/reasoning-timeouts.test.ts` failed because NVIDIA was still registered at `90000` instead of `180000`, and the stream test recorded delays `[777, 90000, 90000, 90000]` instead of including `180000`.
- GREEN focused: `npm run test -w server -- src/__tests__/providers/reasoning-timeouts.test.ts src/__tests__/lib/provider-timeout.test.ts` passed: `2 passed`, `17 passed`.
- Full local validation: `npm run test:migrations && npm test && npm run build` passed: server `108` files / `1085` tests, build passed.
- Review gate: independent staged-diff review passed after confirming the stream path now passes the provider-specific watchdog to the shared SSE reader.

Fix #584
