### PR TITLE
docs: add security policy and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+tashfene@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,91 @@
+# Security Policy
+
+FreeLLMAPI holds real credentials: your provider API keys (encrypted at rest in
+SQLite), a unified `/v1` bearer token, and a dashboard account. Bugs that expose
+any of those are taken seriously. Thanks for reporting them responsibly.
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.6.x (current) | Yes — security fixes land here |
+| 0.5.x | Best effort; please upgrade |
+| 0.4.x and older | No |
+
+Fixes ship on the latest release line. There are no backported patch releases for
+older lines, so the fastest way to stay patched is to track `0.6.x` (Docker users:
+re-pull `:latest`).
+
+## Reporting a vulnerability
+
+**Preferred:** GitHub private vulnerability reporting — go to the
+[Security tab](https://github.com/tashfeenahmed/freellmapi/security) and click
+**Report a vulnerability**. That opens a private thread with the maintainer and
+keeps the details out of public issues.
+
+**Alternate:** email **tashfene@gmail.com** with `[freellmapi security]` in the
+subject.
+
+Please do not open a public issue, PR, or discussion for a security bug until a
+fix is out.
+
+A useful report includes:
+
+- Affected version or commit, and how you run it (Docker, `npm run dev`, desktop app).
+- The impact — what an attacker gets (read keys, bypass auth, RCE, etc.).
+- Steps to reproduce: the exact request, config, or `.env` settings involved.
+  Redact your real provider keys.
+- Server logs around the failing request, where you can share them.
+
+## What to expect
+
+- **Acknowledgement:** within a few days. This is a hobby project maintained by
+  one person, so it is not a 24-hour SLA.
+- **Fix:** best effort, prioritised by severity. Expect a rough timeline in the
+  first reply, and progress updates on the same thread.
+- **Disclosure:** once a fix is released. You get credit in the release notes if
+  you want it — say so in your report, and tell me the name or handle to use.
+- **No bug bounty.** There is no money behind this project to pay one. Credit and
+  a genuine thank-you are what's on offer.
+
+## Scope
+
+In scope:
+
+- The router server and its `/v1` proxy, `/api/*` admin routes, and `/mcp` endpoint.
+- Dashboard authentication — the email + password account (scrypt, session tokens)
+  and the unified `freellmapi-…` API key.
+- Key handling: AES-256-GCM encryption at rest, `ENCRYPTION_KEY` usage, encrypted
+  DB backups, key import/export.
+- The Electron desktop app and its local data directory.
+- The Docker image and packaging (`Dockerfile`, `docker-compose.yml`, the install
+  script), including anything that leaks secrets into image layers or logs.
+- Premium license key validation and the signed catalog feed.
+
+Out of scope:
+
+- Vulnerabilities in upstream LLM providers themselves. Report those to the
+  provider. Bugs in *how this router talks to them* are in scope.
+- Anything that requires the operator to deliberately expose the server to the
+  public internet. FreeLLMAPI is a single-user, trusted-network tool: it binds
+  `127.0.0.1` by default, `HOST_BIND=0.0.0.0` is a documented opt-in with a
+  warning attached, and there is no multi-tenant auth by design. "I put it on a
+  public IP and someone used my quota" is expected behaviour, not a vulnerability.
+- Social engineering, phishing, physical access, or attacks that assume an
+  already-compromised host or user account.
+- Automated-scanner output with no demonstrated impact.
+
+## Hardening tips for self-hosters
+
+- **Keep the localhost binding.** Only set `HOST_BIND=0.0.0.0` on a network you
+  trust, and put it behind a reverse proxy with TLS and auth if it must be
+  reachable more widely. Never expose it straight to the internet.
+- **Protect `ENCRYPTION_KEY` and `.env`.** They decrypt every provider key you
+  have stored. Keep them out of git, off shared drives, and backed up somewhere
+  safe — losing the key means losing the stored keys. In production always set
+  `ENCRYPTION_KEY` explicitly rather than relying on the generated dev fallback.
+- **Update.** Re-pull the Docker image (or `git pull` and rebuild) periodically;
+  dependency and router fixes ride along with feature releases.
+- **Rotate what leaks.** Regenerate the unified API key from the Keys page if a
+  client that held it is compromised, and swap out suspect provider keys — the
+  router falls over to sibling keys, so a rotation is not an outage.


### PR DESCRIPTION
Adds the two remaining community-health files at the repo root so GitHub surfaces them alongside README/CONTRIBUTING/LICENSE:

- **SECURITY.md** — supported versions (0.6.x), private-vulnerability-reporting flow (now enabled on the repo) with email fallback, response expectations, in/out-of-scope grounded in the project's actual threat surface (localhost-default binding, encrypted key store, unified key), and hardening tips for self-hosters.
- **CODE_OF_CONDUCT.md** — standard Contributor Covenant v2.1 with the maintainer contact for enforcement.