### PR TITLE
fix(proxy): clarify the retry time budget message in exhaustion errors

### DIFF
--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -452,7 +452,7 @@ export function exhaustedRetryError(lastError: any, maxRetries?: number, ctx?: E
   const attempts = ctx?.attempts ?? [];
   const trail = attempts.length > 0 ? ` Attempt trail: ${formatAttemptTrail(attempts)}.` : '';
   const budgetNote = ctx?.timedOut
-    ? ` (stopped early: retry time budget ${Math.round((ctx.budgetMs ?? 0) / 1000)}s exceeded)`
+    ? ` (stopped early: retry time budget ${Math.round((ctx.budgetMs ?? 0) / 1000)}s exceeded — the attempt in flight is never aborted mid-flight, the budget only stops STARTING further retries; raise FALLBACK_TIME_BUDGET_MS or the fallback_time_budget_ms setting to allow a longer failover chain)`
     : '';
   const everyAttempt = (cls: AttemptErrorClass | ReadonlySet<AttemptErrorClass>): boolean =>
     attempts.length > 0 && attempts.every(a => (cls instanceof Set ? cls.has(a.errorClass) : a.errorClass === cls));


### PR DESCRIPTION
## What & why

Closes the confusion raised in #666. The "retry time budget 45s exceeded" note read as if the request was aborted after 45 seconds, but the budget only refuses to START further retries — the attempt in flight always runs to its own upstream timeout. A local Ollama model that legitimately needs 120s showed a misleading `(stopped early: retry time budget 45s exceeded)` alongside `(custom, chat, 120s)`.

## Changes

- Clarify the exhaustion note: the in-flight attempt is never aborted mid-flight; the budget only stops starting further retries.
- Point operators at the existing knobs (`FALLBACK_TIME_BUDGET_MS` env var, `fallback_time_budget_ms` setting, default 45s).

No behavior change — message only. Verified with `fallback-loop.test.ts` + `fallback-hardening.test.ts` (41/41 passing; the existing "retry time budget 45s exceeded" assertion still matches).