### PR TITLE
fix(pollinations): validate keys against /account/key instead of the public /models

### DIFF
--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -502,6 +502,9 @@ describe('OpenAICompatProvider - platform instances', () => {
     { platform: 'mistral',    name: 'Mistral',       baseUrl: 'https://api.mistral.ai/v1' },
     { platform: 'openrouter', name: 'OpenRouter',    baseUrl: 'https://openrouter.ai/api/v1' },
     { platform: 'github',     name: 'GitHub Models', baseUrl: 'https://models.github.ai/inference' },
+    // pollinations registers a PollinationsProvider subclass (custom
+    // validateKey, see providers/pollinations.test.ts) but chat routing is
+    // stock openai-compat.
     { platform: 'pollinations', name: 'Pollinations', baseUrl: 'https://gen.pollinations.ai/v1' },
     { platform: 'zhipu',      name: 'Zhipu AI',      baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
     { platform: 'opencode',   name: 'OpenCode Zen',  baseUrl: 'https://opencode.ai/zen/v1' },

--- a/server/src/__tests__/providers/pollinations.test.ts
+++ b/server/src/__tests__/providers/pollinations.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PollinationsProvider } from '../../providers/pollinations.js';
+import { getProvider, hasProvider, resolveProvider } from '../../providers/index.js';
+import type { KeyValidationFailure } from '../../providers/base.js';
+
+// Fake fixtures only — no real Pollinations key appears here or in any
+// assertion message (#608 acceptance criterion: never log the key).
+const REVOKED_KEY = 'sk_test_revoked';
+const VALID_KEY = 'sk_test_valid';
+
+const ACCOUNT_KEY_URL = 'https://gen.pollinations.ai/account/key';
+
+// Verified live 2026-07-28: GET /v1/models answers 200 for a garbage bearer.
+const PUBLIC_MODELS_200 = {
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve({ object: 'list', data: [{ id: 'openai-fast', object: 'model' }] }),
+};
+
+// Verified live 2026-07-28 against /account/key with a garbage bearer.
+const ACCOUNT_KEY_401 = {
+  ok: false,
+  status: 401,
+  statusText: 'Unauthorized',
+  json: () => Promise.resolve({
+    success: false,
+    error: { message: 'API key required. This endpoint validates API keys.', code: 'UNAUTHORIZED' },
+    status: 401,
+  }),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Pollinations registration (#608)', () => {
+  it('is registered and routable in the provider registry', () => {
+    expect(hasProvider('pollinations')).toBe(true);
+    const provider = getProvider('pollinations');
+    expect(provider).toBeInstanceOf(PollinationsProvider);
+    expect(provider?.platform).toBe('pollinations');
+    expect(provider?.name).toBe('Pollinations');
+    expect(provider?.keyless).toBe(false);
+    expect(resolveProvider('pollinations')).toBe(provider);
+  });
+});
+
+describe('Pollinations validateKey (#608)', () => {
+  it('does NOT trust the public GET /v1/models — a revoked key that 200s there is invalid', async () => {
+    // The reported repro: the same revoked key gets 200 from /v1/models and 401
+    // from an authenticated endpoint.
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      calls.push({ url: String(url), init: init as RequestInit });
+      if (String(url).endsWith('/v1/models')) return PUBLIC_MODELS_200 as unknown as Response;
+      return ACCOUNT_KEY_401 as unknown as Response;
+    });
+
+    const provider = new PollinationsProvider();
+    const result = await provider.validateKey(REVOKED_KEY);
+
+    expect(result).not.toBe(true);
+    const failure = result as KeyValidationFailure;
+    expect(failure.valid).toBe(false);
+    expect(failure.error).toContain('401');
+    expect(failure.error).toContain('API key required');
+    // The key itself must never reach a health log line.
+    expect(failure.error).not.toContain(REVOKED_KEY);
+
+    // The public catalog endpoint must not be probed at all.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(ACCOUNT_KEY_URL);
+    expect(calls[0].init.method).toBe('GET');
+    expect((calls[0].init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${REVOKED_KEY}`);
+  });
+
+  it('returns true when /account/key authenticates (200)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, key: { valid: true, tier: 'seed' } }),
+    } as unknown as Response);
+
+    const provider = new PollinationsProvider();
+    await expect(provider.validateKey(VALID_KEY)).resolves.toBe(true);
+  });
+
+  it('treats 402 as a VALID key (billing/quota, not auth)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 402,
+      json: () => Promise.resolve({ error: { message: 'Insufficient pollen balance' } }),
+    } as unknown as Response);
+
+    const provider = new PollinationsProvider();
+    await expect(provider.validateKey(VALID_KEY)).resolves.toBe(true);
+  });
+
+  it('treats 403 as inconclusive (throws) — permission, not a revoked key', async () => {
+    // Pollinations returns 403 when the credential authenticated but lacks the
+    // account permission the probe needs. Throwing keeps health.ts on
+    // status=error (previous verdict preserved, no auto-disable).
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: () => Promise.resolve({ error: { message: 'Insufficient permissions' } }),
+    } as unknown as Response);
+
+    const provider = new PollinationsProvider();
+    await expect(provider.validateKey(VALID_KEY)).rejects.toThrow(/inconclusive/i);
+  });
+
+  it('treats a 5xx from /account/key as inconclusive (throws), never invalid', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const provider = new PollinationsProvider();
+    await expect(provider.validateKey(VALID_KEY)).rejects.toThrow(/HTTP 503/);
+  });
+
+  it('propagates a network timeout instead of reporting the key invalid', async () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    vi.spyOn(global, 'fetch').mockRejectedValue(abort);
+
+    const provider = new PollinationsProvider();
+    await expect(provider.validateKey(VALID_KEY)).rejects.toThrow(/aborted/i);
+  });
+});

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -6,6 +6,7 @@ import { CohereProvider } from './cohere.js';
 import { CloudflareProvider } from './cloudflare.js';
 import { AIHordeProvider } from './aihorde.js';
 import { ModelScopeProvider } from './modelscope.js';
+import { PollinationsProvider } from './pollinations.js';
 
 const providers = new Map<Platform, BaseProvider>();
 
@@ -151,11 +152,11 @@ register(new OpenAICompatProvider({
 // text.pollinations.ai host returned 502 in the July 2026 audit; publishable
 // keys now use the unified gen.pollinations.ai endpoint. Free capacity accrues
 // at one pollen per IP per hour, so chat requires a real publishable key.
-register(new OpenAICompatProvider({
-  platform: 'pollinations',
-  name: 'Pollinations',
-  baseUrl: 'https://gen.pollinations.ai/v1',
-}));
+// Dedicated PollinationsProvider (not plain OpenAICompatProvider) because
+// GET /v1/models is public — it answers 200 for a revoked key — so validation
+// probes the authenticated /account/key instead; see providers/pollinations.ts
+// and issue #608.
+register(new PollinationsProvider());
 
 // LLM7.io — OpenAI-compatible aggregator. 100 req/hr free; anonymous access
 // also works for basic models. Wraps a handful of upstream models behind one

--- a/server/src/providers/pollinations.ts
+++ b/server/src/providers/pollinations.ts
@@ -1,0 +1,71 @@
+import { OpenAICompatProvider } from './openai-compat.js';
+import type { KeyValidationResult } from './base.js';
+import { recordQuotaObservationsFromResponse, type QuotaObservationContext } from '../services/provider-quota.js';
+
+const POLLINATIONS_BASE_URL = 'https://gen.pollinations.ai/v1';
+/** Authenticated key-introspection endpoint — note it sits OUTSIDE /v1. */
+const POLLINATIONS_ACCOUNT_KEY_URL = 'https://gen.pollinations.ai/account/key';
+
+/**
+ * Pollinations — OpenAI-compatible shared-capacity tier.
+ *
+ * Everything except key validation is stock OpenAI-compat. validateKey is
+ * overridden because Pollinations serves its catalog without auth:
+ *
+ *   GET /v1/models answers 200 for a revoked key (and for no key at all —
+ *   verified live 2026-07-28), while POST /v1/chat/completions answers 401.
+ *   The default openai-compat probe therefore reported dead keys as healthy
+ *   and routing degraded silently. See issue #608.
+ *
+ * The probe is GET /account/key instead, which enforces auth (401 for a
+ * garbage bearer, verified the same day) and costs no generation quota.
+ * Response classification, all of it deliberate:
+ *   200 → authenticated, key is live.
+ *   401 → revoked/invalid; surfaces the upstream reason and feeds the
+ *         consecutive-failure auto-disable, same as every other provider.
+ *   402 → authenticated but out of pollen. The credential is fine; benching
+ *         it belongs to the router's quota path, not to key validation.
+ *   403 → Pollinations uses 403 for insufficient PERMISSIONS, so a restricted
+ *         (but live) key can be refused this endpoint. Inconclusive: throw so
+ *         health.ts keeps the previous verdict instead of disabling a good key.
+ *   other non-2xx (endpoint moved, provider 5xx) → inconclusive, same as above.
+ */
+export class PollinationsProvider extends OpenAICompatProvider {
+  constructor() {
+    super({
+      platform: 'pollinations',
+      name: 'Pollinations',
+      baseUrl: POLLINATIONS_BASE_URL,
+    });
+  }
+
+  override async validateKey(apiKey: string, quotaContext?: QuotaObservationContext): Promise<KeyValidationResult> {
+    // Transport errors (DNS / timeout / TLS) propagate — health.ts marks
+    // status='error' without counting toward auto-disable; only a confirmed
+    // 401 disables a key.
+    const res = await this.fetchWithTimeout(POLLINATIONS_ACCOUNT_KEY_URL, {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    }, 30000, { timeoutBounds: 'request' });
+
+    recordQuotaObservationsFromResponse(res, {
+      platform: this.platform,
+      keyId: quotaContext?.keyId,
+      providerAccountId: quotaContext?.providerAccountId,
+      quotaPoolKey: quotaContext?.quotaPoolKey,
+      endpoint: 'account/key',
+    });
+
+    if (res.status === 401) return this.validationResult(res);
+    if (res.ok || res.status === 402) return true;
+
+    if (res.status === 403) {
+      throw new Error(
+        `Pollinations key validation inconclusive: HTTP 403 from /account/key. ` +
+        `The key authenticated but lacks permission for the introspection endpoint, ` +
+        `so it is NOT treated as revoked.`,
+      );
+    }
+    throw new Error(`Pollinations /account/key returned HTTP ${res.status} — key validity unknown`);
+  }
+}


### PR DESCRIPTION
Fixes #608.

Pollinations serves `GET /v1/models` unauthenticated, so the generic openai-compat probe in `services/health.ts` got a 200 for a key that `/v1/chat/completions` rejects with 401. Dead keys showed as healthy on the dashboard and routing degraded silently. Thanks to @MetaMysteries8 for the repro with a revoked key — reconfirmed live on 2026-07-28: `/v1/models` returns 200 for a garbage bearer, `/account/key` returns 401.

The fix is a `PollinationsProvider` subclass (same shape as the existing `ModelScopeProvider`, which exists for the same trap) that probes `GET https://gen.pollinations.ai/account/key`:

- 200 → key is live
- 401 → revoked/invalid; upstream reason surfaces in the health error and feeds the normal consecutive-failure auto-disable
- 402 → authenticated but out of pollen; the credential is fine, so benching stays with the router's quota path
- 403 → Pollinations uses 403 for insufficient permissions, so a restricted-but-live key can be refused this endpoint; treated as inconclusive (throws → health keeps the previous verdict) rather than revoked
- other non-2xx and transport errors → inconclusive as well; only a confirmed 401 can disable a key

Everything else about the provider stays stock openai-compat. No generation quota is spent on validation.

Tests: `server/src/__tests__/providers/pollinations.test.ts` covers the revoked-key repro (asserts the public catalog is never probed and the key never appears in the error), a valid key, 402, 403, a provider 5xx, and a network timeout. Full server suite green (150 files / 1511 tests), no pre-existing failures.

### Other providers with a public /models (not changed here)

Probed each registered base URL with a garbage bearer on 2026-07-28; these answer 200, so the default `/models` probe cannot detect a revoked key on them either:

`nvidia`, `openrouter`, `huggingface`, `ollama`, `llm7`, `opencode`, `routeway`, `bazaarlink`, `ainative`, `requesty`, `navy` — plus `kilo` and `ovh`, which are registered keyless so validation is moot there.

Providers whose `/models` does enforce auth (401/403 with a garbage bearer): `groq`, `cerebras`, `mistral`, `github`, `zhipu`, `agnes`, `reka`, `siliconflow`, `aion`, `nara`, `sealion`. Worth a follow-up to give the ones in the first list an authenticated probe — the issue's suggestion of a per-provider `validation` mode would be the place to do it once instead of one subclass at a time.