### PR TITLE
docs(i18n): give the zh README a 贡献者 heading so the sections match

### DIFF
--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -58,8 +58,9 @@ that someone will trust and act on.
   `repo-assets/x.png` becomes `../../../repo-assets/x.png` and `docs/api.md`
   becomes `../../api.md`. Broken image links are the most common mistake here.
 - **Do not copy the contributor avatar list.** It changes with nearly every merge
-  and nobody wants to update it in six languages. Link to the English README
-  instead.
+  and nobody wants to update it in six languages. Keep the heading so the
+  section structure still matches one-to-one, and link out to the English
+  README from under it.
 - **Keep the numbers in sync or leave them out.** Provider counts and token
   totals move. If you are not going to update them, write around them.
 - **Match the dashboard.** If a term appears in the UI, use whatever the locale's

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -311,7 +311,9 @@ print("Routed via:", resp.headers.get("x-routed-via"))
 
 `npm install && npm run dev` 就能起来：服务在 :3001，仪表盘在 :5173，两边都有热更新。PR 应当包含测试、保持现有测试套件通过（`npm test`），并遵循仓库里已有的 `.editorconfig` 和 tsconfig 默认配置。数据库迁移流程和完整的贡献者循环见 [CONTRIBUTING.md](../../../CONTRIBUTING.md)。
 
-贡献者名单在 [英文 README](../../../README.md#contributors)。
+### 贡献者
+
+约 90 位贡献者的头像墙维护在[英文 README](../../../README.md#contributors) 里。它几乎每次合并都会变动，所以只保留一份，不在各语言版本中重复。
 
 ## 免责声明
 


### PR DESCRIPTION
The zh README linked out to the English contributor list from a bare line inside 参与贡献, so it had **22 sections against the English 23** — the one place the two files did not map one to one.

It now carries the same `###` heading, with the link and a short note under it.

The avatar wall itself still lives in one file only. Duplicating ~90 entries that change on nearly every merge across six languages is the thing worth avoiding; the heading is not. The rule in `docs/i18n/README.md` is updated to say exactly that, so the next translator keeps the heading.

Verified: 23 sections each, 125 relative paths and 52 anchors resolve.