### PR TITLE
fix(csp): only emit upgrade-insecure-requests for HTTPS requests

### DIFF
--- a/client/src/components/keys/import-keys-section.tsx
+++ b/client/src/components/keys/import-keys-section.tsx
@@ -85,6 +85,7 @@ export function ImportKeysSection({ onImported }: { onImported?: () => void } = 
       keyName: row.keyName,
       keyValue: row.keyValue,
       platform: row.platform,
+      baseUrl: row.baseUrl,
     }))
 
   function updateRow(index: number, patch: Partial<ImportRow>) {

--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -111,6 +111,27 @@ describe('key parser', () => {
     expect(result!.skipped).toHaveLength(0);
   });
 
+  it('carries baseUrl through export JSON parsing (#687)', () => {
+    const exportJson = JSON.stringify({
+      version: 1,
+      exportedAt: '2026-07-06T12:00:00Z',
+      source: 'freellmapi',
+      keys: [
+        { platform: 'custom', key: 'sk-relay-123', label: 'My Relay', baseUrl: 'https://relay.example.com/v1' },
+      ],
+    });
+    const result = parseExportJson(exportJson);
+    expect(result).not.toBeNull();
+    expect(result!.keys).toEqual([
+      {
+        rawKey: 'My Relay=sk-relay-123',
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+      },
+    ]);
+  });
+
   it('returns null for non-export JSON', () => {
     expect(parseExportJson('{"foo":"bar"}')).toBeNull();
     expect(parseExportJson('[1,2,3]')).toBeNull();
@@ -123,6 +144,36 @@ describe('key parser', () => {
       { key: 'GOOGLE_KEY', value: 'AIza-test' },
       { key: 'GROQ_KEY', value: 'gsk-test' },
     ]);
+  });
+
+  it('parses the optional base_url column in CSV (#687)', () => {
+    const csv = 'platform,key,label,base_url\n"custom","sk-relay-123","My Relay","https://relay.example.com/v1"\n';
+    expect(parseCsv(csv)).toEqual([
+      { key: 'CUSTOM_KEY', value: 'sk-relay-123', baseUrl: 'https://relay.example.com/v1' },
+    ]);
+    const result = parseKeysFromFile(csv, 'freellmapi-keys.csv');
+    expect(result.keys).toEqual([
+      {
+        rawKey: 'CUSTOM_KEY=sk-relay-123',
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+      },
+    ]);
+  });
+
+  it('pairs CUSTOM_KEY with its CUSTOM_BASE_URL in .env files (#687)', () => {
+    const env = 'CUSTOM_BASE_URL_1=https://relay.example.com/v1\nCUSTOM_KEY_1=sk-relay-123\n';
+    const result = parseKeysFromFile(env, 'freellmapi-keys.env');
+    expect(result.keys).toEqual([
+      {
+        rawKey: 'CUSTOM_KEY_1=sk-relay-123',
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+      },
+    ]);
+    expect(result.skipped).toEqual([]);
   });
 
   it('parses CSV format without header', () => {

--- a/server/src/__tests__/routes/csp-security.test.ts
+++ b/server/src/__tests__/routes/csp-security.test.ts
@@ -3,10 +3,10 @@ import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { initDb } from '../../db/index.js';
 
-async function getHeaders(app: Express, path: string): Promise<Headers> {
+async function getHeaders(app: Express, path: string, headers?: Record<string, string>): Promise<Headers> {
   const server = app.listen(0);
   const addr = server.address() as any;
-  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`);
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, { headers });
   server.close();
   return res.headers;
 }
@@ -47,5 +47,17 @@ describe('CSP security headers', () => {
   it('does not set HSTS (local-only proxy)', async () => {
     const headers = await getHeaders(app, '/api/ping');
     expect(headers.get('strict-transport-security')).toBeNull();
+  });
+
+  it('omits upgrade-insecure-requests on plain HTTP (#682)', async () => {
+    const headers = await getHeaders(app, '/api/ping');
+    const csp = headers.get('content-security-policy')!;
+    expect(csp).not.toContain('upgrade-insecure-requests');
+  });
+
+  it('adds upgrade-insecure-requests when the request arrives over HTTPS (X-Forwarded-Proto) (#682)', async () => {
+    const headers = await getHeaders(app, '/api/ping', { 'x-forwarded-proto': 'https' });
+    const csp = headers.get('content-security-policy')!;
+    expect(csp).toContain('upgrade-insecure-requests');
   });
 });

--- a/server/src/__tests__/routes/keys-export-import-custom.test.ts
+++ b/server/src/__tests__/routes/keys-export-import-custom.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { mintDashboardToken } from '../helpers/auth.js';
+import { encrypt } from '../../lib/crypto.js';
+
+// Round-trip coverage for #687: exporting keys must carry the base_url of
+// custom OpenAI-compatible endpoints, and re-importing the file must restore
+// the endpoint — not silently drop it.
+
+let dashToken = '';
+
+async function post(app: Express, path: string, body?: unknown) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method: 'POST',
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      Authorization: `Bearer ${dashToken}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+async function exportText(app: Express, format: 'json' | 'env' | 'csv') {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys/export?format=${format}`, {
+    headers: { Authorization: `Bearer ${dashToken}`, 'x-reauth-password': 'password123' },
+  });
+  const text = await res.text();
+  server.close();
+  return { status: res.status, text };
+}
+
+async function multipartRequest(
+  app: Express,
+  path: string,
+  field: 'file' | 'files',
+  files: Array<{ filename: string; content: string; type?: string }>,
+) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const url = `http://127.0.0.1:${addr.port}${path}`;
+  const form = new FormData();
+  for (const file of files) {
+    form.append(
+      field,
+      new Blob([file.content], { type: file.type ?? 'text/plain' }),
+      file.filename,
+    );
+  }
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${dashToken}` },
+    body: form,
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+// Insert a custom endpoint directly (the /custom flow needs a model
+// registration; the DB row is all the export/import paths read).
+function insertCustomKey(baseUrl: string, key: string, label = 'My Relay') {
+  const db = getDb();
+  const { encrypted, iv, authTag } = encrypt(key);
+  db.prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
+    VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
+  `).run(label, encrypted, iv, authTag, baseUrl);
+}
+
+describe('Key export/import — custom endpoints round-trip (#687)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM api_keys').run();
+  });
+
+  it('JSON export includes baseUrl for custom keys', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { status, text } = await exportText(app, 'json');
+    expect(status).toBe(200);
+    const parsed = JSON.parse(text);
+    const custom = parsed.keys.find((k: any) => k.platform === 'custom');
+    expect(custom).toMatchObject({
+      platform: 'custom',
+      key: 'sk-relay-123',
+      label: 'My Relay',
+      baseUrl: 'https://relay.example.com/v1',
+    });
+  });
+
+  it('CSV export includes the base_url column for custom keys', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { status, text } = await exportText(app, 'csv');
+    expect(status).toBe(200);
+    const lines = text.trim().split('\n');
+    expect(lines[0]).toBe('platform,key,label,base_url');
+    expect(lines[1]).toBe('"custom","sk-relay-123","My Relay","https://relay.example.com/v1"');
+  });
+
+  it('.env export pairs CUSTOM_BASE_URL with CUSTOM_KEY', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { status, text } = await exportText(app, 'env');
+    expect(status).toBe(200);
+    expect(text).toContain('# My Relay');
+    expect(text).toContain('CUSTOM_BASE_URL_1=https://relay.example.com/v1');
+    expect(text).toContain('CUSTOM_KEY_1=sk-relay-123');
+  });
+
+  it('custom endpoints survive a JSON export → import round-trip', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { text } = await exportText(app, 'json');
+
+    // Wipe everything, then import the file back.
+    getDb().prepare('DELETE FROM api_keys').run();
+    const { status, body } = await multipartRequest(app, '/api/keys/import', 'file', [
+      { filename: 'freellmapi-keys.json', content: text, type: 'application/json' },
+    ]);
+    expect(status).toBe(200);
+    expect(body.imported).toBe(1);
+    expect(body.skipped).toEqual([]);
+
+    const row = getDb().prepare("SELECT platform, base_url, label FROM api_keys WHERE platform = 'custom'").get() as any;
+    expect(row).toMatchObject({ platform: 'custom', base_url: 'https://relay.example.com/v1', label: 'My Relay' });
+  });
+
+  it('custom endpoints survive a CSV export → import round-trip', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { text } = await exportText(app, 'csv');
+
+    getDb().prepare('DELETE FROM api_keys').run();
+    const { status, body } = await multipartRequest(app, '/api/keys/import', 'file', [
+      { filename: 'freellmapi-keys.csv', content: text },
+    ]);
+    expect(status).toBe(200);
+    expect(body.imported).toBe(1);
+
+    const row = getDb().prepare("SELECT platform, base_url FROM api_keys WHERE platform = 'custom'").get() as any;
+    expect(row).toMatchObject({ platform: 'custom', base_url: 'https://relay.example.com/v1' });
+  });
+
+  it('custom endpoints survive a .env export → import round-trip', async () => {
+    insertCustomKey('https://relay.example.com/v1', 'sk-relay-123', 'My Relay');
+    const { text } = await exportText(app, 'env');
+
+    getDb().prepare('DELETE FROM api_keys').run();
+    const { status, body } = await multipartRequest(app, '/api/keys/import', 'file', [
+      { filename: 'freellmapi-keys.env', content: text },
+    ]);
+    expect(status).toBe(200);
+    expect(body.imported).toBe(1);
+
+    const row = getDb().prepare("SELECT platform, base_url FROM api_keys WHERE platform = 'custom'").get() as any;
+    expect(row).toMatchObject({ platform: 'custom', base_url: 'https://relay.example.com/v1' });
+  });
+
+  it('import-selected restores custom keys when baseUrl is present', async () => {
+    const { status, body } = await post(app, '/api/keys/import-selected', {
+      keys: [
+        { keyName: 'sk-relay-123', keyValue: 'sk-relay-123', platform: 'custom', baseUrl: 'https://relay.example.com/v1' },
+      ],
+    });
+    expect(status).toBe(200);
+    expect(body.imported).toBe(1);
+    expect(body.errors).toEqual([]);
+
+    const row = getDb().prepare("SELECT platform, base_url FROM api_keys WHERE platform = 'custom'").get() as any;
+    expect(row).toMatchObject({ platform: 'custom', base_url: 'https://relay.example.com/v1' });
+  });
+
+  it('import-selected still rejects custom keys without a base URL', async () => {
+    const { status, body } = await post(app, '/api/keys/import-selected', {
+      keys: [
+        { keyName: 'sk-relay-123', keyValue: 'sk-relay-123', platform: 'custom' },
+      ],
+    });
+    expect(status).toBe(200);
+    expect(body.imported).toBe(0);
+    expect(body.errors[0].error).toContain('base URL');
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -70,6 +70,12 @@ export function createApp(config?: Config) {
   // are hashed by the Vite/React build, so 'self' works in production. Inline
   // styles from React hydration need 'unsafe-inline'. HSTS stays off because
   // this is a single-user local proxy served over HTTP (see README).
+  //
+  // upgrade-insecure-requests is DISABLED here on purpose (#682): helmet ships
+  // it in the default directives, but it tells the browser to fetch every
+  // subresource over HTTPS, which blanks the dashboard on plain-HTTP LAN
+  // installs (HOST_BIND=0.0.0.0, no TLS terminator). The middleware below
+  // re-adds it only for requests that already arrived over HTTPS.
   app.use(helmet({
     contentSecurityPolicy: {
       directives: {
@@ -81,10 +87,25 @@ export function createApp(config?: Config) {
         fontSrc: ["'self'"],
         formAction: ["'self'"],
         baseUri: ["'self'"],
+        upgradeInsecureRequests: null,
       },
     },
     hsts: false,
   }));
+  // #682: emit upgrade-insecure-requests only for HTTPS-originated requests
+  // (direct TLS, or X-Forwarded-Proto: https behind a reverse proxy). Trusting
+  // the header here is harmless — the worst a spoofed value can do is make the
+  // caller's own browser demand HTTPS for that one response.
+  app.use((req, res, next) => {
+    const isHttps = req.secure || req.headers['x-forwarded-proto'] === 'https';
+    if (isHttps) {
+      const csp = res.getHeader('content-security-policy');
+      if (typeof csp === 'string' && !csp.includes('upgrade-insecure-requests')) {
+        res.setHeader('content-security-policy', `${csp}; upgrade-insecure-requests`);
+      }
+    }
+    next();
+  });
   app.use(cors({
     origin(origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) {
       callback(null, !origin || allowedCorsOrigins.has(origin));

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -2,6 +2,9 @@ export interface ParsedKey {
   rawKey: string;
   prefix: string;
   platform: string | null;
+  /** Upstream endpoint for custom OpenAI-compatible keys (#687). Carried so an
+   *  export → import round-trip restores the custom endpoint, not just the key. */
+  baseUrl?: string;
 }
 
 export interface ParseResult {
@@ -261,7 +264,12 @@ export function parseExportJson(content: string): ParseResult | null {
       const prefix = platform
         ? (Object.entries(PREFIX_MAP).find(([, v]) => v === platform)?.[0] ?? `${platform.toUpperCase()}_`)
         : '';
-      result.keys.push({ rawKey: `${label}=${keyValue}`, prefix, platform });
+      result.keys.push({
+        rawKey: `${label}=${keyValue}`,
+        prefix,
+        platform,
+        baseUrl: typeof row.baseUrl === 'string' && row.baseUrl.trim() ? row.baseUrl : undefined,
+      });
     }
     return result;
   }
@@ -270,31 +278,34 @@ export function parseExportJson(content: string): ParseResult | null {
 }
 
 /**
- * Parse CSV format: platform,key,label (with optional header row).
+ * Parse CSV format: platform,key,label[,base_url] (with optional header row).
+ * The optional 4th column carries the endpoint for custom OpenAI-compatible
+ * keys, so a CSV export → import round-trip restores the full custom provider.
  */
-export function parseCsv(content: string): Array<{ key: string; value: string }> {
+export function parseCsv(content: string): Array<{ key: string; value: string; baseUrl?: string }> {
   const lines = content.split('\n').filter(l => l.trim());
   if (lines.length === 0) return [];
 
-  const result: Array<{ key: string; value: string }> = [];
+  const result: Array<{ key: string; value: string; baseUrl?: string }> = [];
 
   // Skip header row if it looks like a CSV header
   const startIdx = lines[0]!.toLowerCase().startsWith('platform,') ? 1 : 0;
 
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i]!;
-    // Simple CSV parsing: split on comma, strip quotes
-    const match = line.match(/^"?([^"]*?)"?,"?([^"]*?)"?(?:,"?([^"]*?)"?)?$/);
+    // Simple CSV parsing: split on comma, strip quotes. 4th field (base_url) optional.
+    const match = line.match(/^"?([^"]*?)"?,"?([^"]*?)"?(?:,"?([^"]*?)"?)?(?:,"?([^"]*?)"?)?$/);
     if (!match) continue;
 
     const platform = (match[1] ?? '').trim();
     const key = (match[2] ?? '').trim();
     const label = (match[3] ?? '').trim() || platform;
+    const baseUrl = (match[4] ?? '').trim() || undefined;
 
     if (!key || !platform) continue;
 
     const envKey = `${platform.toUpperCase()}_KEY`;
-    result.push({ key: envKey, value: key });
+    result.push({ key: envKey, value: key, baseUrl });
   }
 
   return result;
@@ -382,16 +393,46 @@ export function looksLikeApiKey(value: string): boolean {
   return /[a-z]/i.test(value);
 }
 
-function toParsedKeys(pairs: Array<{ key: string; value: string }>): ParseResult {
+function toParsedKeys(pairs: Array<{ key: string; value: string; baseUrl?: string }>): ParseResult {
   const keys: ParsedKey[] = [];
   const skipped: string[] = [];
 
+  // .env custom-key pairing (#687): a CUSTOM_KEY_<suffix> line may be
+  // accompanied by a CUSTOM_BASE_URL_<suffix> line carrying the endpoint.
+  // Collect the URLs first so a key appearing before its URL still pairs up.
+  const customBaseUrls = new Map<string, string>();
   for (const { key, value } of pairs) {
+    const match = key.match(/^CUSTOM_BASE_URL(?:_(\d+))?$/);
+    if (match) customBaseUrls.set(match[1] ?? '0', value);
+  }
+
+  for (const { key, value, baseUrl } of pairs) {
+    // CUSTOM_BASE_URL_<suffix> lines are endpoint metadata, not keys — they
+    // were collected above and attached to their CUSTOM_KEY partner below.
+    if (/^CUSTOM_BASE_URL(?:_\d+)?$/.test(key)) continue;
+
+    // CSV 4th column / export JSON already attach the endpoint directly.
+    if (baseUrl) {
+      keys.push({ rawKey: `${key}=${value}`, prefix: 'CUSTOM_', platform: 'custom', baseUrl });
+      continue;
+    }
     const prefix = extractPrefix(key);
     const platform = detectPlatform(prefix);
 
     if (platform) {
       keys.push({ rawKey: `${key}=${value}`, prefix, platform });
+      continue;
+    }
+
+    // .env convention: CUSTOM_KEY_<suffix> pairs with CUSTOM_BASE_URL_<suffix>.
+    const customMatch = key.match(/^CUSTOM_KEY(?:_(\d+))?$/);
+    if (customMatch && customBaseUrls.has(customMatch[1] ?? '0')) {
+      keys.push({
+        rawKey: `${key}=${value}`,
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: customBaseUrls.get(customMatch[1] ?? '0'),
+      });
       continue;
     }
 

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -63,6 +63,9 @@ const importKeySchema = z.object({
   keyName: z.string().optional(),
   keyValue: z.string().min(1),
   platform: z.enum(PLATFORMS),
+  // Upstream URL for custom endpoints, carried from an export file so the
+  // round-trip restores the provider (#687).
+  baseUrl: z.string().optional(),
 });
 
 function handleUploadError(err: any, res: Response, next: NextFunction): boolean {
@@ -122,6 +125,23 @@ function insertImportedKey(platform: (typeof PLATFORMS)[number], keyName: string
     INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
     VALUES (?, ?, ?, ?, ?, 'unknown', 1)
   `).run(platform, keyName, encrypted, iv, authTag);
+}
+
+// A custom (OpenAI-compatible) endpoint key imported from an export file needs
+// its base_url — without it the row is a dead placeholder that can't route
+// (#687). The export now carries the URL in every format, so an export → import
+// round-trip restores the endpoint; models for it are re-registered through the
+// normal custom-provider flow (discover/register) as the export carries no
+// model list.
+function insertImportedCustomKey(baseUrl: string, keyName: string, keyValue: string) {
+  const db = getDb();
+  const normalized = normalizeBaseUrl(baseUrl);
+  const keyToStore = keyValue.trim() || 'no-key';
+  const { encrypted, iv, authTag } = encrypt(keyToStore);
+  db.prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, base_url)
+    VALUES ('custom', ?, ?, ?, ?, 'unknown', 1, ?)
+  `).run(keyName, encrypted, iv, authTag, normalized);
 }
 
 // Count enabled catalog models for a platform. Used to warn when a key is
@@ -328,7 +348,10 @@ keysRouter.get('/export', (req: Request, res: Response) => {
 
   const rows = db.prepare(`SELECT * FROM api_keys ${whereClause} ORDER BY platform, created_at ASC`).all() as any[];
 
-  // Decrypt and filter — only export keys with a real value
+  // Decrypt and filter — only export keys with a real value. Custom endpoints
+  // are exempt: their base_url is the essential part, and a local auth-less
+  // server stores the 'no-key' sentinel, which would otherwise drop the whole
+  // endpoint from the export (#687).
   const decryptedKeys = rows
     .map(row => {
       let key = '';
@@ -345,6 +368,7 @@ keysRouter.get('/export', (req: Request, res: Response) => {
       };
     })
     .filter(k => {
+      if (k.platform === 'custom') return true;
       const v = k.key.trim();
       return v.length > 0 && v !== 'no-key';
     });
@@ -355,11 +379,24 @@ keysRouter.get('/export', (req: Request, res: Response) => {
   }
 
   if (format === 'env') {
-    // .env format: GOOGLE_KEY=xxx\nGROQ_KEY=yyy
-    const lines = decryptedKeys.map(k => {
+    // .env format: GOOGLE_KEY=xxx\nGROQ_KEY=yyy. Custom endpoints pair a
+    // numbered CUSTOM_KEY_<n> with its CUSTOM_BASE_URL_<n> so re-import knows
+    // which upstream each key belongs to (#687).
+    const lines: string[] = [];
+    let customIndex = 0;
+    for (const k of decryptedKeys) {
+      if (k.platform === 'custom') {
+        customIndex += 1;
+        const vars = [
+          `CUSTOM_BASE_URL_${customIndex}=${k.baseUrl ?? ''}`,
+          `CUSTOM_KEY_${customIndex}=${k.key}`,
+        ];
+        lines.push(k.label ? `# ${k.label}\n${vars.join('\n')}` : vars.join('\n'));
+        continue;
+      }
       const envKey = `${k.platform.toUpperCase()}_KEY=${k.key}`;
-      return k.label ? `# ${k.label}\n${envKey}` : envKey;
-    });
+      lines.push(k.label ? `# ${k.label}\n${envKey}` : envKey);
+    }
     const content = lines.join('\n\n') + '\n';
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
     res.setHeader('Content-Disposition', 'attachment; filename="freellmapi-keys.env"');
@@ -368,7 +405,9 @@ keysRouter.get('/export', (req: Request, res: Response) => {
   }
 
   if (format === 'csv') {
-    // CSV format: platform,key,label
+    // CSV format: platform,key,label[,base_url] — base_url is the 4th column,
+    // populated only for custom endpoints so the round-trip keeps the upstream
+    // URL (#687).
     const escCsv = (v: string) => `"${v.replace(/"/g, '""')}"`;
     // CSV formula-injection guard: a spreadsheet treats a cell that starts with
     // =, +, -, @, tab or CR as a live formula, so a label like `=HYPERLINK(...)`
@@ -377,9 +416,9 @@ keysRouter.get('/export', (req: Request, res: Response) => {
     // (labels); the key value must round-trip verbatim for re-import, and the
     // platform is one of our own fixed enum values.
     const neutralize = (v: string) => (/^[=+\-@\t\r]/.test(v) ? `'${v}` : v);
-    const header = 'platform,key,label';
+    const header = 'platform,key,label,base_url';
     const lines = decryptedKeys.map(k =>
-      [escCsv(k.platform), escCsv(k.key), escCsv(neutralize(k.label))].join(',')
+      [escCsv(k.platform), escCsv(k.key), escCsv(neutralize(k.label)), escCsv(k.baseUrl ?? '')].join(',')
     );
     const content = [header, ...lines].join('\n') + '\n';
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
@@ -827,8 +866,23 @@ keysRouter.post('/import', (req: Request, res: Response, next: NextFunction) => 
           continue;
         }
         const platformParse = z.enum(PLATFORMS).safeParse(parsedKey.platform);
-        if (!platformParse.success || platformParse.data === 'custom') {
+        if (!platformParse.success) {
           skipped.push(keyName);
+          continue;
+        }
+        // Custom endpoints round-trip only when the export carried the upstream
+        // URL (#687); without it the row would be a dead placeholder.
+        if (platformParse.data === 'custom') {
+          if (!parsedKey.baseUrl) {
+            skipped.push(`${keyName}: custom key has no base URL`);
+            continue;
+          }
+          try {
+            insertImportedCustomKey(parsedKey.baseUrl, keyName, keyValue);
+            imported.push({ keyName, platform: 'custom' });
+          } catch (insertErr) {
+            errors.push({ key: keyName, error: (insertErr as Error).message });
+          }
           continue;
         }
         if (!keyValue.trim()) {
@@ -893,6 +947,7 @@ keysRouter.post('/preview', (req: Request, res: Response, next: NextFunction) =>
             keyValue,
             detectedPlatform: parsedKey.platform,
             prefix: parsedKey.prefix,
+            baseUrl: parsedKey.baseUrl,
             isDuplicate,
           });
         }
@@ -929,8 +984,20 @@ keysRouter.post('/import-selected', (req: Request, res: Response) => {
 
   for (const key of parsed.data.keys) {
     const keyName = key.keyName?.trim() || key.platform;
+    // Custom endpoints round-trip only when the import carries the upstream URL
+    // (#687); the preview flow passes it through from the parsed export file.
     if (key.platform === 'custom') {
-      errors.push({ key: keyName, error: 'Custom providers must be added with a base URL' });
+      if (!key.baseUrl) {
+        errors.push({ key: keyName, error: 'Custom providers must be added with a base URL' });
+        continue;
+      }
+      try {
+        insertImportedCustomKey(key.baseUrl, keyName, key.keyValue);
+        imported++;
+        existingKeys.add(key.keyValue.trim());
+      } catch (err) {
+        errors.push({ key: keyName, error: (err as Error).message });
+      }
       continue;
     }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -5,6 +5,7 @@ export interface PreviewKey {
   keyValue: string;
   detectedPlatform: string | null;
   prefix: string;
+  baseUrl?: string;
   isDuplicate?: boolean;
 }
 
@@ -12,6 +13,7 @@ export interface ImportKey {
   keyName: string;
   keyValue: string;
   platform: string;
+  baseUrl?: string;
 }
 
 export interface PreviewResponse {


### PR DESCRIPTION
## What & why

Fixes #682. helmet's default CSP ships `upgrade-insecure-requests`, which tells the browser to fetch every subresource over HTTPS. On plain-HTTP LAN installs (`HOST_BIND=0.0.0.0`, no TLS terminator) that blanks the dashboard: the document loads over HTTP, `/assets/*` get upgraded to HTTPS, the server has no TLS on that port, and every asset fails with `ERR_SSL_PROTOCOL_ERROR`.

## Changes

- Disable `upgrade-insecure-requests` in the helmet defaults.
- Re-add it via middleware only when the request already arrived over HTTPS (direct TLS, or `X-Forwarded-Proto: https` behind a reverse proxy). Trusting that header is harmless — a spoofed value can only make the caller's own browser demand HTTPS for that one response.
- Tests: plain HTTP omits the directive; `X-Forwarded-Proto: https` keeps it.

Verified with `npx vitest run src/__tests__/routes/csp-security.test.ts` (7/7 passing).