### PR TITLE
Fix custom endpoint model identity (#651)

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -21,6 +21,7 @@ const REQUEST_SERVED_MODEL_FILENAME = '20260726_000005_request_served_model.ts';
 const ATTEMPT_ERROR_SUMMARY_FILENAME = '20260726_000006_attempt_error_summary.ts';
 const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility.ts';
 const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
+const CUSTOM_ENDPOINT_MODEL_IDENTITY_FILENAME = '20260729_000001_custom_endpoint_model_identity.ts';
 
 interface SchemaRow {
   type: string;
@@ -88,6 +89,7 @@ describe('migration round trip', () => {
         ATTEMPT_ERROR_SUMMARY_FILENAME,
         AGENT_COMPATIBILITY_FILENAME,
         TOMBSTONE_PROVENANCE_FILENAME,
+        CUSTOM_ENDPOINT_MODEL_IDENTITY_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -309,6 +309,46 @@ describe('Custom Provider Endpoints', () => {
     });
   });
 
+  describe('same model on independent custom endpoints (#651)', () => {
+    it('keeps distinct model rows, routes, and lifecycle when endpoint model ids collide', async () => {
+      const db = getDb();
+      db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
+      db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
+      db.prepare("DELETE FROM api_keys WHERE platform = 'custom'").run();
+
+      const first = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:18081/v1', model: 'shared-relay-model', label: 'Relay one',
+      });
+      const second = await post(app, '/api/keys/custom', {
+        baseUrl: 'http://127.0.0.1:18082/v1', model: 'shared-relay-model', label: 'Relay two',
+      });
+      expect(first.status).toBe(201);
+      expect(second.status).toBe(201);
+      expect(first.body.modelDbId).not.toBe(second.body.modelDbId);
+
+      const rows = db.prepare(`
+        SELECT m.id, m.custom_endpoint_id, k.base_url
+          FROM models m JOIN api_keys k ON k.id = m.key_id
+         WHERE m.platform = 'custom' AND m.model_id = 'shared-relay-model'
+         ORDER BY k.base_url
+      `).all() as Array<{ id: number; custom_endpoint_id: number; base_url: string }>;
+      expect(rows).toHaveLength(2);
+      expect(new Set(rows.map(row => row.custom_endpoint_id)).size).toBe(2);
+
+      for (const row of rows) {
+        const route = routeRequest(1000, undefined, row.id);
+        expect((route.provider as any).baseUrl).toBe(row.base_url);
+        route.release?.();
+      }
+
+      const firstKey = db.prepare("SELECT id FROM api_keys WHERE base_url = 'http://127.0.0.1:18081/v1'").get() as { id: number };
+      expect((await del(app, `/api/keys/${firstKey.id}`)).status).toBe(200);
+      const remaining = db.prepare("SELECT m.id FROM models m JOIN api_keys k ON k.id = m.key_id WHERE m.platform = 'custom' AND m.model_id = 'shared-relay-model' AND k.base_url = 'http://127.0.0.1:18082/v1'").get();
+      expect(remaining).toBeDefined();
+      expect((db.prepare("SELECT COUNT(*) AS count FROM models WHERE platform = 'custom' AND model_id = 'shared-relay-model'").get() as { count: number }).count).toBe(1);
+    });
+  });
+
   // #281: one submit can bind several model ids to a single endpoint, instead
   // of forcing one POST per model.
   describe('multiple models per endpoint (#281)', () => {

--- a/server/src/__tests__/services/model-retirement.test.ts
+++ b/server/src/__tests__/services/model-retirement.test.ts
@@ -28,7 +28,7 @@ function seedModel(modelId = MODEL_ID): number {
   db.prepare(`
     INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, enabled, source)
     VALUES (?, ?, 'EOL Test', 50, 50, 1, 'catalog')
-    ON CONFLICT(platform, model_id) DO UPDATE SET enabled = 1
+    ON CONFLICT DO UPDATE SET enabled = 1
   `).run(PLATFORM, modelId);
   const row = db.prepare('SELECT id FROM models WHERE platform = ? AND model_id = ?')
     .get(PLATFORM, modelId) as { id: number };
@@ -157,7 +157,7 @@ describe('noteModelRetirementSignal (auto-disable with a reason — #634)', () =
     db.prepare(`
       INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, enabled, source)
       VALUES ('custom', 'eol-test-custom', 'Custom EOL', 50, 50, 1, 'user')
-      ON CONFLICT(platform, model_id) DO UPDATE SET enabled = 1
+      ON CONFLICT DO UPDATE SET enabled = 1
     `).run();
     const row = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = 'eol-test-custom'")
       .get() as { id: number };

--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -315,7 +315,7 @@ describe('Rate Limiter', () => {
           'navy', ?, ?, 1, 1, 'Large', 20, NULL, NULL, ?,
           ?, NULL, 1, 0, 1
         )
-        ON CONFLICT(platform, model_id) DO UPDATE SET
+        ON CONFLICT DO UPDATE SET
           tpd_limit = excluded.tpd_limit,
           monthly_token_budget = excluded.monthly_token_budget
       `).run(modelId, `${modelId} (NavyAI)`, tpdLimit, monthlyTokenBudget);

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -16,6 +16,7 @@ import * as requestServedModel from '../migrations/20260726_000005_request_serve
 import * as attemptErrorSummary from '../migrations/20260726_000006_attempt_error_summary.js';
 import * as agentCompatibility from '../migrations/20260727_000001_agent_compatibility.js';
 import * as tombstoneProvenance from '../migrations/20260728_000001_tombstone_provenance.js';
+import * as customEndpointModelIdentity from '../migrations/20260729_000001_custom_endpoint_model_identity.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -44,6 +45,7 @@ export const REQUEST_SERVED_MODEL_FILENAME = '20260726_000005_request_served_mod
 export const ATTEMPT_ERROR_SUMMARY_FILENAME = '20260726_000006_attempt_error_summary.ts';
 export const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility.ts';
 export const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
+export const CUSTOM_ENDPOINT_MODEL_IDENTITY_FILENAME = '20260729_000001_custom_endpoint_model_identity.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -63,4 +65,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: ATTEMPT_ERROR_SUMMARY_FILENAME, module: attemptErrorSummary },
   { filename: AGENT_COMPATIBILITY_FILENAME, module: agentCompatibility },
   { filename: TOMBSTONE_PROVENANCE_FILENAME, module: tombstoneProvenance },
+  { filename: CUSTOM_ENDPOINT_MODEL_IDENTITY_FILENAME, module: customEndpointModelIdentity },
 ];

--- a/server/src/db/migrations/20260729_000001_custom_endpoint_model_identity.ts
+++ b/server/src/db/migrations/20260729_000001_custom_endpoint_model_identity.ts
@@ -1,0 +1,219 @@
+// Migration: stable custom-endpoint identity for chat models (#651)
+// Created: 2026-07-29
+//
+// DOWN: reversible unless two endpoints now contain the same custom model id
+
+import type { Db } from '../types.js';
+
+interface CustomKeyRow {
+  id: number;
+  base_url: string | null;
+}
+
+function hasColumn(db: Db, table: string, column: string): boolean {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+  return columns.some((candidate) => candidate.name === column);
+}
+
+function normalizeBaseUrl(raw: string): string {
+  return raw.trim().replace(/\/+$/, '');
+}
+
+function createModelsTable(db: Db, name: string, includeEndpoint: boolean): void {
+  db.exec(`
+    CREATE TABLE ${name} (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      platform TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      intelligence_rank INTEGER NOT NULL,
+      speed_rank INTEGER NOT NULL,
+      size_label TEXT NOT NULL DEFAULT '',
+      rpm_limit INTEGER,
+      rpd_limit INTEGER,
+      tpm_limit INTEGER,
+      tpd_limit INTEGER,
+      monthly_token_budget TEXT NOT NULL DEFAULT '',
+      context_window INTEGER,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      supports_vision INTEGER NOT NULL DEFAULT 0,
+      key_id INTEGER,
+      supports_tools INTEGER NOT NULL DEFAULT 1,
+      source TEXT NOT NULL DEFAULT 'catalog',
+      paid_input_per_m REAL,
+      paid_output_per_m REAL${includeEndpoint ? ',\n      custom_endpoint_id INTEGER REFERENCES custom_endpoints(id)' : ''}
+    )
+  `);
+}
+
+function stageModelReferences(db: Db): void {
+  db.exec(`
+    CREATE TABLE fallback_config_stage AS SELECT * FROM fallback_config;
+    CREATE TABLE profile_models_stage AS SELECT * FROM profile_models;
+    DROP TABLE fallback_config;
+    DROP TABLE profile_models;
+  `);
+}
+
+function restoreModelReferences(db: Db): void {
+  db.exec(`
+    CREATE TABLE fallback_config (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      model_db_id INTEGER NOT NULL REFERENCES models(id),
+      priority INTEGER NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      UNIQUE(model_db_id)
+    );
+    INSERT INTO fallback_config (id, model_db_id, priority, enabled)
+      SELECT id, model_db_id, priority, enabled FROM fallback_config_stage;
+    DROP TABLE fallback_config_stage;
+
+    CREATE TABLE profile_models (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      profile_id INTEGER NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+      model_db_id INTEGER NOT NULL REFERENCES models(id) ON DELETE CASCADE,
+      priority INTEGER NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      UNIQUE(profile_id, model_db_id)
+    );
+    INSERT INTO profile_models (id, profile_id, model_db_id, priority, enabled)
+      SELECT id, profile_id, model_db_id, priority, enabled FROM profile_models_stage;
+    DROP TABLE profile_models_stage;
+  `);
+}
+
+function createIdentityIndexes(db: Db): void {
+  db.exec(`
+    CREATE UNIQUE INDEX idx_models_builtin_identity
+      ON models(platform, model_id)
+      WHERE platform != 'custom';
+    CREATE UNIQUE INDEX idx_models_custom_endpoint_identity
+      ON models(custom_endpoint_id, model_id)
+      WHERE platform = 'custom' AND custom_endpoint_id IS NOT NULL;
+    CREATE INDEX idx_models_custom_endpoint
+      ON models(custom_endpoint_id)
+      WHERE platform = 'custom';
+  `);
+}
+
+export function up(db: Db): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS custom_endpoints (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      base_url TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  if (!hasColumn(db, 'api_keys', 'custom_endpoint_id')) {
+    db.prepare('ALTER TABLE api_keys ADD COLUMN custom_endpoint_id INTEGER').run();
+  }
+
+  const customKeys = db.prepare(`
+    SELECT id, base_url FROM api_keys
+     WHERE platform = 'custom' AND base_url IS NOT NULL
+  `).all() as CustomKeyRow[];
+  const insertEndpoint = db.prepare('INSERT OR IGNORE INTO custom_endpoints (base_url) VALUES (?)');
+  const findEndpoint = db.prepare('SELECT id FROM custom_endpoints WHERE base_url = ?');
+  const bindKey = db.prepare('UPDATE api_keys SET custom_endpoint_id = ? WHERE id = ?');
+  for (const key of customKeys) {
+    const baseUrl = normalizeBaseUrl(key.base_url!);
+    insertEndpoint.run(baseUrl);
+    const endpoint = findEndpoint.get(baseUrl) as { id: number };
+    bindKey.run(endpoint.id, key.id);
+  }
+
+  // SQLite cannot drop the old UNIQUE(platform, model_id) constraint in place.
+  // Stage the two tables with foreign keys to models, rebuild while preserving
+  // model ids, then restore those references against the replacement table.
+  stageModelReferences(db);
+  createModelsTable(db, 'models_next', true);
+  db.exec(`
+    INSERT INTO models_next (
+      id, platform, model_id, display_name, intelligence_rank, speed_rank,
+      size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit,
+      monthly_token_budget, context_window, enabled, supports_vision, key_id,
+      supports_tools, source, paid_input_per_m, paid_output_per_m, custom_endpoint_id
+    )
+    SELECT
+      m.id, m.platform, m.model_id, m.display_name, m.intelligence_rank, m.speed_rank,
+      m.size_label, m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit,
+      m.monthly_token_budget, m.context_window, m.enabled,
+      m.supports_vision, m.key_id, m.supports_tools, m.source,
+      m.paid_input_per_m, m.paid_output_per_m,
+      CASE WHEN m.platform = 'custom' THEN k.custom_endpoint_id ELSE NULL END
+    FROM models m
+    LEFT JOIN api_keys k ON k.id = m.key_id
+  `);
+  db.exec('DROP TABLE models; ALTER TABLE models_next RENAME TO models;');
+  createIdentityIndexes(db);
+  restoreModelReferences(db);
+
+  if (!hasColumn(db, 'requests', 'model_db_id')) {
+    db.prepare('ALTER TABLE requests ADD COLUMN model_db_id INTEGER').run();
+    db.prepare('CREATE INDEX idx_requests_model_db_id ON requests(model_db_id)').run();
+  }
+
+  // Historical custom requests can be mapped exactly only while their key row
+  // still exists. Leave orphaned history NULL rather than assigning it to the
+  // wrong endpoint after a prior collision or key deletion.
+  db.exec(`
+    UPDATE requests
+       SET model_db_id = (
+         SELECT m.id FROM models m
+          WHERE m.platform = requests.platform
+            AND m.model_id = requests.model_id
+            AND (
+              m.platform != 'custom'
+              OR m.custom_endpoint_id = (
+                SELECT k.custom_endpoint_id FROM api_keys k WHERE k.id = requests.key_id
+              )
+            )
+          LIMIT 1
+       )
+     WHERE model_db_id IS NULL;
+  `);
+}
+
+export function down(db: Db): void {
+  const duplicate = db.prepare(`
+    SELECT model_id FROM models
+     WHERE platform = 'custom'
+     GROUP BY model_id
+    HAVING COUNT(*) > 1
+     LIMIT 1
+  `).get() as { model_id: string } | undefined;
+  if (duplicate) {
+    throw new Error(`irreversible migration: custom model '${duplicate.model_id}' exists on multiple endpoints`);
+  }
+
+  stageModelReferences(db);
+  createModelsTable(db, 'models_previous', false);
+  db.exec(`
+    INSERT INTO models_previous (
+      id, platform, model_id, display_name, intelligence_rank, speed_rank,
+      size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit,
+      monthly_token_budget, context_window, enabled, supports_vision, key_id,
+      supports_tools, source, paid_input_per_m, paid_output_per_m
+    )
+    SELECT
+      id, platform, model_id, display_name, intelligence_rank, speed_rank,
+      size_label, rpm_limit, rpd_limit, tpm_limit, tpd_limit,
+      monthly_token_budget, context_window, enabled, supports_vision, key_id,
+      supports_tools, source, paid_input_per_m, paid_output_per_m
+    FROM models;
+    DROP TABLE models;
+    ALTER TABLE models_previous RENAME TO models;
+    CREATE UNIQUE INDEX idx_models_legacy_identity ON models(platform, model_id);
+  `);
+  restoreModelReferences(db);
+
+  db.prepare('DROP INDEX IF EXISTS idx_requests_model_db_id').run();
+  if (hasColumn(db, 'requests', 'model_db_id')) {
+    db.prepare('ALTER TABLE requests DROP COLUMN model_db_id').run();
+  }
+  if (hasColumn(db, 'api_keys', 'custom_endpoint_id')) {
+    db.prepare('ALTER TABLE api_keys DROP COLUMN custom_endpoint_id').run();
+  }
+  db.prepare('DROP TABLE custom_endpoints').run();
+}

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -29,6 +29,21 @@ function setSettingIfMissing(db: LogTx, key: string, value: string): void {
   `).run(key, value);
 }
 
+// Custom relays may expose the same upstream model id at different base URLs.
+// Resolve the durable model row using the selected key's endpoint, rather than
+// the globally ambiguous (platform, model_id) pair.
+function resolveModelDbId(db: LogTx, platform: string, modelId: string, keyId: number): number | null {
+  const row = db.prepare(`
+    SELECT m.id
+      FROM models m
+      LEFT JOIN api_keys k ON k.id = ?
+     WHERE m.platform = ? AND m.model_id = ?
+       AND (m.platform != 'custom' OR m.custom_endpoint_id = k.custom_endpoint_id)
+     LIMIT 1
+  `).get(keyId, platform, modelId) as { id: number } | undefined;
+  return row?.id ?? null;
+}
+
 // Append a row to the request analytics table. Shared by the chat proxy, the
 // responses path, and the fusion panel so every served (or failed) sub-request
 // is logged identically. Lives in a neutral lib module to avoid an import cycle
@@ -67,10 +82,11 @@ export function logRequest(
     // middleware); null when logging happens outside an HTTP request.
     const client = getClientContext();
     const tx = db.transaction(() => {
+      const modelDbId = resolveModelDbId(db, platform, modelId, keyId);
       const insert = db.prepare(`
-        INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
+        INSERT INTO requests (platform, model_id, model_db_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(platform, modelId, modelDbId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
 
       // Report the row id back to the fallback loop's attempt trace (if one is
       // active): the LAST id noted during a loop run is the terminal row the

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -99,7 +99,8 @@ analyticsRouter.get('/summary', (req: Request, res: Response) => {
       ELSE 0 END
     ), 0) as est_savings
     FROM requests r
-    LEFT JOIN models m ON m.platform = r.platform AND m.model_id = r.model_id
+    LEFT JOIN models m ON m.id = r.model_db_id
+      OR (r.model_db_id IS NULL AND r.platform != 'custom' AND m.platform = r.platform AND m.model_id = r.model_id)
     WHERE r.created_at >= ?
   `).get(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as { est_savings: number };
 
@@ -197,8 +198,8 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
 
   const rows = db.prepare(`
     SELECT
-      r.platform,
-      r.model_id,
+      COALESCE(m.platform, r.platform) AS platform,
+      COALESCE(m.model_id, r.model_id) AS model_id,
       m.display_name,
       COUNT(*) as requests,
       SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
@@ -211,9 +212,10 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
         r.output_tokens * COALESCE(m.paid_output_per_m, ?) / 1000000.0
       ELSE 0 END) as est_cost
     FROM requests r
-    LEFT JOIN models m ON m.platform = r.platform AND m.model_id = r.model_id
+    LEFT JOIN models m ON m.id = r.model_db_id
+      OR (r.model_db_id IS NULL AND r.platform != 'custom' AND m.platform = r.platform AND m.model_id = r.model_id)
     WHERE r.created_at >= ?
-    GROUP BY r.platform, r.model_id
+    GROUP BY r.model_db_id, r.platform, r.model_id
     ORDER BY requests DESC
   `).all(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as any[];
 

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -72,7 +72,7 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
            m.speed_rank, m.size_label, m.rpm_limit, m.rpd_limit,
            m.tpm_limit, m.tpd_limit, m.context_window,
            m.monthly_token_budget, m.supports_vision, m.supports_tools,
-           m.key_id, ak.label AS key_label,
+           m.key_id, m.custom_endpoint_id, ak.label AS key_label,
            mo.overrides_json IS NOT NULL AS has_overrides,
            mo.overrides_json,
            ts.source AS tombstone_source, ts.reason AS tombstone_reason
@@ -93,7 +93,7 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
            m.speed_rank, m.size_label, m.rpm_limit, m.rpd_limit,
            m.tpm_limit, m.tpd_limit, m.context_window,
            m.monthly_token_budget, m.supports_vision, m.supports_tools,
-           m.key_id, ak.label AS key_label,
+           m.key_id, m.custom_endpoint_id, ak.label AS key_label,
            mo.overrides_json IS NOT NULL AS has_overrides,
            mo.overrides_json,
            ts.source AS tombstone_source, ts.reason AS tombstone_reason
@@ -117,6 +117,10 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
     GROUP BY platform
   `).all() as { platform: string; count: number }[];
   const keyCountMap = new Map(keyCounts.map(k => [k.platform, k.count]));
+  const endpointKeyCountMap = new Map(
+    (db.prepare("SELECT custom_endpoint_id, COUNT(*) AS count FROM api_keys WHERE platform = 'custom' AND custom_endpoint_id IS NOT NULL AND enabled = 1 AND status IN ('healthy', 'unknown') GROUP BY custom_endpoint_id").all() as { custom_endpoint_id: number; count: number }[])
+      .map(k => [k.custom_endpoint_id, k.count]),
+  );
 
   // Get current dynamic penalties
   const penalties = getAllPenalties();
@@ -162,7 +166,8 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
       // Parsed once here (single source of truth) so the dashboard never re-implements
       // budget-label parsing; 0 for rate-limited/placeholder labels. See lib/budget.ts.
       // Scaled by healthy/enabled key count for multi-account pooled capacity.
-      monthlyTokenBudgetTokens: parseBudget(r.monthly_token_budget) * Math.max(1, keyCountMap.get(r.platform) ?? 1),
+      monthlyTokenBudgetTokens: parseBudget(r.monthly_token_budget) * Math.max(1,
+        r.platform === 'custom' ? (endpointKeyCountMap.get(r.custom_endpoint_id) ?? 1) : (keyCountMap.get(r.platform) ?? 1)),
       supportsVision: r.supports_vision === 1,
       supportsTools: r.supports_tools === 1,
       source: r.platform === 'custom' || r.key_id != null ? 'custom' : 'catalog',
@@ -178,7 +183,7 @@ fallbackRouter.get('/', (_req: Request, res: Response) => {
       // provider's own (redacted) wording.
       retiredUpstream: r.tombstone_source === 'upstream_eol',
       retiredReason: r.tombstone_source === 'upstream_eol' ? (r.tombstone_reason ?? null) : null,
-      keyCount: keyCountMap.get(r.platform) ?? 0,
+      keyCount: r.platform === 'custom' ? (endpointKeyCountMap.get(r.custom_endpoint_id) ?? 0) : (keyCountMap.get(r.platform) ?? 0),
     };
   }));
 });
@@ -312,12 +317,12 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
     ? db.prepare('SELECT id FROM profiles WHERE id = ?').get(activeProfileId) as any
     : null;
 
-  let rawModels: { model_db_id: number; platform: string; model_id: string; display_name: string; monthly_token_budget: string; priority: number; enabled: number; rpm_limit: number | null; rpd_limit: number | null; tpm_limit: number | null; tpd_limit: number | null }[];
+  let rawModels: { model_db_id: number; platform: string; model_id: string; display_name: string; monthly_token_budget: string; priority: number; enabled: number; rpm_limit: number | null; rpd_limit: number | null; tpm_limit: number | null; tpd_limit: number | null; custom_endpoint_id: number | null }[];
 
   if (activeProfile) {
     // Profile mode: use profile_models chain (all models in profile, checked against enabled)
     rawModels = db.prepare(`
-      SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.monthly_token_budget,
+      SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.monthly_token_budget, m.custom_endpoint_id,
              pm.priority, pm.enabled,
              m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit
       FROM profile_models pm
@@ -328,7 +333,7 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
   } else {
     // Default mode: use fallback_config (only include enabled models)
     rawModels = db.prepare(`
-      SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.monthly_token_budget,
+      SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.monthly_token_budget, m.custom_endpoint_id,
              fc.priority, fc.enabled,
              m.rpm_limit, m.rpd_limit, m.tpm_limit, m.tpd_limit
       FROM fallback_config fc
@@ -340,30 +345,43 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
 
   // Build per-model breakdown (only platforms with keys), preserving enabled state
   const usageRows = db.prepare(`
-    SELECT platform, model_id, COALESCE(SUM(input_tokens + output_tokens), 0) AS used
-    FROM requests
-    WHERE created_at >= datetime('now', 'start of month')
-      AND request_type = 'chat'
-    GROUP BY platform, model_id
-  `).all() as { platform: string; model_id: string; used: number }[];
-  const usageByModel = new Map(usageRows.map(r => [`${r.platform}:${r.model_id}`, r.used]));
+    WITH matched_requests AS (
+      SELECT r.*,
+        COALESCE(r.model_db_id, CASE WHEN r.platform != 'custom' THEN (
+          SELECT m.id FROM models m WHERE m.platform = r.platform AND m.model_id = r.model_id
+        ) END) AS resolved_model_db_id
+      FROM requests r
+      WHERE r.created_at >= datetime('now', 'start of month') AND r.request_type = 'chat'
+    )
+    SELECT resolved_model_db_id AS model_db_id, COALESCE(SUM(input_tokens + output_tokens), 0) AS used
+    FROM matched_requests
+    WHERE resolved_model_db_id IS NOT NULL
+    GROUP BY resolved_model_db_id
+  `).all() as { model_db_id: number; used: number }[];
+  const usageByModel = new Map(usageRows.map(r => [r.model_db_id, r.used]));
 
   const keyCountMap = new Map(
     (db.prepare("SELECT platform, COUNT(*) as count FROM api_keys WHERE enabled = 1 AND status IN ('healthy', 'unknown') GROUP BY platform").all() as { platform: string; count: number }[])
       .map(k => [k.platform, k.count])
   );
+  const endpointKeyCountMap = new Map(
+    (db.prepare("SELECT custom_endpoint_id, COUNT(*) as count FROM api_keys WHERE platform = 'custom' AND custom_endpoint_id IS NOT NULL AND enabled = 1 AND status IN ('healthy', 'unknown') GROUP BY custom_endpoint_id").all() as { custom_endpoint_id: number; count: number }[])
+      .map(k => [k.custom_endpoint_id, k.count]),
+  );
 
   const modelBudgets = rawModels
     .filter(m => platformSet.has(m.platform))
     .map(m => {
-      const keys = Math.max(1, keyCountMap.get(m.platform) ?? 1);
+      const keys = Math.max(1, m.platform === 'custom'
+        ? (endpointKeyCountMap.get(m.custom_endpoint_id ?? -1) ?? 1)
+        : (keyCountMap.get(m.platform) ?? 1));
       return {
         modelDbId: m.model_db_id,
         displayName: m.display_name,
         platform: m.platform,
         modelId: m.model_id,
         budget: parseBudget(m.monthly_token_budget) * keys,
-        used: usageByModel.get(`${m.platform}:${m.model_id}`) ?? 0,
+        used: usageByModel.get(m.model_db_id) ?? 0,
         enabled: m.enabled === 1,
         rpmLimit: m.rpm_limit,
         rpdLimit: m.rpd_limit,

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -10,7 +10,7 @@ import { parseKeysFromFile, stripJsoncComments, stripTrailingCommas } from '../l
 import { assessProviderUrl } from '../lib/url-guard.js';
 import { ensureModelInProfiles } from '../services/profile-models.js';
 import { getActiveCooldownsForKeys, clearCooldownsForKey } from '../services/ratelimit.js';
-import { resolveCustomEndpointKey, customEndpointKeyIds, siblingEndpointKeyId } from '../services/custom-endpoint.js';
+import { resolveCustomEndpointKey, customEndpointKeyIds, customEndpointIdForKey, siblingEndpointKeyId } from '../services/custom-endpoint.js';
 import { customModelSeed } from '../services/custom-model-seed.js';
 import { discoverEndpointModels, ModelDiscoveryError } from '../services/model-discovery.js';
 
@@ -701,6 +701,8 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
       db, baseUrl, providedKey, label, endpoint.keyId ?? undefined,
     );
     const endpointKeyIds = customEndpointKeyIds(db, keyId);
+    const customEndpointId = customEndpointIdForKey(db, keyId);
+    if (customEndpointId == null) throw new Error('Custom endpoint identity is unavailable for this key');
     // Unknown ≠ worst: seed the routing ranks at the catalog median so a new
     // custom model is explored instead of buried at intelligence 0 (#488).
     const seed = customModelSeed(db);
@@ -716,8 +718,8 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
       // Capability flags: an unset flag binds NULL so COALESCE picks the insert
       // default (tools 1, vision 0) on a new row and preserves the existing
       // value on re-registration. (#470)
-      const bound = db.prepare("SELECT key_id FROM models WHERE platform = 'custom' AND model_id = ?")
-        .get(modelId) as { key_id: number | null } | undefined;
+      const bound = db.prepare("SELECT key_id FROM models WHERE platform = 'custom' AND custom_endpoint_id = ? AND model_id = ?")
+        .get(customEndpointId, modelId) as { key_id: number | null } | undefined;
       const created = bound === undefined;
       const bindKeyId = bound?.key_id != null && endpointKeyIds.has(bound.key_id) ? bound.key_id : keyId;
       const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
@@ -729,23 +731,22 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
         INSERT INTO models
           (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
            rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, key_id,
-           supports_tools, supports_vision, source)
+           supports_tools, supports_vision, source, custom_endpoint_id)
         VALUES ('custom', @modelId, @displayName, @intelligenceRank, @speedRank, @sizeLabel,
            NULL, NULL, NULL, NULL, '', NULL, 1, @keyId,
-           COALESCE(@tools, 1), COALESCE(@vision, 0), 'user')
-        ON CONFLICT(platform, model_id)
-        DO UPDATE SET
+           COALESCE(@tools, 1), COALESCE(@vision, 0), 'user', @customEndpointId)
+        ON CONFLICT DO UPDATE SET
           display_name = excluded.display_name,
           key_id = excluded.key_id,
           enabled = 1,
           supports_tools = COALESCE(@tools, supports_tools),
           supports_vision = COALESCE(@vision, supports_vision)
       `).run({
-        modelId, displayName, keyId: bindKeyId, tools: toolsParam, vision: visionParam,
+        modelId, displayName, keyId: bindKeyId, customEndpointId, tools: toolsParam, vision: visionParam,
         intelligenceRank: seed.intelligenceRank, speedRank: seed.speedRank, sizeLabel: seed.sizeLabel,
       });
 
-      const modelRow = db.prepare("SELECT id, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ?").get(modelId) as { id: number; supports_tools: number; supports_vision: number };
+      const modelRow = db.prepare("SELECT id, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND custom_endpoint_id = ? AND model_id = ?").get(customEndpointId, modelId) as { id: number; supports_tools: number; supports_vision: number };
 
       // Append to the fallback chain if not already present.
       const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
@@ -952,7 +953,7 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const row = db.prepare('SELECT platform, base_url FROM api_keys WHERE id = ?').get(id) as { platform: string; base_url: string | null } | undefined;
+  const row = db.prepare('SELECT platform, base_url, custom_endpoint_id FROM api_keys WHERE id = ?').get(id) as { platform: string; base_url: string | null; custom_endpoint_id: number | null } | undefined;
   if (!row) {
     res.status(404).json({ error: { message: 'Key not found' } });
     return;
@@ -963,7 +964,11 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
 
   const remove = db.transaction(() => {
     if (sibling != null) {
+      if (row.platform === 'custom' && row.custom_endpoint_id != null) {
+        db.prepare("UPDATE models SET key_id = ? WHERE platform = 'custom' AND custom_endpoint_id = ?").run(sibling, row.custom_endpoint_id);
+      }
       for (const table of ['models', 'embedding_models', 'media_models']) {
+        if (table === 'models' && row.platform === 'custom' && row.custom_endpoint_id != null) continue;
         db.prepare(`UPDATE ${table} SET key_id = ? WHERE platform = 'custom' AND key_id = ?`).run(sibling, id);
       }
       db.prepare('DELETE FROM api_keys WHERE id = ?').run(id);
@@ -978,8 +983,14 @@ keysRouter.delete('/:id', (req: Request, res: Response) => {
     // so they never linger in the fallback chain forever (#189).
     if (row.platform === 'custom') {
       const defaultEmbedding = db.prepare("SELECT value FROM settings WHERE key = 'embeddings_default_family'").get() as { value: string } | undefined;
-      db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom' AND key_id = ?)").run(id);
-      db.prepare("DELETE FROM models WHERE platform = 'custom' AND key_id = ?").run(id);
+      if (row.custom_endpoint_id != null) {
+        db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom' AND custom_endpoint_id = ?)").run(row.custom_endpoint_id);
+        db.prepare("DELETE FROM models WHERE platform = 'custom' AND custom_endpoint_id = ?").run(row.custom_endpoint_id);
+        db.prepare('DELETE FROM custom_endpoints WHERE id = ?').run(row.custom_endpoint_id);
+      } else {
+        db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom' AND key_id = ?)").run(id);
+        db.prepare("DELETE FROM models WHERE platform = 'custom' AND key_id = ?").run(id);
+      }
       db.prepare("DELETE FROM embedding_models WHERE platform = 'custom' AND key_id = ?").run(id);
       db.prepare("DELETE FROM media_models WHERE platform = 'custom' AND key_id = ?").run(id);
       const remaining = db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom'").get() as { n: number };

--- a/server/src/services/custom-endpoint.ts
+++ b/server/src/services/custom-endpoint.ts
@@ -7,9 +7,9 @@ import type { Db } from '../db/types.js';
 // pooling them is the whole point of adding more than one (#619). Registration
 // therefore matches on (base_url, secret), never on base_url alone: a new
 // secret for a known endpoint INSERTs, it does not overwrite the key already
-// stored. Models still bind to one api_keys row via key_id (#212); the router
-// treats every key sharing that row's base_url as an alternative for the same
-// model, so the binding names the ENDPOINT and the pool rotates underneath it.
+// stored. Models bind to the stable custom_endpoints row; key_id is retained as
+// the pool's preferred credential, while the router can rotate within that
+// endpoint's credentials.
 
 // Stored for endpoints that need no credential (llama.cpp / LM Studio / vLLM
 // with auth off). It is a placeholder, not a secret, so a real key may replace
@@ -21,6 +21,17 @@ interface StoredKeyRow {
   encrypted_key: string;
   iv: string;
   auth_tag: string;
+}
+
+function endpointIdForBaseUrl(db: Db, baseUrl: string): number {
+  db.prepare('INSERT OR IGNORE INTO custom_endpoints (base_url) VALUES (?)').run(baseUrl);
+  return (db.prepare('SELECT id FROM custom_endpoints WHERE base_url = ?').get(baseUrl) as { id: number }).id;
+}
+
+export function customEndpointIdForKey(db: Db, keyId: number): number | null {
+  const row = db.prepare('SELECT custom_endpoint_id FROM api_keys WHERE id = ? AND platform = \'custom\'').get(keyId) as
+    { custom_endpoint_id: number | null } | undefined;
+  return row?.custom_endpoint_id ?? null;
 }
 
 export interface ResolvedEndpointKey {
@@ -55,10 +66,11 @@ function touch(db: Db, id: number, label: string | undefined): void {
 
 function insertKey(db: Db, baseUrl: string, secret: string, label: string | undefined): ResolvedEndpointKey {
   const { encrypted, iv, authTag } = encrypt(secret);
+  const endpointId = endpointIdForBaseUrl(db, baseUrl);
   const r = db.prepare(`
-    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-    VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
-  `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl);
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url, custom_endpoint_id)
+    VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?, ?)
+  `).run(label ?? 'Custom', encrypted, iv, authTag, baseUrl, endpointId);
   return { keyId: Number(r.lastInsertRowid), storedKey: secret, created: true };
 }
 
@@ -125,11 +137,11 @@ export function resolveCustomEndpointKey(
  * key itself when the row is gone or carries no base_url.
  */
 export function customEndpointKeyIds(db: Db, keyId: number): Set<number> {
-  const row = db.prepare("SELECT base_url FROM api_keys WHERE id = ?").get(keyId) as
-    { base_url: string | null } | undefined;
-  if (!row?.base_url) return new Set([keyId]);
-  const siblings = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND base_url = ?")
-    .all(row.base_url) as { id: number }[];
+  const row = db.prepare('SELECT custom_endpoint_id FROM api_keys WHERE id = ?').get(keyId) as
+    { custom_endpoint_id: number | null } | undefined;
+  if (row?.custom_endpoint_id == null) return new Set([keyId]);
+  const siblings = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND custom_endpoint_id = ?")
+    .all(row.custom_endpoint_id) as { id: number }[];
   return new Set(siblings.map(s => s.id));
 }
 
@@ -139,6 +151,15 @@ export function customEndpointKeyIds(db: Db, keyId: number): Set<number> {
  * them with the key.
  */
 export function siblingEndpointKeyId(db: Db, keyId: number, baseUrl: string | null): number | null {
+  const endpoint = customEndpointIdForKey(db, keyId);
+  if (endpoint != null) {
+    const sibling = db.prepare(`
+      SELECT id FROM api_keys
+       WHERE platform = 'custom' AND custom_endpoint_id = ? AND id != ?
+       ORDER BY id LIMIT 1
+    `).get(endpoint, keyId) as { id: number } | undefined;
+    return sibling?.id ?? null;
+  }
   if (!baseUrl) return null;
   const row = db.prepare(`
     SELECT id FROM api_keys

--- a/server/src/services/declarative-config.ts
+++ b/server/src/services/declarative-config.ts
@@ -7,6 +7,7 @@ import { resolveProvider } from '../providers/index.js';
 import { setCustomWeights, setRoutingStrategy } from './router.js';
 import { ensureModelInProfiles } from './profile-models.js';
 import { customModelSeed } from './custom-model-seed.js';
+import { customEndpointIdForKey, resolveCustomEndpointKey } from './custom-endpoint.js';
 import {
   clearCatalogModelTombstone,
   isCatalogManagedModel,
@@ -161,20 +162,9 @@ function upsertApiKey(db: Db, input: z.infer<typeof keySchema>): number {
 
   if (isCustom) {
     if (!baseUrl) throw new Error('baseUrl is required for custom keys');
-    const existing = db.prepare("SELECT id FROM api_keys WHERE platform = 'custom' AND base_url = ?").get(baseUrl) as { id: number } | undefined;
-    if (existing) {
-      db.prepare(`
-        UPDATE api_keys
-           SET label = ?, encrypted_key = ?, iv = ?, auth_tag = ?, enabled = ?, status = 'unknown'
-         WHERE id = ?
-      `).run(label, key.encrypted, key.iv, key.authTag, enabled, existing.id);
-      return existing.id;
-    }
-    const inserted = db.prepare(`
-      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
-      VALUES ('custom', ?, ?, ?, ?, 'unknown', ?, ?)
-    `).run(label, key.encrypted, key.iv, key.authTag, enabled, baseUrl);
-    return Number(inserted.lastInsertRowid);
+    const resolved = resolveCustomEndpointKey(db, baseUrl, input.key?.trim() || undefined, label);
+    db.prepare('UPDATE api_keys SET enabled = ? WHERE id = ?').run(enabled, resolved.keyId);
+    return resolved.keyId;
   }
 
   const existing = db.prepare('SELECT id FROM api_keys WHERE platform = ? AND label = ? AND base_url IS NULL LIMIT 1')
@@ -226,6 +216,8 @@ function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSche
     baseUrl: input.baseUrl,
     enabled: true,
   });
+  const endpointId = customEndpointIdForKey(db, keyId);
+  if (endpointId == null) throw new Error('custom endpoint identity is unavailable');
   // Same median seeding as the dashboard's custom-model path (#488): an
   // undeclared rank means "unknown", not "worst". An explicitly declared rank
   // always wins.
@@ -233,25 +225,31 @@ function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSche
   let registered = 0;
   for (const entry of input.models) {
     const model = normalizeModelEntry(entry);
-    db.prepare(`
+    const existing = db.prepare(`
+      SELECT id FROM models
+       WHERE platform = 'custom' AND custom_endpoint_id = ? AND model_id = ?
+    `).get(endpointId, model.modelId) as { id: number } | undefined;
+    if (existing) {
+      db.prepare(`
+        UPDATE models SET
+          display_name = ?, intelligence_rank = ?, speed_rank = ?, size_label = ?,
+          monthly_token_budget = ?, context_window = ?, supports_vision = ?,
+          supports_tools = ?, key_id = ?, enabled = 1
+        WHERE id = ?
+      `).run(
+        model.displayName, model.intelligenceRank ?? seed.intelligenceRank,
+        model.speedRank ?? seed.speedRank, model.sizeLabel ?? seed.sizeLabel,
+        model.monthlyTokenBudget ?? '', model.contextWindow ?? null,
+        model.supportsVision ? 1 : 0, model.supportsTools ? 1 : 0, keyId, existing.id,
+      );
+    } else {
+      db.prepare(`
       INSERT INTO models
         (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
          rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window,
-         enabled, supports_vision, supports_tools, key_id, source)
-      VALUES ('custom', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 1, ?, ?, ?, 'user')
-      ON CONFLICT(platform, model_id)
-      DO UPDATE SET
-        display_name = excluded.display_name,
-        intelligence_rank = excluded.intelligence_rank,
-        speed_rank = excluded.speed_rank,
-        size_label = excluded.size_label,
-        monthly_token_budget = excluded.monthly_token_budget,
-        context_window = excluded.context_window,
-        supports_vision = excluded.supports_vision,
-        supports_tools = excluded.supports_tools,
-        key_id = excluded.key_id,
-        enabled = 1
-    `).run(
+         enabled, supports_vision, supports_tools, key_id, source, custom_endpoint_id)
+      VALUES ('custom', ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, 1, ?, ?, ?, 'user', ?)
+      `).run(
       model.modelId,
       model.displayName,
       model.intelligenceRank ?? seed.intelligenceRank,
@@ -262,8 +260,11 @@ function registerCustomProvider(db: Db, input: z.infer<typeof customProviderSche
       model.supportsVision ? 1 : 0,
       model.supportsTools ? 1 : 0,
       keyId,
+      endpointId,
     );
-    const row = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND model_id = ?").get(model.modelId) as { id: number };
+    }
+    const row = db.prepare("SELECT id FROM models WHERE platform = 'custom' AND custom_endpoint_id = ? AND model_id = ?")
+      .get(endpointId, model.modelId) as { id: number };
     ensureFallbackRow(db, row.id, model.fallbackEnabled !== false);
     registered++;
   }

--- a/server/src/services/model-groups.ts
+++ b/server/src/services/model-groups.ts
@@ -48,6 +48,7 @@ export interface GroupableRow {
   model_id: string;
   display_name: string;
   intelligence_rank?: number;
+  custom_endpoint_id?: number | null;
 }
 
 export interface ModelGroup {
@@ -130,6 +131,9 @@ export function slugifyGroupLabel(label: string): string {
 
 // ── Grouping ─────────────────────────────────────────────────────────────────
 function memberId(row: GroupableRow): string {
+  if (row.platform === 'custom' && row.custom_endpoint_id != null) {
+    return `custom:${row.custom_endpoint_id}:${row.model_id}`;
+  }
   return `${row.platform}:${row.model_id}`;
 }
 
@@ -232,7 +236,8 @@ export function resolveRequestedIdToMembers(requested: string, groups: ModelGrou
 export function getModelGroups(): ModelGroup[] {
   const db = getDb();
   const rows = db.prepare(`
-    SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.intelligence_rank
+    SELECT m.id as model_db_id, m.platform, m.model_id, m.display_name, m.intelligence_rank,
+           m.custom_endpoint_id
     FROM models m
   `).all() as GroupableRow[];
   return groupRows(rows, getUnifyOverrides());

--- a/server/src/services/model-listing.ts
+++ b/server/src/services/model-listing.ts
@@ -37,7 +37,11 @@ export function buildModelListing(): ModelListing {
         SELECT 1 FROM api_keys k
         WHERE k.platform = m.platform
           AND k.enabled = 1
-          AND (m.key_id IS NULL OR k.id = m.key_id)
+          AND (
+            m.key_id IS NULL
+            OR (m.platform = 'custom' AND k.custom_endpoint_id = m.custom_endpoint_id)
+            OR (m.platform != 'custom' AND k.id = m.key_id)
+          )
       ) THEN 1 ELSE 0 END)`;
   const db = getDb();
 

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -369,7 +369,7 @@ interface KeyStats {
 }
 
 let statsCache: Map<string, ModelStats> | null = null;
-let keyStatsCache: Map<string, KeyStats> | null = null; // "platform:model_id:key_id"
+let keyStatsCache: Map<string, KeyStats> | null = null; // "model_db_id:key_id"
 let statsCacheTime = 0;
 
 function decayWeight(ageDays: number): number {
@@ -395,7 +395,15 @@ export function refreshStatsCache(db: Db, force = false): void {
   // 60s-cached shape. Aggregated two ways below: rolled up per model (ordering)
   // and per key (in-model key selection, #580).
   const buckets = db.prepare(`
-    SELECT platform, model_id, key_id,
+    WITH matched_requests AS (
+      SELECT r.*,
+        COALESCE(r.model_db_id, CASE WHEN r.platform != 'custom' THEN (
+          SELECT m.id FROM models m WHERE m.platform = r.platform AND m.model_id = r.model_id
+        ) END) AS resolved_model_db_id
+      FROM requests r WHERE r.created_at >= ?
+    )
+    SELECT resolved_model_db_id AS model_db_id,
+           key_id,
       CAST((julianday('now') - julianday(created_at)) AS INTEGER) AS age_days,
       COUNT(*) AS total,
       SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS successes,
@@ -405,11 +413,11 @@ export function refreshStatsCache(db: Db, force = false): void {
       SUM(CASE WHEN status = 'success' AND ttfb_ms IS NOT NULL THEN 1 ELSE 0 END) AS succ_ttfb_cnt,
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN 1 ELSE 0 END) AS timeouts,
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN MIN(MAX(latency_ms, 0), ${TIMEOUT_LATENCY_CAP_MS}) ELSE 0 END) AS timeout_lat
-    FROM requests
-    WHERE created_at >= ?
-    GROUP BY platform, model_id, key_id, age_days
+    FROM matched_requests
+    WHERE resolved_model_db_id IS NOT NULL
+    GROUP BY resolved_model_db_id, key_id, age_days
   `).all(since) as Array<{
-    platform: string; model_id: string; key_id: number | null; age_days: number; total: number; successes: number;
+    model_db_id: number; key_id: number | null; age_days: number; total: number; successes: number;
     succ_out: number; succ_lat: number; succ_ttfb_sum: number; succ_ttfb_cnt: number;
     timeouts: number; timeout_lat: number;
   }>;
@@ -437,7 +445,7 @@ export function refreshStatsCache(db: Db, force = false): void {
   const acc = new Map<string, Acc>();
   const keyAcc = new Map<string, Acc>();
   for (const b of buckets) {
-    const key = `${b.platform}:${b.model_id}`;
+    const key = String(b.model_db_id);
     const w = decayWeight(b.age_days);
     let a = acc.get(key);
     if (!a) acc.set(key, a = emptyAcc());
@@ -452,13 +460,21 @@ export function refreshStatsCache(db: Db, force = false): void {
 
   // Calendar-month token usage per model, for the headroom guardrail.
   const usageRows = db.prepare(`
-    SELECT platform, model_id, COALESCE(SUM(input_tokens + output_tokens), 0) AS used
-    FROM requests
-    WHERE created_at >= datetime('now', 'start of month')
-      AND request_type = 'chat'
-    GROUP BY platform, model_id
-  `).all() as Array<{ platform: string; model_id: string; used: number }>;
-  const usageMap = new Map(usageRows.map(r => [`${r.platform}:${r.model_id}`, r.used]));
+    WITH matched_requests AS (
+      SELECT r.*,
+        COALESCE(r.model_db_id, CASE WHEN r.platform != 'custom' THEN (
+          SELECT m.id FROM models m WHERE m.platform = r.platform AND m.model_id = r.model_id
+        ) END) AS resolved_model_db_id
+      FROM requests r
+      WHERE r.created_at >= datetime('now', 'start of month') AND r.request_type = 'chat'
+    )
+    SELECT resolved_model_db_id AS model_db_id,
+           COALESCE(SUM(input_tokens + output_tokens), 0) AS used
+    FROM matched_requests
+    WHERE resolved_model_db_id IS NOT NULL
+    GROUP BY resolved_model_db_id
+  `).all() as Array<{ model_db_id: number; used: number }>;
+  const usageMap = new Map(usageRows.map(r => [String(r.model_db_id), r.used]));
 
   const next = new Map<string, ModelStats>();
   for (const [key, a] of acc) {
@@ -551,9 +567,9 @@ export function writeObservedSpeedRanks(db: Db): number {
   let written = 0;
   const tx = db.transaction(() => {
     for (const row of rows) {
-      const key = `${row.platform}:${row.model_id}`;
-      if (pinned.has(key)) continue;
-      const stats = statsCache!.get(key);
+      const legacyKey = `${row.platform}:${row.model_id}`;
+      if (row.platform !== 'custom' && pinned.has(legacyKey)) continue;
+      const stats = statsCache!.get(String(row.id));
       if (!stats || stats.speedSamples < SPEED_RANK_MIN_SAMPLES) continue;
       const rank = observedSpeedRank(speedScore(stats.tokPerSec, stats.avgTtfbMs));
       if (rank === row.speed_rank) continue;
@@ -591,6 +607,18 @@ function usableKeyCountsByPlatform(db: Db): Map<string, number> {
   return new Map(rows.map(r => [r.platform, r.count]));
 }
 
+function usableCustomEndpointKeyCount(db: Db, keyId: number | null): number {
+  if (keyId == null) return 1;
+  const ids = customEndpointKeyIds(db, keyId);
+  if (ids.size === 0) return 1;
+  const placeholders = [...ids].map(() => '?').join(', ');
+  const row = db.prepare(`
+    SELECT COUNT(*) AS count FROM api_keys
+     WHERE id IN (${placeholders}) AND enabled = 1 AND status IN ('healthy', 'unknown')
+  `).get(...ids) as { count: number };
+  return Math.max(1, row.count);
+}
+
 function scoreChainEntry(
   entry: ChainRow,
   weights: RoutingWeights,
@@ -599,7 +627,7 @@ function scoreChainEntry(
   sampled: boolean,
   keyCounts: Map<string, number>,
 ): ScoredEntry {
-  const stats = statsCache?.get(`${entry.platform}:${entry.model_id}`);
+  const stats = statsCache?.get(String(entry.model_db_id));
   const successes = stats?.successes ?? 0;
   const failures = stats?.failures ?? 0;
 
@@ -619,7 +647,10 @@ function scoreChainEntry(
   // Scale the per-key monthly budget by the usable key count for this platform,
   // matching the pooled `monthlyUsedTokens` aggregate (#456). Math.max(1, …) so a
   // model whose platform currently has no usable key isn't handed a 0 budget.
-  const budget = parseBudget(entry.monthly_token_budget) * Math.max(1, keyCounts.get(entry.platform) ?? 1);
+  const usableKeyCount = entry.platform === 'custom'
+    ? usableCustomEndpointKeyCount(getDb(), entry.key_id)
+    : Math.max(1, keyCounts.get(entry.platform) ?? 1);
+  const budget = parseBudget(entry.monthly_token_budget) * usableKeyCount;
   const headroom = headroomFactor(stats?.monthlyUsedTokens ?? 0, budget);
   const rl = rateLimitFactor(getPenalty(entry.model_db_id));
 
@@ -832,7 +863,7 @@ const KEY_SCORE_WEIGHTS = { reliability: 0.75, speed: 0.25 };
  */
 function orderKeysByScore(entry: ChainRow, keys: KeyRow[]): KeyRow[] | null {
   if (keys.length < 2 || !keyStatsCache) return null;
-  const prefix = `${entry.platform}:${entry.model_id}:`;
+  const prefix = `${entry.model_db_id}:`;
   if (!keys.some(k => keyStatsCache!.has(prefix + k.id))) return null;
 
   return keys
@@ -894,7 +925,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   // 60s-TTL aggregate the model-level bandit uses (refresh is a no-op when
   // fresh, and cheap when not). With no data at all, keep the legacy rotation.
   refreshStatsCache(db);
-  const rrKey = `${entry.platform}:${entry.model_id}`;
+  const rrKey = String(entry.model_db_id);
   let idx = roundRobinIndex.get(rrKey) ?? 0;
   const ranked = orderKeysByScore(entry, keys);
 
@@ -1386,7 +1417,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
 
   const scores: RoutingScore[] = chain.map(entry => {
     const scored = scoreChainEntry(entry, weights, intelMin, intelMax, false, keyCounts);
-    const stats = statsCache?.get(`${entry.platform}:${entry.model_id}`);
+    const stats = statsCache?.get(String(entry.model_db_id));
     return {
       modelDbId: entry.model_db_id,
       platform: entry.platform,


### PR DESCRIPTION
# Fix custom endpoint model identity (#651)

## Summary

Fixes #651 by allowing multiple custom OpenAI-compatible endpoints to register
the same upstream `model_id` without overwriting each other's model row or
routing traffic to the wrong base URL.

Custom chat models are now identified by their stable custom endpoint and
`model_id`. Built-in providers retain their existing `(platform, model_id)`
identity.

## What changed

- Add a file-per-migration schema change for stable custom endpoint records,
  endpoint-aware custom key associations, and endpoint-scoped custom-model
  uniqueness.
- Preserve existing model ids and fallback/profile references while rebuilding
  the legacy `models` table without its global custom-model uniqueness rule.
- Keep pricing columns during the table rebuild and make the migration
  reversible while no duplicate custom model ids exist across endpoints.
- Register, re-register, list, route, score, group, delete, and budget custom
  chat models by endpoint identity rather than only `platform + model_id`.
- Attribute new request logs, routing statistics, fallback token usage, and
  analytics to `models.id`, so two relays exposing the same model no longer
  share performance or usage data.
- Make declarative custom-provider configuration endpoint-aware.
- Update built-in-only test fixtures to use targetless SQLite upserts, since
  the legacy global `ON CONFLICT(platform, model_id)` target no longer exists.

## Behaviour before and after

Before:

1. Register `shared-model` on relay A.
2. Register `shared-model` on relay B.
3. The single `custom/shared-model` row is rebound to relay B; relay A is no
   longer independently routable.

After:

1. Register `shared-model` on relay A.
2. Register `shared-model` on relay B.
3. Two independent model rows exist, each routes through its own endpoint and
   each can be removed without affecting the other.

## Scope

This PR intentionally covers custom **chat** models, which is the collision
path described by #651. Custom embedding and media-model tables retain their
existing key-based identity and are out of scope for this focused fix.

## Tests

Ran successfully:

```text
npm run build -w server
npm run test -w server -- \
  src/__tests__/routes/analytics.test.ts \
  src/__tests__/routes/custom-provider.test.ts \
  src/__tests__/routes/custom-provider-multikey.test.ts \
  src/__tests__/db/migrate/roundtrip.test.ts \
  src/__tests__/services/declarative-config.test.ts \
  src/__tests__/services/declarative-config-profiles.test.ts
```

The focused run passed 70 tests. The added regression test verifies that two
custom endpoints with the same model id receive different database ids, route
to their respective base URLs, and retain the surviving model when the other
endpoint is deleted.

I also ran the full server suite. All issue-related tests and the affected
routing, analytics, migration, ratelimit, and model-retirement tests passed.
The suite has two Windows-specific failures in `db/hardening.test.ts`: POSIX
permission assertions expect `0600`, while the Windows filesystem reports
mode `054`. These failures are unrelated to this change.

## Migration notes

Existing custom keys are assigned to normalized endpoint records. Existing
custom request history is backfilled only when its key still identifies the
endpoint unambiguously; ambiguous orphaned rows intentionally remain without a
`model_db_id` rather than being attributed to the wrong relay.
