### PR TITLE
fix(key-parser): strip quotes from .env values that carry an inline comment

### DIFF
--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -21,6 +21,19 @@ describe('key parser', () => {
     ]);
   });
 
+  it('unquotes dotenv values that carry an inline comment', () => {
+    expect(parseDotEnv('GOOGLE_API_KEY="ai-test" # primary\nGROQ_API_KEY=\'gsk-test\'  # backup')).toEqual([
+      { key: 'GOOGLE_API_KEY', value: 'ai-test' },
+      { key: 'GROQ_API_KEY', value: 'gsk-test' },
+    ]);
+  });
+
+  it('keeps a # that is inside the quotes', () => {
+    expect(parseDotEnv('NVIDIA_API_KEY="nv # test"')).toEqual([
+      { key: 'NVIDIA_API_KEY', value: 'nv # test' },
+    ]);
+  });
+
   it('parses flat JSON string values', () => {
     expect(parseJson(JSON.stringify({ MISTRAL_API_KEY: 'mist-test', PORT: 3001 }))).toEqual([
       { key: 'MISTRAL_API_KEY', value: 'mist-test' },

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -90,11 +90,15 @@ export function parseDotEnv(content: string): Array<{ key: string; value: string
 
     const key = line.slice(0, eqIndex).trim();
     let value = line.slice(eqIndex + 1).trimStart();
-    const doubleQuoted = value.startsWith('"') && value.endsWith('"');
-    const singleQuoted = value.startsWith("'") && value.endsWith("'");
+    // A quoted value ends at its closing quote; whatever follows is an inline
+    // comment, not part of the credential. Matching on endsWith instead meant
+    // `KEY="secret" # note` failed the quoted test, took the unquoted branch,
+    // and imported the key with its quote characters still attached.
+    const quote = value.startsWith('"') || value.startsWith("'") ? value[0] : '';
+    const closeIndex = quote ? value.indexOf(quote, 1) : -1;
 
-    if (doubleQuoted || singleQuoted) {
-      value = value.slice(1, -1);
+    if (closeIndex !== -1) {
+      value = value.slice(1, closeIndex);
     } else {
       const commentIndex = value.indexOf(' #');
       if (commentIndex !== -1) value = value.slice(0, commentIndex);


### PR DESCRIPTION
## The bug

`server/src/lib/key-parser.ts:93-97` detected quoting with `startsWith(q) && endsWith(q)`. A trailing inline comment makes `endsWith` false, so this line:

```
GROQ_API_KEY="gsk-live-xxx" # backup key
```

falls into the *unquoted* branch, which strips the comment but never the quotes. The parsed value is `"gsk-live-xxx"` — quote characters included.

This is not cosmetic. `routes/keys.ts:110` stores `encrypt(keyValue.trim())`, and `trim()` removes whitespace but not quotes, so the credential is persisted with literal `"` characters. Every upstream call with that key 401s, while the import UI reports success. `.env` upload is an advertised bulk-import path, and quoting a value plus annotating it with a comment is an ordinary thing to have in a `.env` file.

The existing test at `key-parser.test.ts:18` covers quoted-**without**-comment and unquoted-**with**-comment — exactly the two halves that already worked. The combination was untested.

## The fix

A quoted value now ends at its closing quote; anything after it is a comment. This matches the semantics of the `dotenv` package already in the dependency tree.

## How to test

```
cd server && npx vitest run src/__tests__/lib/key-parser.test.ts
```
→ 15 passed.

Two tests added:
- `unquotes dotenv values that carry an inline comment` — the bug, both quote styles
- `keeps a # that is inside the quotes` — guard so the fix cannot over-strip `KEY="nv # test"`

Regression value verified: with the source change reverted and the tests left in place, exactly one fails:

```
× key parser > unquotes dotenv values that carry an inline comment
-   "value": "ai-test",     +   "value": "\"ai-test\""
-   "value": "gsk-test",    +   "value": "'gsk-test'"
Tests  1 failed | 14 passed (15)
```

The guard test passes in both states, as intended.

## Behaviour changes on degenerate input — please sanity-check these

The fix adopts dotenv's "first closing quote wins" rule, which changes three malformed cases:

| input | before | after |
|---|---|---|
| `KEY="ab"cd"` | `ab"cd` | `ab` |
| `KEY="` | `` (empty) | `"` |
| `KEY=  "x"  ` (trailing space) | `"x"` | `x` |
| `KEY="abc` (unterminated) | unchanged | unchanged |

The third is the same root cause and is arguably a second bug fixed. If you would rather have a strictly zero-delta change, gating the quoted branch on `value.endsWith(quote)` first would preserve all of the old degenerate behaviour — happy to switch.

## Note on the test suite

`npm test` is flaky on a clean tree, independent of this change. Across five full runs a *different* route test failed each time (`audio-transcriptions`, `proxy-array-content`, `proxy-stream-integrity`, `proxy-auto-model`), including two runs on an unmodified checkout; all are `fetch failed / other side closed` from tests that spin up a real HTTP server. This change touches only `parseDotEnv`, which no route test exercises. Might be worth its own issue.
