### PR TITLE
fix(models): keep the usage bar visible at zero, and retitle to "Monthly usage"

### DIFF
--- a/client/src/components/usage-summary-card.tsx
+++ b/client/src/components/usage-summary-card.tsx
@@ -51,7 +51,10 @@ export function UsageSummaryCard({
         </span>
       </div>
 
-      {total > 0 && (
+      {/* The track always renders. Hiding it at zero made the whole card read as
+          missing on tabs with no traffic yet, which is exactly when a reader is
+          checking whether the feature is there at all. */}
+      {total > 0 ? (
         <div className="flex h-2.5 rounded-full overflow-hidden bg-muted">
           {spent.map((r, i) => (
             <div
@@ -64,6 +67,8 @@ export function UsageSummaryCard({
             />
           ))}
         </div>
+      ) : (
+        <div className="h-2.5 rounded-full bg-muted" />
       )}
 
       <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-5 gap-y-1.5 text-xs tabular-nums">

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "ገደብ እንዳይኖር ባዶ ይተዉት።",
-    "usageThisMonth": "የዚህ ወር አጠቃቀም",
+    "usageThisMonth": "ወርሃዊ አጠቃቀም",
     "usageEmpty": "በዚህ ወር ገና ጥያቄዎች የሉም።",
     "usageRequestsMonth": "በዚህ ወር {count} ጥያቄዎች"
   },

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "اتركه فارغًا لعدم وجود حد.",
-    "usageThisMonth": "الاستخدام هذا الشهر",
+    "usageThisMonth": "الاستخدام الشهري",
     "usageEmpty": "لا توجد طلبات هذا الشهر بعد.",
     "usageRequestsMonth": "{count} طلب هذا الشهر"
   },

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Limit olmaması üçün boş buraxın.",
-    "usageThisMonth": "Bu ayın istifadəsi",
+    "usageThisMonth": "Aylıq istifadə",
     "usageEmpty": "Bu ay hələ sorğu yoxdur.",
     "usageRequestsMonth": "bu ay {count} sorğu"
   },

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Оставете празно за без ограничение.",
-    "usageThisMonth": "Потребление този месец",
+    "usageThisMonth": "Месечно потребление",
     "usageEmpty": "Няма заявки този месец.",
     "usageRequestsMonth": "{count} заявки този месец"
   },

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "কোনো সীমা না রাখতে ফাঁকা রাখুন।",
-    "usageThisMonth": "এই মাসের ব্যবহার",
+    "usageThisMonth": "মাসিক ব্যবহার",
     "usageEmpty": "এই মাসে এখনও কোনো অনুরোধ নেই।",
     "usageRequestsMonth": "এই মাসে {count}টি অনুরোধ"
   },

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Ponechte prázdné pro žádný limit.",
-    "usageThisMonth": "Spotřeba tento měsíc",
+    "usageThisMonth": "Měsíční spotřeba",
     "usageEmpty": "Tento měsíc zatím žádné požadavky.",
     "usageRequestsMonth": "{count} pož. tento měsíc"
   },

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Lad stå tomt for ingen grænse.",
-    "usageThisMonth": "Forbrug denne måned",
+    "usageThisMonth": "Månedligt forbrug",
     "usageEmpty": "Ingen anmodninger denne måned endnu.",
     "usageRequestsMonth": "{count} anmodn. denne måned"
   },

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Leer lassen für kein Limit.",
-    "usageThisMonth": "Nutzung diesen Monat",
+    "usageThisMonth": "Monatliche Nutzung",
     "usageEmpty": "Diesen Monat noch keine Anfragen.",
     "usageRequestsMonth": "{count} Anfr. diesen Monat"
   },

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Αφήστε το κενό για κανένα όριο.",
-    "usageThisMonth": "Χρήση αυτόν τον μήνα",
+    "usageThisMonth": "Μηνιαία χρήση",
     "usageEmpty": "Δεν υπάρχουν αιτήματα αυτόν τον μήνα.",
     "usageRequestsMonth": "{count} αιτήματα αυτόν τον μήνα"
   },

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Leave blank for no limit.",
-    "usageThisMonth": "Usage this month",
+    "usageThisMonth": "Monthly usage",
     "usageEmpty": "No requests yet this month.",
     "usageRequestsMonth": "{count} req this month"
   },

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Déjalo en blanco para no aplicar límite.",
-    "usageThisMonth": "Uso de este mes",
+    "usageThisMonth": "Uso mensual",
     "usageEmpty": "Aún no hay solicitudes este mes.",
     "usageRequestsMonth": "{count} sol. este mes"
   },

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "برای بدون محدودیت خالی بگذارید.",
-    "usageThisMonth": "مصرف این ماه",
+    "usageThisMonth": "مصرف ماهانه",
     "usageEmpty": "هنوز درخواستی در این ماه نیست.",
     "usageRequestsMonth": "{count} درخواست این ماه"
   },

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Jätä tyhjäksi, jos ei rajaa.",
-    "usageThisMonth": "Tämän kuun käyttö",
+    "usageThisMonth": "Kuukausikäyttö",
     "usageEmpty": "Ei vielä pyyntöjä tässä kuussa.",
     "usageRequestsMonth": "{count} pyyntöä tässä kuussa"
   },

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Laissez vide pour aucune limite.",
-    "usageThisMonth": "Utilisation ce mois-ci",
+    "usageThisMonth": "Utilisation mensuelle",
     "usageEmpty": "Aucune requête ce mois-ci pour l'instant.",
     "usageRequestsMonth": "{count} req. ce mois-ci"
   },

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "કોઈ મર્યાદા ન રાખવા ખાલી છોડો.",
-    "usageThisMonth": "આ મહિનાનો વપરાશ",
+    "usageThisMonth": "માસિક વપરાશ",
     "usageEmpty": "આ મહિને હજી કોઈ વિનંતી નથી.",
     "usageRequestsMonth": "આ મહિને {count} વિનંતી"
   },

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Bar shi fanko domin babu iyaka.",
-    "usageThisMonth": "Amfani na wannan wata",
+    "usageThisMonth": "Amfani na wata-wata",
     "usageEmpty": "Babu buƙatu tukuna wannan wata.",
     "usageRequestsMonth": "buƙatu {count} wannan wata"
   },

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "השאירו ריק כדי לא להגביל.",
-    "usageThisMonth": "שימוש החודש",
+    "usageThisMonth": "שימוש חודשי",
     "usageEmpty": "אין עדיין בקשות החודש.",
     "usageRequestsMonth": "{count} בקשות החודש"
   },

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "कोई सीमा न रखने के लिए खाली छोड़ें।",
-    "usageThisMonth": "इस महीने का उपयोग",
+    "usageThisMonth": "मासिक उपयोग",
     "usageEmpty": "इस महीने अभी कोई अनुरोध नहीं।",
     "usageRequestsMonth": "इस महीने {count} अनुरोध"
   },

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Ostavite prazno za bez ograničenja.",
-    "usageThisMonth": "Potrošnja ovog mjeseca",
+    "usageThisMonth": "Mjesečna potrošnja",
     "usageEmpty": "Ovog mjeseca još nema zahtjeva.",
     "usageRequestsMonth": "{count} zaht. ovog mjeseca"
   },

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Kosongkan untuk tanpa batas.",
-    "usageThisMonth": "Penggunaan bulan ini",
+    "usageThisMonth": "Penggunaan bulanan",
     "usageEmpty": "Belum ada permintaan bulan ini.",
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Hapụ ya efu ka enweghị oke.",
-    "usageThisMonth": "Ojiji ọnwa a",
+    "usageThisMonth": "Ojiji kwa ọnwa",
     "usageEmpty": "Enweghị arịrịọ ọ bụla ọnwa a.",
     "usageRequestsMonth": "arịrịọ {count} ọnwa a"
   },

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Lascia vuoto per nessun limite.",
-    "usageThisMonth": "Utilizzo di questo mese",
+    "usageThisMonth": "Utilizzo mensile",
     "usageEmpty": "Nessuna richiesta questo mese.",
     "usageRequestsMonth": "{count} rich. questo mese"
   },

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "制限なしにするには空欄にします。",
-    "usageThisMonth": "今月の使用量",
+    "usageThisMonth": "月間使用量",
     "usageEmpty": "今月はまだリクエストがありません。",
     "usageRequestsMonth": "今月 {count} 件"
   },

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "დატოვეთ ცარიელი ლიმიტის გარეშე.",
-    "usageThisMonth": "ამ თვის მოხმარება",
+    "usageThisMonth": "თვიური მოხმარება",
     "usageEmpty": "ამ თვეში ჯერ მოთხოვნები არ არის.",
     "usageRequestsMonth": "{count} მოთხოვნა ამ თვეში"
   },

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "ទុកឱ្យទទេ ដើម្បីគ្មានដែនកំណត់។",
-    "usageThisMonth": "ការប្រើប្រាស់ខែនេះ",
+    "usageThisMonth": "ការប្រើប្រាស់ប្រចាំខែ",
     "usageEmpty": "មិនទាន់មានសំណើនៅខែនេះទេ។",
     "usageRequestsMonth": "ខែនេះ {count} សំណើ"
   },

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "ಮಿತಿ ಬೇಡವಾದರೆ ಖಾಲಿ ಬಿಡಿ.",
-    "usageThisMonth": "ಈ ತಿಂಗಳ ಬಳಕೆ",
+    "usageThisMonth": "ಮಾಸಿಕ ಬಳಕೆ",
     "usageEmpty": "ಈ ತಿಂಗಳು ಇನ್ನೂ ವಿನಂತಿಗಳಿಲ್ಲ.",
     "usageRequestsMonth": "ಈ ತಿಂಗಳು {count} ವಿನಂತಿಗಳು"
   },

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "제한 없음으로 두려면 비워 두세요.",
-    "usageThisMonth": "이번 달 사용량",
+    "usageThisMonth": "월간 사용량",
     "usageEmpty": "이번 달에는 아직 요청이 없습니다.",
     "usageRequestsMonth": "이번 달 {count}건"
   },

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Palikite tuščią, jei nėra ribos.",
-    "usageThisMonth": "Šio mėnesio naudojimas",
+    "usageThisMonth": "Mėnesio naudojimas",
     "usageEmpty": "Šį mėnesį užklausų dar nėra.",
     "usageRequestsMonth": "{count} užkl. šį mėnesį"
   },

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "പരിധി വേണ്ടെങ്കിൽ ശൂന്യമായി വിടുക.",
-    "usageThisMonth": "ഈ മാസത്തെ ഉപയോഗം",
+    "usageThisMonth": "പ്രതിമാസ ഉപയോഗം",
     "usageEmpty": "ഈ മാസം ഇതുവരെ അഭ്യർത്ഥനകളില്ല.",
     "usageRequestsMonth": "ഈ മാസം {count} അഭ്യർത്ഥനകൾ"
   },

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "मर्यादा नको असल्यास रिकामे ठेवा.",
-    "usageThisMonth": "या महिन्याचा वापर",
+    "usageThisMonth": "मासिक वापर",
     "usageEmpty": "या महिन्यात अद्याप विनंत्या नाहीत.",
     "usageRequestsMonth": "या महिन्यात {count} विनंत्या"
   },

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Biarkan kosong untuk tiada had.",
-    "usageThisMonth": "Penggunaan bulan ini",
+    "usageThisMonth": "Penggunaan bulanan",
     "usageEmpty": "Tiada permintaan lagi bulan ini.",
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "ကန့်သတ်ချက်မလိုပါက ကွက်လပ်ထားပါ။",
-    "usageThisMonth": "ဤလအသုံးပြုမှု",
+    "usageThisMonth": "လစဉ်အသုံးပြုမှု",
     "usageEmpty": "ဤလတွင် တောင်းဆိုမှု မရှိသေးပါ။",
     "usageRequestsMonth": "ဤလတွင် တောင်းဆိုမှု {count} ခု"
   },

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "कुनै सीमा नराख्न खाली छोड्नुहोस्।",
-    "usageThisMonth": "यो महिनाको प्रयोग",
+    "usageThisMonth": "मासिक प्रयोग",
     "usageEmpty": "यो महिना अहिलेसम्म कुनै अनुरोध छैन।",
     "usageRequestsMonth": "यो महिना {count} अनुरोध"
   },

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Laat leeg voor geen limiet.",
-    "usageThisMonth": "Gebruik deze maand",
+    "usageThisMonth": "Maandelijks gebruik",
     "usageEmpty": "Nog geen verzoeken deze maand.",
     "usageRequestsMonth": "{count} verz. deze maand"
   },

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "La stå tomt for ingen grense.",
-    "usageThisMonth": "Bruk denne måneden",
+    "usageThisMonth": "Månedlig bruk",
     "usageEmpty": "Ingen forespørsler denne måneden ennå.",
     "usageRequestsMonth": "{count} forespørsler denne måneden"
   },

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "କୌଣସି ସୀମା ନ ରଖିବାକୁ ଖାଲି ଛାଡ଼ନ୍ତୁ।",
-    "usageThisMonth": "ଏହି ମାସର ବ୍ୟବହାର",
+    "usageThisMonth": "ମାସିକ ବ୍ୟବହାର",
     "usageEmpty": "ଏହି ମାସରେ ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି ଅନୁରୋଧ ନାହିଁ।",
     "usageRequestsMonth": "ଏହି ମାସରେ {count} ଅନୁରୋଧ"
   },

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "ਕੋਈ ਹੱਦ ਨਾ ਰੱਖਣ ਲਈ ਖਾਲੀ ਛੱਡੋ।",
-    "usageThisMonth": "ਇਸ ਮਹੀਨੇ ਦੀ ਵਰਤੋਂ",
+    "usageThisMonth": "ਮਹੀਨਾਵਾਰ ਵਰਤੋਂ",
     "usageEmpty": "ਇਸ ਮਹੀਨੇ ਹਾਲੇ ਕੋਈ ਬੇਨਤੀ ਨਹੀਂ।",
     "usageRequestsMonth": "ਇਸ ਮਹੀਨੇ {count} ਬੇਨਤੀਆਂ"
   },

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Pozostaw puste, aby nie było limitu.",
-    "usageThisMonth": "Zużycie w tym miesiącu",
+    "usageThisMonth": "Zużycie miesięczne",
     "usageEmpty": "Brak żądań w tym miesiącu.",
     "usageRequestsMonth": "{count} żąd. w tym miesiącu"
   },

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Deixe em branco para não ter limite.",
-    "usageThisMonth": "Uso neste mês",
+    "usageThisMonth": "Uso mensal",
     "usageEmpty": "Ainda não há solicitações neste mês.",
     "usageRequestsMonth": "{count} sol. neste mês"
   },

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Deixe em branco para não ter limite.",
-    "usageThisMonth": "Utilização este mês",
+    "usageThisMonth": "Utilização mensal",
     "usageEmpty": "Ainda não há pedidos este mês.",
     "usageRequestsMonth": "{count} ped. este mês"
   },

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Lăsați gol pentru nicio limită.",
-    "usageThisMonth": "Utilizare luna aceasta",
+    "usageThisMonth": "Utilizare lunară",
     "usageEmpty": "Nicio cerere luna aceasta.",
     "usageRequestsMonth": "{count} cereri luna aceasta"
   },

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Оставьте пустым, чтобы не было ограничения.",
-    "usageThisMonth": "Расход за этот месяц",
+    "usageThisMonth": "Расход за месяц",
     "usageEmpty": "В этом месяце запросов пока нет.",
     "usageRequestsMonth": "{count} запр. за месяц"
   },

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "සීමාවක් නොමැති නම් හිස්ව තබන්න.",
-    "usageThisMonth": "මෙම මාසයේ භාවිතය",
+    "usageThisMonth": "මාසික භාවිතය",
     "usageEmpty": "මෙම මාසයේ තවම ඉල්ලීම් නැත.",
     "usageRequestsMonth": "මෙම මාසයේ ඉල්ලීම් {count}"
   },

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Ponechajte prázdne pre žiadny limit.",
-    "usageThisMonth": "Spotreba tento mesiac",
+    "usageThisMonth": "Mesačná spotreba",
     "usageEmpty": "Tento mesiac zatiaľ žiadne požiadavky.",
     "usageRequestsMonth": "{count} pož. tento mesiac"
   },

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Оставите празно за без ограничења.",
-    "usageThisMonth": "Потрошња овог месеца",
+    "usageThisMonth": "Месечна потрошња",
     "usageEmpty": "Овог месеца још нема захтева.",
     "usageRequestsMonth": "{count} захтева овог месеца"
   },

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Lämna tomt för ingen gräns.",
-    "usageThisMonth": "Användning denna månad",
+    "usageThisMonth": "Månatlig användning",
     "usageEmpty": "Inga förfrågningar denna månad än.",
     "usageRequestsMonth": "{count} förfr. denna månad"
   },

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Acha wazi ili kusiwe na kikomo.",
-    "usageThisMonth": "Matumizi ya mwezi huu",
+    "usageThisMonth": "Matumizi ya kila mwezi",
     "usageEmpty": "Bado hakuna maombi mwezi huu.",
     "usageRequestsMonth": "maombi {count} mwezi huu"
   },

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "வரம்பு வேண்டாம் எனில் காலியாக விடவும்.",
-    "usageThisMonth": "இந்த மாத பயன்பாடு",
+    "usageThisMonth": "மாதாந்திர பயன்பாடு",
     "usageEmpty": "இந்த மாதம் இதுவரை கோரிக்கைகள் இல்லை.",
     "usageRequestsMonth": "இந்த மாதம் {count} கோரிக்கை"
   },

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "పరిమితి వద్దనుకుంటే ఖాళీగా వదిలేయండి.",
-    "usageThisMonth": "ఈ నెల వినియోగం",
+    "usageThisMonth": "నెలవారీ వినియోగం",
     "usageEmpty": "ఈ నెలలో ఇంకా అభ్యర్థనలు లేవు.",
     "usageRequestsMonth": "ఈ నెలలో {count} అభ్యర్థనలు"
   },

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "เว้นว่างไว้หากไม่จำกัด",
-    "usageThisMonth": "การใช้งานเดือนนี้",
+    "usageThisMonth": "การใช้งานรายเดือน",
     "usageEmpty": "ยังไม่มีคำขอในเดือนนี้",
     "usageRequestsMonth": "เดือนนี้ {count} คำขอ"
   },

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Iwanang blangko para walang limitasyon.",
-    "usageThisMonth": "Paggamit ngayong buwan",
+    "usageThisMonth": "Buwanang paggamit",
     "usageEmpty": "Wala pang mga kahilingan ngayong buwan.",
     "usageRequestsMonth": "{count} kahilingan ngayong buwan"
   },

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Sınır olmaması için boş bırakın.",
-    "usageThisMonth": "Bu ayki kullanım",
+    "usageThisMonth": "Aylık kullanım",
     "usageEmpty": "Bu ay henüz istek yok.",
     "usageRequestsMonth": "bu ay {count} istek"
   },

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Залиште порожнім, щоб не було обмеження.",
-    "usageThisMonth": "Витрати цього місяця",
+    "usageThisMonth": "Місячні витрати",
     "usageEmpty": "Цього місяця ще немає запитів.",
     "usageRequestsMonth": "{count} запитів цього місяця"
   },

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "کوئی حد نہ رکھنے کے لیے خالی چھوڑیں۔",
-    "usageThisMonth": "اس مہینے کا استعمال",
+    "usageThisMonth": "ماہانہ استعمال",
     "usageEmpty": "اس مہینے ابھی کوئی درخواست نہیں۔",
     "usageRequestsMonth": "اس مہینے {count} درخواستیں"
   },

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Cheklov boʻlmasligi uchun boʻsh qoldiring.",
-    "usageThisMonth": "Shu oydagi foydalanish",
+    "usageThisMonth": "Oylik foydalanish",
     "usageEmpty": "Bu oyda hali so'rovlar yo'q.",
     "usageRequestsMonth": "bu oyda {count} ta so'rov"
   },

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Để trống nếu không giới hạn.",
-    "usageThisMonth": "Mức dùng tháng này",
+    "usageThisMonth": "Mức dùng hằng tháng",
     "usageEmpty": "Chưa có yêu cầu nào trong tháng này.",
     "usageRequestsMonth": "{count} yêu cầu tháng này"
   },

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "Fi sílẹ̀ ní òfìfo fún àìní ààlà.",
-    "usageThisMonth": "Ìlò oṣù yìí",
+    "usageThisMonth": "Ìlò oṣooṣù",
     "usageEmpty": "Kò sí ìbéèrè kankan ní oṣù yìí.",
     "usageRequestsMonth": "ìbéèrè {count} ní oṣù yìí"
   },

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "留空表示不限制。",
-    "usageThisMonth": "本月用量",
+    "usageThisMonth": "每月用量",
     "usageEmpty": "本月还没有请求。",
     "usageRequestsMonth": "本月 {count} 次请求"
   },

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -218,7 +218,7 @@
     "limitTpm": "TPM",
     "limitTpd": "TPD",
     "limitHint": "留空表示不限制。",
-    "usageThisMonth": "本月用量",
+    "usageThisMonth": "每月用量",
     "usageEmpty": "本月尚無請求。",
     "usageRequestsMonth": "本月 {count} 次請求"
   },


### PR DESCRIPTION
Two fixes from trying #695 on the demo box.

### The Image and Audio cards looked missing

They were rendering; the bar was not. Hiding the track at zero was a change I made in #695, and it backfires precisely where it matters. The box's traffic this month:

| type | requests |
| --- | --- |
| chat | 560 |
| embedding | 37 |
| image | **0** |
| audio | **0** |

Embeddings had 37 requests so it drew a bar and looked right. Image and audio had none, so the card collapsed to a heading and a row of zeros, which reads as "nothing shipped" — exactly when a reader is checking whether the feature is there. The track renders again, muted when empty.

### Retitled to "Monthly usage"

`Usage this month` didn't match the grammar of the chat tab's `Monthly token budget` sitting in the same slot one tab over. It's now `Monthly usage`.

Not `Monthly budget`, deliberately: these tabs have no budget to report — `embedding_models` and `media_models` carry no budget column, which is the whole reason #695 reports spend instead of a percentage. A heading promising a budget sends the reader hunting for a denominator that isn't there. `Monthly usage` keeps the parallel phrasing without the false promise. One-word change if you'd rather have `Monthly budget` anyway.

Value updated across all 60 locales; `check:i18n` clean at 726 keys. No server changes.