### PR TITLE
fix(docker): point :latest at the newest release instead of main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,15 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            # `latest` must follow the newest RELEASE, not main. This workflow runs
+            # on both main pushes and v* tags, so `{{is_default_branch}}` attached
+            # `latest` to every main build and `docker pull ...:latest` served
+            # unreleased code — the opposite of what the tag conventionally means,
+            # and what sent people to pin `v0.6.5` by hand (discussion #533).
+            # Prereleases (v1.2.3-rc1) are excluded so `latest` stays on stable.
+            # Main builds keep their `main` and `sha-` tags, so anything tracking
+            # the development stream is unaffected.
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests


### PR DESCRIPTION
Reported in discussion #533.

`latest` was gated on `{{is_default_branch}}`, which is true only on the main-push builds, so every merge to main retagged `latest`. `docker pull ghcr.io/tashfeenahmed/freellmapi:latest` therefore served unreleased main rather than the newest release, which is the reverse of what the tag conventionally means and why users have been pinning version tags by hand.

Verified against the registry before the change: `latest` resolved to revision `8d459bb` (main tip, built minutes earlier) while `v0.6.5` resolved to `bd438d2` (the release commit).

Now attached on non-prerelease `v*` tag builds only. Main builds keep their `main` and `sha-<sha>` tags, so anything tracking the development stream is unaffected.

Note: `latest` in the registry still points at main until the next release tag is pushed; this only changes behaviour going forward.