### PR TITLE
Fix X-Routed-Via crashing on non-ASCII relay model ids

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -233,6 +233,8 @@ Request the virtual `fusion` model and the router fans your prompt out to a pane
 
 Every response carries an `X-Routed-Via: <platform>/<model>` header so you can see which provider actually served each call. If a request fell over between providers, you'll also see `X-Fallback-Attempts: N`.
 
+HTTP headers only carry printable ASCII, so a model id with characters outside that range (a Chinese name from a relay catalog, for example) is percent-encoded in the header — run the value through `decodeURIComponent` (or `urllib.parse.unquote`) to read it back.
+
 The opt-in response cache can be toggled per request with `X-FreeLLM-Cache: on|off` — an exact-match in-memory LRU for identical non-streaming requests (canonical SHA-256 keys over the full request, TTL and temperature gates, saved-token stats on the dashboard). Off by default; cache hits consume zero provider quota.
 
 When [prompt compression](compression.md) is enabled, `X-FreeLLM-Compress: off|on|lossless|standard|aggressive` can disable or lower the configured mode for one request. It cannot raise the operator's configured mode. The response reports the effective mode and estimated savings, for example `X-FreeLLM-Compress: standard; saved~=1840`.

--- a/server/src/__tests__/lib/header-value.test.ts
+++ b/server/src/__tests__/lib/header-value.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { validateHeaderValue } from 'node:http';
+import { safeHeaderValue, routedViaValue } from '../../lib/header-value.js';
+
+// #619: relay model ids are arbitrary text. Whatever comes out of here has to
+// be something Node will actually put on the wire, or an already-successful
+// upstream call dies while the response is being written.
+describe('safeHeaderValue', () => {
+  it('leaves an ordinary provider/model pair byte-identical', () => {
+    expect(safeHeaderValue('groq/llama-3.3-70b-versatile')).toBe('groq/llama-3.3-70b-versatile');
+    expect(safeHeaderValue('openrouter/meta-llama/llama-4-scout:free')).toBe('openrouter/meta-llama/llama-4-scout:free');
+  });
+
+  it('percent-encodes non-ASCII so the value survives as something decodable', () => {
+    const encoded = safeHeaderValue('custom/我的模型[test] v2');
+    expect(encoded).toBe('custom/%E6%88%91%E7%9A%84%E6%A8%A1%E5%9E%8B[test] v2');
+    expect(decodeURIComponent(encoded)).toBe('custom/我的模型[test] v2');
+  });
+
+  it('encodes control characters, so a model id cannot inject a header line', () => {
+    const encoded = safeHeaderValue('custom/evil\r\nX-Admin: yes');
+    expect(encoded).toBe('custom/evil%0D%0AX-Admin: yes');
+    expect(encoded).not.toContain('\r');
+    expect(encoded).not.toContain('\n');
+  });
+
+  it('escapes a literal % so the encoding round-trips unambiguously', () => {
+    expect(safeHeaderValue('custom/100%-free')).toBe('custom/100%25-free');
+    expect(decodeURIComponent(safeHeaderValue('custom/100%-free'))).toBe('custom/100%-free');
+  });
+
+  it('encodes astral code points as one UTF-8 sequence, not broken halves', () => {
+    expect(decodeURIComponent(safeHeaderValue('custom/🚀-turbo'))).toBe('custom/🚀-turbo');
+  });
+
+  it('survives a lone surrogate instead of throwing', () => {
+    const encoded = safeHeaderValue('custom/\uD800-model');
+    expect(() => validateHeaderValue('X-Routed-Via', encoded)).not.toThrow();
+    expect(encoded).toContain('-model');
+  });
+
+  it('caps the length without ever cutting an escape sequence in half', () => {
+    const capped = safeHeaderValue(`${'a'.repeat(255)}我`, 256);
+    expect(capped).toBe('a'.repeat(255));
+    expect(safeHeaderValue('a'.repeat(1000)).length).toBe(256);
+    expect(safeHeaderValue('a'.repeat(1000), 1024).length).toBe(1000);
+  });
+
+  it('returns an empty string for empty or missing input', () => {
+    expect(safeHeaderValue('')).toBe('');
+    expect(safeHeaderValue(undefined as unknown as string)).toBe('');
+  });
+
+  it('produces a value Node accepts for every hostile shape', () => {
+    const hostile = [
+      '我的模型[test] v2',
+      'модель/тест',
+      'model\u0000null',
+      'model\u007Fdel',
+      'tab\there',
+      'a'.repeat(4000),
+      '日本語モデル（高速）',
+      'emoji 🚀 model',
+      '%not-an-escape',
+    ];
+    for (const raw of hostile) {
+      const value = safeHeaderValue(`custom/${raw}`);
+      expect(() => validateHeaderValue('X-Routed-Via', value)).not.toThrow();
+      expect(value).toMatch(/^[\x20-\x7e]*$/);
+    }
+  });
+
+  it('composes the routed-via value from platform and model', () => {
+    expect(routedViaValue('groq', 'llama-3.3-70b')).toBe('groq/llama-3.3-70b');
+    expect(decodeURIComponent(routedViaValue('custom', '我的模型'))).toBe('custom/我的模型');
+  });
+});

--- a/server/src/__tests__/routes/routed-via-header.test.ts
+++ b/server/src/__tests__/routes/routed-via-header.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { mintDashboardToken } from '../helpers/auth.js';
+
+// #619: relays hand out model ids that are not header-safe — Chinese names,
+// bracketed variant suffixes, spaces. Splicing one straight into X-Routed-Via
+// made Node throw ERR_INVALID_CHAR while writing the response, so a call that
+// had already succeeded upstream came back as a failure. Every surface that
+// stamps the header is exercised here, streaming and not.
+const HOSTILE_MODEL = '我的模型[test] v2';
+const BASE_URL = 'http://127.0.0.1:9411/v1';
+const EXPECTED = `custom/${HOSTILE_MODEL}`;
+
+let dashToken = '';
+
+async function request(app: Express, method: string, path: string, body?: unknown, headers: Record<string, string> = {}) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method,
+    headers: { ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}), ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  server.close();
+  let json: any = null;
+  try { json = JSON.parse(text); } catch { /* SSE or plain text */ }
+  return { status: res.status, headers: res.headers, text, body: json };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
+}
+
+/** The header must be a valid RFC 7230 field value AND still name the route. */
+function expectRoutedVia(headers: Headers): void {
+  const value = headers.get('x-routed-via');
+  expect(value).toBeTruthy();
+  expect(value).toMatch(/^[\x20-\x7e]*$/);
+  expect(decodeURIComponent(value!)).toBe(EXPECTED);
+}
+
+const chatCompletion = {
+  id: 'chatcmpl-hostile',
+  object: 'chat.completion',
+  created: 1,
+  model: HOSTILE_MODEL,
+  choices: [{ index: 0, message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' }],
+  usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+};
+
+const streamBody = [
+  `data: {"id":"chatcmpl-hostile","object":"chat.completion.chunk","created":1,"model":"x","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}\n\n`,
+  `data: {"id":"chatcmpl-hostile","object":"chat.completion.chunk","created":1,"model":"x","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n`,
+  'data: [DONE]\n\n',
+].join('');
+
+/** Answer the custom relay with JSON or SSE depending on what was asked for. */
+function mockRelay(): void {
+  const origFetch = global.fetch;
+  vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    if (urlStr.includes('127.0.0.1:9411')) {
+      const sent = JSON.parse(String((init as RequestInit)?.body ?? '{}'));
+      if (sent.stream) {
+        const encoder = new TextEncoder();
+        return {
+          ok: true,
+          headers: new Headers(),
+          body: new ReadableStream({
+            start(controller) {
+              controller.enqueue(encoder.encode(streamBody));
+              controller.close();
+            },
+          }),
+        } as any;
+      }
+      return { ok: true, headers: new Headers(), json: async () => chatCompletion } as any;
+    }
+    return origFetch(url as any, init);
+  });
+}
+
+describe('X-Routed-Via with a header-hostile model id (#619)', () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare("DELETE FROM settings WHERE key = 'active_profile_id'").run();
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
+    db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+    db.prepare('DELETE FROM rate_limit_usage').run();
+    db.prepare('DELETE FROM rate_limit_cooldowns').run();
+
+    const reg = await request(app, 'POST', '/api/keys/custom', {
+      baseUrl: BASE_URL,
+      model: HOSTILE_MODEL,
+      apiKey: 'relay-token',
+    }, { Authorization: `Bearer ${dashToken}` });
+    expect(reg.status).toBe(201);
+    mockRelay();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('answers /v1/chat/completions instead of dying on the header', async () => {
+    const { status, headers, body } = await request(app, 'POST', '/v1/chat/completions', {
+      model: HOSTILE_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(body.choices[0].message.content).toBe('hello');
+    expectRoutedVia(headers);
+  });
+
+  it('answers a streaming /v1/chat/completions', async () => {
+    const { status, headers, text } = await request(app, 'POST', '/v1/chat/completions', {
+      model: HOSTILE_MODEL,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(text).toContain('data: [DONE]');
+    expectRoutedVia(headers);
+  });
+
+  it('answers /v1/completions, streaming and not', async () => {
+    const plain = await request(app, 'POST', '/v1/completions', {
+      model: HOSTILE_MODEL,
+      prompt: 'hi',
+    }, authHeaders());
+    expect(plain.status).toBe(200);
+    expectRoutedVia(plain.headers);
+
+    const streamed = await request(app, 'POST', '/v1/completions', {
+      model: HOSTILE_MODEL,
+      prompt: 'hi',
+      stream: true,
+    }, authHeaders());
+    expect(streamed.status).toBe(200);
+    expectRoutedVia(streamed.headers);
+  });
+
+  it('answers /v1/responses, streaming and not', async () => {
+    const plain = await request(app, 'POST', '/v1/responses', {
+      model: HOSTILE_MODEL,
+      input: 'hi',
+    }, authHeaders());
+    expect(plain.status).toBe(200);
+    expectRoutedVia(plain.headers);
+
+    const streamed = await request(app, 'POST', '/v1/responses', {
+      model: HOSTILE_MODEL,
+      input: 'hi',
+      stream: true,
+    }, authHeaders());
+    expect(streamed.status).toBe(200);
+    expectRoutedVia(streamed.headers);
+  });
+
+  it('answers /v1/messages, streaming and not', async () => {
+    const anthropicAuth = { 'x-api-key': getUnifiedApiKey(), 'anthropic-version': '2023-06-01' };
+
+    const plain = await request(app, 'POST', '/v1/messages', {
+      model: HOSTILE_MODEL,
+      max_tokens: 32,
+      messages: [{ role: 'user', content: 'hi' }],
+    }, anthropicAuth);
+    expect(plain.status).toBe(200);
+    expectRoutedVia(plain.headers);
+
+    const streamed = await request(app, 'POST', '/v1/messages', {
+      model: HOSTILE_MODEL,
+      max_tokens: 32,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+    }, anthropicAuth);
+    expect(streamed.status).toBe(200);
+    expectRoutedVia(streamed.headers);
+  });
+
+  it('answers the native Gemini surface', async () => {
+    const { status, headers } = await request(
+      app,
+      'POST',
+      `/v1beta/models/gemini-2.5-flash:generateContent?key=${getUnifiedApiKey()}`,
+      { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] },
+    );
+    expect(status).toBe(200);
+    expectRoutedVia(headers);
+  });
+});

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -17,6 +17,7 @@
 
 import type { RouteResult } from '../services/router.js';
 import { recordRateLimitHit, recordSuccess, hasOtherUsableKey, formatResetEta } from '../services/router.js';
+import { safeHeaderValue } from './header-value.js';
 import {
   recordRequest,
   recordTokens,
@@ -302,6 +303,7 @@ export function classifyAttemptError(err: any): AttemptErrorClass {
 }
 
 const TRAIL_MAX_SHOWN = 10;
+const TRAIL_HEADER_MAX_LENGTH = 1024;
 
 export function formatAttemptTrail(attempts: AttemptRecord[]): string {
   const shown = attempts
@@ -317,8 +319,9 @@ export function formatAttemptTrail(attempts: AttemptRecord[]): string {
  * X-Fallback-Trail (what each hop was and why it failed). Until now the trail
  * only reached clients inside exhaustion error MESSAGES — a request that
  * eventually succeeded gave no hint that it burned five hops first, which is
- * exactly the case an operator wants to notice. Control characters are
- * scrubbed so a hostile model id can't inject header lines.
+ * exactly the case an operator wants to notice. Values go through
+ * safeHeaderValue so a non-ASCII or control-laden model id can neither inject
+ * header lines nor make Node reject the response outright (#619).
  */
 export function setFallbackHeaders(
   res: { setHeader(name: string, value: string): void },
@@ -331,7 +334,9 @@ export function setFallbackHeaders(
       .slice(0, TRAIL_MAX_SHOWN)
       .map(a => `${a.platform}/${a.modelId} key${a.keyOrdinal}=${a.errorClass}`)
       .join('; ') + (trail.length > TRAIL_MAX_SHOWN ? `; +${trail.length - TRAIL_MAX_SHOWN} more` : '');
-    res.setHeader('X-Fallback-Trail', value.replace(/[^\t\x20-\x7e]/g, '?'));
+    // Ten hops of "platform/model keyN=class" outgrow the default cap, so the
+    // trail gets its own budget.
+    res.setHeader('X-Fallback-Trail', safeHeaderValue(value, TRAIL_HEADER_MAX_LENGTH));
   }
 }
 

--- a/server/src/lib/header-value.ts
+++ b/server/src/lib/header-value.ts
@@ -1,0 +1,55 @@
+// Header-value sanitizer for the diagnostics headers built out of provider and
+// model names (#619).
+//
+// Node validates every outgoing header value against RFC 7230's field-value
+// grammar and throws ERR_INVALID_CHAR ("Invalid character in header content")
+// on anything outside it. Relay catalogs happily hand out ids like
+// `我的模型[test] v2`, and splicing one into `X-Routed-Via` killed the response
+// AFTER the upstream call had already succeeded. Worse, the throw surfaced
+// inside the failover loop, so the router booked it as a provider failure and
+// cooled the model down — every request to that relay failed, forever.
+//
+// Encoding rules, deliberately narrow so the output is safe on every surface:
+//   - SP and VCHAR (0x21-0x7E) pass through, so ordinary ids like
+//     `groq/llama-3.3-70b-versatile` are byte-identical to before;
+//   - everything else — control characters (header injection), DEL, and every
+//     non-ASCII code point — becomes its percent-encoded UTF-8 bytes, so the
+//     value stays decodable with decodeURIComponent instead of being lost;
+//   - a literal '%' becomes '%25', which is what makes that decode unambiguous.
+// The result is capped so a pathological id cannot push a response past a
+// proxy's header budget.
+
+const MAX_HEADER_VALUE_LENGTH = 256;
+
+function percentEncode(char: string): string {
+  try {
+    return encodeURIComponent(char);
+  } catch {
+    // Lone surrogate — encodeURIComponent refuses it. Stand in the UTF-8
+    // replacement character rather than dropping the position silently.
+    return '%EF%BF%BD';
+  }
+}
+
+/**
+ * Coerce an arbitrary string into a valid HTTP header field value. Never
+ * throws, and never returns a value Node will reject.
+ */
+export function safeHeaderValue(value: string, maxLength = MAX_HEADER_VALUE_LENGTH): string {
+  if (value == null) return '';
+  let out = '';
+  // Iterate by code point so astral characters (emoji in a display name) encode
+  // as one UTF-8 sequence instead of two broken surrogate halves.
+  for (const char of String(value)) {
+    const code = char.codePointAt(0)!;
+    const piece = code >= 0x20 && code <= 0x7e && char !== '%' ? char : percentEncode(char);
+    if (out.length + piece.length > maxLength) break;
+    out += piece;
+  }
+  return out;
+}
+
+/** `<platform>/<model>` for X-Routed-Via, sanitized. */
+export function routedViaValue(platform: string, modelId: string): string {
+  return safeHeaderValue(`${platform}/${modelId}`);
+}

--- a/server/src/lib/inbound-chat.ts
+++ b/server/src/lib/inbound-chat.ts
@@ -27,6 +27,7 @@ import {
   type AttemptRecord,
   type ExhaustionBody,
 } from './fallback-loop.js';
+import { routedViaValue } from './header-value.js';
 import { applyTokenBudget, tokenBudgetMessage } from './guardrails.js';
 import { contentToString } from './content.js';
 import { repairToolArguments, toolSchemaMap } from './tool-args.js';
@@ -295,7 +296,7 @@ export async function runInboundChat(
         };
         recordUpstreamSuccess(route, result.usage?.total_tokens ?? promptTokens + completionTokens);
         if (pin.pinnedLabel == null) setStickyModel(input.messages, route.modelDbId, input.sessionId);
-        res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+        res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
         setFallbackHeaders(res, attempt, attemptLog);
         logRequest(
           route.platform,
@@ -323,7 +324,7 @@ export async function runInboundChat(
       let heldText = '';
       const commit = () => {
         if (committed) return;
-        res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+        res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
         setFallbackHeaders(res, attempt, attemptLog);
         wire.startStream(res, route);
         committed = true;

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -19,6 +19,7 @@ import { isClientAbortError, newClientAbortError } from '../lib/error-classify.j
 import { logRequest } from '../lib/request-log.js';
 import { extractApiToken, timingSafeStringEqual, getStickyModel, setStickyModel } from './proxy.js';
 import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, type ExhaustionBody, setFallbackHeaders, setExhaustionHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
+import { routedViaValue } from '../lib/header-value.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { resolveAnthropicModel } from '../services/anthropic-map.js';
 import type { ReasoningEffort } from '../lib/sampling-params.js';
@@ -607,7 +608,7 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
         usage: { input_tokens: promptTokens, output_tokens: completionTokens },
       };
 
-      res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+      res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
       setFallbackHeaders(res, attempt, attemptLog);
       logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null, null, pinnedModelId);
       res.json(anthropicResponse);
@@ -687,7 +688,7 @@ async function streamCompletion(
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+    res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
     setFallbackHeaders(res, ctx.attempt, ctx.attemptLog);
     writeSse(res, 'message_start', {
       type: 'message_start',

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -20,6 +20,7 @@ import { logRequest } from '../lib/request-log.js';
 import { observeServedModel } from '../lib/served-model.js';
 import { parseCacheDirective, cacheActive, isCacheableTemperature, computeCacheKey, getCachedResponse, storeCachedResponse } from '../services/cache.js';
 import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, exhaustedRetryError, setFallbackHeaders, exhaustionErrorPayload, setExhaustionHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
+import { routedViaValue, safeHeaderValue } from '../lib/header-value.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { samplingParamSchemaFields, pickSamplingParams, supportedParametersForPlatforms } from '../lib/sampling-params.js';
 import { enforceJsonContent } from '../lib/structured-output.js';
@@ -567,7 +568,7 @@ proxyRouter.post('/audio/speech', async (req: Request, res: Response) => {
       input: parsed.data.input, voice: parsed.data.voice, format: parsed.data.response_format,
     });
     res.setHeader('Content-Type', result.contentType);
-    res.setHeader('X-Provider', result.platform);
+    res.setHeader('X-Provider', safeHeaderValue(result.platform));
     res.send(result.audio);
   } catch (err: any) {
     const status = err instanceof MediaError ? err.status : 502;
@@ -674,8 +675,8 @@ proxyRouter.post('/audio/transcriptions', (req: Request, res: Response, next) =>
       temperature,
       responseFormat,
     });
-    res.setHeader('X-Provider', result.platform);
-    res.setHeader('X-Model', result.modelId);
+    res.setHeader('X-Provider', safeHeaderValue(result.platform));
+    res.setHeader('X-Model', safeHeaderValue(result.modelId));
     if (responseFormat === 'text') {
       res.type('text/plain').send(result.text);
       return;
@@ -925,7 +926,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
           res.setHeader('Content-Type', 'text/event-stream');
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
-          res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+          res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
           setFallbackHeaders(res, attempt, attemptLog);
           headerSent = true;
           for (const frame of buffered) res.write(`data: ${JSON.stringify(frame)}\n\n`);
@@ -1050,7 +1051,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
       const totalTokens = result.usage?.total_tokens ?? (promptTokens + completionTokens);
       recordUpstreamSuccess(route, totalTokens);
 
-      res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+      res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
       setFallbackHeaders(res, attempt, attemptLog);
       res.json({
         id: completionIdFromChat(result.id),
@@ -1459,7 +1460,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           if (enforced.healed) fusionMsg.content = enforced.content;
         }
       }
-      res.setHeader('X-Routed-Via', routedVia);
+      res.setHeader('X-Routed-Via', safeHeaderValue(routedVia));
       res.json(response);
     } catch (err: any) {
       if (err instanceof FusionError) {
@@ -1734,7 +1735,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           res.setHeader('Content-Type', 'text/event-stream');
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
-          res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+          res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
           setFallbackHeaders(res, attempt, attemptLog);
           headerSent = true;
           for (const p of preamble) res.write(`data: ${JSON.stringify(p)}\n\n`);
@@ -2088,7 +2089,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         setStickyModel(messages, route.modelDbId, sessionIdHeader, stickyStrategyKey);
         if (handoffMode !== 'off' && sessionKey) recordSuccessfulModel({ sessionKey, modelKey });
 
-        res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+        res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
         setFallbackHeaders(res, attempt, attemptLog);
         // Repair double-encoded tool arguments against the request's tool
         // schemas (e.g. GLM emitting an array parameter as a JSON string),

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -25,6 +25,7 @@ import {
   logRequest,
 } from './proxy.js';
 import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, setFallbackHeaders, exhaustionErrorPayload, setExhaustionHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
+import { routedViaValue } from '../lib/header-value.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
 import { samplingParamSchemaFields, pickSamplingParams, type ResponseFormat } from '../lib/sampling-params.js';
 import { enforceJsonContent } from '../lib/structured-output.js';
@@ -550,7 +551,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           res.setHeader('Content-Type', 'text/event-stream');
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
-          res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+          res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
           setFallbackHeaders(res, attempt, attemptLog);
           const skeleton = {
             id: responseId, object: 'response', created_at: nowUnix(),
@@ -862,7 +863,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       recordUpstreamSuccess(route, result.usage?.total_tokens ?? (promptTokens + completionTokens));
       setStickyModel(messages, route.modelDbId, sessionIdHeader);
 
-      res.setHeader('X-Routed-Via', `${route.platform}/${route.modelId}`);
+      res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
       setFallbackHeaders(res, attempt, attemptLog);
       res.json(buildResponseObject({
         id: responseId, model: route.modelId, text, toolCalls,


### PR DESCRIPTION
Part of #619.

A relay whose catalog has a model id like `我的模型[test] v2` fails every single request. The id is spliced into `X-Routed-Via`, Node refuses the header value ("Invalid character in header content"), and because the throw happens inside the failover loop the router books it as a provider failure and cools the model down — so the upstream call succeeds and the client still gets a 502.

There was no shared sanitizer: only `X-Fallback-Trail` had an inline scrub, and none of the ~12 `X-Routed-Via` sites used it.

- new `server/src/lib/header-value.ts` — SP and VCHAR pass through unchanged (`groq/llama-3.3-70b-versatile` is byte-identical to before), control characters, DEL and non-ASCII are percent-encoded as UTF-8 so the value still decodes with `decodeURIComponent`, and the result is length-capped
- applied everywhere a header is built from provider/model names: `X-Routed-Via` on `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/messages`, the Gemini and Ollama surfaces and the fusion path (streaming and non-streaming), `X-Provider`/`X-Model` on the audio endpoints, and `X-Fallback-Trail`
- tests: unit coverage for the sanitizer plus an end-to-end test per surface that registers a custom relay with a hostile model id and asserts a 200 with a decodable header

Docs note the encoding in the response-headers section.

Full server suite: 1520 passing.

The other items in #619 (per-key/per-channel scoring for same-named models, custom-endpoint model editing, timeout as a speed penalty, `reasoning_effort: max`) are untouched here.