### PR TITLE
Fix: routing exhaustion misreported as retry-budget timeout

### DIFF
--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -768,17 +768,10 @@ export async function runFallbackLoop(hooks: FallbackHooks): Promise<void> {
       return;
     }
 
-    // Wall-clock budget: refuse to START another retry once spent. The first
-    // attempt always runs; a slow attempt is never aborted mid-flight (that is
-    // the TODO(fallback-v2) hedging work), it just becomes the last one.
-    if (attempt > 0 && budgetMs > 0 && Date.now() - startedAt >= budgetMs) {
-      hooks.onExhausted(
-        exhaustedRetryError(lastError, maxRetries, { attempts, timedOut: true, budgetMs }),
-        { attempts, timedOut: true },
-      );
-      return;
-    }
-
+    // Routing exhaustion (no more keys/candidates) takes priority over the
+    // wall-clock budget below: if there was never another attempt to make,
+    // say so, rather than blaming a budget that nothing was actually cut
+    // short by.
     let route: RouteResult;
     try {
       route = hooks.route(attempt);
@@ -792,11 +785,23 @@ export async function runFallbackLoop(hooks: FallbackHooks): Promise<void> {
 
     // Everything from here to the end of the iteration runs inside a finally that
     // frees the route's in-flight lease. Every exit — success, auth rotation,
-    // retryable continue, fatal, breaker trip, contract violation — passes through
-    // it, so no path can leak a lease and leave the key's concurrency budget short.
-    // Success accounting happens inside dispatch, so the persisted counters are
-    // already written by the time the provisional lease goes away.
+    // retryable continue, fatal, breaker trip, contract violation, wall-clock
+    // budget — passes through it, so no path can leak a lease and leave the
+    // key's concurrency budget short. Success accounting happens inside
+    // dispatch, so the persisted counters are already written by the time the
+    // provisional lease goes away.
     try {
+    // Wall-clock budget: refuse to START another retry once spent. The first
+    // attempt always runs; a slow attempt is never aborted mid-flight (that is
+    // the TODO(fallback-v2) hedging work), it just becomes the last one.
+    if (attempt > 0 && budgetMs > 0 && Date.now() - startedAt >= budgetMs) {
+      hooks.onExhausted(
+        exhaustedRetryError(lastError, maxRetries, { attempts, timedOut: true, budgetMs }),
+        { attempts, timedOut: true },
+      );
+      return;
+    }
+
     let outcome: DispatchOutcome;
     try {
       outcome = await hooks.dispatch(route, attempt);


### PR DESCRIPTION
## Summary
Fixes #666.

The wall-clock retry budget (default 45s, `DEFAULT_FALLBACK_TIME_BUDGET_MS`) was checked *before* checking whether another route/key even existed. With a single custom/Ollama key configured, the one legitimate attempt could legitimately take its full configured `timeoutMs` (e.g. 120s for custom providers). By the time the loop looped around to consider a second attempt, elapsed time already exceeded the 45s budget, so it reported `stopped early: retry time budget 45s exceeded` — even though there was no second key to retry anyway. The real reason was routing exhaustion (no more candidates), not the time budget.

The 120s provider timeout itself was never truncated — this was purely a misleading error message.

## Fix
In `server/src/lib/fallback-loop.ts`, swapped the order: `hooks.route(attempt)` is now checked first, so a routing dead-end reports honestly via `onRoutingExhausted`. The wall-clock budget check now only fires when a route candidate genuinely exists but time is already spent skipping it. Also moved the budget check inside the lease-release `finally` block so no in-flight lease leaks on that early return path.

## Test plan
- [x] `npx vitest run src/__tests__/lib/fallback-loop.test.ts src/__tests__/routes/fallback-hardening.test.ts` — 41/41 pass
- [x] Full suite: 1238/1240 pass (2 pre-existing failures are unrelated Unix file-permission-bit assertions, not reproducible/relevant on this platform)