### PR TITLE
[BUG] catalog-sync wipes seeded embedding_models when published catalog has embeddings: []

### DIFF
--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -523,7 +523,12 @@ export function applyCatalog(db: Db, catalog: Catalog): NonNullable<SyncResult['
       }
     }
 
-    if (catalog.embeddings) {
+    // Embeddings are their own full snapshot. Older catalogs omit this field,
+    // AND catalogs may publish `embeddings: []` while still shipping model
+    // rows — both cases mean "retain the app's bundled embedding baseline
+    // untouched". The JS truthy check on a non-empty array object would
+    // misfire on `[]`, wiping the seeded rows; gate on length instead.
+    if (catalog.embeddings && catalog.embeddings.length > 0) {
       const embeddingCandidates = db
         .prepare(`
           SELECT id, platform, model_id


### PR DESCRIPTION
## Summary

**High-priority bug.** `applyCatalog()` in `server/src/services/catalog-sync.ts` deletes the entire bundled baseline of `embedding_models` rows whenever the published catalog has `embeddings: []` — a guard that's supposed to mean "older catalog, retain baseline" instead means "wipe the seeded models". Affects every install that bootstrapped against a recent monthly catalog.

## Root cause

The prune block gates on JS truthiness:

```ts
if (catalog.embeddings) {                          // ← truthy check
  // inEmbeddingCatalog = new Set from catalog.embeddings
  // prune any row in embedding_models whose key isn't in the Set
}
```

In JavaScript, `Boolean([])` is `true` — an empty array is an object, and any non-null array is truthy. So when the published catalog contains `"embeddings": []`:

1. `catalog.embeddings` is truthy → prune block runs
2. `inEmbeddingCatalog` is an empty `Set`
3. For every row in `embedding_models` (`platform != 'custom' AND key_id IS NULL`), `inEmbeddingCatalog.has(...)` returns false
4. Every seeded baseline row gets `DELETE FROM embedding_models WHERE id = ?`

The bundled baseline (`migrateEmbeddingsV1` in `20260101_000000_legacy_baseline.ts`) seeds 12 catalog-managed rows: 3 NVIDIA, 3 Cloudflare, 2 GitHub, 1 Google, 1 HuggingFace, 1 Cohere, 1 OpenRouter. They vanish on every service restart that triggers a catalog sync.

## Reproduction

1. Insert the 12 baseline rows from the legacy migration (or run a fresh install with the v0.6.0 binary against an empty DB — the seed runs, rows persist briefly, then disappear)
2. `systemctl restart freellmapi` (or any path that triggers `applyCatalog` — boot, scheduled sync, manual `syncCatalog(force=true)`)
3. Observe `SELECT COUNT(*) FROM embedding_models;` returns 0 after restart

The reproduction is exact: I instrumented the prune block with a debug log and observed:
```
[DEBUG-EMBED] prune-block: catalog.embeddings=[], truthy=true, count=12
[DEBUG-EMBED] candidates: 12, inEmbeddingCatalog size: 0
[DEBUG-EMBED] DELETE: google:gemini-embedding-001
[DEBUG-EMBED] DELETE: nvidia:nvidia/llama-nemotron-embed-vl-1b-v2
... [12 DELETEs total] ...
```

## Why upstream may have missed it

Two compounding factors:
1. The bundled baseline migration runs ONCE per install (on first boot). After that, `embedding_models` is populated only by the catalog — so anyone who bootstrapped with an old catalog that had `embeddings: [...]` and then upgraded to a binary that ships against newer empty catalogs would have already had their rows wiped, then never get them back because the seed is one-shot.
2. The latest monthly catalogs (`2026.07.27`, `2026.07.28`) ship `embeddings: []` while older catalogs had real entries — so anyone upgrading in the last two weeks is in the danger zone. The issue is silent: `/v1/embeddings` returns "no embedding family found" but doesn't crash, so most users wouldn't notice.

## Fix

Gate the prune on length, not truthiness:

```ts
if (catalog.embeddings && catalog.embeddings.length > 0) {
  // ...same prune logic
}
```

Both `embeddings: undefined` (omitted from catalog) and `embeddings: []` (empty explicit array) now correctly mean "retain the bundled baseline untouched". The intent — documented in the existing comment block above the prune ("Older catalogs omit this field; in that case retain the app's bundled embedding baseline untouched.") — applies equally to catalogs that publish `embeddings: []` while still shipping model rows.

Note: the apply block at line 384 uses the same `if (catalog.embeddings)` guard but is safe — when embeddings is `[]`, the `for (const m of catalog.embeddings)` loop iterates zero times, no harm done. Only the prune block needs the fix.

## Testing

Reproduced and verified the fix on `integration/v0.6-with-my-prs` (a fork working branch based on v0.6.0):

- **Before fix**: insert 12 rows → restart service → rows gone (catalog sync prune fires)
- **After fix**: insert 12 rows → restart service → rows persist across multiple restarts, persist across manual `syncCatalog` calls

The fix is one-line behavioral change plus a 5-line comment explaining why. No schema changes, no migration, no API change.

## Files changed

- `server/src/services/catalog-sync.ts` — 6 insertions, 1 deletion

## Severity

**High** for affected installs:
- Silent data loss on every service restart
- `/v1/embeddings` becomes non-functional
- No error logs or alerts
- No easy way for users to discover what happened (the seeded rows don't leave a paper trail)
- The bundled baseline represents months of upstream curation (`migrateEmbeddingsV1` was live-verified against each provider on 2026-06-04)

Not security-critical, no CVEs, but a high-impact correctness bug for the embeddings feature surface.