### PR TITLE
feat: ModelScope (魔搭社区) provider — testers with cn-site accounts wanted (#581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # FreeLLMAPI
 
-**One OpenAI-compatible endpoint. 28 free LLM providers. 339 free model endpoints. ~4 billion tokens per month.**
+**One OpenAI-compatible endpoint. 29 free LLM providers. 339 free model endpoints. ~4 billion tokens per month.**
 
 Aggregate free tiers from dozens of providers, plus custom OpenAI-compatible chat, embedding, image, and audio endpoints, behind a single `/v1` API. Keys are stored encrypted. A router picks the best available model for each request, falls over to the next provider when one is rate-limited, and tracks per-key usage so you stay under every free-tier cap.
 
@@ -51,7 +51,7 @@ Your router updates its own model catalog from a signed feed: new free models, q
 
 Every serious AI lab now offers a free tier — a few million tokens a month, a few thousand requests a day. On its own each tier is a toy. Stacked together, they add up to roughly **4 billion tokens per month** of working inference capacity, across **235 model families / 339 provider endpoints** from small-and-fast to reasonably capable.
 
-The problem is that stacking them by hand is painful: twenty-eight different SDKs, twenty-eight different rate limits, twenty-eight places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
+The problem is that stacking them by hand is painful: twenty-nine different SDKs, twenty-nine different rate limits, twenty-nine places a request can fail. FreeLLMAPI collapses that into one OpenAI-compatible endpoint. Point any OpenAI client library at your local server, and it routes transparently across whichever providers you've added keys for.
 
 And the free-tier landscape shifts weekly: providers launch models, retire them, and change quotas without notice. FreeLLMAPI tracks all of that for you. The router pulls a signed model catalog from [freellmapi.co](https://freellmapi.co) on its own, so your install keeps up without a `git pull`. See [Premium (live catalog)](#premium-live-catalog) for how fast it keeps up.
 
@@ -75,6 +75,9 @@ And the free-tier landscape shifts weekly: providers launch models, retire them,
 <td align="center"><a href="https://docs.z.ai"><b>Z.ai (Zhipu)</b><br/>GLM-4.5 · GLM-4.7 Flash</a></td>
 <td align="center"><a href="https://build.nvidia.com"><b>NVIDIA</b><br/>NIM · 40 RPM free (eval-only ToS)</a></td>
 <td align="center"><a href="https://huggingface.co/docs/inference-providers"><b>HuggingFace</b><br/>Router → DeepSeek V4 · Kimi K2.6 · Qwen3</a></td>
+</tr>
+<tr>
+<td align="center"><a href="https://modelscope.cn"><b>ModelScope</b><br/>Qwen3 · DeepSeek V4 · GLM-5 (needs Aliyun cn binding)</a></td>
 </tr>
 </table>
 

--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -54,6 +54,7 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'navy', label: 'NavyAI (free key)', url: 'https://api.navy' },
   { value: 'nara', label: 'NaraRouter (free key)', url: 'https://router.bynara.id' },
   { value: 'sealion', label: 'SEA-LION (free key)', url: 'https://sea-lion.ai' },
+  { value: 'modelscope', label: 'ModelScope (free key, needs Aliyun cn binding)', url: 'https://modelscope.cn/my/myaccesstoken' },
   { value: 'aihorde', label: 'AI Horde (no key needed, slow)', url: 'https://aihorde.net/register', keyless: true },
 ]
 

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -168,6 +168,7 @@ export const platformColors: Record<string, string> = {
   navy:         '#1d4ed8',
   nara:         '#2563eb',
   sealion:     '#0ea5e9',
+  modelscope:  '#624aff',
   aihorde:     '#dc2626',
 }
 

--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -42,6 +42,7 @@ describe('key parser', () => {
     expect(detectPlatform('REQUESTY_')).toBe('requesty');
     expect(detectPlatform('NAVYAI_')).toBe('navy');
     expect(detectPlatform('SEALION_')).toBe('sealion');
+    expect(detectPlatform('MODELSCOPE_')).toBe('modelscope');
     expect(detectPlatform('SAMBANOVA_')).toBeNull();
   });
 
@@ -52,6 +53,7 @@ describe('key parser', () => {
     expect(AUTH_JSON_PROVIDER_MAP['requesty']).toBe('requesty');
     expect(AUTH_JSON_PROVIDER_MAP['api-navy']).toBe('navy');
     expect(AUTH_JSON_PROVIDER_MAP['sea-lion']).toBe('sealion');
+    expect(AUTH_JSON_PROVIDER_MAP['model-scope']).toBe('modelscope');
     const result = parseAuthJson(JSON.stringify({
       credential_pool: {
         gemini: [{ id: '1', label: 'Gemini', auth_type: 'api_key', access_token: 'AIza-test' }],

--- a/server/src/__tests__/providers/modelscope.test.ts
+++ b/server/src/__tests__/providers/modelscope.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ModelScopeProvider } from '../../providers/modelscope.js';
+import { getProvider, hasProvider, resolveProvider } from '../../providers/index.js';
+import type { KeyValidationFailure } from '../../providers/base.js';
+
+// All fixtures are deliberately fake — no real ModelScope tokens exist for
+// this project yet (auth requires an Alibaba Cloud cn-site account binding).
+const GARBAGE_KEY = 'ms-test-invalid';
+
+const ROSTER = {
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve({
+    object: 'list',
+    data: [
+      { id: 'Qwen/Qwen3-235B-A22B-Instruct-2507', object: 'model' },
+      { id: 'deepseek-ai/DeepSeek-V4-Flash', object: 'model' },
+    ],
+  }),
+};
+
+// The verified keyless probe (2026-07-26): a 401 from chat/completions with a
+// garbage Bearer token. The alibaba-binding variant below is the
+// maintainer-documented shape for unbound accounts — unconfirmed until a
+// community tester runs a real token (#581).
+const AUTH_FAILED_401 = {
+  ok: false,
+  status: 401,
+  json: () => Promise.resolve({
+    error: { message: 'please bind your alibaba cloud account before use' },
+  }),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ModelScope registration (#581)', () => {
+  it('is registered and routable in the provider registry', () => {
+    expect(hasProvider('modelscope')).toBe(true);
+    const provider = getProvider('modelscope');
+    expect(provider).toBeInstanceOf(ModelScopeProvider);
+    expect(provider?.platform).toBe('modelscope');
+    expect(provider?.name).toBe('ModelScope');
+    expect(provider?.keyless).toBe(false);
+    // resolveProvider (the routing entry point) returns the same singleton.
+    expect(resolveProvider('modelscope')).toBe(provider);
+  });
+});
+
+describe('ModelScope validateKey (#581)', () => {
+  it('does NOT trust GET /v1/models — a garbage key that 200s there is still invalid', async () => {
+    // The trap: ModelScope's /v1/models answers 200 with or without auth
+    // (verified keyless 2026-07-26), so the default openai-compat validateKey
+    // would mark garbage keys healthy forever.
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      calls.push({ url: String(url), init: init as RequestInit });
+      if (String(url).endsWith('/models')) return ROSTER as unknown as Response;
+      return AUTH_FAILED_401 as unknown as Response;
+    });
+
+    const provider = new ModelScopeProvider();
+    const result = await provider.validateKey(GARBAGE_KEY);
+
+    expect(result).not.toBe(true);
+    const failure = result as KeyValidationFailure;
+    expect(failure.valid).toBe(false);
+    // The alibaba-binding reason must surface verbatim in the health error.
+    expect(failure.error).toContain('please bind your alibaba cloud account before use');
+    expect(failure.error).toContain('401');
+
+    // Probe shape: models list first (to pick a live model id), then a
+    // 1-token chat completion that actually enforces auth.
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe('https://api-inference.modelscope.cn/v1/models');
+    expect(calls[1].url).toBe('https://api-inference.modelscope.cn/v1/chat/completions');
+    expect(calls[1].init.method).toBe('POST');
+    const body = JSON.parse(String(calls[1].init.body));
+    expect(body.model).toBe('Qwen/Qwen3-235B-A22B-Instruct-2507'); // first roster entry
+    expect(body.max_tokens).toBe(1);
+    expect((calls[1].init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${GARBAGE_KEY}`);
+  });
+
+  it('returns true when the 1-token chat probe authenticates (200)', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      if (String(url).endsWith('/models')) return ROSTER as unknown as Response;
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          id: 'chatcmpl-1', object: 'chat.completion', created: 1,
+          model: 'Qwen/Qwen3-235B-A22B-Instruct-2507',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'p' }, finish_reason: 'length' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+      } as unknown as Response;
+    });
+
+    const provider = new ModelScopeProvider();
+    await expect(provider.validateKey('ms-test-valid-shaped')).resolves.toBe(true);
+  });
+
+  it('treats a 429 probe answer as a VALID key (quota, not auth)', async () => {
+    // ModelScope also 429s for retired models ("insufficient balance (1008)").
+    // Neither case is an auth failure, so the key must not be disabled.
+    vi.spyOn(global, 'fetch').mockImplementation(async (url) => {
+      if (String(url).endsWith('/models')) return ROSTER as unknown as Response;
+      return {
+        ok: false,
+        status: 429,
+        json: () => Promise.resolve({ error: { message: 'Request limit exceeded' } }),
+      } as unknown as Response;
+    });
+
+    const provider = new ModelScopeProvider();
+    await expect(provider.validateKey('ms-test-valid-shaped')).resolves.toBe(true);
+  });
+
+  it('throws (health status=error, never invalid) when the roster fetch fails', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const provider = new ModelScopeProvider();
+    await expect(provider.validateKey(GARBAGE_KEY)).rejects.toThrow(/HTTP 503/);
+  });
+
+  it('throws when the roster is empty (no probe model available)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ object: 'list', data: [] }),
+    } as unknown as Response);
+
+    const provider = new ModelScopeProvider();
+    await expect(provider.validateKey(GARBAGE_KEY)).rejects.toThrow(/no models/);
+  });
+});

--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -510,6 +510,9 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'navy',       name: 'NavyAI',        baseUrl: 'https://api.navy/v1' },
     { platform: 'nara',       name: 'NaraRouter',    baseUrl: 'https://router.bynara.id/v1' },
     { platform: 'sealion',    name: 'SEA-LION',      baseUrl: 'https://api.sea-lion.ai/v1' },
+    // modelscope registers a ModelScopeProvider subclass (custom validateKey,
+    // see providers/modelscope.test.ts) but chat routing is stock openai-compat.
+    { platform: 'modelscope', name: 'ModelScope',    baseUrl: 'https://api-inference.modelscope.cn/v1' },
   ] as const;
 
   for (const p of platforms) {

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -130,6 +130,19 @@ describe('Keys API', () => {
     expect(body.notice ?? null).toBeNull();
   });
 
+  it('POST /api/keys accepts the modelscope platform (#581)', async () => {
+    const { status, body } = await request(app, 'POST', '/api/keys', {
+      platform: 'modelscope',
+      key: 'ms-test-invalid-not-a-real-token',
+      label: 'ModelScope test',
+    });
+    expect(status).toBe(201);
+    expect(body.platform).toBe('modelscope');
+    // Catalog rows land only after community testing (#581), so a fresh DB
+    // has no modelscope models and the no-catalog-models notice is expected.
+    expect(body.modelsAvailable).toBe(0);
+  });
+
   it('POST /api/keys rejects invalid platform', async () => {
     const { status } = await request(app, 'POST', '/api/keys', {
       platform: 'invalid_platform',

--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -264,6 +264,8 @@ describe('Rate Limiter', () => {
     it('defaults to OpenRouter ~1000/day and allows env override / disable', () => {
       delete process.env[ENV];
       expect(getProviderDailyRequestCap('openrouter')).toBe(1000);
+      // ModelScope: 2000/day account-wide upstream, shipped as 1800 for margin (#581).
+      expect(getProviderDailyRequestCap('modelscope')).toBe(1800);
       expect(getProviderDailyRequestCap('groq')).toBeNull(); // no shared cap
       process.env[ENV] = '50';
       expect(getProviderDailyRequestCap('openrouter')).toBe(50);

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -44,6 +44,8 @@ export const PREFIX_MAP: Record<string, string> = {
   BYNARA_: 'nara',
   SEALION_: 'sealion',
   SEA_LION_: 'sealion',
+  MODELSCOPE_: 'modelscope',
+  MODEL_SCOPE_: 'modelscope',
   AIHORDE_: 'aihorde',
 };
 
@@ -69,6 +71,8 @@ export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
   'nara-router': 'nara',
   sealion: 'sealion',
   'sea-lion': 'sealion',
+  modelscope: 'modelscope',
+  'model-scope': 'modelscope',
 };
 
 export function detectPlatform(prefix: string): string | null {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -5,6 +5,7 @@ import { OpenAICompatProvider } from './openai-compat.js';
 import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
 import { AIHordeProvider } from './aihorde.js';
+import { ModelScopeProvider } from './modelscope.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -328,6 +329,25 @@ register(new OpenAICompatProvider({
   name: 'SEA-LION',
   baseUrl: 'https://api.sea-lion.ai/v1',
 }));
+
+// ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
+// (api-inference.modelscope.cn/v1, Bearer auth). Free tier: 2000 requests/day
+// account-wide. Token from modelscope.cn/my/myaccesstoken, BUT calls only work
+// after binding the ModelScope account to an Alibaba Cloud CHINA-site (cn)
+// account with Chinese real-name verification — unbound tokens 401 on every
+// call ("please bind your alibaba cloud account before use"). Dedicated
+// ModelScopeProvider (not plain OpenAICompatProvider) because GET /v1/models
+// answers 200 even for garbage tokens, so key validation needs a 1-token chat
+// probe instead — see providers/modelscope.ts.
+//
+// RETIRED-model gotcha (#581): ModelScope answers requests for retired models
+// with `429 insufficient balance (1008)`. isPaymentRequiredError
+// (lib/error-classify.ts) reads "insufficient balance" as out-of-credits and
+// benches the key ~24h — intentionally NOT special-cased in the shared
+// classifier (the string is a genuine payment marker everywhere else). Keep
+// retired ids out of the catalog instead; the quota-header path in
+// provider-quota.ts keys on response headers, never on that message text.
+register(new ModelScopeProvider());
 
 // AI Horde — free, community-powered inference (volunteer workers) via an
 // OpenAI-compatible proxy. Dedicated AIHordeProvider (not OpenAICompatProvider)

--- a/server/src/providers/modelscope.ts
+++ b/server/src/providers/modelscope.ts
@@ -1,0 +1,106 @@
+import { OpenAICompatProvider } from './openai-compat.js';
+import type { KeyValidationResult } from './base.js';
+import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+
+const MODELSCOPE_BASE_URL = 'https://api-inference.modelscope.cn/v1';
+
+/**
+ * ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API.
+ *
+ * Everything except key validation is stock OpenAI-compat. validateKey is
+ * overridden because of a trap in ModelScope's API surface:
+ *
+ *   GET /v1/models returns 200 WITHOUT auth — and, verified keyless on
+ *   2026-07-26, it also returns 200 with a GARBAGE Bearer token. The default
+ *   openai-compat validateKey (GET /v1/models with the key) would therefore
+ *   mark any invalid key healthy forever. /v1/models is useless for
+ *   validation on this platform.
+ *
+ * The only endpoint verified to enforce auth is POST /v1/chat/completions:
+ * a garbage token gets a clean
+ *   401 {"error":{"message":"Authentication failed, please make sure that a
+ *        valid ModelScope token is supplied."}}
+ * before any generation happens. So validation makes a 1-token chat
+ * completion. The model id is picked dynamically from GET /v1/models (first
+ * entry) because the roster churns — a hardcoded id would rot.
+ *
+ * COST: a successful validation burns 1 request (and ~1 output token) of the
+ * 2000-requests/day account-wide free quota per health check. A failed-auth
+ * validation is rejected before generation and, per maintainer reports, does
+ * not count against quota.
+ *
+ * Community testers must confirm (we have NO real token for this platform):
+ * the maintainer-documented bad-binding failure is
+ *   `401 please bind your alibaba cloud account before use`
+ * — a token minted without binding the ModelScope account to an Alibaba
+ * Cloud CHINA-site account fails every call with that message. It flows
+ * through validationResult() into the health error verbatim so users see the
+ * actionable reason instead of a generic "invalid key". See issue #581.
+ */
+export class ModelScopeProvider extends OpenAICompatProvider {
+  constructor() {
+    super({
+      platform: 'modelscope',
+      name: 'ModelScope',
+      // Serves large reasoning models (DeepSeek-V4, Qwen3 Thinking variants)
+      // from cn-region infrastructure; cross-region TTFB plus buffered
+      // reasoning phases blow the 60s default. 90s matches NVIDIA NIM's
+      // allowance for the same model class.
+      baseUrl: MODELSCOPE_BASE_URL,
+      timeoutMs: 90_000,
+    });
+  }
+
+  override async validateKey(apiKey: string, quotaContext?: QuotaObservationContext): Promise<KeyValidationResult> {
+    // Transport errors (DNS / timeout / TLS) propagate — health.ts marks
+    // status='error' without counting toward auto-disable; only a confirmed
+    // 401/403 disables a key.
+
+    // Step 1: pick a live model id for the auth probe. This call is NOT the
+    // validation (it answers 200 for any token, see class comment) — it only
+    // keeps the probe's model id in sync with the churning roster.
+    const modelsRes = await this.fetchWithTimeout(`${MODELSCOPE_BASE_URL}/models`, {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    }, 30000, { timeoutBounds: 'request' });
+    if (!modelsRes.ok) {
+      // Auth failures cannot happen here (endpoint is unauthenticated); treat
+      // any non-200 as an upstream outage → status='error', never 'invalid'.
+      throw new Error(`ModelScope /models returned HTTP ${modelsRes.status} while picking a validation probe model`);
+    }
+    const roster = await modelsRes.json().catch(() => null) as { data?: Array<{ id?: string }> } | null;
+    const probeModel = roster?.data?.[0]?.id;
+    if (!probeModel) {
+      throw new Error('ModelScope /models returned no models to probe key validity against');
+    }
+
+    // Step 2: the actual auth check — a minimal 1-token completion.
+    const res = await this.fetchWithTimeout(`${MODELSCOPE_BASE_URL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: probeModel,
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+      }),
+    }, 30000, { timeoutBounds: 'request' });
+
+    recordQuotaObservationsFromResponse(res, {
+      platform: this.platform,
+      keyId: quotaContext?.keyId,
+      providerAccountId: quotaContext?.providerAccountId,
+      modelId: probeModel,
+      quotaPoolKey: quotaContext?.quotaPoolKey,
+      endpoint: 'chat/completions',
+    });
+
+    // validationResult: 401/403 → {valid:false, error:<upstream message>}
+    // (surfaces the alibaba-binding reason); everything else — 200, but also
+    // 400/404 (probe model quirk), 429 (quota) — proves the token
+    // authenticated and returns true.
+    return this.validationResult(res);
+  }
+}

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -21,7 +21,7 @@ const PLATFORMS = [
   'google', 'groq', 'cerebras', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
-  'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'aihorde', 'custom',
+  'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'modelscope', 'aihorde', 'custom',
 ] as const;
 
 const ALLOWED_IMPORT_EXTENSIONS = new Set(['.env', '.json', '.jsonc', '.md', '.txt', '.csv']);

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -141,11 +141,13 @@ function inferPoolForPlatform(platform: Platform, modelId?: string | null): stri
   if (platform === 'navy') return 'navy::free';
   if (platform === 'nara') return 'nara::free';
   if (platform === 'sealion') return 'sealion::free';
+  // ModelScope: one 2000-requests/day quota across the whole account.
+  if (platform === 'modelscope') return 'modelscope::account';
   return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'aihorde'].includes(platform);
+  return ['openrouter', 'google', 'groq', 'cerebras', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'modelscope', 'aihorde'].includes(platform);
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };
@@ -162,6 +164,17 @@ const HEADER_SPECS: Partial<Record<Platform, HeaderSpec[]>> = {
   openrouter: [
     { metric: 'requests', limit: 'x-ratelimit-limit-requests', remaining: 'x-ratelimit-remaining-requests', reset: 'x-ratelimit-reset-requests', strategy: 'provider_reported' },
     { metric: 'tokens', limit: 'x-ratelimit-limit-tokens', remaining: 'x-ratelimit-remaining-tokens', reset: 'x-ratelimit-reset-tokens', strategy: 'provider_reported' },
+  ],
+  // ModelScope reportedly returns `modelscope-ratelimit-*`-style headers on
+  // authenticated responses. UNCONFIRMED: no real token exists for this
+  // platform yet (auth needs an Alibaba Cloud cn-site binding, #581), and the
+  // keyless probes we could run (401s, unauthenticated /v1/models) carry no
+  // ratelimit headers at all. Absent headers are a no-op in
+  // maybeAddObservation, so a wrong guess here costs nothing; community
+  // testers should dump response headers (see the #581 tester guide) and
+  // correct these names.
+  modelscope: [
+    { metric: 'requests', limit: 'modelscope-ratelimit-requests-limit', remaining: 'modelscope-ratelimit-requests-remaining', reset: 'modelscope-ratelimit-requests-reset', strategy: 'provider_reported' },
   ],
 };
 

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -347,6 +347,10 @@ export function canUseTokens(
 //   PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50   (set 0 to disable the cap)
 const DEFAULT_PROVIDER_DAILY_REQUEST_CAPS: Record<string, number> = {
   openrouter: 1000,
+  // ModelScope's free tier is 2000 requests/day across the whole account (all
+  // models share it). 1800 leaves margin for validation probes and for drift
+  // between our ledger and the provider's own daily boundary (#581).
+  modelscope: 1800,
 };
 
 const DEFAULT_PROVIDER_DAILY_TOKEN_CAPS: Record<string, number> = {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -102,6 +102,13 @@ export type Platform =
   // (Google sign-in, no card, no region wall) at 10 RPM; catalog rows live in
   // the Oracle catalog (premium now, free after 30 days).
   | 'sealion'
+  // ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
+  // (api-inference.modelscope.cn/v1). Free tier is 2000 requests/day
+  // account-wide, but calls only work after the ModelScope account is bound to
+  // an Alibaba Cloud CHINA-site (cn) account with Chinese real-name
+  // verification — tokens mint without binding, then every call 401s. Catalog
+  // rows land after community testing confirms per-model behavior (#581).
+  | 'modelscope'
   // AI Horde — free, community-powered inference (volunteer workers) via an
   // OpenAI-compatible proxy (https://oai.aihorde.net/v1). Queue-based, so calls
   // can take tens of seconds; no tool support; usage is reported as kudos, not


### PR DESCRIPTION
Implements the provider half of #581 — ModelScope (魔搭社区) API-Inference as a `modelscope` platform. **Not merged yet: we need a community tester with a working token before this ships** (see the ask below).

## What this adds
- `modelscope` platform on the OpenAI-compat adapter (`api-inference.modelscope.cn/v1`, Bearer auth, 90s timeout for its large reasoning models)
- **Custom key validation**: ModelScope's `GET /v1/models` returns 200 even for garbage tokens (verified keyless), so the standard validation would mark broken keys healthy forever. Validation instead makes a 1-token chat completion against a dynamically picked roster model; auth failures surface the provider's actual message (including the alibaba-binding one) in health errors
- **Account-wide quota**: 1,800/day provider-wide cap (ModelScope allows 2,000/day per account across all models; margin for their reported soft throttling). Per-model `rpd` caps arrive with the catalog rows
- Key onboarding, dashboard entry + get-key link, pricing rows, README

## What deliberately does NOT ship yet
- **Catalog rows.** The 15-model roster (Qwen3.5/Qwen3 family, DeepSeek V4/V3.2, GLM-5.2, MiniMax-M3, Kimi-K2.5 — all verified present in today's live roster) is staged and publishes to the catalog only after testing confirms. Until then the platform is inert even if merged.
- **Tool-calling flags.** A ModelScope maintainer confirmed tools are per-model (DeepSeek/Kimi models hard-400 on them), so every staged row is `supportsTools: false` until individually proven.

## ⚠️ Important access constraint
ModelScope's free tier requires binding your modelscope.cn account to an **Alibaba Cloud China-site (cn) account with Chinese real-name verification** — international Alibaba accounts do not qualify (maintainer-confirmed). Tokens mint without the binding but every call returns 401. This is effectively a China-KYC-gated provider and will be labelled as such in the catalog.

## 🙏 Call for testers
If you have a working ModelScope token (cn-site-bound), we'd love your help — the full checklist is below. The headline items:
1. Add your key on this branch, confirm the health check goes green (or reports the binding error with the exact upstream wording)
2. Register 2–3 models locally (snippet below — catalog rows don't exist yet), run non-streaming + streaming chat
3. Probe `tools` per model and tell us which models accept vs 400
4. Run a `*-Thinking-*` model and confirm reasoning arrives in `reasoning_content` (not inline `</think>` text)
5. Paste the `modelscope-ratelimit-*` response headers you see — we want to wire real remaining-quota tracking to them

Please report results as a comment here; we'll flip the catalog flags accordingly and merge.

---

# ModelScope (魔搭社区) community tester checklist — issue #581

The provider half of #581 ships in `feat/modelscope-provider`; catalog rows land only after
these checks come back. We (the maintainers) have NO working token — everything auth-side
below needs your confirmation.

## 0. Prerequisites

- A ModelScope account (modelscope.cn) **bound to an Alibaba Cloud CHINA-site (cn) account
  with Chinese real-name verification**. International alibabacloud.com accounts do NOT
  qualify. The token mints fine without the binding, but every API call then returns
  `401 please bind your alibaba cloud account before use` — please confirm that exact
  message if you hit it (we surface it in health errors and want the wording right).
- Token from: https://modelscope.cn/my/myaccesstoken
- Free tier: 2000 requests/day account-wide (the server ships a 1800/day safety cap).

## 1. Add the key, confirm health

1. Dashboard → Keys → platform **ModelScope** → paste your token.
2. Run a health check. Expected:
   - Good, bound token → key goes **healthy**. Note: validation costs 1 request of your
     daily quota (a 1-token chat completion — ModelScope's `GET /v1/models` answers 200
     even for garbage tokens, so it can't be used for validation).
   - Unbound token → **invalid**, error containing the alibaba-binding message above.
   - Garbage token → **invalid**, error containing
     `Authentication failed, please make sure that a valid ModelScope token is supplied.`

## 2. Register 2–3 models locally

Catalog rows won't exist yet, so add rows declaratively. Set `FREEAPI_CONFIG_JSON` in the
server's environment (or your `.env`) and restart — the ids below were verified live in
`GET /v1/models` on 2026-07-26:

```bash
FREEAPI_CONFIG_JSON='{"keys":[{"platform":"modelscope","key":"YOUR_MODELSCOPE_TOKEN","label":"ModelScope"}],"models":[{"platform":"modelscope","modelId":"Qwen/Qwen3-235B-A22B-Instruct-2507","displayName":"Qwen3 235B Instruct 2507 (ModelScope)","contextWindow":262144,"rpdLimit":200,"supportsTools":false},{"platform":"modelscope","modelId":"deepseek-ai/DeepSeek-V4-Flash","displayName":"DeepSeek V4 Flash (ModelScope)","contextWindow":131072,"rpdLimit":200,"supportsTools":false},{"platform":"modelscope","modelId":"Qwen/Qwen3-235B-A22B-Thinking-2507","displayName":"Qwen3 235B Thinking 2507 (ModelScope)","contextWindow":262144,"rpdLimit":200,"supportsTools":false}]}'
```

(If you already added the key in step 1, drop the `"keys"` array — the `"models"` entries
alone are fine.)

## 3. Test matrix (per model)

Run through the gateway (`http://localhost:3001/v1/chat/completions`) unless stated.

1. **Non-streaming chat** — one short prompt, expect 200 with normal content.
2. **Streaming chat** — `"stream": true`, expect SSE deltas ending in `[DONE]`.
3. **Tools probe** — send a trivial `tools` array. Some models are expected to hard-400
   with something like "tool call not supported" (that is WHY every proposed catalog row
   ships `supportsTools: false`). Record per model: worked / 400 (exact message).
4. **Thinking models** (`Qwen/Qwen3-235B-A22B-Thinking-2507`, any `*-Thinking-*`) — check
   the reasoning arrives in `reasoning_content` (stream: `delta.reasoning_content`),
   SEPARATE from `content`, and that `content` still carries the actual answer.
5. **Response headers dump** — hit ModelScope DIRECTLY so the gateway doesn't hide
   anything, and paste all headers:

   ```bash
   curl -sD - -o /dev/null https://api-inference.modelscope.cn/v1/chat/completions \
     -H "Authorization: Bearer YOUR_MODELSCOPE_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"model":"Qwen/Qwen3-235B-A22B-Instruct-2507","messages":[{"role":"user","content":"hi"}],"max_tokens":8}'
   ```

   We especially want any `modelscope-ratelimit-*` / `x-ratelimit-*` names — the server
   has a provisional header spec (`modelscope-ratelimit-requests-{limit,remaining,reset}`)
   that needs the real names. Keyless 401 responses carry none, so this is blind-wired.
6. **Sampling params** — one call with `temperature`, `top_p`, `presence_penalty` set.
   Some models proxy to DashScope and may reject params others accept; report any 400s.
7. **(Optional) Retired-model behavior** — if you know a retired id, confirm it answers
   `429 insufficient balance (1008)` (this is why retired ids must stay out of the catalog:
   that message reads as out-of-credits and benches the key ~24h).

## 4. Report template

```
Token binding: cn-Aliyun bound? yes/no · unbound-call error message (verbatim, if seen):
Health check: pass/fail · error text:
Per model (id):
  non-stream: ok/fail (detail)
  stream: ok/fail
  tools: ok / 400 "<message>"
  reasoning_content separated (thinking models): yes/no
  sampling-param 400s: none / <param>: "<message>"
Headers dump (full paste from step 3.5):
Observed rate limiting: any 429s? headers/message:
Anything else (latency, truncations, wrong model served):
```

Post results on issue #581. Thanks!