### PR TITLE
release: v0.6.6

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for the v0.6.6 release.

Since v0.6.5:
- admin endpoint hardening, with export re-auth asked as a second step (#498)
- `:latest` now follows the newest release instead of main (#679, discussion #533)
- zh-CN and zh-TW translation rewrites (#669, #670)
- `freellmapi` CLI published to npm (#672)