### PR TITLE
test: fix flaky start_offset_ms assertion in request-attempts test

### DIFF
--- a/server/src/__tests__/lib/request-attempts.test.ts
+++ b/server/src/__tests__/lib/request-attempts.test.ts
@@ -180,8 +180,12 @@ describe('per-attempt routing traces', () => {
       model_id: 'solo-model',
       key_ordinal: 1,
       outcome: 'ok',
-      start_offset_ms: 0,
     });
+    // Wall-clock delta between trace start and first dispatch: 0 on a fast
+    // machine, a few ms on a loaded CI runner — assert small, not exactly 0
+    // (flaked on the Node 22 CI job).
+    expect(rows[0].start_offset_ms).toBeGreaterThanOrEqual(0);
+    expect(rows[0].start_offset_ms).toBeLessThan(1000);
     expect(rows[0].duration_ms).toBeGreaterThanOrEqual(0);
   });
 


### PR DESCRIPTION
The Node 22 CI job on #605's branch run flaked on `persists exactly one 'ok' attempt`: `start_offset_ms` is a wall-clock delta that's 0 on a fast machine and 1-2ms on a loaded runner. Assert tolerantly (>= 0, < 1000), matching the multi-attempt test's existing treatment of timing fields. Verified 5/5 repeat runs.
