### PR TITLE
chore: prep v0.6.0 release

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bump `desktop/package.json` to 0.6.0 so the tagged release installers are named correctly (`FreeLLMAPI Setup 0.6.0.exe` / `FreeLLMAPI-0.6.0-arm64.dmg`).

Same single-file bump as the v0.5.0 prep (#562). Tag `v0.6.0` follows once this is merged.