### PR TITLE
release: v0.6.5

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bumps the desktop app version to 0.6.5 for the v0.6.5 release.

Ships the real brand marks for each supported coding agent on the Agents page (#665).