### PR TITLE
fix(desktop): real System theme in the shell + RTL traffic-light gutter

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,8 @@
           document.documentElement.classList.add('dark')
         }
         document.documentElement.style.colorScheme = dark ? 'dark' : 'light'
+        document.documentElement.dataset.themeChoice =
+          theme === 'dark' || theme === 'light' ? theme : 'system'
         // Same idea for text direction; keep in sync with RTL_LOCALES in
         // src/i18n/locale-config.ts.
         const locale = localStorage.getItem('freellmapi.locale')

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -169,7 +169,10 @@ function Navbar() {
         style={isDesktopApp ? ({ WebkitAppRegion: 'drag' } as React.CSSProperties) : undefined}
       >
         <div
-          className={`mx-auto flex max-w-6xl items-center px-4 sm:px-6 ${isDesktopApp ? 'ps-20 sm:ps-20' : ''}`}
+          // Physical pl (not logical ps): the gutter reserves the macOS
+          // traffic lights, which stay top-left even when an RTL locale
+          // flips the document direction.
+          className={`mx-auto flex max-w-6xl items-center px-4 sm:px-6 ${isDesktopApp ? 'pl-20 sm:pl-20' : ''}`}
           style={isDesktopApp ? { minHeight: 52 } : undefined}
         >
           <Brand />

--- a/client/src/theme.tsx
+++ b/client/src/theme.tsx
@@ -33,6 +33,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     window.localStorage.setItem('theme', theme)
+    // The desktop preload mirrors this attribute to the Electron main process
+    // so nativeTheme.themeSource can follow a 'system' choice for real.
+    document.documentElement.dataset.themeChoice = theme
   }, [theme])
 
   useEffect(() => {

--- a/desktop/src/config.ts
+++ b/desktop/src/config.ts
@@ -4,7 +4,7 @@ import { app } from 'electron';
 
 export interface DesktopConfig {
   port?: number;
-  theme?: 'dark' | 'light';
+  theme?: 'dark' | 'light' | 'system';
   // BCP-47 locale mirrored from the dashboard (en, zh-CN, fr, es, pt-BR).
   locale?: string;
   // Bind the embedded server to 0.0.0.0 instead of 127.0.0.1 so other devices

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -22,15 +22,29 @@ if (!app.requestSingleInstanceLock()) {
 } else {
   let resolvedPort = DEFAULT_PORT;
   let sessionToken = '';
-  // The dashboard owns the theme (its navbar toggle); the popover and the
-  // window vibrancy follow. Last choice persists in config; before the
-  // dashboard has ever reported, fall back to the system appearance —
-  // matching the dashboard's own prefers-color-scheme default.
-  let theme: 'dark' | 'light' =
-    (process.env.FREEAPI_THEME as 'dark' | 'light' | undefined) // dev-only screenshot override
+  // The dashboard owns the theme (its Settings dialog); the popover and the
+  // window vibrancy follow. The persisted choice may be 'system', in which
+  // case themeSource is handed back to the OS so the dashboard's
+  // prefers-color-scheme tracks live appearance changes; `theme` is always
+  // the resolved dark/light the popover snapshot needs.
+  let themeChoice: 'dark' | 'light' | 'system' =
+    (process.env.FREEAPI_THEME as 'dark' | 'light' | 'system' | undefined) // dev-only screenshot override
     ?? loadConfig().theme
-    ?? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light');
-  nativeTheme.themeSource = theme;
+    ?? 'system';
+  nativeTheme.themeSource = themeChoice;
+  let theme: 'dark' | 'light' = themeChoice === 'system'
+    ? (nativeTheme.shouldUseDarkColors ? 'dark' : 'light')
+    : themeChoice;
+  // With a 'system' choice the OS can flip appearance while the dashboard
+  // window (and its reporting preload) is closed — track it here too.
+  nativeTheme.on('updated', async () => {
+    if (themeChoice !== 'system') return;
+    const next = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+    if (next === theme) return;
+    theme = next;
+    const { getPopoverWindow } = await import('./popover.js');
+    getPopoverWindow()?.webContents.send('freeapi:refresh');
+  });
   // The dashboard also owns the language (its ⋯-menu selector); the native tray
   // menu and popover follow via the same mirror-and-persist pattern as the theme.
   let locale: NativeLocale = normalizeLocale(
@@ -90,13 +104,20 @@ if (!app.requestSingleInstanceLock()) {
       strings: nativeStrings(locale),
     };
   });
-  ipcMain.on('freeapi:theme-changed', async (_e, next: 'dark' | 'light') => {
-    if (next !== 'dark' && next !== 'light') return;
-    if (next === theme) return;
-    theme = next;
-    saveConfig({ ...loadConfig(), theme });
-    // Flips the vibrancy materials (popover glass + dashboard backdrop).
-    nativeTheme.themeSource = theme;
+  ipcMain.on('freeapi:theme-changed', async (_e, raw: unknown) => {
+    // Older preloads sent the bare resolved string; current ones send
+    // { resolved, choice } so a 'system' choice can reach nativeTheme.
+    const payload = typeof raw === 'string' ? { resolved: raw } : (raw ?? {}) as { resolved?: unknown; choice?: unknown };
+    const resolved = payload.resolved;
+    if (resolved !== 'dark' && resolved !== 'light') return;
+    const choice: 'dark' | 'light' | 'system' = payload.choice === 'system' ? 'system' : resolved;
+    if (resolved === theme && choice === themeChoice) return;
+    theme = resolved;
+    themeChoice = choice;
+    saveConfig({ ...loadConfig(), theme: themeChoice });
+    // Flips the vibrancy materials (popover glass + dashboard backdrop);
+    // 'system' delegates to the OS appearance.
+    nativeTheme.themeSource = themeChoice;
     const { getPopoverWindow } = await import('./popover.js');
     getPopoverWindow()?.webContents.send('freeapi:refresh');
   });

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -36,15 +36,16 @@ try {
 }
 
 // Mirror the dashboard's theme to the main process so the tray popover
-// matches. The dashboard expresses its theme as the `dark` class on
-// documentElement (set by the early script in index.html and toggled by
-// the navbar) — observe that class rather than reaching across worlds
-// into localStorage.
+// matches. The dashboard expresses its resolved theme as the `dark` class
+// and the underlying choice (dark/light/system) as `data-theme-choice`,
+// both on documentElement — observe those rather than reaching across
+// worlds into localStorage. The choice lets the main process hand
+// nativeTheme.themeSource back to the OS when the user picks System.
 function reportTheme() {
-  ipcRenderer.send(
-    'freeapi:theme-changed',
-    document.documentElement.classList.contains('dark') ? 'dark' : 'light',
-  );
+  ipcRenderer.send('freeapi:theme-changed', {
+    resolved: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+    choice: document.documentElement.dataset.themeChoice,
+  });
 }
 
 // Mirror the dashboard's locale to the main process so the native tray menu and
@@ -64,6 +65,6 @@ window.addEventListener('DOMContentLoaded', () => {
     reportLocale();
   }).observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ['class', 'lang'],
+    attributeFilter: ['class', 'lang', 'data-theme-choice'],
   });
 });


### PR DESCRIPTION
Follow-ups from the v0.6.0 desktop compatibility review.

- **System theme was inert in the desktop app**: `main.ts` always pinned `nativeTheme.themeSource` to an explicit `dark`/`light`, which overrides `prefers-color-scheme` in every renderer — so the dashboard's new System option could never track live OS appearance changes inside the shell. The dashboard now exposes its raw choice as `data-theme-choice` on `documentElement` (set by the ThemeProvider and the index.html no-flash script); the preload mirrors `{ resolved, choice }` over the existing IPC channel (older bare-string payloads still accepted), and the main process sets `themeSource` to `system` when chosen, persisting the choice in `config.json`. A `nativeTheme` listener keeps the popover's resolved snapshot fresh when the OS flips appearance while the dashboard window is closed.
- **RTL traffic-light collision**: the navbar reserved the macOS traffic-light gutter with logical `ps-20`, which lands on the wrong edge under `dir=rtl` (ar/he/fa/ur) and parks the search/menu cluster under the window controls. The gutter is physical (`pl-20`) now, since AppKit keeps the traffic lights top-left regardless of content direction.

Verified: desktop esbuild main/preload builds, client `tsc -b` + vite build, client tests and 60-locale i18n validation all pass.