### PR TITLE
feat(keys): add GET /api/keys/providers provider checklist (#543)

### DIFF
--- a/server/src/__tests__/routes/keys-providers-checklist.test.ts
+++ b/server/src/__tests__/routes/keys-providers-checklist.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { encrypt } from '../../lib/crypto.js';
+import { mintDashboardToken } from '../helpers/auth.js';
+
+let dashToken = '';
+
+async function request(app: Express, path: string, withAuth = true) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    headers: withAuth ? { Authorization: `Bearer ${dashToken}` } : {},
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+function addKey(platform: string) {
+  const secret = encrypt(`${platform}-test-key`);
+  getDb().prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+    VALUES (?, 'test', ?, ?, ?, 'healthy', 1)
+  `).run(platform, secret.encrypted, secret.iv, secret.authTag);
+}
+
+describe('GET /api/keys/providers — provider checklist (#543)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  it('requires dashboard auth', async () => {
+    const { status } = await request(app, '/api/keys/providers', false);
+    expect(status).toBe(401);
+  });
+
+  it('lists every registered provider as unconfigured before any key, excluding custom', async () => {
+    const { status, body } = await request(app, '/api/keys/providers');
+    expect(status).toBe(200);
+    expect(body.providers.length).toBeGreaterThan(0);
+    expect(body.providers.every((p: { configured: boolean }) => p.configured === false)).toBe(true);
+    expect(body.providers.some((p: { platform: string }) => p.platform === 'custom')).toBe(false);
+    // A well-known free provider is present with the expected shape.
+    const groq = body.providers.find((p: { platform: string }) => p.platform === 'groq');
+    expect(groq).toMatchObject({ platform: 'groq', configured: false, keyCount: 0 });
+    expect(typeof groq.name).toBe('string');
+    expect(typeof groq.keyless).toBe('boolean');
+    expect(body.summary).toEqual({
+      total: body.providers.length,
+      configured: 0,
+      unconfigured: body.providers.length,
+    });
+  });
+
+  it('marks a provider configured once it has a key and updates the summary', async () => {
+    addKey('groq');
+    const { status, body } = await request(app, '/api/keys/providers');
+    expect(status).toBe(200);
+    const groq = body.providers.find((p: { platform: string }) => p.platform === 'groq');
+    expect(groq).toMatchObject({ configured: true, keyCount: 1, enabledKeyCount: 1 });
+    expect(body.summary.configured).toBe(1);
+    expect(body.summary.unconfigured).toBe(body.summary.total - 1);
+  });
+});

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import multer from 'multer';
 import path from 'path';
 import { getDb } from '../db/index.js';
-import { resolveProvider } from '../providers/index.js';
+import { resolveProvider, getAllProviders } from '../providers/index.js';
 import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
 import { parseKeysFromFile, stripJsoncComments, stripTrailingCommas } from '../lib/key-parser.js';
 import { assessProviderUrl } from '../lib/url-guard.js';
@@ -144,6 +144,50 @@ function noModelsNotice(platform: string): string | undefined {
     `OpenAI-compatible provider with its base URL.`
   );
 }
+
+// Provider checklist (#543): every registered provider with whether the user
+// has added at least one key yet, so the dashboard can show what's still
+// missing without enumerating the whole list by hand. `custom` is excluded —
+// it's a per-key user-defined placeholder, not a fixed free-tier provider to
+// "check off".
+keysRouter.get('/providers', (_req: Request, res: Response) => {
+  const db = getDb();
+  const countRows = db.prepare(`
+    SELECT
+      platform,
+      COUNT(*) AS total_keys,
+      SUM(CASE WHEN enabled = 1 THEN 1 ELSE 0 END) AS enabled_keys
+    FROM api_keys
+    GROUP BY platform
+  `).all() as Array<{ platform: string; total_keys: number; enabled_keys: number }>;
+  const countsByPlatform = new Map(countRows.map(r => [r.platform, r]));
+
+  const providers = getAllProviders()
+    .filter(p => p.platform !== 'custom')
+    .map(p => {
+      const counts = countsByPlatform.get(p.platform);
+      const keyCount = counts?.total_keys ?? 0;
+      return {
+        platform: p.platform,
+        name: p.name,
+        keyless: p.keyless,
+        configured: keyCount > 0,
+        keyCount,
+        enabledKeyCount: counts?.enabled_keys ?? 0,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const configured = providers.filter(p => p.configured).length;
+  res.json({
+    providers,
+    summary: {
+      total: providers.length,
+      configured,
+      unconfigured: providers.length - configured,
+    },
+  });
+});
 
 // List all keys (masked)
 keysRouter.get('/', (_req: Request, res: Response) => {


### PR DESCRIPTION
Addresses #543.

Adds the data layer for a provider checklist: an endpoint that lists **every registered provider** and whether the user has added at least one key for it yet — so they can see what's still missing without scrolling the full list and enumerating by hand.

## Why a new endpoint

`GET /api/health` already reports per-platform key stats, but only for platforms that **already have keys** — it can't tell you which providers you *haven't* configured yet. The checklist needs the complement: the full registry joined with configured-status.

## `GET /api/keys/providers`

Behind the existing dashboard-session auth (like the rest of `/api/keys`). Returns, per provider:

```json
{
  "providers": [
    { "platform": "cerebras", "name": "Cerebras", "keyless": false, "configured": false, "keyCount": 0, "enabledKeyCount": 0 },
    { "platform": "groq", "name": "Groq", "keyless": false, "configured": true, "keyCount": 1, "enabledKeyCount": 1 }
  ],
  "summary": { "total": 29, "configured": 1, "unconfigured": 28 }
}
```

## Implementation notes

- Enumerated from the runtime registry via `getAllProviders()`, so it stays in sync automatically as providers are registered — no second hardcoded list to maintain.
- The `custom` placeholder is excluded: it's a per-key, user-defined entry, not a fixed free-tier provider to "check off".
- Sorted by display name; `configured = keyCount > 0`.
- Read-only, additive, no changes to existing routes.

## Scope

This is the **backend/data layer** — deliberately kept small and testable. Happy to follow up with the dashboard checklist UI that consumes it (or fold it into the Keys page) if you'd like it in the same PR; I split it out so the endpoint can land and be reviewed on its own.

## Testing

- New `server/src/__tests__/routes/keys-providers-checklist.test.ts` (3 cases: auth required, all-unconfigured shape + `custom` excluded, configured/summary update after a key is added).
- **Full server suite green locally: 109 files, 1086 tests.**
