### PR TITLE
cli: publish freellmapi to npm (#671)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -8,16 +8,29 @@ name: CLI release
 # Triggers:
 #   - push to main touching cli/**   publish when cli/package.json's version is
 #                                    not on the registry yet; no-op otherwise
-#   - workflow_dispatch              manual run (used for the very first publish)
+#   - workflow_dispatch              manual run
 #
 # The version guard makes this idempotent: ordinary cli/src changes re-run the
 # job, see the version already published, and skip. To ship a new version, bump
 # `version` in cli/package.json in the PR that changes the code.
 #
-# Requires the NPM_TOKEN secret (npm automation token with publish rights).
-# Until it is set, an automatic run warns and skips instead of failing, so
-# merging this workflow does not redden main. A manual run still fails loudly —
-# asking for a publish and silently getting none would be worse.
+# Auth is npm trusted publishing (OIDC) — no NPM_TOKEN, no long-lived secret.
+# npm revoked all classic tokens in December 2025, and granular tokens with
+# "bypass 2FA" are being wound down through 2026 (they lose direct publish
+# around January 2027), so a token-based workflow would have been born
+# deprecated. OIDC mints a short-lived credential per job instead, and npm
+# attaches provenance automatically.
+#
+# One-time setup on npmjs.com (Package settings → Trusted Publisher):
+#   Organization or user: tashfeenahmed
+#   Repository:           freellmapi
+#   Workflow filename:    cli-release.yml
+# Trusted publishing cannot bootstrap a package that does not exist yet — npm
+# has no package settings page to configure until the first version is up — so
+# 0.3.0 was published manually. Every version after it goes through here.
+#
+# Requires npm >= 11.5.1 and Node >= 22.14.0 for OIDC, hence Node 24 below
+# (still inside the repo's engines range of >=20.18 <25).
 
 on:
   workflow_dispatch:
@@ -29,7 +42,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # npm provenance
+  id-token: write # OIDC credential for trusted publishing
 
 jobs:
   publish:
@@ -40,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -64,37 +77,16 @@ jobs:
             echo "should-publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check for the publish token
-        id: token
-        if: steps.version.outputs.should-publish == 'true'
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -n "${NPM_TOKEN:-}" ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "present=false" >> "$GITHUB_OUTPUT"
-          # A manual run is an explicit request to publish, so a missing token
-          # is a real error. An automatic push just means the secret isn't set
-          # up yet — warn and skip rather than redden main.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "::error::NPM_TOKEN is not set. Add an npm automation token with publish rights as a repository secret."
-            exit 1
-          fi
-          echo "::warning::NPM_TOKEN is not set — skipping publish. Add the secret, then run this workflow manually."
-
       # `npm publish` runs cli's prepublishOnly (build + test) as a safety net.
       # Building here as well keeps a broken tsc from reaching the publish step.
       - name: Build and test the CLI
-        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
+        if: steps.version.outputs.should-publish == 'true'
         run: |
           npm run build -w cli
           npm run test -w cli
 
       - name: Smoke-test the packed tarball
-        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
+        if: steps.version.outputs.should-publish == 'true'
         run: |
           set -euo pipefail
           # Install what subscribers will actually download — catches a `files`
@@ -107,22 +99,18 @@ jobs:
           npx freellmapi --help
           npx freellmapi list >/dev/null
 
+      # No NODE_AUTH_TOKEN: the OIDC credential comes from id-token: write.
+      # Provenance is attached automatically under trusted publishing.
       - name: Publish
-        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
-        run: npm publish --provenance --access public -w cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: steps.version.outputs.should-publish == 'true'
+        run: npm publish --access public -w cli
 
       - name: Summary
         if: always()
         run: |
           V="${{ steps.version.outputs.version }}"
-          if [ "${{ steps.version.outputs.should-publish }}" != "true" ]; then
-            echo "freellmapi@$V is already on the registry — skipped." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.token.outputs.present }}" != "true" ]; then
-            echo "freellmapi@$V is unpublished, but NPM_TOKEN is not set — skipped." >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Add an npm automation token as the NPM_TOKEN repository secret, then run this workflow manually." >> "$GITHUB_STEP_SUMMARY"
-          else
+          if [ "${{ steps.version.outputs.should-publish }}" = "true" ]; then
             echo "Published freellmapi@$V" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "freellmapi@$V is already on the registry — skipped." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -15,6 +15,9 @@ name: CLI release
 # `version` in cli/package.json in the PR that changes the code.
 #
 # Requires the NPM_TOKEN secret (npm automation token with publish rights).
+# Until it is set, an automatic run warns and skips instead of failing, so
+# merging this workflow does not redden main. A manual run still fails loudly —
+# asking for a publish and silently getting none would be worse.
 
 on:
   workflow_dispatch:
@@ -61,26 +64,37 @@ jobs:
             echo "should-publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify the token is configured
+      - name: Check for the publish token
+        id: token
         if: steps.version.outputs.should-publish == 'true'
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ -z "${NPM_TOKEN:-}" ]; then
+          set -euo pipefail
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "present=false" >> "$GITHUB_OUTPUT"
+          # A manual run is an explicit request to publish, so a missing token
+          # is a real error. An automatic push just means the secret isn't set
+          # up yet — warn and skip rather than redden main.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "::error::NPM_TOKEN is not set. Add an npm automation token with publish rights as a repository secret."
             exit 1
           fi
+          echo "::warning::NPM_TOKEN is not set — skipping publish. Add the secret, then run this workflow manually."
 
       # `npm publish` runs cli's prepublishOnly (build + test) as a safety net.
       # Building here as well keeps a broken tsc from reaching the publish step.
       - name: Build and test the CLI
-        if: steps.version.outputs.should-publish == 'true'
+        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
         run: |
           npm run build -w cli
           npm run test -w cli
 
       - name: Smoke-test the packed tarball
-        if: steps.version.outputs.should-publish == 'true'
+        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
         run: |
           set -euo pipefail
           # Install what subscribers will actually download — catches a `files`
@@ -94,15 +108,21 @@ jobs:
           npx freellmapi list >/dev/null
 
       - name: Publish
-        if: steps.version.outputs.should-publish == 'true'
+        if: steps.version.outputs.should-publish == 'true' && steps.token.outputs.present == 'true'
         run: npm publish --provenance --access public -w cli
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
+        if: always()
         run: |
-          if [ "${{ steps.version.outputs.should-publish }}" = "true" ]; then
-            echo "Published freellmapi@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          V="${{ steps.version.outputs.version }}"
+          if [ "${{ steps.version.outputs.should-publish }}" != "true" ]; then
+            echo "freellmapi@$V is already on the registry — skipped." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${{ steps.token.outputs.present }}" != "true" ]; then
+            echo "freellmapi@$V is unpublished, but NPM_TOKEN is not set — skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Add an npm automation token as the NPM_TOKEN repository secret, then run this workflow manually." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "freellmapi@${{ steps.version.outputs.version }} was already published — skipped." >> "$GITHUB_STEP_SUMMARY"
+            echo "Published freellmapi@$V" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,108 @@
+name: CLI release
+
+# Publishes the `freellmapi` CLI to npm. Closes #671 — the README and
+# docs/clients.md have always documented `npx freellmapi setup-claude`, but the
+# package was never pushed to the registry, so every one of those commands died
+# with npm E404.
+#
+# Triggers:
+#   - push to main touching cli/**   publish when cli/package.json's version is
+#                                    not on the registry yet; no-op otherwise
+#   - workflow_dispatch              manual run (used for the very first publish)
+#
+# The version guard makes this idempotent: ordinary cli/src changes re-run the
+# job, see the version already published, and skip. To ship a new version, bump
+# `version` in cli/package.json in the PR that changes the code.
+#
+# Requires the NPM_TOKEN secret (npm automation token with publish rights).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/**'
+      - '.github/workflows/cli-release.yml'
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./cli/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # `npm view` exits non-zero for an unpublished name/version; an empty
+          # result is the signal to publish, not an error.
+          PUBLISHED=$(npm view "freellmapi@$VERSION" version 2>/dev/null || true)
+          if [ -n "$PUBLISHED" ]; then
+            echo "freellmapi@$VERSION is already on the registry — nothing to do."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "freellmapi@$VERSION is not published yet."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify the token is configured
+        if: steps.version.outputs.should-publish == 'true'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN is not set. Add an npm automation token with publish rights as a repository secret."
+            exit 1
+          fi
+
+      # `npm publish` runs cli's prepublishOnly (build + test) as a safety net.
+      # Building here as well keeps a broken tsc from reaching the publish step.
+      - name: Build and test the CLI
+        if: steps.version.outputs.should-publish == 'true'
+        run: |
+          npm run build -w cli
+          npm run test -w cli
+
+      - name: Smoke-test the packed tarball
+        if: steps.version.outputs.should-publish == 'true'
+        run: |
+          set -euo pipefail
+          # Install what subscribers will actually download — catches a `files`
+          # array that omits a runtime import, which `npm test` cannot see.
+          TARBALL=$(cd cli && npm pack --silent --pack-destination "$RUNNER_TEMP")
+          WORKDIR="$RUNNER_TEMP/smoke"
+          mkdir -p "$WORKDIR" && cd "$WORKDIR"
+          npm init -y >/dev/null
+          npm install "$RUNNER_TEMP/$TARBALL" >/dev/null
+          npx freellmapi --help
+          npx freellmapi list >/dev/null
+
+      - name: Publish
+        if: steps.version.outputs.should-publish == 'true'
+        run: npm publish --provenance --access public -w cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          if [ "${{ steps.version.outputs.should-publish }}" = "true" ]; then
+            echo "Published freellmapi@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "freellmapi@${{ steps.version.outputs.version }} was already published — skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Anything that can target an OpenAI-compatible base URL works: set it to `http://
 The fastest setup is generated from the models available on your live server:
 
 ```bash
-npx freellmapi setup-claude --url http://localhost:3001
+npx freellmapi setup-claude --url http://localhost:3001 --api-key <unified-key>
 ```
 
 Every generator supports `--dry-run`, creates a timestamped backup before changing an existing file, and merges into the user's configuration. Launchers keep credentials out of config files entirely: `npx freellmapi launch` for Claude Code and `npx freellmapi launch-codex` for Codex.

--- a/cli/LICENSE
+++ b/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tashfeen Ahmed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,66 @@
+# freellmapi
+
+Point your coding agent at a [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi)
+gateway in one command. The generators read the models your server is actually
+serving and write the config file each tool expects.
+
+```bash
+npx freellmapi setup-claude --url http://localhost:3001 --api-key <your-key>
+```
+
+No install step, no account. The unified API key comes from your FreeLLMAPI
+dashboard (or the tray popover in the desktop app).
+
+## Commands
+
+| Command | Tool |
+| --- | --- |
+| `setup-claude` | Claude Code |
+| `setup-codex` | Codex CLI |
+| `setup-cline` | Cline |
+| `setup-continue` | Continue |
+| `setup-aider` | Aider |
+| `setup-opencode` | OpenCode |
+| `setup-goose` | Goose |
+| `setup-qwen` | Qwen Code |
+| `setup-roo` | Roo Code |
+| `setup-kilo` | Kilo Code |
+| `setup-crush` | Crush |
+| `setup-cursor` | Cursor |
+| `setup-generic` | Any OpenAI-compatible client |
+| `launch` | Run Claude Code with credentials injected into the child process |
+| `launch-codex` | Run Codex the same way |
+| `list` | Print the supported tools and their base URLs |
+
+## Options
+
+| Flag | Meaning |
+| --- | --- |
+| `--url URL` | Gateway base URL (default `http://localhost:3001`) |
+| `--api-key KEY` | Unified API key |
+| `--profile NAME` | Name the generated profile/provider entry |
+| `--model ID` | Pin a specific model instead of the catalog default |
+| `--dry-run` | Print the diff and write nothing |
+
+`FREELLMAPI_URL` and `FREELLMAPI_API_KEY` work in place of `--url` / `--api-key`.
+
+## Safety
+
+Every generator is non-destructive: it merges into your existing configuration
+rather than replacing it, and takes a timestamped backup before touching a file
+that already exists. `--dry-run` shows the exact diff first.
+
+The two `launch` commands never write credentials to disk at all — they inject
+them into the child process environment for that run only.
+
+## Requirements
+
+Node.js >= 20.18. A running FreeLLMAPI gateway
+([install guide](https://github.com/tashfeenahmed/freellmapi/blob/main/docs/install.md)).
+
+## Links
+
+- [Clients & coding agents guide](https://github.com/tashfeenahmed/freellmapi/blob/main/docs/clients.md)
+- [Issue tracker](https://github.com/tashfeenahmed/freellmapi/issues)
+
+MIT © Tashfeen Ahmed

--- a/cli/package.json
+++ b/cli/package.json
@@ -8,6 +8,21 @@
     "url": "git+https://github.com/tashfeenahmed/freellmapi.git",
     "directory": "cli"
   },
+  "homepage": "https://github.com/tashfeenahmed/freellmapi/tree/main/cli#readme",
+  "bugs": {
+    "url": "https://github.com/tashfeenahmed/freellmapi/issues"
+  },
+  "keywords": [
+    "freellmapi",
+    "llm",
+    "openai-compatible",
+    "claude-code",
+    "codex",
+    "aider",
+    "cline",
+    "coding-agent",
+    "cli"
+  ],
   "type": "module",
   "bin": {
     "freellmapi": "./dist/index.js"
@@ -17,6 +32,8 @@
     "./tools": "./dist/tools.js"
   },
   "files": [
+    "README.md",
+    "LICENSE",
     "dist/index.js",
     "dist/index.d.ts",
     "dist/config-files.js",

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,7 @@
   ],
   "type": "module",
   "bin": {
-    "freellmapi": "./dist/index.js"
+    "freellmapi": "dist/index.js"
   },
   "exports": {
     ".": "./dist/index.js",

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -25,6 +25,7 @@ Any client that can target an OpenAI-compatible base URL can use FreeLLMAPI:
 Use the generator instead of hand-editing a client configuration:
 
 ```bash
+export FREELLMAPI_API_KEY=<unified-key>   # or pass --api-key on each command
 npx freellmapi setup-claude --url http://localhost:3001 --dry-run
 npx freellmapi setup-claude --url http://localhost:3001
 ```


### PR DESCRIPTION
Fixes #671.

`npx freellmapi setup-claude` (and every other documented generator and launcher) fails with npm `E404`. The `cli/` workspace already builds a complete, tested package named `freellmapi` — it has simply never been pushed to the registry. The name is still unregistered.

## What this changes

**`.github/workflows/cli-release.yml`** — publishes the package.

- Runs on pushes to `main` touching `cli/**`, and on `workflow_dispatch` for the first publish.
- Guarded by a registry lookup: if `freellmapi@<version>` already exists, the job skips. Ordinary `cli/src` edits are a no-op; shipping a new version means bumping `version` in `cli/package.json` in the same PR that changes the code. Re-runs are safe.
- Before publishing it packs the tarball, installs it into a scratch project, and runs the binary. A `files` array that drops a runtime import passes unit tests but breaks every consumer, and this is the only step that catches it.
- Publishes with `--provenance`, so npm shows the tarball's link back to this repo and commit.
- If `NPM_TOKEN` is missing the job fails with an explicit message instead of a confusing error from inside `npm publish`.

**`cli/README.md` + `cli/LICENSE`** — the package shipped neither, so its npm page would have rendered blank and the tarball carried no license text. That is a poor look for a package whose entire job is to be trusted enough to `npx`. Both are added to `files`, along with `homepage`, `bugs`, and `keywords`.

**Docs** — the documented command omitted the credential:

```
$ npx freellmapi setup-claude --url http://localhost:3001
freellmapi: No API key supplied. Pass --api-key or set FREELLMAPI_API_KEY.
```

Fixing only the E404 would have walked the reporter straight into this, so `README.md` and `docs/clients.md` now show `--api-key` and the `FREELLMAPI_API_KEY` alternative.

No CLI source changes.

## Verification

Packed the tarball and installed it into a clean project, as a consumer would:

```
$ npx freellmapi --help
FreeLLMAPI coding-agent setup
...
$ npx freellmapi list
claude	Anthropic Messages	root
codex	OpenAI Responses	/v1
...
$ npx freellmapi setup-claude --url http://localhost:3001 --api-key testkey --dry-run
freellmapi: Could not reach the FreeLLMAPI gateway at http://localhost:3001 ...
```

The last one gets past the credential check and stops only at the unreachable local gateway, which is correct. `FREELLMAPI_API_KEY` behaves identically.

Tarball is 12 files / 12 kB. Repo suite green: 44 CLI tests, 64 client tests, i18n across 60 locales, `npm run build` clean.

## Before this can ship

The workflow needs an **`NPM_TOKEN`** repository secret — an npm automation token on an account that will own `freellmapi`. Once it is set, run the workflow manually to publish `0.3.0`; after that it is automatic on version bumps.

Worth noting: the name is unregistered while a public README instructs people to `npx freellmapi`. Anyone can claim it and serve arbitrary code to users following our own docs, so this is worth landing sooner rather than later.