### PR TITLE
Proposal: Attribute request history to concrete model rows

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -22,6 +22,7 @@ const ATTEMPT_ERROR_SUMMARY_FILENAME = '20260726_000006_attempt_error_summary.ts
 const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility.ts';
 const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
 const CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME = '20260729_000001_custom_model_endpoint_identity.ts';
+const REQUEST_MODEL_ATTRIBUTION_FILENAME = '20260730_000001_request_model_attribution.ts';
 
 interface SchemaRow {
   type: string;
@@ -90,6 +91,7 @@ describe('migration round trip', () => {
         AGENT_COMPATIBILITY_FILENAME,
         TOMBSTONE_PROVENANCE_FILENAME,
         CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME,
+        REQUEST_MODEL_ATTRIBUTION_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -253,6 +253,7 @@ describe('Analytics API', () => {
   function insertRaw(opts: {
     platform?: string;
     modelId?: string;
+    modelDbId?: number | null;
     keyId?: number | null;
     status?: 'success' | 'error';
     inputTokens?: number;
@@ -266,6 +267,7 @@ describe('Analytics API', () => {
     const {
       platform = 'test',
       modelId = 'test-model',
+      modelDbId = null,
       keyId = null,
       status = 'success',
       inputTokens = 0,
@@ -277,10 +279,38 @@ describe('Analytics API', () => {
       createdAt,
     } = opts;
     getDb().prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, ttfb_ms, request_type, error, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, ttfbMs, requestType, error, createdAt);
+      INSERT INTO requests (platform, model_id, model_db_id, key_id, status, input_tokens, output_tokens, latency_ms, ttfb_ms, request_type, error, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(platform, modelId, modelDbId, keyId, status, inputTokens, outputTokens, latencyMs, ttfbMs, requestType, error, createdAt);
   }
+
+  it('keeps same-named relay requests attached to their own model rows', async () => {
+    const db = getDb();
+    const modelId = 'shared-relay-analytics-model';
+    const insertModel = db.prepare(`
+      INSERT INTO models (
+        platform, model_id, display_name, intelligence_rank, speed_rank,
+        enabled, source, endpoint_scope, paid_input_per_m, paid_output_per_m
+      ) VALUES ('custom', ?, ?, 50, 50, 1, 'user', ?, ?, 0)
+    `);
+    const relayA = Number(insertModel.run(modelId, 'Relay A', 'http://relay-a.test/v1', 1).lastInsertRowid);
+    const relayB = Number(insertModel.run(modelId, 'Relay B', 'http://relay-b.test/v1', 3).lastInsertRowid);
+
+    insertRaw({ platform: 'custom', modelId, modelDbId: relayA, inputTokens: 1_000_000, createdAt: '2026-05-29 11:00:00' });
+    insertRaw({ platform: 'custom', modelId, modelDbId: relayB, inputTokens: 1_000_000, createdAt: '2026-05-29 11:01:00' });
+
+    const summary = await request(app, '/api/analytics/summary?range=24h');
+    expect(summary.status).toBe(200);
+    expect(summary.body.estimatedCostSavings).toBe(4);
+
+    const byModel = await request(app, '/api/analytics/by-model?range=24h');
+    expect(byModel.status).toBe(200);
+    const rows = byModel.body.filter((row: any) => row.modelId === modelId);
+    expect(rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ displayName: 'Relay A', requests: 1, estimatedCost: 1 }),
+      expect.objectContaining({ displayName: 'Relay B', requests: 1, estimatedCost: 3 }),
+    ]));
+  });
 
   describe('extended summary fields', () => {
     it('returns latency percentiles from the raw rows', async () => {

--- a/server/src/__tests__/routes/custom-endpoint-identity.test.ts
+++ b/server/src/__tests__/routes/custom-endpoint-identity.test.ts
@@ -7,6 +7,7 @@ import { setCooldown, isOnCooldown, clearCooldownsForKey } from '../../services/
 import { getModelGroups, resolveRequestedIdToMembers, setUnifyOverrides } from '../../services/model-groups.js';
 import { noteModelRetirementSignal, resetModelRetirementObservations } from '../../services/model-retirement.js';
 import { endpointHandle, qualifiedModelMemberId } from '../../lib/endpoint-scope.js';
+import { logRequest } from '../../lib/request-log.js';
 import { buildModelListing } from '../../services/model-listing.js';
 import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 
@@ -58,14 +59,14 @@ function rowOn(scope: string, modelId = SHARED_MODEL): Row {
 }
 
 /** Log `n` requests against one model + key, so the stats cache has something to see. */
-function logRequests(modelId: string, keyId: number, status: 'success' | 'error', n: number, latencyMs = 500) {
+function logRequests(modelDbId: number, modelId: string, keyId: number, status: 'success' | 'error', n: number, latencyMs = 500) {
   const db = getDb();
   const stmt = db.prepare(`
-    INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
-    VALUES ('custom', ?, ?, ?, 100, 100, ?, ?, 'chat')
+    INSERT INTO requests (platform, model_id, model_db_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
+    VALUES ('custom', ?, ?, ?, ?, 100, 100, ?, ?, 'chat')
   `);
   for (let i = 0; i < n; i++) {
-    stmt.run(modelId, keyId, status, latencyMs, status === 'error' ? 'upstream timeout' : null);
+    stmt.run(modelId, modelDbId, keyId, status, latencyMs, status === 'error' ? 'upstream timeout' : null);
   }
 }
 
@@ -156,8 +157,8 @@ describe('per-endpoint identity for custom relay models (#651)', () => {
       const a = rowOn(RELAY_A);
       const b = rowOn(RELAY_B);
 
-      logRequests(SHARED_MODEL, a.key_id!, 'error', 40);
-      logRequests(SHARED_MODEL, b.key_id!, 'success', 40);
+      logRequests(a.id, SHARED_MODEL, a.key_id!, 'error', 40);
+      logRequests(b.id, SHARED_MODEL, b.key_id!, 'success', 40);
       refreshStatsCache(getDb(), true);
 
       const scores = getRoutingScores().scores;
@@ -175,8 +176,8 @@ describe('per-endpoint identity for custom relay models (#651)', () => {
       const b = rowOn(RELAY_B);
 
       // Relay A answers slowly, relay B quickly — same model id, same tokens.
-      logRequests(SHARED_MODEL, a.key_id!, 'success', 40, 20_000);
-      logRequests(SHARED_MODEL, b.key_id!, 'success', 40, 200);
+      logRequests(a.id, SHARED_MODEL, a.key_id!, 'success', 40, 20_000);
+      logRequests(b.id, SHARED_MODEL, b.key_id!, 'success', 40, 200);
       refreshStatsCache(getDb(), true);
       writeObservedSpeedRanks(getDb());
 
@@ -202,6 +203,20 @@ describe('per-endpoint identity for custom relay models (#651)', () => {
       // The cooldown map is process-local and outlives the in-memory DB, so
       // hand it back before the next case reuses these key ids.
       clearCooldownsForKey(a.key_id!);
+    });
+
+    it('records the concrete model row selected for each relay', async () => {
+      await registerBothRelays(app);
+      const b = rowOn(RELAY_B);
+
+      logRequest('custom', SHARED_MODEL, b.key_id!, 'success', 10, 20, 30, null);
+
+      const logged = getDb().prepare(`
+        SELECT model_db_id FROM requests
+         WHERE platform = 'custom' AND model_id = ?
+         ORDER BY id DESC LIMIT 1
+      `).get(SHARED_MODEL) as { model_db_id: number };
+      expect(logged.model_db_id).toBe(b.id);
     });
 
     it('counts an end-of-life signal against one endpoint only', async () => {

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -17,6 +17,7 @@ import * as attemptErrorSummary from '../migrations/20260726_000006_attempt_erro
 import * as agentCompatibility from '../migrations/20260727_000001_agent_compatibility.js';
 import * as tombstoneProvenance from '../migrations/20260728_000001_tombstone_provenance.js';
 import * as customModelEndpointIdentity from '../migrations/20260729_000001_custom_model_endpoint_identity.js';
+import * as requestModelAttribution from '../migrations/20260730_000001_request_model_attribution.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -46,6 +47,7 @@ export const ATTEMPT_ERROR_SUMMARY_FILENAME = '20260726_000006_attempt_error_sum
 export const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility.ts';
 export const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
 export const CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME = '20260729_000001_custom_model_endpoint_identity.ts';
+export const REQUEST_MODEL_ATTRIBUTION_FILENAME = '20260730_000001_request_model_attribution.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -66,4 +68,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: AGENT_COMPATIBILITY_FILENAME, module: agentCompatibility },
   { filename: TOMBSTONE_PROVENANCE_FILENAME, module: tombstoneProvenance },
   { filename: CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME, module: customModelEndpointIdentity },
+  { filename: REQUEST_MODEL_ATTRIBUTION_FILENAME, module: requestModelAttribution },
 ];

--- a/server/src/db/migrations/20260730_000001_request_model_attribution.ts
+++ b/server/src/db/migrations/20260730_000001_request_model_attribution.ts
@@ -6,11 +6,19 @@
 
 import type { Db } from '../types.js';
 
+function hasColumn(db: Db, table: string, column: string): boolean {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[])
+    .some(candidate => candidate.name === column);
+}
+
 export function up(db: Db): void {
-  db.exec(`
-    ALTER TABLE requests ADD COLUMN model_db_id INTEGER REFERENCES models(id);
-    CREATE INDEX idx_requests_model_db_id ON requests(model_db_id);
-  `);
+  // Deliberately no foreign key: request history must survive a user deleting
+  // the model row it once served. This also keeps cleanup paths from requiring
+  // a raw-history delete first.
+  if (!hasColumn(db, 'requests', 'model_db_id')) {
+    db.exec('ALTER TABLE requests ADD COLUMN model_db_id INTEGER;');
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_requests_model_db_id ON requests(model_db_id);');
 
   // Historical catalog requests remain unambiguous. A custom request can be
   // attributed only while its key survives: the key's normalized base URL is
@@ -39,8 +47,8 @@ export function up(db: Db): void {
 }
 
 export function down(db: Db): void {
-  db.exec(`
-    DROP INDEX IF EXISTS idx_requests_model_db_id;
-    ALTER TABLE requests DROP COLUMN model_db_id;
-  `);
+  db.exec('DROP INDEX IF EXISTS idx_requests_model_db_id;');
+  if (hasColumn(db, 'requests', 'model_db_id')) {
+    db.exec('ALTER TABLE requests DROP COLUMN model_db_id;');
+  }
 }

--- a/server/src/db/migrations/20260730_000001_request_model_attribution.ts
+++ b/server/src/db/migrations/20260730_000001_request_model_attribution.ts
@@ -1,0 +1,46 @@
+// Migration: attach request history to the concrete model row that served it.
+// Created: 2026-07-30
+//
+// Custom relays may share an upstream model id, so (platform, model_id) is no
+// longer enough to identify the row whose price, reliability, and speed apply.
+
+import type { Db } from '../types.js';
+
+export function up(db: Db): void {
+  db.exec(`
+    ALTER TABLE requests ADD COLUMN model_db_id INTEGER REFERENCES models(id);
+    CREATE INDEX idx_requests_model_db_id ON requests(model_db_id);
+  `);
+
+  // Historical catalog requests remain unambiguous. A custom request can be
+  // attributed only while its key survives: the key's normalized base URL is
+  // the endpoint_scope of the concrete model row. Leave orphaned custom rows
+  // NULL rather than assigning their traffic to the wrong relay.
+  db.exec(`
+    UPDATE requests
+       SET model_db_id = (
+         SELECT m.id
+           FROM models m
+          WHERE m.platform = requests.platform
+            AND m.model_id = requests.model_id
+            AND (
+              m.platform != 'custom'
+              OR m.endpoint_scope = (
+                SELECT rtrim(trim(k.base_url), '/')
+                  FROM api_keys k
+                 WHERE k.id = requests.key_id
+                   AND k.platform = 'custom'
+              )
+            )
+          LIMIT 1
+       )
+     WHERE model_db_id IS NULL;
+  `);
+}
+
+export function down(db: Db): void {
+  db.exec(`
+    DROP INDEX IF EXISTS idx_requests_model_db_id;
+    ALTER TABLE requests DROP COLUMN model_db_id;
+  `);
+}

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -29,6 +29,29 @@ function setSettingIfMissing(db: LogTx, key: string, value: string): void {
   `).run(key, value);
 }
 
+// A custom model id can exist on more than one relay. Resolve through the key
+// selected for this request, whose normalized base URL is the row's endpoint
+// scope; catalog models remain uniquely identified by platform + model id.
+function resolveModelDbId(db: LogTx, platform: string, modelId: string, keyId: number): number | null {
+  const row = db.prepare(`
+    SELECT m.id
+      FROM models m
+     WHERE m.platform = ?
+       AND m.model_id = ?
+       AND (
+         m.platform != 'custom'
+         OR m.endpoint_scope = (
+           SELECT rtrim(trim(k.base_url), '/')
+             FROM api_keys k
+            WHERE k.id = ?
+              AND k.platform = 'custom'
+         )
+       )
+     LIMIT 1
+  `).get(platform, modelId, keyId) as { id: number } | undefined;
+  return row?.id ?? null;
+}
+
 // Append a row to the request analytics table. Shared by the chat proxy, the
 // responses path, and the fusion panel so every served (or failed) sub-request
 // is logged identically. Lives in a neutral lib module to avoid an import cycle
@@ -67,10 +90,11 @@ export function logRequest(
     // middleware); null when logging happens outside an HTTP request.
     const client = getClientContext();
     const tx = db.transaction(() => {
+      const modelDbId = resolveModelDbId(db, platform, modelId, keyId);
       const insert = db.prepare(`
-        INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
+        INSERT INTO requests (platform, model_id, model_db_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(platform, modelId, modelDbId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
 
       // Report the row id back to the fallback loop's attempt trace (if one is
       // active): the LAST id noted during a loop run is the terminal row the

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -99,7 +99,9 @@ analyticsRouter.get('/summary', (req: Request, res: Response) => {
       ELSE 0 END
     ), 0) as est_savings
     FROM requests r
-    LEFT JOIN models m ON m.platform = r.platform AND m.model_id = r.model_id
+    LEFT JOIN models m ON m.id = r.model_db_id
+      OR (r.model_db_id IS NULL AND r.platform != 'custom'
+        AND m.platform = r.platform AND m.model_id = r.model_id)
     WHERE r.created_at >= ?
   `).get(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as { est_savings: number };
 
@@ -197,8 +199,8 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
 
   const rows = db.prepare(`
     SELECT
-      r.platform,
-      r.model_id,
+      COALESCE(m.platform, r.platform) AS platform,
+      COALESCE(m.model_id, r.model_id) AS model_id,
       m.display_name,
       COUNT(*) as requests,
       SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
@@ -211,9 +213,11 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
         r.output_tokens * COALESCE(m.paid_output_per_m, ?) / 1000000.0
       ELSE 0 END) as est_cost
     FROM requests r
-    LEFT JOIN models m ON m.platform = r.platform AND m.model_id = r.model_id
+    LEFT JOIN models m ON m.id = r.model_db_id
+      OR (r.model_db_id IS NULL AND r.platform != 'custom'
+        AND m.platform = r.platform AND m.model_id = r.model_id)
     WHERE r.created_at >= ?
-    GROUP BY r.platform, r.model_id
+    GROUP BY r.model_db_id, r.platform, r.model_id
     ORDER BY requests DESC
   `).all(FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M, since) as any[];
 

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -26,7 +26,6 @@ import { platformDropsResponseFormat } from '../lib/sampling-params.js';
 import { isUnifyEnabled, getModelGroups, resolveRequestedIdForDispatch } from './model-groups.js';
 import { getActiveProfileId } from './profile-models.js';
 import { customEndpointKeyIds } from './custom-endpoint.js';
-import { modelStatsKey, endpointScopeForBaseUrl } from '../lib/endpoint-scope.js';
 import type { BaseProvider } from '../providers/base.js';
 import type { Platform } from '@freellmapi/shared/types.js';
 import type { Db } from '../db/types.js';
@@ -388,11 +387,8 @@ interface KeyStats {
   avgTtfbMs: number | null;
 }
 
-// Keyed by modelStatsKey(): "platform:model_id" for catalog models, and
-// "custom:model_id@base_url" for a relay model that carries an endpoint scope
-// (#651). A single-endpoint install produces the same keys it always did.
 let statsCache: Map<string, ModelStats> | null = null;
-let keyStatsCache: Map<string, KeyStats> | null = null; // "platform:model_id:key_id"
+let keyStatsCache: Map<string, KeyStats> | null = null; // "model_db_id:key_id"
 let statsCacheTime = 0;
 
 function decayWeight(ageDays: number): number {
@@ -409,13 +405,6 @@ const IS_TIMEOUT_SQL = `(status != 'success' AND (${
   TIMEOUT_ERROR_MARKERS.map(m => `LOWER(COALESCE(error, '')) LIKE '%${m}%'`).join(' OR ')
 }))`;
 
-/** api_keys.id → endpoint scope, for every custom credential on record (#651). */
-function customEndpointScopes(db: Db): Map<number, string> {
-  const rows = db.prepare("SELECT id, base_url FROM api_keys WHERE platform = 'custom'")
-    .all() as { id: number; base_url: string | null }[];
-  return new Map(rows.map(r => [r.id, endpointScopeForBaseUrl(r.base_url)]));
-}
-
 export function refreshStatsCache(db: Db, force = false): void {
   if (!force && statsCache && Date.now() - statsCacheTime < CACHE_TTL_MS) return;
 
@@ -425,7 +414,14 @@ export function refreshStatsCache(db: Db, force = false): void {
   // 60s-cached shape. Aggregated two ways below: rolled up per model (ordering)
   // and per key (in-model key selection, #580).
   const buckets = db.prepare(`
-    SELECT platform, model_id, key_id,
+    WITH matched_requests AS (
+      SELECT r.*,
+        COALESCE(r.model_db_id, CASE WHEN r.platform != 'custom' THEN (
+          SELECT m.id FROM models m WHERE m.platform = r.platform AND m.model_id = r.model_id
+        ) END) AS resolved_model_db_id
+      FROM requests r WHERE r.created_at >= ?
+    )
+    SELECT resolved_model_db_id AS model_db_id, key_id,
       CAST((julianday('now') - julianday(created_at)) AS INTEGER) AS age_days,
       COUNT(*) AS total,
       SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS successes,
@@ -435,11 +431,11 @@ export function refreshStatsCache(db: Db, force = false): void {
       SUM(CASE WHEN status = 'success' AND ttfb_ms IS NOT NULL THEN 1 ELSE 0 END) AS succ_ttfb_cnt,
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN 1 ELSE 0 END) AS timeouts,
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN MIN(MAX(latency_ms, 0), ${TIMEOUT_LATENCY_CAP_MS}) ELSE 0 END) AS timeout_lat
-    FROM requests
-    WHERE created_at >= ?
-    GROUP BY platform, model_id, key_id, age_days
+    FROM matched_requests
+    WHERE resolved_model_db_id IS NOT NULL
+    GROUP BY resolved_model_db_id, key_id, age_days
   `).all(since) as Array<{
-    platform: string; model_id: string; key_id: number | null; age_days: number; total: number; successes: number;
+    model_db_id: number; key_id: number | null; age_days: number; total: number; successes: number;
     succ_out: number; succ_lat: number; succ_ttfb_sum: number; succ_ttfb_cnt: number;
     timeouts: number; timeout_lat: number;
   }>;
@@ -464,19 +460,10 @@ export function refreshStatsCache(db: Db, force = false): void {
     a.wTtfbCnt += w * (b.succ_ttfb_cnt + b.timeouts);
     a.wTimeouts += w * b.timeouts;
   };
-  // Which endpoint each custom credential belongs to, so a request logged
-  // against relay A's key lands in relay A's bucket and nowhere else (#651).
-  // `requests` has always recorded key_id, so pre-migration history splits
-  // correctly too; rows whose key is gone (or that never had one) fall into the
-  // un-scoped bucket, which only un-scoped rows read.
-  const scopeByKeyId = customEndpointScopes(db);
-  const scopeOf = (platform: string, keyId: number | null): string =>
-    platform === 'custom' && keyId != null ? (scopeByKeyId.get(keyId) ?? '') : '';
-
   const acc = new Map<string, Acc>();
   const keyAcc = new Map<string, Acc>();
   for (const b of buckets) {
-    const key = modelStatsKey(b.platform, b.model_id, scopeOf(b.platform, b.key_id));
+    const key = String(b.model_db_id);
     const w = decayWeight(b.age_days);
     let a = acc.get(key);
     if (!a) acc.set(key, a = emptyAcc());
@@ -491,17 +478,21 @@ export function refreshStatsCache(db: Db, force = false): void {
 
   // Calendar-month token usage per model, for the headroom guardrail.
   const usageRows = db.prepare(`
-    SELECT platform, model_id, key_id, COALESCE(SUM(input_tokens + output_tokens), 0) AS used
-    FROM requests
-    WHERE created_at >= datetime('now', 'start of month')
-      AND request_type = 'chat'
-    GROUP BY platform, model_id, key_id
-  `).all() as Array<{ platform: string; model_id: string; key_id: number | null; used: number }>;
-  const usageMap = new Map<string, number>();
-  for (const r of usageRows) {
-    const key = modelStatsKey(r.platform, r.model_id, scopeOf(r.platform, r.key_id));
-    usageMap.set(key, (usageMap.get(key) ?? 0) + r.used);
-  }
+    WITH matched_requests AS (
+      SELECT r.*,
+        COALESCE(r.model_db_id, CASE WHEN r.platform != 'custom' THEN (
+          SELECT m.id FROM models m WHERE m.platform = r.platform AND m.model_id = r.model_id
+        ) END) AS resolved_model_db_id
+      FROM requests r
+      WHERE r.created_at >= datetime('now', 'start of month') AND r.request_type = 'chat'
+    )
+    SELECT resolved_model_db_id AS model_db_id,
+           COALESCE(SUM(input_tokens + output_tokens), 0) AS used
+    FROM matched_requests
+    WHERE resolved_model_db_id IS NOT NULL
+    GROUP BY resolved_model_db_id
+  `).all() as Array<{ model_db_id: number; used: number }>;
+  const usageMap = new Map(usageRows.map(r => [String(r.model_db_id), r.used]));
 
   const next = new Map<string, ModelStats>();
   for (const [key, a] of acc) {
@@ -587,19 +578,15 @@ export function writeObservedSpeedRanks(db: Db): number {
   if (!statsCache || statsCache.size === 0) return 0;
 
   const pinned = modelsWithOverriddenField(db, 'speedRank');
-  const rows = db.prepare('SELECT id, platform, model_id, speed_rank, endpoint_scope FROM models')
-    .all() as { id: number; platform: string; model_id: string; speed_rank: number; endpoint_scope: string }[];
+  const rows = db.prepare('SELECT id, platform, model_id, speed_rank FROM models')
+    .all() as { id: number; platform: string; model_id: string; speed_rank: number }[];
 
   const update = db.prepare('UPDATE models SET speed_rank = ? WHERE id = ?');
   let written = 0;
   const tx = db.transaction(() => {
     for (const row of rows) {
-      // Overrides are keyed (platform, model_id) — they only exist for
-      // catalog-managed rows, which are never endpoint-scoped — while the
-      // measured stats are per endpoint, so each relay's copy gets its own
-      // observed rank instead of one shared number (#651).
-      if (pinned.has(`${row.platform}:${row.model_id}`)) continue;
-      const stats = statsCache!.get(modelStatsKey(row.platform, row.model_id, row.endpoint_scope));
+      if (row.platform !== 'custom' && pinned.has(`${row.platform}:${row.model_id}`)) continue;
+      const stats = statsCache!.get(String(row.id));
       if (!stats || stats.speedSamples < SPEED_RANK_MIN_SAMPLES) continue;
       const rank = observedSpeedRank(speedScore(stats.tokPerSec, stats.avgTtfbMs));
       if (rank === row.speed_rank) continue;
@@ -645,7 +632,7 @@ function scoreChainEntry(
   sampled: boolean,
   keyCounts: Map<string, number>,
 ): ScoredEntry {
-  const stats = statsCache?.get(modelStatsKey(entry.platform, entry.model_id, entry.endpoint_scope));
+  const stats = statsCache?.get(String(entry.model_db_id));
   const successes = stats?.successes ?? 0;
   const failures = stats?.failures ?? 0;
 
@@ -883,7 +870,7 @@ const KEY_SCORE_WEIGHTS = { reliability: 0.75, speed: 0.25 };
  */
 function orderKeysByScore(entry: ChainRow, keys: KeyRow[]): KeyRow[] | null {
   if (keys.length < 2 || !keyStatsCache) return null;
-  const prefix = `${modelStatsKey(entry.platform, entry.model_id, entry.endpoint_scope)}:`;
+  const prefix = `${entry.model_db_id}:`;
   if (!keys.some(k => keyStatsCache!.has(prefix + k.id))) return null;
 
   return keys
@@ -945,9 +932,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   // 60s-TTL aggregate the model-level bandit uses (refresh is a no-op when
   // fresh, and cheap when not). With no data at all, keep the legacy rotation.
   refreshStatsCache(db);
-  // Scoped so two relays offering the same model id don't share one rotation
-  // cursor over the platform's key list (#651).
-  const rrKey = modelStatsKey(entry.platform, entry.model_id, entry.endpoint_scope);
+  const rrKey = String(entry.model_db_id);
   let idx = roundRobinIndex.get(rrKey) ?? 0;
   const ranked = orderKeysByScore(entry, keys);
 
@@ -1452,7 +1437,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
 
   const scores: RoutingScore[] = chain.map(entry => {
     const scored = scoreChainEntry(entry, weights, intelMin, intelMax, false, keyCounts);
-    const stats = statsCache?.get(modelStatsKey(entry.platform, entry.model_id, entry.endpoint_scope));
+    const stats = statsCache?.get(String(entry.model_db_id));
     return {
       modelDbId: entry.model_db_id,
       platform: entry.platform,


### PR DESCRIPTION
# Proposal: Attribute request history to concrete model rows

## Summary

This is a focused follow-up to my earlier [PR #658](https://github.com/tashfeenahmed/freellmapi/pull/658), which addressed the custom-relay model-identity collision in #651.

While #658 was open, the maintainer merged [PR #659](https://github.com/tashfeenahmed/freellmapi/pull/659), which solved the core collision by making custom models unique per normalized endpoint scope. #658 was therefore closed because it conflicted with `main`, not because its approach was rejected. The closing feedback specifically invited two parts of #658 as separate follow-ups:

- attribute request logs, routing statistics, and analytics to `models.id`;
- introduce first-class endpoint records for future per-key model groups (#657).

This PR implements the first item only, adapted to #659's existing `endpoint_scope` design.

## Problem

After #659, two custom relays can correctly have separate `models` rows for the same upstream `model_id`. However, historical and new requests were still identified primarily by `(platform, model_id)`.

That leaves an ambiguity for same-named custom relays. In particular, analytics joins can match a request to both rows, duplicating request counts and pricing. It also keeps routing performance history tied to a derived string key instead of the durable row that routing actually selects.

## Changes

- Add a reversible migration that introduces nullable `requests.model_db_id` with an index.
  - Backfill catalog requests where identity is unambiguous.
  - Backfill custom requests only when the saved key still resolves to the matching normalized endpoint scope.
  - Leave orphaned custom history `NULL` rather than attributing it to the wrong relay.
  - Keep the column intentionally free of a foreign-key constraint so request history survives model deletion.
- Resolve and persist the concrete `models.id` whenever a request is logged.
- Key router statistics, monthly usage, speed-rank writeback, key scoring, and round-robin state by `model_db_id`.
- Join analytics to `models.id`, so duplicated relay model IDs remain separate for pricing and per-model reporting.
- Retain a safe catalog-only fallback for legacy request rows that predate the migration.

## Scope

This PR intentionally does **not** introduce a `custom_endpoints` table or alter the endpoint-scope identity model from #659. That is the separate follow-up suggested for #657, where endpoint records may be useful for per-key model-group metadata.

## Validation

Added regression coverage for:

- logging a request against the specific model row selected for a relay;
- independent scoring for two relays exposing the same upstream model ID;
- independent analytics counts and pricing for those relays;
- migration round-trips and rerunnable catalog migration state.

Ran successfully:

```text
npm run build -w server
npm test -w server -- \
  src/__tests__/routes/custom-endpoint-identity.test.ts \
  src/__tests__/routes/analytics.test.ts \
  src/__tests__/services/router-speed-scoring.test.ts \
  src/__tests__/routes/custom-provider.test.ts \
  src/__tests__/routes/proxy-model-groups.test.ts \
  src/__tests__/routes/routed-via-header.test.ts \
  src/__tests__/services/catalog-sync.test.ts \
  src/__tests__/db/migrate/roundtrip.test.ts
```

The focused run passed 64 tests. The full server suite also passed all affected tests; its only remaining failures are the repository's existing Windows-specific POSIX permission assertions in `db/hardening.test.ts`.
