### PR TITLE
docs: center the language toggle above the hero screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**English** · [简体中文](docs/i18n/zh-CN/README.md)
-
 <div align="center">
 
 # FreeLLMAPI
@@ -16,6 +14,8 @@ Aggregate free tiers from dozens of providers, plus custom OpenAI-compatible cha
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tashfeenahmed/freellmapi)
 
 **[freellmapi.co](https://freellmapi.co/?utm_source=github&utm_medium=readme&utm_campaign=repository&utm_content=readme_top)** · browse the full catalog: 251 model families, 358 free endpoints
+
+**English** · [简体中文](docs/i18n/zh-CN/README.md)
 
 ![FreeLLMAPI dashboard — Models page with the monthly token budget](repo-assets/github-hero.png)
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -1,5 +1,3 @@
-[English](../../../README.md) · **简体中文**
-
 <div align="center">
 
 # FreeLLMAPI
@@ -16,6 +14,8 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tashfeenahmed/freellmapi)
 
 **[freellmapi.co](https://freellmapi.co/?utm_source=github&utm_medium=readme&utm_campaign=repository&utm_content=readme_top)** · 浏览完整目录：251 个模型系列，358 个免费端点
+
+[English](../../../README.md) · **简体中文**
 
 ![FreeLLMAPI 仪表盘 —— 带每月词元额度的模型页](../../../repo-assets/github-hero.png)
 


### PR DESCRIPTION
The toggle was sitting above the `<div align="center">` wrapper, so it rendered left-aligned on its own line before the title. This moves it inside the centered block and directly above the hero screenshot, which is where someone scanning for their own language actually looks.

Same change applied to the zh-CN README so the two pages stay symmetrical.

Verified: 124 relative paths and 52 anchors across both files still resolve.