### PR TITLE
fix(models): disable Cloudflare Kimi models that left the free tier

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -23,6 +23,7 @@ const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility.ts';
 const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
 const CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME = '20260729_000001_custom_model_endpoint_identity.ts';
 const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endpoint_host_labels.ts';
+const DISABLE_PAID_CLOUDFLARE_KIMI_FILENAME = '20260803_000001_disable_paid_cloudflare_kimi.ts';
 
 interface SchemaRow {
   type: string;
@@ -92,6 +93,7 @@ describe('migration round trip', () => {
         TOMBSTONE_PROVENANCE_FILENAME,
         CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME,
         CUSTOM_ENDPOINT_HOST_LABELS_FILENAME,
+        DISABLE_PAID_CLOUDFLARE_KIMI_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -18,6 +18,7 @@ import * as agentCompatibility from '../migrations/20260727_000001_agent_compati
 import * as tombstoneProvenance from '../migrations/20260728_000001_tombstone_provenance.js';
 import * as customModelEndpointIdentity from '../migrations/20260729_000001_custom_model_endpoint_identity.js';
 import * as customEndpointHostLabels from '../migrations/20260802_000001_custom_endpoint_host_labels.js';
+import * as disablePaidCloudflareKimi from '../migrations/20260803_000001_disable_paid_cloudflare_kimi.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -48,6 +49,7 @@ export const AGENT_COMPATIBILITY_FILENAME = '20260727_000001_agent_compatibility
 export const TOMBSTONE_PROVENANCE_FILENAME = '20260728_000001_tombstone_provenance.ts';
 export const CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME = '20260729_000001_custom_model_endpoint_identity.ts';
 export const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endpoint_host_labels.ts';
+export const DISABLE_PAID_CLOUDFLARE_KIMI_FILENAME = '20260803_000001_disable_paid_cloudflare_kimi.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -69,4 +71,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: TOMBSTONE_PROVENANCE_FILENAME, module: tombstoneProvenance },
   { filename: CUSTOM_MODEL_ENDPOINT_IDENTITY_FILENAME, module: customModelEndpointIdentity },
   { filename: CUSTOM_ENDPOINT_HOST_LABELS_FILENAME, module: customEndpointHostLabels },
+  { filename: DISABLE_PAID_CLOUDFLARE_KIMI_FILENAME, module: disablePaidCloudflareKimi },
 ];

--- a/server/src/db/migrations/20260803_000001_disable_paid_cloudflare_kimi.ts
+++ b/server/src/db/migrations/20260803_000001_disable_paid_cloudflare_kimi.ts
@@ -1,0 +1,29 @@
+// Migration: disable Cloudflare Kimi models that moved off the free tier
+// Created: 2026-08-03
+//
+// Cloudflare Workers AI moved @cf/moonshotai/kimi-k2.6 and
+// @cf/moonshotai/kimi-k2.7-code onto the Workers Paid plan, so every free-tier
+// request now returns 403 and burns a fallback slot (issue #713). The monthly
+// catalog snapshot still lists them enabled, so the bundled baseline disables
+// them here — catalog-sync's rule is "local disable wins" (enabled = catalog
+// enabled ? local : 0), so a stale catalog cannot re-enable these rows.
+//
+// DOWN: reversible — re-enables the two rows. The user can also flip them back
+// on from the dashboard at any time.
+
+import type { Db } from '../types.js';
+
+const PAID_CLOUDFLARE_KIMI: ReadonlyArray<[string, string]> = [
+  ['cloudflare', '@cf/moonshotai/kimi-k2.6'],
+  ['cloudflare', '@cf/moonshotai/kimi-k2.7-code'],
+];
+
+export function up(db: Db): void {
+  const disable = db.prepare(`UPDATE models SET enabled = 0 WHERE platform = ? AND model_id = ?`);
+  for (const [platform, modelId] of PAID_CLOUDFLARE_KIMI) disable.run(platform, modelId);
+}
+
+export function down(db: Db): void {
+  const enable = db.prepare(`UPDATE models SET enabled = 1 WHERE platform = ? AND model_id = ?`);
+  for (const [platform, modelId] of PAID_CLOUDFLARE_KIMI) enable.run(platform, modelId);
+}


### PR DESCRIPTION
## What

Cloudflare moved `@cf/moonshotai/kimi-k2.6` and `@cf/moonshotai/kimi-k2.7-code` onto the **Workers Paid plan**, but the monthly catalog snapshot still lists them enabled. Every free-tier request now returns 403 (`error code 5035`) and burns a fallback slot.

## Fix

New bundled migration `20260803_000001_disable_paid_cloudflare_kimi.ts` sets both rows `enabled = 0`:

- catalog-sync's rule is **local disable wins** (`enabled = catalog_enabled ? local_enabled : 0`), so a stale catalog that still lists them enabled cannot re-enable these rows;
- rows are kept (not deleted), so an operator can still flip them back on if Cloudflare ever restores the free tier;
- `down()` re-enables both, and the migration is idempotent like the rest of the suite.

## Files

- `server/src/db/migrations/20260803_000001_disable_paid_cloudflare_kimi.ts` — new migration
- `server/src/db/migrate/defaults.ts` — register the migration
- `server/src/__tests__/db/migrate/roundtrip.test.ts` — expected migration list

## Verification

`vitest` roundtrip + idempotency suites pass (14 tests).

Closes #713