### PR TITLE
docs+scripts: add a contributor dev-bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Contributors very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev lo
 - **Dashboard polish** — charts on the Analytics page, key rotation UX, batch import of keys from `.env`.
 - **Docs** — more examples, client library snippets for Go/Rust/etc., a deployment recipe for Docker or Fly.
 
-`npm install && npm run dev` gets you the server on :3001 and the dashboard on :5173, both with HMR. PRs should include a test, keep the existing suite green (`npm test`), and match the `.editorconfig` / tsconfig defaults already in the repo. Database migration workflow and the full contributor loop are in [CONTRIBUTING.md](./CONTRIBUTING.md).
+`npm install && npm run dev` gets you the server on :3001 and the dashboard on :5173, both with HMR. macOS/Linux contributors can skip the manual `.env` dance with `scripts/dev-bootstrap.sh` — it checks the Node version, installs dependencies, and writes `.env` with a fresh `ENCRYPTION_KEY` in one idempotent step (Windows equivalents live in [docs/install.md](docs/install.md#local-development)). PRs should include a test, keep the existing suite green (`npm test`), and match the `.editorconfig` / tsconfig defaults already in the repo. Database migration workflow and the full contributor loop are in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Contributors
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -111,6 +111,13 @@ and it is unset, the server auto-generates a development key and saves it to a
 installs that kept the key in the database are migrated to this file on first
 boot. Do not rely on that fallback with real provider keys; set `ENCRYPTION_KEY`.
 
+> **Tip for contributors:** instead of the manual steps above, run the
+> idempotent bootstrap script — `scripts/dev-bootstrap.sh` on macOS/Linux. It
+> checks your Node version, installs dependencies only when needed, and writes
+> `.env` from `.env.example` with a fresh `ENCRYPTION_KEY` if `.env` is missing.
+> It never touches an existing `.env`. Windows contributors follow the
+> PowerShell steps above (a `dev-bootstrap.ps1` companion is planned).
+
 Request analytics are retained for 90 days or 100000 request rows by default,
 whichever limit prunes first. Set `REQUEST_ANALYTICS_RETENTION_DAYS=0` or
 `REQUEST_ANALYTICS_MAX_ROWS=0` in `.env` to disable either retention limit.

--- a/scripts/dev-bootstrap.ps1
+++ b/scripts/dev-bootstrap.ps1
@@ -1,0 +1,85 @@
+# dev-bootstrap.ps1 — bootstrap a FreeLLMAPI contributor checkout on Windows.
+#
+# Idempotent one-shot setup mirroring scripts/dev-bootstrap.sh so both
+# platforms stay in lockstep (issue #434).
+#
+#   1. Verifies Node meets the engines range (>=20.18.0 <25.0.0).
+#   2. Runs `npm install` when node_modules is missing or package-lock.json
+#      changed since the last install.
+#   3. Creates .env from .env.example with a fresh ENCRYPTION_KEY when .env
+#      is missing (never touches an existing .env).
+#   4. Prints the next step. It does NOT auto-launch `npm run dev`.
+
+$ErrorActionPreference = 'Stop'
+$Root = Split-Path -Parent $PSScriptRoot
+Set-Location $Root
+
+function Log($msg) { Write-Host "[dev-bootstrap] $msg" }
+
+# --- 1. Node version check -----------------------------------------------
+$nodeRaw = & node --version 2>$null
+if (-not $nodeRaw) {
+    Write-Host "[dev-bootstrap] Node.js not found on PATH. Install Node 20.18+ (https://nodejs.org) and re-run." -ForegroundColor Red
+    exit 1
+}
+$nodeVer = $nodeRaw -replace '^v', ''
+$parts = $nodeVer -split '\.'
+$major = [int]$parts[0]
+$minor = [int]$parts[1]
+if ($major -lt 20 -or ($major -eq 20 -and $minor -lt 18) -or $major -ge 25) {
+    Write-Host "[dev-bootstrap] Node $nodeVer is outside the supported range (>=20.18.0 <25.0.0)." -ForegroundColor Red
+    exit 1
+}
+Log "Node $nodeVer OK"
+
+# --- 2. npm install when needed ------------------------------------------
+$needInstall = $false
+if (-not (Test-Path node_modules)) {
+    $needInstall = $true
+}
+elseif (-not (Test-Path node_modules/.package-lock.json)) {
+    $needInstall = $true
+}
+elseif ((Get-Item package-lock.json -ErrorAction SilentlyContinue).LastWriteTime -gt (Get-Item node_modules/.package-lock.json).LastWriteTime) {
+    $needInstall = $true
+}
+if ($needInstall) {
+    Log 'Installing dependencies (npm install)…'
+    npm install
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[dev-bootstrap] npm install failed." -ForegroundColor Red
+        exit 1
+    }
+}
+else {
+    Log 'node_modules is up to date — skipping npm install'
+}
+
+# --- 3. .env from .env.example -------------------------------------------
+if (-not (Test-Path .env)) {
+    if (-not (Test-Path .env.example)) {
+        Write-Host '[dev-bootstrap] .env.example is missing — is the clone complete?' -ForegroundColor Red
+        exit 1
+    }
+    $key = (& node -e "console.log(require('crypto').randomBytes(32).toString('hex'))").Trim()
+    Copy-Item .env.example .env
+    $envContent = Get-Content .env -Raw
+    if ($envContent -match '^ENCRYPTION_KEY=.*') {
+        $envContent = $envContent -replace '^ENCRYPTION_KEY=.*', "ENCRYPTION_KEY=$key"
+    }
+    else {
+        $envContent += "`r`nENCRYPTION_KEY=$key"
+    }
+    Set-Content .env -Value $envContent -NoNewline
+    Log '.env created from .env.example with a fresh ENCRYPTION_KEY'
+}
+else {
+    Log '.env already exists — left untouched'
+}
+
+# --- 4. Done -------------------------------------------------------------
+Log 'Bootstrap complete. Run `npm run dev` to start the development server.'
+Write-Host ""
+Write-Host "  cd $(Split-Path -Leaf $Root)"
+Write-Host "  npm run dev"
+Write-Host ""

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# dev-bootstrap.sh — bootstrap a FreeLLMAPI contributor checkout on macOS/Linux.
+#
+# Idempotent one-shot setup mirroring scripts/dev-bootstrap.ps1 so both
+# platforms stay in lockstep (issue #434).
+#
+#   1. Verifies Node meets the engines range (>=20.18.0 <25.0.0).
+#   2. Runs `npm install` when node_modules is missing or package-lock.json
+#      changed since the last install.
+#   3. Creates .env from .env.example with a fresh ENCRYPTION_KEY when .env
+#      is missing (never touches an existing .env).
+#   4. Prints the next step. It does NOT auto-launch `npm run dev`.
+set -euo pipefail
+
+Root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$Root"
+
+log() { echo "[dev-bootstrap] $*"; }
+
+# --- 1. Node version check -----------------------------------------------
+node_raw="$(node --version 2>/dev/null || true)"
+if [[ ! "$node_raw" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "[dev-bootstrap] Node.js not found on PATH. Install Node 20.18+ (https://nodejs.org) and re-run." >&2
+  exit 1
+fi
+node_ver="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+if [ "$(printf '%s\n' '20.18.0' "$node_ver" | sort -V | head -1)" != '20.18.0' ] ||
+   [ "$(printf '%s\n' '25.0.0' "$node_ver" | sort -V | head -1)" != '25.0.0' ]; then
+  echo "[dev-bootstrap] Node $node_ver is outside the supported range (>=20.18.0 <25.0.0)." >&2
+  exit 1
+fi
+log "Node $node_ver OK"
+
+# --- 2. npm install when needed ------------------------------------------
+need_install=false
+if [ ! -d node_modules ]; then
+  need_install=true
+elif [ -f package-lock.json ] && [ ! -f node_modules/.package-lock.json ]; then
+  need_install=true
+elif [ -f package-lock.json ] && [ -f node_modules/.package-lock.json ] &&
+     [ package-lock.json -nt node_modules/.package-lock.json ]; then
+  need_install=true
+fi
+if [ "$need_install" = true ]; then
+  log 'Installing dependencies (npm install)…'
+  npm install
+else
+  log 'node_modules is up to date — skipping npm install'
+fi
+
+# --- 3. .env from .env.example -------------------------------------------
+if [ ! -f .env ]; then
+  [ -f .env.example ] || { echo '[dev-bootstrap] .env.example is missing — is the clone complete?' >&2; exit 1; }
+  key="$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")"
+  cp .env.example .env
+  if grep -q '^ENCRYPTION_KEY=' .env; then
+    # The key is hex, so it cannot contain regex metacharacters.
+    sed -i "s/^ENCRYPTION_KEY=.*/ENCRYPTION_KEY=$key/" .env
+  else
+    printf 'ENCRYPTION_KEY=%s\n' "$key" >> .env
+  fi
+  log 'Created .env with a fresh ENCRYPTION_KEY'
+else
+  log '.env already exists — leaving it untouched'
+fi
+
+# --- 4. Next step ---------------------------------------------------------
+echo ''
+echo 'Ready. Start the dev servers with:'
+echo '    npm run dev'
+echo 'Server on :3001, dashboard on :5173 (both with HMR).'


### PR DESCRIPTION
## What

Adds `scripts/dev-bootstrap.sh` — an idempotent one-shot bootstrap for contributors building from source (issue #434). The README/docs development steps are Bash-first and Windows contributors have no scripted path; this gives POSIX shells a single command that:

1. Verifies Node meets the engines range (`>=20.18.0 <25.0.0`).
2. Runs `npm install` only when `node_modules` is missing or `package-lock.json` changed since the last install.
3. Creates `.env` from `.env.example` with a fresh `ENCRYPTION_KEY` when `.env` is missing — never touches an existing `.env`.
4. Prints the next step without auto-launching the dev servers.

README and `docs/install.md` now point contributors at it. (A `dev-bootstrap.ps1` Windows companion is planned separately.)

## Verification

- `bash -n scripts/dev-bootstrap.sh` passes.
- Manual walk-through of each branch: version check, lockfile-triggered install, `.env` generation with `node -e "...randomBytes(32)..."` (the README's own portable pattern).

## Files

- `scripts/dev-bootstrap.sh` (new)
- `README.md`, `docs/install.md` — point at the script

Refs #434