### PR TITLE
release: v0.6.2

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bump desktop app version to 0.6.2 for the v0.6.2 release.