### PR TITLE
docs: credit @suantea in the contributors list (#699, #694)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Contributors very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev lo
 <a href="https://github.com/yfdyh000"><img src="https://images.weserv.nl/?url=github.com/yfdyh000.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@yfdyh000" /></a>
 <a href="https://github.com/s-uryansh"><img src="https://images.weserv.nl/?url=github.com/s-uryansh.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@s-uryansh" /></a>
 <a href="https://github.com/arsalanyavari"><img src="https://images.weserv.nl/?url=github.com/arsalanyavari.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@arsalanyavari" /></a>
+<a href="https://github.com/suantea"><img src="https://images.weserv.nl/?url=github.com/suantea.png&w=60&h=60&fit=cover&mask=circle" width="60" alt="@suantea" /></a>
 
 ## Disclaimer
 


### PR DESCRIPTION
Adds @suantea to the contributors avatar list for #699 (conditional `upgrade-insecure-requests`, fixing the blank dashboard on plain-HTTP LAN installs) and #694 (retry-budget message wording).