### PR TITLE
fix(keys): 导出包含 custom 端点并支持完整 round-trip (#687)

### DIFF
--- a/server/src/__tests__/lib/key-parser.test.ts
+++ b/server/src/__tests__/lib/key-parser.test.ts
@@ -120,15 +120,29 @@ describe('key parser', () => {
   it('parses CSV format with header', () => {
     const csv = 'platform,key,label\n"google","AIza-test","Google Key"\n"groq","gsk-test","Groq Key"\n';
     expect(parseCsv(csv)).toEqual([
-      { key: 'GOOGLE_KEY', value: 'AIza-test' },
-      { key: 'GROQ_KEY', value: 'gsk-test' },
+      { key: 'GOOGLE_KEY', value: 'AIza-test', platform: 'google' },
+      { key: 'GROQ_KEY', value: 'gsk-test', platform: 'groq' },
     ]);
   });
 
   it('parses CSV format without header', () => {
     const csv = 'google,AIza-test,Google Key\n';
     expect(parseCsv(csv)).toEqual([
-      { key: 'GOOGLE_KEY', value: 'AIza-test' },
+      { key: 'GOOGLE_KEY', value: 'AIza-test', platform: 'google' },
+    ]);
+  });
+
+  it('parses CSV format with custom base_url column (#687)', () => {
+    const csv = 'platform,key,label,base_url\n"custom","sk-test","My Ollama","http://localhost:11434/v1"\n';
+    expect(parseCsv(csv)).toEqual([
+      { key: 'My Ollama', value: 'sk-test', platform: 'custom', baseUrl: 'http://localhost:11434/v1' },
+    ]);
+  });
+
+  it('parses keyless custom CSV row (#687)', () => {
+    const csv = 'platform,key,label,base_url\n"custom","","Local LM Studio","http://192.168.1.10:1234/v1"\n';
+    expect(parseCsv(csv)).toEqual([
+      { key: 'Local LM Studio', value: 'no-key', platform: 'custom', baseUrl: 'http://192.168.1.10:1234/v1' },
     ]);
   });
 

--- a/server/src/__tests__/routes/keys-export-custom.test.ts
+++ b/server/src/__tests__/routes/keys-export-custom.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { mintDashboardToken } from '../helpers/auth.js';
+
+// #687: Export of keys did not contain custom keys. Custom endpoints are
+// stored as their own api_keys rows with platform='custom' and a per-endpoint
+// base_url; the previous filter silently dropped every custom endpoint because
+// their key row is often the 'no-key' sentinel. These tests cover the full
+// round-trip — export (json/env/csv) of a custom endpoint, then re-import of
+// that export restores the endpoint row.
+
+let dashToken = '';
+let app: Express;
+
+async function request(
+  app: Express,
+  method: string,
+  path: string,
+  opts: { body?: unknown; form?: { field: string; content: string; filename: string }[]; headers?: Record<string, string> } = {},
+) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${dashToken}`,
+    ...(opts.headers ?? {}),
+  };
+  let body: BodyInit | undefined;
+  if (opts.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(opts.body);
+  } else if (opts.form) {
+    const boundary = '----vitestboundary' + Math.random().toString(16);
+    headers['Content-Type'] = `multipart/form-data; boundary=${boundary}`;
+    const parts: string[] = [];
+    for (const f of opts.form) {
+      parts.push(`--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${f.filename}"\r\nContent-Type: application/octet-stream\r\n\r\n${f.content}\r\n`);
+    }
+    parts.push(`--${boundary}--\r\n`);
+    body = parts.join('');
+  }
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, { method, headers, body });
+  const data = await res.text();
+  server.close();
+  return { status: res.status, text: data, json: () => JSON.parse(data) };
+}
+
+async function registerCustom(
+  baseUrl: string,
+  model: string,
+  apiKey?: string,
+  label?: string,
+) {
+  return request(app, 'POST', '/api/keys/custom', {
+    body: { baseUrl, model, apiKey, label },
+  });
+}
+
+async function exportFormat(format: 'json' | 'env' | 'csv') {
+  return request(app, 'GET', `/api/keys/export?format=${format}`, {
+    headers: { 'x-reauth-password': 'password123' },
+  });
+}
+
+async function importFile(content: string, filename: string) {
+  return request(app, 'POST', '/api/keys/import', {
+    form: [{ field: 'file', content, filename }],
+  });
+}
+
+describe('Keys export/import — custom endpoints (#687)', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM api_keys').run();
+  });
+
+  it('exports a custom endpoint in json format with baseUrl', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+
+    const { status, text } = await exportFormat('json');
+    expect(status).toBe(200);
+    const json = JSON.parse(text);
+    expect(json.keys).toHaveLength(1);
+    expect(json.keys[0].platform).toBe('custom');
+    expect(json.keys[0].baseUrl).toBe('http://localhost:11434/v1');
+    expect(json.keys[0].key).toBe('sk-test-1');
+  });
+
+  it('exports a keyless custom endpoint (no-key sentinel) in json', async () => {
+    // LM Studio with auth off registers without an apiKey.
+    await registerCustom('http://192.168.1.10:1234/v1', 'local-model', undefined, 'Local LM Studio');
+
+    const { status, text } = await exportFormat('json');
+    expect(status).toBe(200);
+    const json = JSON.parse(text);
+    expect(json.keys).toHaveLength(1);
+    expect(json.keys[0].platform).toBe('custom');
+    expect(json.keys[0].baseUrl).toBe('http://192.168.1.10:1234/v1');
+  });
+
+  it('exports custom endpoints in csv format with base_url column', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+
+    const { status, text } = await exportFormat('csv');
+    expect(status).toBe(200);
+    const lines = text.trim().split('\n');
+    expect(lines[0]).toBe('platform,key,label,base_url');
+    // The custom row carries the base_url in the 4th column.
+    expect(lines[1]).toContain('http://localhost:11434/v1');
+    expect(lines[1]).toContain('custom');
+  });
+
+  it('exports custom endpoints in env format with CUSTOM_BASE_URL/CUSTOM_KEY', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+
+    const { status, text } = await exportFormat('env');
+    expect(status).toBe(200);
+    expect(text).toContain('CUSTOM_BASE_URL=http://localhost:11434/v1');
+    expect(text).toContain('CUSTOM_KEY=sk-test-1');
+  });
+
+  it('round-trips a custom endpoint through json export and re-import', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+    // Capture the export BEFORE wiping, so it carries the registered endpoint.
+    const { text: exportText } = await exportFormat('json');
+    expect(exportText).toContain('http://localhost:11434/v1');
+    getDb().prepare('DELETE FROM api_keys').run(); // wipe — simulate fresh install
+
+    // Re-import the export
+    const importRes = await importFile(exportText, 'freellmapi-keys.json');
+    expect(importRes.status).toBe(200);
+    const importBody = importRes.json();
+    expect(importBody.imported).toBe(1);
+
+    // The endpoint row is restored with base_url and the credential.
+    const rows = getDb().prepare("SELECT platform, base_url, label FROM api_keys WHERE platform = 'custom'").all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].base_url).toBe('http://localhost:11434/v1');
+  });
+
+  it('round-trips a custom endpoint through csv export and re-import', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+    const { text: exportText } = await exportFormat('csv');
+    expect(exportText).toContain('http://localhost:11434/v1');
+    getDb().prepare('DELETE FROM api_keys').run();
+
+    const importRes = await importFile(exportText, 'freellmapi-keys.csv');
+    expect(importRes.status).toBe(200);
+    const importBody = importRes.json();
+    expect(importBody.imported).toBe(1);
+
+    const rows = getDb().prepare("SELECT base_url FROM api_keys WHERE platform = 'custom'").all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].base_url).toBe('http://localhost:11434/v1');
+  });
+
+  it('round-trips a custom endpoint through env export and re-import', async () => {
+    await registerCustom('http://localhost:11434/v1', 'llama3:8b', 'sk-test-1', 'My Ollama');
+    const { text: exportText } = await exportFormat('env');
+    expect(exportText).toContain('CUSTOM_BASE_URL=http://localhost:11434/v1');
+    getDb().prepare('DELETE FROM api_keys').run();
+
+    const importRes = await importFile(exportText, 'freellmapi-keys.env');
+    expect(importRes.status).toBe(200);
+    const importBody = importRes.json();
+    expect(importBody.imported).toBe(1);
+
+    const rows = getDb().prepare("SELECT base_url FROM api_keys WHERE platform = 'custom'").all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].base_url).toBe('http://localhost:11434/v1');
+  });
+});

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -2,6 +2,11 @@ export interface ParsedKey {
   rawKey: string;
   prefix: string;
   platform: string | null;
+  /**
+   * Present for custom-provider entries that carry their endpoint URL. The
+   * import path uses it to rebuild the custom endpoint (#687).
+   */
+  baseUrl?: string;
 }
 
 export interface ParseResult {
@@ -79,12 +84,15 @@ export function detectPlatform(prefix: string): string | null {
   return PREFIX_MAP[prefix] ?? null;
 }
 
-export function parseDotEnv(content: string): Array<{ key: string; value: string }> {
+export function parseDotEnv(content: string): Array<{ key: string; value: string; platform?: string; baseUrl?: string }> {
   let text = content;
   if (text.charCodeAt(0) === 0xfeff) text = text.slice(1);
   text = text.replace(/\r\n/g, '\n');
 
-  const result = new Map<string, string>();
+  // First pass: collect raw key=value pairs (preserving order) so a later
+  // CUSTOM_KEY can be matched back to the CUSTOM_BASE_URL it belongs with.
+  const raw = new Map<string, string>();
+  const order: string[] = [];
   for (let line of text.split('\n')) {
     line = line.trim();
     if (!line || line.startsWith('#')) continue;
@@ -109,10 +117,38 @@ export function parseDotEnv(content: string): Array<{ key: string; value: string
       value = value.trimEnd();
     }
 
-    result.set(key, value);
+    if (!raw.has(key)) order.push(key);
+    raw.set(key, value);
   }
 
-  return Array.from(result.entries()).map(([key, value]) => ({ key, value }));
+  const result: Array<{ key: string; value: string; platform?: string; baseUrl?: string }> = [];
+  const consumedBaseUrls = new Set<string>();
+
+  // Second pass: emit catalog keys verbatim, and pair CUSTOM_BASE_URL with the
+  // CUSTOM_KEY that follows it (the export writes them as a single block).
+  for (const key of order) {
+    const value = raw.get(key)!;
+
+    if (key === 'CUSTOM_BASE_URL') {
+      const baseUrl = value.trim();
+      if (!baseUrl) continue;
+      // Find the matching CUSTOM_KEY (only one per export block by design).
+      const customKey = raw.get('CUSTOM_KEY');
+      const keyValue = (customKey ?? '').trim() || 'no-key';
+      result.push({ key: 'CUSTOM', value: keyValue, platform: 'custom', baseUrl });
+      consumedBaseUrls.add(baseUrl);
+      continue;
+    }
+
+    if (key === 'CUSTOM_KEY') {
+      // Already consumed by the CUSTOM_BASE_URL entry above.
+      continue;
+    }
+
+    result.push({ key, value });
+  }
+
+  return result;
 }
 
 export function stripJsoncComments(text: string): string {
@@ -252,6 +288,28 @@ export function parseExportJson(content: string): ParseResult | null {
       const platform = typeof row.platform === 'string' ? row.platform : null;
       const keyValue = typeof row.key === 'string' ? row.key : '';
       const label = typeof row.label === 'string' ? row.label : platform ?? 'imported';
+      // Custom endpoints (#687) round-trip their base_url; a keyless custom
+      // endpoint is still importable as long as base_url is present.
+      const baseUrl = typeof row.baseUrl === 'string' && row.baseUrl.trim()
+        ? row.baseUrl.trim()
+        : undefined;
+
+      if (platform === 'custom') {
+        if (!baseUrl) {
+          result.skipped.push(`${label}: custom entry missing baseUrl`);
+          continue;
+        }
+        // A keyless endpoint stores the 'no-key' sentinel on export; keep the
+        // raw value (which may be '') so the import path can distinguish.
+        const rawValue = keyValue.trim() || 'no-key';
+        result.keys.push({
+          rawKey: `${label}=${rawValue}`,
+          prefix: 'CUSTOM_',
+          platform: 'custom',
+          baseUrl,
+        });
+        continue;
+      }
 
       if (!keyValue.trim()) {
         result.skipped.push(`${label}: empty key value`);
@@ -270,13 +328,13 @@ export function parseExportJson(content: string): ParseResult | null {
 }
 
 /**
- * Parse CSV format: platform,key,label (with optional header row).
+ * Parse CSV format: platform,key,label(,base_url)? (with optional header row).
  */
-export function parseCsv(content: string): Array<{ key: string; value: string }> {
+export function parseCsv(content: string): Array<{ key: string; value: string; platform?: string; baseUrl?: string }> {
   const lines = content.split('\n').filter(l => l.trim());
   if (lines.length === 0) return [];
 
-  const result: Array<{ key: string; value: string }> = [];
+  const result: Array<{ key: string; value: string; platform?: string; baseUrl?: string }> = [];
 
   // Skip header row if it looks like a CSV header
   const startIdx = lines[0]!.toLowerCase().startsWith('platform,') ? 1 : 0;
@@ -284,17 +342,26 @@ export function parseCsv(content: string): Array<{ key: string; value: string }>
   for (let i = startIdx; i < lines.length; i++) {
     const line = lines[i]!;
     // Simple CSV parsing: split on comma, strip quotes
-    const match = line.match(/^"?([^"]*?)"?,"?([^"]*?)"?(?:,"?([^"]*?)"?)?$/);
+    const match = line.match(/^"?([^"]*?)"?,"?([^"]*?)"?(?:,"?([^"]*?)"?)?(?:,"?([^"]*?)"?)?$/);
     if (!match) continue;
 
     const platform = (match[1] ?? '').trim();
     const key = (match[2] ?? '').trim();
     const label = (match[3] ?? '').trim() || platform;
+    const baseUrl = (match[4] ?? '').trim() || undefined;
 
-    if (!key || !platform) continue;
+    if (!platform) continue;
+    // Custom rows are valid with an empty key (keyless endpoint) as long as
+    // they carry a base_url; everything else still needs a non-empty key.
+    if (platform === 'custom') {
+      if (!baseUrl) continue;
+      result.push({ key: label, value: key || 'no-key', platform, baseUrl });
+      continue;
+    }
+    if (!key) continue;
 
     const envKey = `${platform.toUpperCase()}_KEY`;
-    result.push({ key: envKey, value: key });
+    result.push({ key: envKey, value: key, platform });
   }
 
   return result;
@@ -382,11 +449,28 @@ export function looksLikeApiKey(value: string): boolean {
   return /[a-z]/i.test(value);
 }
 
-function toParsedKeys(pairs: Array<{ key: string; value: string }>): ParseResult {
+function toParsedKeys(pairs: Array<{ key: string; value: string; platform?: string; baseUrl?: string }>): ParseResult {
   const keys: ParsedKey[] = [];
   const skipped: string[] = [];
 
-  for (const { key, value } of pairs) {
+  for (const { key, value, platform: explicitPlatform, baseUrl } of pairs) {
+    // Custom entries come from parseCsv with their baseUrl already attached
+    // and platform='custom' set explicitly. toParsedKeys otherwise infers
+    // platform from the env-var prefix, which doesn't exist for custom rows.
+    if (explicitPlatform === 'custom') {
+      if (!baseUrl) {
+        skipped.push(`${key}: custom entry missing baseUrl`);
+        continue;
+      }
+      keys.push({
+        rawKey: `${key}=${value || 'no-key'}`,
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl,
+      });
+      continue;
+    }
+
     const prefix = extractPrefix(key);
     const platform = detectPlatform(prefix);
 

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -328,7 +328,12 @@ keysRouter.get('/export', (req: Request, res: Response) => {
 
   const rows = db.prepare(`SELECT * FROM api_keys ${whereClause} ORDER BY platform, created_at ASC`).all() as any[];
 
-  // Decrypt and filter — only export keys with a real value
+  // Decrypt every row. Custom providers (#117/#212/#619/#640) are stored as
+  // their own api_keys rows with platform='custom' and a per-endpoint base_url;
+  // a keyless custom endpoint (local Ollama / LM Studio) stores the 'no-key'
+  // sentinel just like a keyless catalog provider, so the filter below keeps
+  // any custom row that has a base_url — otherwise the export silently drops
+  // every custom endpoint and the "Will export N keys" counter lies (#687).
   const decryptedKeys = rows
     .map(row => {
       let key = '';
@@ -337,15 +342,19 @@ keysRouter.get('/export', (req: Request, res: Response) => {
       } catch {
         key = '';
       }
+      const isCustom = row.platform === 'custom';
       return {
         platform: row.platform,
         key,
         label: row.label || '',
-        baseUrl: row.base_url || undefined,
+        baseUrl: isCustom ? (row.base_url || undefined) : undefined,
       };
     })
     .filter(k => {
       const v = k.key.trim();
+      // A custom endpoint is exportable as long as it has a base_url, even
+      // when the upstream is keyless (key === 'no-key' or empty).
+      if (k.platform === 'custom') return !!k.baseUrl;
       return v.length > 0 && v !== 'no-key';
     });
 
@@ -356,9 +365,19 @@ keysRouter.get('/export', (req: Request, res: Response) => {
 
   if (format === 'env') {
     // .env format: GOOGLE_KEY=xxx\nGROQ_KEY=yyy
+    // Custom endpoints also emit CUSTOM_BASE_URL so the pair round-trips
+    // through re-import; a keyless endpoint omits the *_KEY line.
     const lines = decryptedKeys.map(k => {
-      const envKey = `${k.platform.toUpperCase()}_KEY=${k.key}`;
-      return k.label ? `# ${k.label}\n${envKey}` : envKey;
+      const parts: string[] = [];
+      if (k.label) parts.push(`# ${k.label}`);
+      if (k.platform === 'custom') {
+        if (k.baseUrl) parts.push(`CUSTOM_BASE_URL=${k.baseUrl}`);
+        const v = k.key.trim();
+        if (v && v !== 'no-key') parts.push(`CUSTOM_KEY=${v}`);
+      } else {
+        parts.push(`${k.platform.toUpperCase()}_KEY=${k.key}`);
+      }
+      return parts.join('\n');
     });
     const content = lines.join('\n\n') + '\n';
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
@@ -368,7 +387,7 @@ keysRouter.get('/export', (req: Request, res: Response) => {
   }
 
   if (format === 'csv') {
-    // CSV format: platform,key,label
+    // CSV format: platform,key,label,base_url
     const escCsv = (v: string) => `"${v.replace(/"/g, '""')}"`;
     // CSV formula-injection guard: a spreadsheet treats a cell that starts with
     // =, +, -, @, tab or CR as a live formula, so a label like `=HYPERLINK(...)`
@@ -377,9 +396,14 @@ keysRouter.get('/export', (req: Request, res: Response) => {
     // (labels); the key value must round-trip verbatim for re-import, and the
     // platform is one of our own fixed enum values.
     const neutralize = (v: string) => (/^[=+\-@\t\r]/.test(v) ? `'${v}` : v);
-    const header = 'platform,key,label';
+    const header = 'platform,key,label,base_url';
     const lines = decryptedKeys.map(k =>
-      [escCsv(k.platform), escCsv(k.key), escCsv(neutralize(k.label))].join(',')
+      [
+        escCsv(k.platform),
+        escCsv(k.key),
+        escCsv(neutralize(k.label)),
+        escCsv(k.baseUrl ?? ''),
+      ].join(',')
     );
     const content = [header, ...lines].join('\n') + '\n';
     res.setHeader('Content-Type', 'text/csv; charset=utf-8');
@@ -388,12 +412,22 @@ keysRouter.get('/export', (req: Request, res: Response) => {
     return;
   }
 
-  // Default: JSON format (round-trip safe — can be imported directly)
+  // Default: JSON format (round-trip safe — can be imported directly).
+  // Omit baseUrl for non-custom rows so the export stays compact; custom
+  // rows always carry it so re-import can rebuild the endpoint.
   const jsonExport = {
     version: 1,
     exportedAt: new Date().toISOString(),
     source: 'freellmapi',
-    keys: decryptedKeys,
+    keys: decryptedKeys.map(k => {
+      const entry: Record<string, string> = {
+        platform: k.platform,
+        key: k.key,
+        label: k.label,
+      };
+      if (k.platform === 'custom' && k.baseUrl) entry.baseUrl = k.baseUrl;
+      return entry;
+    }),
   };
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
   res.setHeader('Content-Disposition', 'attachment; filename="freellmapi-keys.json"');
@@ -827,10 +861,39 @@ keysRouter.post('/import', (req: Request, res: Response, next: NextFunction) => 
           continue;
         }
         const platformParse = z.enum(PLATFORMS).safeParse(parsedKey.platform);
-        if (!platformParse.success || platformParse.data === 'custom') {
+        if (!platformParse.success) {
           skipped.push(keyName);
           continue;
         }
+
+        // Custom endpoints (#687) round-trip through baseUrl; they can't use
+        // insertImportedKey (which rejects 'custom') because their key row
+        // needs base_url too. Register the credential via the same resolver
+        // POST /custom uses, minus model binding — the user can run discovery
+        // afterwards to repopulate the model list.
+        if (platformParse.data === 'custom') {
+          const baseUrl = parsedKey.baseUrl;
+          if (!baseUrl) {
+            skipped.push(`${keyName}: custom entry missing baseUrl`);
+            continue;
+          }
+          try {
+            const db = getDb();
+            const trimmedKey = keyValue.trim();
+            const resolved = resolveCustomEndpointKey(
+              db,
+              baseUrl,
+              trimmedKey && trimmedKey !== 'no-key' ? trimmedKey : undefined,
+              keyName || undefined,
+            );
+            imported.push({ keyName: keyName || baseUrl, platform: 'custom' });
+            void resolved;
+          } catch (importErr) {
+            errors.push({ key: keyName, error: (importErr as Error).message });
+          }
+          continue;
+        }
+
         if (!keyValue.trim()) {
           errors.push({ key: keyName, error: 'keyValue must be at least 1 character' });
           continue;


### PR DESCRIPTION
## 修复 #687

导出 (json/env/csv) 此前会过滤掉所有 `platform='custom'` 的 api_keys 行——keyless 的本地端点（Ollama / LM Studio）存储 `'no-key'` sentinel 被判为空，导致 issue 中描述的「Will export N keys」计数虚高、再导入时整条端点丢失。

## 修复全链路

**导出端** (`server/src/routes/keys.ts`)
- custom 行只要有 `base_url` 就保留，不再被 `'no-key'` 过滤
- JSON 格式带 `baseUrl` 字段
- CSV 格式新增 `base_url` 列（header: `platform,key,label,base_url`）
- ENV 格式输出 `CUSTOM_BASE_URL=...` + `CUSTOM_KEY=...`（keyless 端点省略 `CUSTOM_KEY`）

**导入端** (`server/src/lib/key-parser.ts`)
- `ParsedKey` 接口新增 `baseUrl?: string` 字段
- `parseExportJson`：识别 custom 项的 `baseUrl`，允许 keyless 的 custom 通过
- `parseCsv`：读取第 4 列 `base_url`，custom 行即使 key 为空也保留
- `parseDotEnv`：配对 `CUSTOM_BASE_URL` + `CUSTOM_KEY` 为单个 custom 项
- `toParsedKeys`：透传 custom 项的 `baseUrl`

**导入路由** (`server/src/routes/keys.ts`)
- `/api/keys/import` 此前对 `platform === 'custom'` 直接 `skipped`，现改走 `resolveCustomEndpointKey`（与 `POST /custom` 同一通路）注册端点，不绑定 model——用户可在导入后跑 discovery 重建 model list

## 测试

- 更新 `parseCsv` 现有用例以匹配新增的 `platform` 字段
- 新增 `server/src/__tests__/routes/keys-export-custom.test.ts` 覆盖：
  - custom 端点在 json / csv / env 三种格式的导出
  - keyless custom 端点的导出
  - 三种格式的 round-trip：导出 → 清表 → 重导入 → 验证 `base_url` 还原

## 兼容性

- CSV 导出新增了第 4 列 `base_url`。旧的 3 列 CSV（无 header 或 `platform,key,label` header）仍能被 `parseCsv` 正常导入——第 4 列是 optional 的（regex 用了 `(?:,"?([^"]*?)"?)?`）
- JSON 导出的非 custom 项不含 `baseUrl` 字段，保持紧凑；custom 项才带 `baseUrl`

## CONTRIBUTING.md 合规

- ✅ 包含测试，全套 `npm test`（server）通过（除已知的 flaky `compression` 时间断言，与本 PR 无关）
- ✅ 保持范围小，只动 export/import 链路
- ✅ 未触碰已应用的 migration 文件
- ✅ 未引入付费/card-gated 服务

Closes #687