### PR TITLE
Add contextual icons to analytics

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -4,7 +4,29 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   LineChart, Line, Legend,
 } from 'recharts'
-import { X } from 'lucide-react'
+import {
+  Activity,
+  ArrowDown,
+  ArrowUp,
+  Bot,
+  ChartLine,
+  CheckCircle2,
+  CircleAlert,
+  CircleDollarSign,
+  Clock,
+  Coins,
+  Gauge,
+  GitBranch,
+  KeyRound,
+  Layers,
+  List,
+  Network,
+  Server,
+  TriangleAlert,
+  Zap,
+  X,
+  type LucideIcon,
+} from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -168,10 +190,15 @@ function formatTokens(n?: number): string {
   return String(n)
 }
 
-function Stat({ label, value, hint, className }: { label: string; value: string | number; hint?: string; className?: string }) {
+function Stat({ icon: Icon, label, value, hint, className }: { icon: LucideIcon; label: string; value: string | number; hint?: string; className?: string }) {
   const card = (
     <div className="rounded-3xl border bg-card px-4 py-3">
-      <p className="text-[11px] text-muted-foreground uppercase tracking-wider">{label}</p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11px] text-muted-foreground uppercase tracking-wider">{label}</p>
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+          <Icon className="size-3.5" aria-hidden="true" />
+        </span>
+      </div>
       <p className={`text-xl font-semibold tabular-nums mt-1 ${className ?? ''}`}>{value}</p>
     </div>
   )
@@ -180,11 +207,14 @@ function Stat({ label, value, hint, className }: { label: string; value: string 
   return hint ? <HoverTooltip text={hint} side="bottom" className="block">{card}</HoverTooltip> : card
 }
 
-function Panel({ title, actions, children }: { title: string; actions?: React.ReactNode; children: React.ReactNode }) {
+function Panel({ icon: Icon, title, actions, children }: { icon: LucideIcon; title: string; actions?: React.ReactNode; children: React.ReactNode }) {
   return (
     <div className="rounded-3xl border bg-card">
       <div className="px-4 py-3 border-b flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-sm font-medium">{title}</h3>
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+          {title}
+        </h3>
         {actions}
       </div>
       <div className="p-4">{children}</div>
@@ -238,7 +268,10 @@ function RequestDetailDialog({ requestId, onClose }: { requestId: number | null;
     <Dialog open={requestId != null} onOpenChange={(open) => { if (!open) onClose() }}>
       <DialogPopup maxWidth="max-w-2xl">
         <div className="mb-4 flex items-center justify-between gap-4">
-          <DialogTitle>{t('analytics.requestDetailTitle', { id: requestId ?? '' })}</DialogTitle>
+          <div className="flex items-center gap-2">
+            <Activity className="size-4 text-muted-foreground" aria-hidden="true" />
+            <DialogTitle>{t('analytics.requestDetailTitle', { id: requestId ?? '' })}</DialogTitle>
+          </div>
           <DialogClose
             aria-label={t('common.dismiss')}
             className="-mr-1 rounded-lg p-1 text-muted-foreground/70 transition-colors outline-none hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50"
@@ -298,7 +331,10 @@ function RequestDetailDialog({ requestId, onClose }: { requestId: number | null;
             )}
 
             <div>
-              <h4 className="text-sm font-medium">{t('analytics.failoverLadder')}</h4>
+              <h4 className="flex items-center gap-2 text-sm font-medium">
+                <GitBranch className="size-4 text-muted-foreground" aria-hidden="true" />
+                {t('analytics.failoverLadder')}
+              </h4>
               <p className="text-xs text-muted-foreground mt-0.5">{t('analytics.failoverLadderHint')}</p>
               {detail.attempts.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-6">{t('analytics.noAttemptTrace')}</p>
@@ -503,25 +539,25 @@ export default function AnalyticsPage() {
             Array.from({ length: 8 }).map((_, i) => <Skeleton key={i} className="h-[74px] rounded-3xl" />)
           ) : (
             <>
-              <Stat label={t('analytics.requests')} value={summary?.totalRequests ?? 0} hint={requestsHint} />
-              <Stat label={t('analytics.successRate')} value={`${summary?.successRate ?? 0}%`} />
-              <Stat label={t('analytics.inputTokens')} value={formatTokens(summary?.totalInputTokens)} />
-              <Stat label={t('analytics.outputTokens')} value={formatTokens(summary?.totalOutputTokens)} />
-              <Stat label={t('analytics.avgLatency')} value={`${summary?.avgLatencyMs ?? 0} ms`} />
-              <Stat label={t('analytics.p95Latency')} value={p95Value} />
-              <Stat label={t('analytics.avgTtft')} value={ttftValue} />
+              <Stat icon={Activity} label={t('analytics.requests')} value={summary?.totalRequests ?? 0} hint={requestsHint} />
+              <Stat icon={CheckCircle2} label={t('analytics.successRate')} value={`${summary?.successRate ?? 0}%`} />
+              <Stat icon={ArrowDown} label={t('analytics.inputTokens')} value={formatTokens(summary?.totalInputTokens)} />
+              <Stat icon={ArrowUp} label={t('analytics.outputTokens')} value={formatTokens(summary?.totalOutputTokens)} />
+              <Stat icon={Gauge} label={t('analytics.avgLatency')} value={`${summary?.avgLatencyMs ?? 0} ms`} />
+              <Stat icon={Clock} label={t('analytics.p95Latency')} value={p95Value} />
+              <Stat icon={Zap} label={t('analytics.avgTtft')} value={ttftValue} />
               {/* Priced per request at the served model's paid-API equivalent
                   rate (not a flat frontier-model rate) — see db/model-pricing.ts.
                   The value is a 30-day projection; the hover hint tells the whole
                   story (actual period amount + whether it was extrapolated). */}
-              <Stat label={t('analytics.estSavings')} value={`$${savings30d.toFixed(2)}`} hint={savingsHint} />
+              <Stat icon={CircleDollarSign} label={t('analytics.estSavings')} value={`$${savings30d.toFixed(2)}`} hint={savingsHint} />
             </>
           )}
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.requestsOverTime')}>
+            <Panel icon={ChartLine} title={t('analytics.requestsOverTime')}>
               {timeline.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
               ) : (
@@ -542,7 +578,7 @@ export default function AnalyticsPage() {
 
           {/* Tokens over time: input vs output, one axis, two-series legend. */}
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.tokensOverTime')}>
+            <Panel icon={Coins} title={t('analytics.tokensOverTime')}>
               {timeline.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
               ) : (
@@ -561,7 +597,7 @@ export default function AnalyticsPage() {
             </Panel>
           </div>
 
-          <Panel title={t('analytics.requestsByProvider')}>
+          <Panel icon={Server} title={t('analytics.requestsByProvider')}>
             {byPlatform.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
             ) : (
@@ -577,7 +613,7 @@ export default function AnalyticsPage() {
             )}
           </Panel>
 
-          <Panel title={t('analytics.requestsByAgent')}>
+          <Panel icon={Bot} title={t('analytics.requestsByAgent')}>
             {byClient.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
             ) : (
@@ -594,7 +630,7 @@ export default function AnalyticsPage() {
           </Panel>
 
           {/* Latency by provider: grouped avg + p95, same unit (ms), one axis. */}
-          <Panel title={t('analytics.avgLatencyByProvider')}>
+          <Panel icon={Gauge} title={t('analytics.avgLatencyByProvider')}>
             {byPlatform.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
             ) : (
@@ -613,7 +649,7 @@ export default function AnalyticsPage() {
           </Panel>
 
           {/* Time to first token by provider (single series → no legend). */}
-          <Panel title={t('analytics.ttftByProvider')}>
+          <Panel icon={Zap} title={t('analytics.ttftByProvider')}>
             {byPlatform.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
             ) : !ttftHasData ? (
@@ -632,7 +668,7 @@ export default function AnalyticsPage() {
           </Panel>
 
           {/* Errors by category: horizontal bars, destructive hue, no legend. */}
-          <Panel title={t('analytics.errorDistribution')}>
+          <Panel icon={TriangleAlert} title={t('analytics.errorDistribution')}>
             {!errorDist?.byCategory?.length ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noErrors')}</p>
             ) : (
@@ -648,7 +684,7 @@ export default function AnalyticsPage() {
             )}
           </Panel>
 
-          <Panel title={t('analytics.errorsByProvider')}>
+          <Panel icon={CircleAlert} title={t('analytics.errorsByProvider')}>
             {!errorDist?.byPlatform?.length ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noErrors')}</p>
             ) : (
@@ -664,7 +700,7 @@ export default function AnalyticsPage() {
             )}
           </Panel>
 
-          <Panel title={t('analytics.recentErrors')}>
+          <Panel icon={CircleAlert} title={t('analytics.recentErrors')}>
             {errors.length === 0 ? (
               <p className="text-sm text-muted-foreground text-center py-8">{t('analytics.noErrors')}</p>
             ) : (
@@ -700,6 +736,7 @@ export default function AnalyticsPage() {
               filters (server-side, so total reflects the filtered set). */}
           <div className="lg:col-span-2">
             <Panel
+              icon={List}
               title={t('analytics.recentCalls')}
               actions={
                 <div className="flex flex-wrap items-center gap-2">
@@ -796,7 +833,7 @@ export default function AnalyticsPage() {
               the charts above show volume/latency, this row surfaces the
               success-rate and error-count numbers (#335). */}
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.providerBreakdown')}>
+            <Panel icon={Network} title={t('analytics.providerBreakdown')}>
               {byPlatform.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
               ) : (
@@ -846,7 +883,7 @@ export default function AnalyticsPage() {
           </div>
 
           <div className="lg:col-span-2">
-            <Panel title={t('analytics.perModelBreakdown')}>
+            <Panel icon={Layers} title={t('analytics.perModelBreakdown')}>
               {byModel.length === 0 ? (
                 <p className="text-sm text-muted-foreground text-center py-8">{t('common.noData')}</p>
               ) : (
@@ -889,7 +926,7 @@ export default function AnalyticsPage() {
           {/* Usage by key: only rendered when the endpoint returns rows. */}
           {byKey.length > 0 && (
             <div className="lg:col-span-2">
-              <Panel title={t('analytics.usageByKey')}>
+              <Panel icon={KeyRound} title={t('analytics.usageByKey')}>
                 <div className="max-h-[360px] overflow-y-auto -mx-4">
                   <Table>
                     <TableHeader>


### PR DESCRIPTION
## Summary
- add restrained, contextual Lucide icons to analytics summary cards and panel headings
- add icons to request details and the failover ladder for faster visual scanning
- keep chart legends and table headers text-only, with decorative icons hidden from assistive technology

## Validation
- `npx eslint src/pages/AnalyticsPage.tsx`
- `npm test -w client`
- `npm run build -w client`
- `git diff --check`