### PR TITLE
docs: provider grid cleanup + security contact email

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,16 @@ And the free-tier landscape shifts weekly: providers launch models, retire them,
 <tr>
 <td align="center"><a href="https://mistral.ai"><b>Mistral</b><br/>Large 3 · Medium 3.5 · Codestral · Devstral</a></td>
 <td align="center"><a href="https://openrouter.ai"><b>OpenRouter</b><br/>21 free-tier models</a></td>
-<td align="center"><a href="https://github.com/marketplace/models"><b>GitHub Models</b><br/>GPT-4.1 · GPT-4o</a></td>
 <td align="center"><a href="https://developers.cloudflare.com/workers-ai"><b>Cloudflare</b><br/>Kimi K2 · GLM-4.7 · GPT-OSS · Granite 4</a></td>
+<td align="center"><a href="https://cohere.com"><b>Cohere</b><br/>Command R+ · Command-A (trial)</a></td>
 </tr>
 <tr>
-<td align="center"><a href="https://cohere.com"><b>Cohere</b><br/>Command R+ · Command-A (trial)</a></td>
 <td align="center"><a href="https://docs.z.ai"><b>Z.ai (Zhipu)</b><br/>GLM-4.5 · GLM-4.7 Flash</a></td>
 <td align="center"><a href="https://build.nvidia.com"><b>NVIDIA</b><br/>NIM · 40 RPM free (eval-only ToS)</a></td>
 <td align="center"><a href="https://huggingface.co/docs/inference-providers"><b>HuggingFace</b><br/>Router → DeepSeek V4 · Kimi K2.6 · Qwen3</a></td>
+<td align="center"><a href="https://freellmapi.co/models.html"><b>…and many more</b><br/>full live list</a></td>
 </tr>
 </table>
-
-<p align="center"><strong>…and many more.</strong></p>
 
 Plus a **custom** provider — point chat, embedding, image, or audio models at any OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, a local Ollama, or a remote gateway) from the Keys page.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ re-pull `:latest`).
 **Report a vulnerability**. That opens a private thread with the maintainer and
 keeps the details out of public issues.
 
-**Alternate:** email **tashfene@gmail.com** with `[freellmapi security]` in the
+**Alternate:** email **support@freellmapi.co** with `[freellmapi security]` in the
 subject.
 
 Please do not open a public issue, PR, or discussion for a security bug until a


### PR DESCRIPTION
Removes GitHub Models from the README provider grid (remaining cells shift up one; the freed last cell now reads "…and many more" and links to the live model list, replacing the separate tagline below the table) and switches the SECURITY.md alternate contact to support@freellmapi.co.