### PR TITLE
Keep every API key added to a custom endpoint

### DIFF
--- a/server/src/__tests__/routes/custom-provider-multikey.test.ts
+++ b/server/src/__tests__/routes/custom-provider-multikey.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { decrypt } from '../../lib/crypto.js';
+import { routePinnedModel } from '../../services/router.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+
+// #619(b): a custom endpoint can hold SEVERAL credentials. Adding a second key
+// for a base_url that already has one used to UPDATE the existing row — the
+// first key vanished with no warning — and the models upsert re-bound every
+// model of that endpoint to whichever key was submitted last.
+
+const ENDPOINT = 'http://127.0.0.1:18080/v1';
+let dashToken = '';
+
+async function request(app: Express, method: string, path: string, body?: unknown) {
+  const server = app.listen(0);
+  const addr = server.address() as any;
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+const post = (app: Express, path: string, body: unknown) => request(app, 'POST', path, body);
+const get = (app: Express, path: string) => request(app, 'GET', path);
+const del = (app: Express, path: string) => request(app, 'DELETE', path);
+
+function customKeys(baseUrl = ENDPOINT) {
+  return getDb().prepare(`
+    SELECT id, label, encrypted_key, iv, auth_tag, base_url
+      FROM api_keys
+     WHERE platform = 'custom' AND base_url = ?
+     ORDER BY id
+  `).all(baseUrl) as Array<{ id: number; label: string; encrypted_key: string; iv: string; auth_tag: string; base_url: string }>;
+}
+
+function secrets(baseUrl = ENDPOINT) {
+  return customKeys(baseUrl).map(k => decrypt(k.encrypted_key, k.iv, k.auth_tag));
+}
+
+function chatModel(modelId: string) {
+  return getDb().prepare("SELECT id, key_id FROM models WHERE platform = 'custom' AND model_id = ?")
+    .get(modelId) as { id: number; key_id: number | null } | undefined;
+}
+
+describe('multiple keys per custom endpoint (#619)', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare("DELETE FROM settings WHERE key = 'active_profile_id'").run();
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  it('inserts a second key row instead of overwriting the first', async () => {
+    expect((await post(app, '/api/keys/custom', {
+      baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret', label: 'Relay A',
+    })).status).toBe(201);
+    expect((await post(app, '/api/keys/custom', {
+      baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret', label: 'Relay B',
+    })).status).toBe(201);
+
+    expect(secrets()).toEqual(['first-secret', 'second-secret']);
+  });
+
+  it('keeps an existing model bound to a key of its endpoint', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    const firstKeyId = customKeys()[0]!.id;
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret' });
+
+    // The binding must not be silently moved to the last-added key.
+    expect(chatModel('relay-model')!.key_id).toBe(firstKeyId);
+  });
+
+  it('rotates request-time key selection across every key of the endpoint', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret' });
+
+    const modelDbId = chatModel('relay-model')!.id;
+    const usedKeyIds = new Set<number>();
+    const usedSecrets = new Set<string>();
+    for (let i = 0; i < 6; i++) {
+      const route = routePinnedModel(modelDbId);
+      expect(route).not.toBeNull();
+      expect((route!.provider as any).baseUrl).toBe(ENDPOINT);
+      usedKeyIds.add(route!.keyId);
+      usedSecrets.add(route!.apiKey);
+      route!.release?.();
+    }
+
+    expect(usedKeyIds.size).toBe(2);
+    expect([...usedSecrets].sort()).toEqual(['first-secret', 'second-secret']);
+  });
+
+  it('updates in place when the same secret is submitted again', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret', label: 'Relay A' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret', label: 'Relay renamed' });
+
+    const keys = customKeys();
+    expect(keys).toHaveLength(1);
+    expect(keys[0]!.label).toBe('Relay renamed');
+  });
+
+  it('upgrades a keyless endpoint in place when a real key arrives', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+
+    // 'no-key' is a placeholder, not a credential — replacing it loses nothing.
+    expect(secrets()).toEqual(['first-secret']);
+  });
+
+  it('lists the endpoint models against every key of that endpoint', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret' });
+
+    const { body } = await get(app, '/api/keys');
+    const rows = (body as any[]).filter(k => k.platform === 'custom');
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.models.map((m: any) => m.modelId)).toEqual(['relay-model']);
+    }
+  });
+
+  it('re-binds the endpoint models to a sibling key when one key is deleted', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret' });
+    const [first, second] = customKeys();
+
+    expect((await del(app, `/api/keys/${first!.id}`)).status).toBe(200);
+
+    const model = chatModel('relay-model');
+    expect(model).toBeDefined();
+    expect(model!.key_id).toBe(second!.id);
+    expect(getDb().prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(model!.id)).toBeDefined();
+
+    // Still routable through the surviving credential.
+    const route = routePinnedModel(model!.id);
+    expect(route).not.toBeNull();
+    expect(route!.apiKey).toBe('second-secret');
+    route!.release?.();
+  });
+
+  it('still cascades the models away when the endpoints last key is deleted', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    const only = customKeys()[0]!;
+    const modelDbId = chatModel('relay-model')!.id;
+
+    expect((await del(app, `/api/keys/${only.id}`)).status).toBe(200);
+
+    expect(chatModel('relay-model')).toBeUndefined();
+    expect(getDb().prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelDbId)).toBeUndefined();
+  });
+
+  it('clears every key of the endpoint once its last model is removed', async () => {
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'first-secret' });
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'second-secret' });
+    expect(customKeys()).toHaveLength(2);
+
+    const modelDbId = chatModel('relay-model')!.id;
+    expect((await del(app, `/api/models/custom/${modelDbId}`)).status).toBe(200);
+
+    expect(customKeys()).toHaveLength(0);
+  });
+
+  it('keeps a second custom media key for the same endpoint', async () => {
+    expect((await post(app, '/api/media/custom', {
+      baseUrl: ENDPOINT, model: 'relay-image', modality: 'image', apiKey: 'first-secret',
+    })).status).toBe(201);
+    expect((await post(app, '/api/media/custom', {
+      baseUrl: ENDPOINT, model: 'relay-image', modality: 'image', apiKey: 'second-secret',
+    })).status).toBe(201);
+
+    expect(secrets()).toEqual(['first-secret', 'second-secret']);
+  });
+
+  it('does not merge keys that share a secret across different endpoints', async () => {
+    const other = 'http://127.0.0.1:18081/v1';
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-model', apiKey: 'shared-secret' });
+    await post(app, '/api/keys/custom', { baseUrl: other, model: 'other-model', apiKey: 'shared-secret' });
+
+    expect(secrets()).toEqual(['shared-secret']);
+    expect(secrets(other)).toEqual(['shared-secret']);
+    expect(routePinnedModel(chatModel('other-model')!.id)!.provider).toMatchObject({ baseUrl: other });
+  });
+});

--- a/server/src/lib/custom-provider-cleanup.ts
+++ b/server/src/lib/custom-provider-cleanup.ts
@@ -1,11 +1,29 @@
 import type { Db } from '../db/types.js';
 
-export function deleteUnusedCustomEndpointKey(db: Db, keyId: number | null | undefined) {
-  if (keyId == null) return;
+function boundModelCount(db: Db, keyId: number): number {
   const chat = db.prepare("SELECT COUNT(*) AS n FROM models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
   const embeddings = db.prepare("SELECT COUNT(*) AS n FROM embedding_models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
   const media = db.prepare("SELECT COUNT(*) AS n FROM media_models WHERE platform = 'custom' AND key_id = ?").get(keyId) as { n: number };
-  if (chat.n + embeddings.n + media.n === 0) {
-    db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+  return chat.n + embeddings.n + media.n;
+}
+
+export function deleteUnusedCustomEndpointKey(db: Db, keyId: number | null | undefined) {
+  if (keyId == null) return;
+  if (boundModelCount(db, keyId) > 0) return;
+
+  const row = db.prepare("SELECT base_url FROM api_keys WHERE id = ? AND platform = 'custom'")
+    .get(keyId) as { base_url: string | null } | undefined;
+  db.prepare("DELETE FROM api_keys WHERE id = ? AND platform = 'custom'").run(keyId);
+  if (!row?.base_url) return;
+
+  // An endpoint can hold several credentials (#619). Once nothing is registered
+  // against it any more, its other keys are dead weight too — but a sibling that
+  // still carries models of its own stays.
+  const siblings = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND base_url = ?")
+    .all(row.base_url) as { id: number }[];
+  for (const sibling of siblings) {
+    if (boundModelCount(db, sibling.id) === 0) {
+      db.prepare('DELETE FROM api_keys WHERE id = ?').run(sibling.id);
+    }
   }
 }

--- a/server/src/routes/embeddings.ts
+++ b/server/src/routes/embeddings.ts
@@ -2,8 +2,9 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb, setSetting } from '../db/index.js';
-import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
+import { decrypt, maskKey } from '../lib/crypto.js';
 import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
+import { resolveCustomEndpointKey, customEndpointKeyIds } from '../services/custom-endpoint.js';
 import {
   listEmbeddingModels,
   getDefaultFamily,
@@ -136,47 +137,22 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
   }
 
   const upsert = db.transaction(() => {
-    let keyId: number;
-    let storedKeyForMask = probeKey;
-    if (existingKey) {
-      keyId = existingKey.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label),
-                 encrypted_key = ?,
-                 iv = ?,
-                 auth_tag = ?,
-                 status = 'unknown',
-                 enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, encrypted, iv, authTag, keyId);
-        storedKeyForMask = providedKey;
-      } else {
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label), status = 'unknown', enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, keyId);
-      }
-    } else {
-      const keyToStore = providedKey ?? 'no-key';
-      const { encrypted, iv, authTag } = encrypt(keyToStore);
-      const key = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(key.lastInsertRowid);
-      storedKeyForMask = keyToStore;
-    }
+    // A new secret for a known endpoint is an ADDITIONAL credential, never a
+    // replacement for the stored one (#619).
+    const { keyId, storedKey: storedKeyForMask } = resolveCustomEndpointKey(db, baseUrl, providedKey, label);
+    const endpointKeyIds = customEndpointKeyIds(db, keyId);
 
     const existingModel = db.prepare(`
-      SELECT id, priority
+      SELECT id, priority, key_id
         FROM embedding_models
        WHERE platform = 'custom' AND model_id = ?
        LIMIT 1
-    `).get(modelId) as { id: number; priority: number } | undefined;
+    `).get(modelId) as { id: number; priority: number; key_id: number | null } | undefined;
+    // A model already on this endpoint keeps the key it has; only a move to a
+    // different endpoint re-binds it.
+    const bindKeyId = existingModel?.key_id != null && endpointKeyIds.has(existingModel.key_id)
+      ? existingModel.key_id
+      : keyId;
     const priority = existingModel?.priority ?? (
       (db.prepare('SELECT COALESCE(MAX(priority), 0) AS maxPriority FROM embedding_models WHERE family = ?')
         .get(family) as { maxPriority: number }).maxPriority + 1
@@ -194,7 +170,7 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
                quota_label = ?,
                key_id = ?
          WHERE id = ?
-      `).run(family, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, keyId, existingModel.id);
+      `).run(family, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, bindKeyId, existingModel.id);
       return { modelDbId: existingModel.id, keyId, storedKeyForMask };
     }
 
@@ -202,7 +178,7 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
       INSERT INTO embedding_models
         (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
       VALUES (?, 'custom', ?, ?, ?, ?, ?, 1, ?, ?)
-    `).run(family, modelId, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, keyId);
+    `).run(family, modelId, displayName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, bindKeyId);
     return { modelDbId: Number(model.lastInsertRowid), keyId, storedKeyForMask };
   });
 

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -10,6 +10,7 @@ import { parseKeysFromFile, stripJsoncComments, stripTrailingCommas } from '../l
 import { assessProviderUrl } from '../lib/url-guard.js';
 import { ensureModelInProfiles } from '../services/profile-models.js';
 import { getActiveCooldownsForKeys, clearCooldownsForKey } from '../services/ratelimit.js';
+import { resolveCustomEndpointKey, customEndpointKeyIds, siblingEndpointKeyId } from '../services/custom-endpoint.js';
 
 export const keysRouter = Router();
 
@@ -212,11 +213,20 @@ keysRouter.get('/', (_req: Request, res: Response) => {
        WHERE platform = 'custom' AND key_id IS NOT NULL
     `).all() as any[],
   ];
-  const modelsByKeyId = new Map<number, any[]>();
+  // Models are grouped by ENDPOINT, not by key row: an endpoint can hold
+  // several credentials (#619) while each model binds to just one of them, and
+  // every one of those keys serves the endpoint's whole model list.
+  const endpointOfKey = new Map<number, string>();
+  for (const row of rows) {
+    if (row.platform === 'custom' && row.base_url) endpointOfKey.set(Number(row.id), row.base_url);
+  }
+  const endpointOf = (keyId: number) => endpointOfKey.get(keyId) ?? `key:${keyId}`;
+
+  const modelsByEndpoint = new Map<string, any[]>();
   for (const m of customModels) {
     const keyId = Number(m.key_id);
     if (!Number.isInteger(keyId)) continue;
-    const list = modelsByKeyId.get(keyId) ?? [];
+    const list = modelsByEndpoint.get(endpointOf(keyId)) ?? [];
     list.push({
       id: m.id,
       kind: m.kind,
@@ -224,9 +234,9 @@ keysRouter.get('/', (_req: Request, res: Response) => {
       displayName: m.display_name,
       family: m.family ?? null,
     });
-    modelsByKeyId.set(keyId, list);
+    modelsByEndpoint.set(endpointOf(keyId), list);
   }
-  for (const list of modelsByKeyId.values()) {
+  for (const list of modelsByEndpoint.values()) {
     list.sort((a, b) => {
       const ka = ['chat', 'embedding', 'image', 'audio'].indexOf(a.kind);
       const kb = ['chat', 'embedding', 'image', 'audio'].indexOf(b.kind);
@@ -259,7 +269,7 @@ keysRouter.get('/', (_req: Request, res: Response) => {
       createdAt: row.created_at,
       lastCheckedAt: row.last_checked_at,
       lastHealthError: row.last_health_error ?? null,
-      models: row.platform === 'custom' ? (modelsByKeyId.get(row.id) ?? []) : undefined,
+      models: row.platform === 'custom' ? (modelsByEndpoint.get(endpointOf(Number(row.id))) ?? []) : undefined,
       cooldowns: cooldowns.map(c => ({
         modelId: c.modelId,
         expiresAtMs: c.expiresAtMs,
@@ -534,50 +544,27 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
 
   const db = getDb();
   const upsert = db.transaction(() => {
-    // One 'custom' key row PER ENDPOINT (matched on base_url). Re-submitting
-    // the same endpoint updates its key/label; a new base_url gets its own
-// row instead of clobbering the previous provider. (#212) Re-submitting with a
-// blank key preserves the stored key; only a provided key updates credentials.
-    const existing = db.prepare("SELECT id, encrypted_key, iv, auth_tag FROM api_keys WHERE platform = 'custom' AND base_url = ? LIMIT 1")
-      .get(baseUrl) as { id: number; encrypted_key: string; iv: string; auth_tag: string } | undefined;
-    let keyId: number;
-    let storedKeyForMask = providedKey ?? 'no-key';
-    if (existing) {
-      keyId = existing.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare("UPDATE api_keys SET label = COALESCE(?, label), encrypted_key = ?, iv = ?, auth_tag = ?, status = 'unknown', enabled = 1 WHERE id = ?")
-          .run(label ?? null, encrypted, iv, authTag, existing.id);
-        storedKeyForMask = providedKey;
-      } else {
-        try {
-          storedKeyForMask = decrypt(existing.encrypted_key, existing.iv, existing.auth_tag);
-        } catch {
-          storedKeyForMask = 'no-key';
-        }
-        db.prepare("UPDATE api_keys SET label = COALESCE(?, label), status = 'unknown', enabled = 1 WHERE id = ?")
-          .run(label ?? null, existing.id);
-      }
-    } else {
-      const keyToStore = providedKey ?? 'no-key';
-      const { encrypted, iv, authTag } = encrypt(keyToStore);
-      const r = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(r.lastInsertRowid);
-      storedKeyForMask = keyToStore;
-    }
+    // Key rows are matched on (base_url, secret): a new secret for a known
+    // endpoint is a SECOND credential for it, not a replacement (#619), and a
+    // new base_url is a separate provider (#212). Re-submitting with a blank
+    // key preserves the stored one.
+    const { keyId, storedKey: storedKeyForMask } = resolveCustomEndpointKey(db, baseUrl, providedKey, label);
+    const endpointKeyIds = customEndpointKeyIds(db, keyId);
 
     const registered: { modelDbId: number; model: string; displayName: string; supportsTools: boolean; supportsVision: boolean }[] = [];
     for (const { modelId, displayName, supportsTools, supportsVision } of entries) {
       // Register each model bound to THIS endpoint's key. Custom models carry no
       // rate limits and sort last in the intelligence preset (size_label tier).
-      // Re-registering an existing model id re-binds it (model ids are unique
-      // per platform, so one id can't live on two endpoints at once).
+      // Re-registering an existing model id re-binds it to the submitted
+      // ENDPOINT (model ids are unique per platform, so one id can't live on two
+      // endpoints at once) — but a model already on this endpoint keeps the key
+      // it has, so adding a second credential doesn't silently re-bind it (#619).
       // Capability flags: an unset flag binds NULL so COALESCE picks the insert
       // default (tools 1, vision 0) on a new row and preserves the existing
       // value on re-registration. (#470)
+      const bound = db.prepare("SELECT key_id FROM models WHERE platform = 'custom' AND model_id = ?")
+        .get(modelId) as { key_id: number | null } | undefined;
+      const bindKeyId = bound?.key_id != null && endpointKeyIds.has(bound.key_id) ? bound.key_id : keyId;
       const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
       const visionParam = supportsVision === undefined ? null : (supportsVision ? 1 : 0);
       db.prepare(`
@@ -594,7 +581,7 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
           enabled = 1,
           supports_tools = COALESCE(@tools, supports_tools),
           supports_vision = COALESCE(@vision, supports_vision)
-      `).run({ modelId, displayName, keyId, tools: toolsParam, vision: visionParam });
+      `).run({ modelId, displayName, keyId: bindKeyId, tools: toolsParam, vision: visionParam });
 
       const modelRow = db.prepare("SELECT id, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number; supports_tools: number; supports_vision: number };
 
@@ -798,13 +785,24 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const row = db.prepare('SELECT platform FROM api_keys WHERE id = ?').get(id) as { platform: string } | undefined;
+  const row = db.prepare('SELECT platform, base_url FROM api_keys WHERE id = ?').get(id) as { platform: string; base_url: string | null } | undefined;
   if (!row) {
     res.status(404).json({ error: { message: 'Key not found' } });
     return;
   }
+  // Another credential for the SAME endpoint keeps it alive — the models move
+  // over to it instead of being cascaded away with this key (#619).
+  const sibling = row.platform === 'custom' ? siblingEndpointKeyId(db, id, row.base_url) : null;
 
   const remove = db.transaction(() => {
+    if (sibling != null) {
+      for (const table of ['models', 'embedding_models', 'media_models']) {
+        db.prepare(`UPDATE ${table} SET key_id = ? WHERE platform = 'custom' AND key_id = ?`).run(sibling, id);
+      }
+      db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
+      return;
+    }
+
     db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
     // Custom models exist only because POST /custom registered them alongside
     // their endpoint key (#117) — they can't route without it. Cascade away

--- a/server/src/routes/media.ts
+++ b/server/src/routes/media.ts
@@ -2,8 +2,9 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
-import { encrypt, decrypt, maskKey } from '../lib/crypto.js';
+import { maskKey } from '../lib/crypto.js';
 import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
+import { resolveCustomEndpointKey, customEndpointKeyIds } from '../services/custom-endpoint.js';
 import { listAllMediaModels } from '../services/media.js';
 
 export const mediaRouter = Router();
@@ -71,56 +72,22 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
   const quotaLabel = parsed.data.quotaLabel?.trim() || 'custom endpoint';
 
   const upsert = db.transaction(() => {
-    const existingKey = db.prepare(`
-      SELECT id, encrypted_key, iv, auth_tag
-        FROM api_keys
-       WHERE platform = 'custom' AND base_url = ?
-       LIMIT 1
-    `).get(baseUrl) as { id: number; encrypted_key: string; iv: string; auth_tag: string } | undefined;
-    let keyId: number;
-    let storedKeyForMask = providedKey ?? 'no-key';
-    if (existingKey) {
-      keyId = existingKey.id;
-      if (providedKey) {
-        const { encrypted, iv, authTag } = encrypt(providedKey);
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label),
-                 encrypted_key = ?,
-                 iv = ?,
-                 auth_tag = ?,
-                 status = 'unknown',
-                 enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, encrypted, iv, authTag, keyId);
-        storedKeyForMask = providedKey;
-      } else {
-        try {
-          storedKeyForMask = decrypt(existingKey.encrypted_key, existingKey.iv, existingKey.auth_tag);
-        } catch {
-          storedKeyForMask = 'no-key';
-        }
-        db.prepare(`
-          UPDATE api_keys
-             SET label = COALESCE(?, label), status = 'unknown', enabled = 1
-           WHERE id = ?
-        `).run(label ?? null, keyId);
-      }
-    } else {
-      const { encrypted, iv, authTag } = encrypt(providedKey ?? 'no-key');
-      const key = db.prepare(`
-        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-        VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-      `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
-      keyId = Number(key.lastInsertRowid);
-    }
+    // A new secret for a known endpoint is an ADDITIONAL credential, never a
+    // replacement for the stored one (#619).
+    const { keyId, storedKey: storedKeyForMask } = resolveCustomEndpointKey(db, baseUrl, providedKey, label);
+    const endpointKeyIds = customEndpointKeyIds(db, keyId);
 
     const existingModel = db.prepare(`
-      SELECT id, modality, priority
+      SELECT id, modality, priority, key_id
         FROM media_models
        WHERE platform = 'custom' AND model_id = ?
        LIMIT 1
-    `).get(modelId) as { id: number; modality: string; priority: number } | undefined;
+    `).get(modelId) as { id: number; modality: string; priority: number; key_id: number | null } | undefined;
+    // A model already on this endpoint keeps the key it has; only a move to a
+    // different endpoint re-binds it.
+    const bindKeyId = existingModel?.key_id != null && endpointKeyIds.has(existingModel.key_id)
+      ? existingModel.key_id
+      : keyId;
     const priority = existingModel && existingModel.modality === parsed.data.modality
       ? existingModel.priority
       : (db.prepare('SELECT COALESCE(MAX(priority), 0) AS maxPriority FROM media_models WHERE modality = ?')
@@ -136,7 +103,7 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
                quota_label = ?,
                key_id = ?
          WHERE id = ?
-      `).run(displayName, parsed.data.modality, priority, quotaLabel, keyId, existingModel.id);
+      `).run(displayName, parsed.data.modality, priority, quotaLabel, bindKeyId, existingModel.id);
       return { modelDbId: existingModel.id, keyId, storedKeyForMask };
     }
 
@@ -144,7 +111,7 @@ mediaRouter.post('/custom', (req: Request, res: Response) => {
       INSERT INTO media_models
         (platform, model_id, display_name, modality, priority, enabled, quota_label, key_id)
       VALUES ('custom', ?, ?, ?, ?, 1, ?, ?)
-    `).run(modelId, displayName, parsed.data.modality, priority, quotaLabel, keyId);
+    `).run(modelId, displayName, parsed.data.modality, priority, quotaLabel, bindKeyId);
     return { modelDbId: Number(model.lastInsertRowid), keyId, storedKeyForMask };
   });
 

--- a/server/src/services/custom-endpoint.ts
+++ b/server/src/services/custom-endpoint.ts
@@ -1,0 +1,139 @@
+import { encrypt, decrypt } from '../lib/crypto.js';
+import type { Db } from '../db/types.js';
+
+// ── Custom OpenAI-compatible endpoints: keys per endpoint ────────────────────
+// A custom endpoint is identified by its base_url and can hold SEVERAL
+// credentials — relay services routinely hand out one key per plan/group, and
+// pooling them is the whole point of adding more than one (#619). Registration
+// therefore matches on (base_url, secret), never on base_url alone: a new
+// secret for a known endpoint INSERTs, it does not overwrite the key already
+// stored. Models still bind to one api_keys row via key_id (#212); the router
+// treats every key sharing that row's base_url as an alternative for the same
+// model, so the binding names the ENDPOINT and the pool rotates underneath it.
+
+// Stored for endpoints that need no credential (llama.cpp / LM Studio / vLLM
+// with auth off). It is a placeholder, not a secret, so a real key may replace
+// it in place instead of piling up a second row.
+const NO_KEY = 'no-key';
+
+interface StoredKeyRow {
+  id: number;
+  encrypted_key: string;
+  iv: string;
+  auth_tag: string;
+}
+
+export interface ResolvedEndpointKey {
+  keyId: number;
+  /** Plaintext of the key now bound to this endpoint — for masking in responses. */
+  storedKey: string;
+  /** True when this call added a credential rather than updating one. */
+  created: boolean;
+}
+
+function endpointKeyRows(db: Db, baseUrl: string): StoredKeyRow[] {
+  return db.prepare(`
+    SELECT id, encrypted_key, iv, auth_tag
+      FROM api_keys
+     WHERE platform = 'custom' AND base_url = ?
+     ORDER BY id
+  `).all(baseUrl) as StoredKeyRow[];
+}
+
+function plaintextOf(row: StoredKeyRow): string | null {
+  try {
+    return decrypt(row.encrypted_key, row.iv, row.auth_tag);
+  } catch {
+    return null;
+  }
+}
+
+function touch(db: Db, id: number, label: string | undefined): void {
+  db.prepare("UPDATE api_keys SET label = COALESCE(?, label), status = 'unknown', enabled = 1 WHERE id = ?")
+    .run(label ?? null, id);
+}
+
+function insertKey(db: Db, baseUrl: string, secret: string, label: string | undefined): ResolvedEndpointKey {
+  const { encrypted, iv, authTag } = encrypt(secret);
+  const r = db.prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
+    VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
+  `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
+  return { keyId: Number(r.lastInsertRowid), storedKey: secret, created: true };
+}
+
+/**
+ * Resolve the api_keys row a custom-endpoint registration should bind to,
+ * creating or updating it as needed. Never destroys a stored credential:
+ *  - no key submitted        → reuse the endpoint's first key (label refresh only)
+ *  - a key already on record  → update that row (label / re-enable)
+ *  - a new key, placeholder-only endpoint → replace the placeholder in place
+ *  - a new key, endpoint already has one → INSERT a second credential (#619)
+ */
+export function resolveCustomEndpointKey(
+  db: Db,
+  baseUrl: string,
+  providedKey: string | undefined,
+  label: string | undefined,
+): ResolvedEndpointKey {
+  const rows = endpointKeyRows(db, baseUrl);
+  const stored = rows.map(row => ({ row, secret: plaintextOf(row) }));
+
+  if (!providedKey) {
+    const first = stored[0];
+    if (!first) return insertKey(db, baseUrl, NO_KEY, label);
+    touch(db, first.row.id, label);
+    return { keyId: first.row.id, storedKey: first.secret ?? NO_KEY, created: false };
+  }
+
+  const same = stored.find(s => s.secret === providedKey);
+  if (same) {
+    touch(db, same.row.id, label);
+    return { keyId: same.row.id, storedKey: providedKey, created: false };
+  }
+
+  // Only placeholders on record: the endpoint was registered without auth and
+  // is being given a key now, so upgrade rather than leave a dead sentinel row.
+  if (stored.length > 0 && stored.every(s => s.secret === NO_KEY)) {
+    const target = stored[0]!.row;
+    const { encrypted, iv, authTag } = encrypt(providedKey);
+    db.prepare(`
+      UPDATE api_keys
+         SET label = COALESCE(?, label), encrypted_key = ?, iv = ?, auth_tag = ?,
+             status = 'unknown', enabled = 1
+       WHERE id = ?
+    `).run(label ?? null, encrypted, iv, authTag, target.id);
+    return { keyId: target.id, storedKey: providedKey, created: false };
+  }
+
+  return insertKey(db, baseUrl, providedKey, label);
+}
+
+/**
+ * Every api_keys id that serves the SAME custom endpoint as `keyId` — i.e. the
+ * credential pool a model bound to `keyId` may rotate across. Falls back to the
+ * key itself when the row is gone or carries no base_url.
+ */
+export function customEndpointKeyIds(db: Db, keyId: number): Set<number> {
+  const row = db.prepare("SELECT base_url FROM api_keys WHERE id = ?").get(keyId) as
+    { base_url: string | null } | undefined;
+  if (!row?.base_url) return new Set([keyId]);
+  const siblings = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND base_url = ?")
+    .all(row.base_url) as { id: number }[];
+  return new Set(siblings.map(s => s.id));
+}
+
+/**
+ * The other key still serving this endpoint once `keyId` is gone, or null when
+ * it was the last one. Used to re-home an endpoint's models instead of deleting
+ * them with the key.
+ */
+export function siblingEndpointKeyId(db: Db, keyId: number, baseUrl: string | null): number | null {
+  if (!baseUrl) return null;
+  const row = db.prepare(`
+    SELECT id FROM api_keys
+     WHERE platform = 'custom' AND base_url = ? AND id != ?
+     ORDER BY id LIMIT 1
+  `).get(baseUrl, keyId) as { id: number } | undefined;
+  return row?.id ?? null;
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -22,6 +22,7 @@ import { parseBudget } from '../lib/budget.js';
 import { platformDropsResponseFormat } from '../lib/sampling-params.js';
 import { isUnifyEnabled, getModelGroups, resolveRequestedIdToMembers } from './model-groups.js';
 import { getActiveProfileId } from './profile-models.js';
+import { customEndpointKeyIds } from './custom-endpoint.js';
 import type { BaseProvider } from '../providers/base.js';
 import type { Platform } from '@freellmapi/shared/types.js';
 import type { Db } from '../db/types.js';
@@ -788,13 +789,19 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   let idx = roundRobinIndex.get(rrKey) ?? 0;
   const ranked = orderKeysByScore(entry, keys);
 
+  // A custom model belongs to exactly one endpoint (#212), but an endpoint can
+  // hold several credentials — so the pool is every key on the same base_url,
+  // rotated like any other platform's keys (#619). Legacy rows (key_id NULL)
+  // keep the old any-key match.
+  const endpointKeyIds = entry.platform === 'custom' && entry.key_id != null
+    ? customEndpointKeyIds(db, entry.key_id)
+    : null;
+
   for (let attempt = 0; attempt < keys.length; attempt++) {
     const key = ranked ? ranked[attempt] : keys[idx % keys.length];
     idx++;
 
-    // A custom model belongs to exactly one endpoint (#212); legacy rows
-    // (key_id NULL) keep the old any-key match.
-    if (entry.platform === 'custom' && entry.key_id != null && key.id !== entry.key_id) { note('custom-key-mismatch'); continue; }
+    if (endpointKeyIds && !endpointKeyIds.has(key.id)) { note('custom-key-mismatch'); continue; }
 
     const skipId = `${entry.platform}:${entry.model_id}:${key.id}`;
     if (skipKeys?.has(skipId)) { note('already-failed-this-request'); continue; }
@@ -886,11 +893,15 @@ export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, ski
     "SELECT id FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')"
   ).all(m.platform) as { id: number }[];
 
+  // Keys of the model's own custom endpoint (#212, #619); a key belonging to a
+  // DIFFERENT endpoint cannot serve it, so it doesn't count as an alternative.
+  const endpointKeyIds = m.platform === 'custom' && m.key_id != null
+    ? customEndpointKeyIds(db, m.key_id)
+    : null;
+
   for (const k of keys) {
     if (k.id === excludingKeyId) continue;
-    // A custom model binds to exactly one endpoint key (#212); a sibling custom
-    // key cannot serve it, so it doesn't count as an alternative.
-    if (m.platform === 'custom' && m.key_id != null && k.id !== m.key_id) continue;
+    if (endpointKeyIds && !endpointKeyIds.has(k.id)) continue;
     if (skipKeys?.has(`${m.platform}:${m.model_id}:${k.id}`)) continue;
     if (isOnCooldown(m.platform, m.model_id, k.id)) continue;
     if (!canUseProvider(m.platform, k.id)) continue;
@@ -1044,9 +1055,13 @@ export function getOrderedFusionChain(estimatedTokens: number): FusionCandidate[
     if (e.context_window != null && estimatedTokens > e.context_window) return false;
     const keyIds = keysByPlatform.get(e.platform);
     if (!keyIds) return false;
+    // Same endpoint-pool rule the router applies (#619).
+    const endpointKeyIds = e.platform === 'custom' && e.key_id != null
+      ? customEndpointKeyIds(db, e.key_id)
+      : null;
     const limits = { rpm: e.rpm_limit, rpd: e.rpd_limit, tpm: e.tpm_limit, tpd: e.tpd_limit };
     return keyIds.some(kid =>
-      (e.key_id == null || kid === e.key_id) &&
+      (endpointKeyIds == null || endpointKeyIds.has(kid)) &&
       !isOnCooldown(e.platform, e.model_id, kid) &&
       canUseProvider(e.platform, kid) &&
       canUseProviderMinute(e.platform, kid) &&


### PR DESCRIPTION
Adding a second key for a custom provider with the same base URL silently overwrote the first one — the key lookup matched on `base_url` alone and UPDATEd the row. The models upsert then re-bound the endpoint's models to whichever key was submitted last, so you also couldn't tell what happened afterwards. Reported in #619.

What changed:

- key rows match on (base_url, secret). A new secret for a known endpoint inserts a second key; the same secret updates in place; a blank submit still keeps the stored key. A `no-key` placeholder gets upgraded in place, since there's no credential to lose there.
- a model already registered on an endpoint keeps its key binding. Moving a model id to a different endpoint still re-binds, as before.
- key selection at request time pools every key sharing a base URL, so a custom endpoint rotates across its keys like any built-in platform — cooldowns, quotas and the per-key scoring all apply unchanged.
- deleting one key of an endpoint re-homes its models to a sibling key instead of cascading them away. Deleting the last key cascades as it always did.
- the custom embedding and media endpoints used the same destructive lookup, so they now share the fix.

No schema change — models keep binding to one `api_keys` row, that row just names the endpoint rather than the only credential for it.

Tests: new `custom-provider-multikey.test.ts` covers both loss modes (both key rows survive, the existing model keeps a working binding) plus rotation across both keys, the delete/re-home path, and the media endpoint. Full server suite passes (1515 tests).