### PR TITLE
release: v0.6.4

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bumps the desktop app version to 0.6.4 for the v0.6.4 release.

Ships per-endpoint identity for custom relay models (#659, closes #651).