### PR TITLE
feat(routing): add an exploration toggle for unmeasured models

### DIFF
--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "በዚህ ወር {count} ጥያቄዎች"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "የማዞሪያ ስትራቴጂ",
     "description": "የማዞሪያ ስልት ይምረጡ። በእጅ ሁነታ ትዕዛዙን ለማዘጋጀት ይጎትቱታል; ሌሎቹ ስልቶች በአስተማማኝነት፣ ፍጥነት እና ብልህነት ላይ በቀጥታ ውጤት ይጓዛሉ።",
     "weightsSummary": "አስተማማኝነት {reliability}% · ፍጥነት {speed}% · ብልህነት {intelligence}%",

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "በዚህ ወር {count} ጥያቄዎች"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "ያልተለኩ ሞዴሎችን ያስሱ",
+    "exploreHint": "የአስተማማኝነት/የፍጥነት ውሂብ የሌላቸው ሞዴሎች ናሙና እንዲሰበስቡ 10% የመሞከር እድል ይሰጣል።",
     "title": "የማዞሪያ ስትራቴጂ",
     "description": "የማዞሪያ ስልት ይምረጡ። በእጅ ሁነታ ትዕዛዙን ለማዘጋጀት ይጎትቱታል; ሌሎቹ ስልቶች በአስተማማኝነት፣ ፍጥነት እና ብልህነት ላይ በቀጥታ ውጤት ይጓዛሉ።",
     "weightsSummary": "አስተማማኝነት {reliability}% · ፍጥነት {speed}% · ብልህነት {intelligence}%",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} طلب هذا الشهر"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "استراتيجية التوجيه",
     "description": "اختر استراتيجية التوجيه. في الوضع اليدوي، يمكنك السحب لتعيين الترتيب؛ يتم توجيه الاستراتيجيات الأخرى من خلال النتيجة المباشرة عبر الموثوقية والسرعة والذكاء.",
     "weightsSummary": "الموثوقية {reliability}% · السرعة {speed}% · الذكاء {intelligence}%",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} طلب هذا الشهر"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "استكشاف النماذج غير المقيسة",
+    "exploreHint": "امنح النماذج التي لا تملك بيانات موثوقية/سرعة فرصة 10% للتجربة حتى تجمع عينات.",
     "title": "استراتيجية التوجيه",
     "description": "اختر استراتيجية التوجيه. في الوضع اليدوي، يمكنك السحب لتعيين الترتيب؛ يتم توجيه الاستراتيجيات الأخرى من خلال النتيجة المباشرة عبر الموثوقية والسرعة والذكاء.",
     "weightsSummary": "الموثوقية {reliability}% · السرعة {speed}% · الذكاء {intelligence}%",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "bu ay {count} sorğu"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Marşrut strategiyası",
     "description": "Bir marşrut strategiyası seçin. Əl rejimində isə ardıcıllığı təyin etmək üçün sürükləyirsən; Digər strategiyalar isə etibarlılıq, sürət və zəka üzrə canlı skora əsaslanır.",
     "weightsSummary": "etibarlılıq {reliability}% · sürət {speed}% · Zəka {intelligence}%",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "bu ay {count} sorğu"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Ölçülməmiş modelləri araşdır",
+    "exploreHint": "Etibarlılıq/sürət məlumatı olmayan modellərə nümunə toplamaları üçün 10% sınaq şansı verin.",
     "title": "Marşrut strategiyası",
     "description": "Bir marşrut strategiyası seçin. Əl rejimində isə ardıcıllığı təyin etmək üçün sürükləyirsən; Digər strategiyalar isə etibarlılıq, sürət və zəka üzrə canlı skora əsaslanır.",
     "weightsSummary": "etibarlılıq {reliability}% · sürət {speed}% · Zəka {intelligence}%",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} заявки този месец"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Изследване на неизмерени модели",
+    "exploreHint": "Дава на модели без данни за надеждност/скорост 10% шанс да бъдат изпробвани, за да натрупат извадки.",
     "title": "Стратегия за маршрутизиране",
     "description": "Изберете стратегия за маршрутизиране. В ръчен режим плъзгате, за да зададете реда; Останалите стратегии се насочват по реален резултат по надеждност, скорост и интелигентност.",
     "weightsSummary": "Надеждност {reliability}% · Скорост {speed}% · Интелигентност {intelligence}%",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} заявки този месец"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Стратегия за маршрутизиране",
     "description": "Изберете стратегия за маршрутизиране. В ръчен режим плъзгате, за да зададете реда; Останалите стратегии се насочват по реален резултат по надеждност, скорост и интелигентност.",
     "weightsSummary": "Надеждност {reliability}% · Скорост {speed}% · Интелигентност {intelligence}%",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "এই মাসে {count}টি অনুরোধ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "রাউটিং কৌশল",
     "description": "একটি রাউটিং কৌশল বেছে নিন। ম্যানুয়াল মোডে আপনি অর্ডার সেট করতে টেনে আনুন; নির্ভরযোগ্যতা, গতি এবং বুদ্ধিমত্তা জুড়ে লাইভ স্কোরের মাধ্যমে অন্যান্য কৌশলগুলি।",
     "weightsSummary": "নির্ভরযোগ্যতা {reliability}% · গতি {speed}% · বুদ্ধিমত্তা {intelligence}%",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "এই মাসে {count}টি অনুরোধ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "অপরিমাপিত মডেল অন্বেষণ করুন",
+    "exploreHint": "নির্ভরযোগ্যতা/গতির ডেটা নেই এমন মডেলগুলিকে নমুনা তৈরির জন্য 10% চেষ্টার সুযোগ দিন।",
     "title": "রাউটিং কৌশল",
     "description": "একটি রাউটিং কৌশল বেছে নিন। ম্যানুয়াল মোডে আপনি অর্ডার সেট করতে টেনে আনুন; নির্ভরযোগ্যতা, গতি এবং বুদ্ধিমত্তা জুড়ে লাইভ স্কোরের মাধ্যমে অন্যান্য কৌশলগুলি।",
     "weightsSummary": "নির্ভরযোগ্যতা {reliability}% · গতি {speed}% · বুদ্ধিমত্তা {intelligence}%",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} pož. tento měsíc"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Prozkoumávat nezměřené modely",
+    "exploreHint": "Dá modelům bez dat o spolehlivosti/rychlosti 10% šanci na vyzkoušení, aby nasbíraly vzorky.",
     "title": "Strategie směrování",
     "description": "Vyberte strategii směrování. V manuálním režimu přetahujete pro nastavení pořadí; Ostatní strategie se podle živého skóre zaměřují na spolehlivost, rychlost a inteligenci.",
     "weightsSummary": "spolehlivost {reliability} % · rychlost {speed} % · inteligence {intelligence} %",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} pož. tento měsíc"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategie směrování",
     "description": "Vyberte strategii směrování. V manuálním režimu přetahujete pro nastavení pořadí; Ostatní strategie se podle živého skóre zaměřují na spolehlivost, rychlost a inteligenci.",
     "weightsSummary": "spolehlivost {reliability} % · rychlost {speed} % · inteligence {intelligence} %",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} anmodn. denne måned"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Udforsk umålte modeller",
+    "exploreHint": "Giver modeller uden pålideligheds-/hastighedsdata en chance på 10 % for at blive prøvet, så de opbygger stikprøver.",
     "title": "Routingstrategi",
     "description": "Vælg en routing-strategi. I manuel tilstand trækker du for at sætte rækkefølgen; De andre strategier følger live score på tværs af pålidelighed, hastighed og intelligens.",
     "weightsSummary": "Pålidelighed {reliability}% · hastighed {speed}% · intelligens {intelligence}%",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} anmodn. denne måned"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routingstrategi",
     "description": "Vælg en routing-strategi. I manuel tilstand trækker du for at sætte rækkefølgen; De andre strategier følger live score på tværs af pålidelighed, hastighed og intelligens.",
     "weightsSummary": "Pålidelighed {reliability}% · hastighed {speed}% · intelligens {intelligence}%",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} Anfr. diesen Monat"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Unvermessene Modelle erkunden",
+    "exploreHint": "Gibt Modellen ohne Zuverlässigkeits-/Geschwindigkeitsdaten eine 10-%-Chance, ausprobiert zu werden, damit sie Stichproben aufbauen.",
     "title": "Routing-Strategie",
     "description": "Wählen Sie eine Routing-Strategie. Im manuellen Modus können Sie durch Ziehen die Reihenfolge festlegen. Die anderen Strategien orientieren sich am Live-Score hinsichtlich Zuverlässigkeit, Geschwindigkeit und Intelligenz.",
     "weightsSummary": "Zuverlässigkeit {reliability}% · Geschwindigkeit {speed}% · Intelligenz {intelligence}%",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} Anfr. diesen Monat"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routing-Strategie",
     "description": "Wählen Sie eine Routing-Strategie. Im manuellen Modus können Sie durch Ziehen die Reihenfolge festlegen. Die anderen Strategien orientieren sich am Live-Score hinsichtlich Zuverlässigkeit, Geschwindigkeit und Intelligenz.",
     "weightsSummary": "Zuverlässigkeit {reliability}% · Geschwindigkeit {speed}% · Intelligenz {intelligence}%",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} αιτήματα αυτόν τον μήνα"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Εξερεύνηση μη μετρημένων μοντέλων",
+    "exploreHint": "Δίνει στα μοντέλα χωρίς δεδομένα αξιοπιστίας/ταχύτητας 10% πιθανότητα να δοκιμαστούν ώστε να συγκεντρώσουν δείγματα.",
     "title": "Στρατηγική δρομολόγησης",
     "description": "Επιλέξτε μια στρατηγική δρομολόγησης. Στη χειροκίνητη λειτουργία σύρετε για να ορίσετε τη σειρά. Οι άλλες στρατηγικές δρομολογούνται με ζωντανό σκορ σε αξιοπιστία, ταχύτητα και ευφυΐα.",
     "weightsSummary": "αξιοπιστία {reliability}% · Ταχύτητα {speed}% · νοημοσύνη {intelligence}%",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} αιτήματα αυτόν τον μήνα"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Στρατηγική δρομολόγησης",
     "description": "Επιλέξτε μια στρατηγική δρομολόγησης. Στη χειροκίνητη λειτουργία σύρετε για να ορίσετε τη σειρά. Οι άλλες στρατηγικές δρομολογούνται με ζωντανό σκορ σε αξιοπιστία, ταχύτητα και ευφυΐα.",
     "weightsSummary": "αξιοπιστία {reliability}% · Ταχύτητα {speed}% · νοημοσύνη {intelligence}%",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} req this month"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routing strategy",
     "description": "Pick a routing strategy. In Manual mode you drag to set the order; the other strategies route by live score across reliability, speed and intelligence.",
     "weightsSummary": "reliability {reliability}% · speed {speed}% · intelligence {intelligence}%",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} sol. este mes"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Explorar modelos sin mediciones",
+    "exploreHint": "Da a los modelos sin datos de fiabilidad/velocidad un 10 % de probabilidad de ser probados para que acumulen muestras.",
     "title": "Estrategia de enrutamiento",
     "description": "Elige una estrategia de enrutamiento. En el modo manual, arrastra para definir el orden; las demás estrategias enrutan según una puntuación en vivo de fiabilidad, velocidad e inteligencia.",
     "weightsSummary": "fiabilidad {reliability}% · velocidad {speed}% · inteligencia {intelligence}%",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} sol. este mes"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Estrategia de enrutamiento",
     "description": "Elige una estrategia de enrutamiento. En el modo manual, arrastra para definir el orden; las demás estrategias enrutan según una puntuación en vivo de fiabilidad, velocidad e inteligencia.",
     "weightsSummary": "fiabilidad {reliability}% · velocidad {speed}% · inteligencia {intelligence}%",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} درخواست این ماه"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "کاوش مدل‌های اندازه‌گیری‌نشده",
+    "exploreHint": "به مدل‌هایی که داده قابلیت اطمینان/سرعت ندارند 10٪ شانس امتحان شدن بدهید تا نمونه جمع کنند.",
     "title": "استراتژی مسیریابی",
     "description": "استراتژی مسیریابی را انتخاب کنید. در حالت دستی، برای تنظیم ترتیب آن را بکشید. راهبردهای دیگر از طریق امتیاز زنده از قابلیت اطمینان، سرعت و هوش عبور می کنند.",
     "weightsSummary": "قابلیت اطمینان {reliability}٪ · سرعت {speed}٪ · هوش {intelligence}٪",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} درخواست این ماه"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "استراتژی مسیریابی",
     "description": "استراتژی مسیریابی را انتخاب کنید. در حالت دستی، برای تنظیم ترتیب آن را بکشید. راهبردهای دیگر از طریق امتیاز زنده از قابلیت اطمینان، سرعت و هوش عبور می کنند.",
     "weightsSummary": "قابلیت اطمینان {reliability}٪ · سرعت {speed}٪ · هوش {intelligence}٪",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} pyyntöä tässä kuussa"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Reititysstrategia",
     "description": "Valitse reititysstrategia. Manuaalitilassa raahaat järjestyksen asettamiseksi; Muut strategiat ohjaavat reaaliaikaisen tuloksen mukaan luotettavuuden, nopeuden ja älykkyyden välillä.",
     "weightsSummary": "luotettavuus {reliability} % · nopeus {speed}% · älykkyys {intelligence} %",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} pyyntöä tässä kuussa"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Tutki mittaamattomia malleja",
+    "exploreHint": "Antaa malleille, joilla ei ole luotettavuus-/nopeusdataa, 10 %:n mahdollisuuden tulla kokeilluiksi, jotta ne keräävät näytteitä.",
     "title": "Reititysstrategia",
     "description": "Valitse reititysstrategia. Manuaalitilassa raahaat järjestyksen asettamiseksi; Muut strategiat ohjaavat reaaliaikaisen tuloksen mukaan luotettavuuden, nopeuden ja älykkyyden välillä.",
     "weightsSummary": "luotettavuus {reliability} % · nopeus {speed}% · älykkyys {intelligence} %",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} req. ce mois-ci"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Stratégie de routage",
     "description": "Choisissez une stratégie de routage. En mode manuel, glissez pour définir l'ordre ; les autres stratégies routent selon un score en direct combinant fiabilité, vitesse et intelligence.",
     "weightsSummary": "fiabilité {reliability}% · vitesse {speed}% · intelligence {intelligence}%",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} req. ce mois-ci"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Explorer les modèles non mesurés",
+    "exploreHint": "Donne aux modèles sans données de fiabilité/vitesse 10 % de chances d'être essayés afin qu'ils accumulent des échantillons.",
     "title": "Stratégie de routage",
     "description": "Choisissez une stratégie de routage. En mode manuel, glissez pour définir l'ordre ; les autres stratégies routent selon un score en direct combinant fiabilité, vitesse et intelligence.",
     "weightsSummary": "fiabilité {reliability}% · vitesse {speed}% · intelligence {intelligence}%",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "આ મહિને {count} વિનંતી"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "રૂટીંગ વ્યૂહરચના",
     "description": "રૂટીંગ વ્યૂહરચના પસંદ કરો. મેન્યુઅલ મોડમાં તમે ઓર્ડર સેટ કરવા માટે ખેંચો છો; અન્ય વ્યૂહરચનાઓ સમગ્ર વિશ્વસનીયતા, ઝડપ અને બુદ્ધિમત્તા પર લાઇવ સ્કોર દ્વારા રૂટ કરે છે.",
     "weightsSummary": "વિશ્વસનીયતા {reliability}% · ઝડપ {speed}% · બુદ્ધિ {intelligence}%",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "આ મહિને {count} વિનંતી"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "માપ્યા વગરના મોડલ્સ એક્સપ્લોર કરો",
+    "exploreHint": "વિશ્વસનીયતા/ઝડપ ડેટા વગરના મોડલ્સને નમૂના એકત્રિત કરવા 10% અજમાવવાની તક આપો.",
     "title": "રૂટીંગ વ્યૂહરચના",
     "description": "રૂટીંગ વ્યૂહરચના પસંદ કરો. મેન્યુઅલ મોડમાં તમે ઓર્ડર સેટ કરવા માટે ખેંચો છો; અન્ય વ્યૂહરચનાઓ સમગ્ર વિશ્વસનીયતા, ઝડપ અને બુદ્ધિમત્તા પર લાઇવ સ્કોર દ્વારા રૂટ કરે છે.",
     "weightsSummary": "વિશ્વસનીયતા {reliability}% · ઝડપ {speed}% · બુદ્ધિ {intelligence}%",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "buƙatu {count} wannan wata"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Dabarar hanya",
     "description": "Zabi dabarar hanya. A Yanayin Manual zaka ja don saita tsari; da sauran dabarun hanya ta live ci a kan dogara, gudun da hankali.",
     "weightsSummary": "Amintaccen {reliability}% · saurin {speed}% · hankali {intelligence}%",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "buƙatu {count} wannan wata"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Bincika samfuran da ba a auna ba",
+    "exploreHint": "Ba samfuran da ba su da bayanan aminci/sauri damar 10% a gwada su domin su tara bayanai.",
     "title": "Dabarar hanya",
     "description": "Zabi dabarar hanya. A Yanayin Manual zaka ja don saita tsari; da sauran dabarun hanya ta live ci a kan dogara, gudun da hankali.",
     "weightsSummary": "Amintaccen {reliability}% · saurin {speed}% · hankali {intelligence}%",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} בקשות החודש"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "חקירת דגמים שטרם נמדדו",
+    "exploreHint": "נותן לדגמים ללא נתוני אמינות/מהירות סיכוי של 10% להיבחר לניסיון כדי שיצברו דגימות.",
     "title": "אסטרטגיית ניתוב",
     "description": "בחר אסטרטגיית ניתוב. במצב ידני אתה גורר כדי להגדיר את הסדר; האסטרטגיות האחרות מתמקדות לפי ניקוד חי בין אמינות, מהירות ואינטליגנציה.",
     "weightsSummary": "אמינות {reliability}% · מהירות {speed}% · אינטליגנציה {intelligence}%",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} בקשות החודש"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "אסטרטגיית ניתוב",
     "description": "בחר אסטרטגיית ניתוב. במצב ידני אתה גורר כדי להגדיר את הסדר; האסטרטגיות האחרות מתמקדות לפי ניקוד חי בין אמינות, מהירות ואינטליגנציה.",
     "weightsSummary": "אמינות {reliability}% · מהירות {speed}% · אינטליגנציה {intelligence}%",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "इस महीने {count} अनुरोध"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "रूटिंग रणनीति",
     "description": "एक रूटिंग रणनीति चुनें. मैन्युअल मोड में आप ऑर्डर सेट करने के लिए खींचते हैं; अन्य रणनीतियाँ विश्वसनीयता, गति और बुद्धिमत्ता के आधार पर लाइव स्कोर बनाती हैं।",
     "weightsSummary": "विश्वसनीयता {reliability}% · गति {speed}% · बुद्धिमत्ता {intelligence}%",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "इस महीने {count} अनुरोध"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "बिना मापे गए मॉडल एक्सप्लोर करें",
+    "exploreHint": "विश्वसनीयता/गति डेटा रहित मॉडल को नमूने जुटाने के लिए 10% आज़माए जाने का मौका दें।",
     "title": "रूटिंग रणनीति",
     "description": "एक रूटिंग रणनीति चुनें. मैन्युअल मोड में आप ऑर्डर सेट करने के लिए खींचते हैं; अन्य रणनीतियाँ विश्वसनीयता, गति और बुद्धिमत्ता के आधार पर लाइव स्कोर बनाती हैं।",
     "weightsSummary": "विश्वसनीयता {reliability}% · गति {speed}% · बुद्धिमत्ता {intelligence}%",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} zaht. ovog mjeseca"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Istraži nemjerene modele",
+    "exploreHint": "Modelima bez podataka o pouzdanosti/brzini daje 10 % šanse da budu isprobani kako bi prikupili uzorke.",
     "title": "Strategija usmjeravanja",
     "description": "Odaberite strategiju usmjeravanja. U ručnom načinu povlačite da postavite redoslijed; Ostale strategije usmjeravaju rezultat uživo kroz pouzdanost, brzinu i inteligenciju.",
     "weightsSummary": "pouzdanost {reliability}% · brzina {speed}% · Inteligencija {intelligence}%",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} zaht. ovog mjeseca"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategija usmjeravanja",
     "description": "Odaberite strategiju usmjeravanja. U ručnom načinu povlačite da postavite redoslijed; Ostale strategije usmjeravaju rezultat uživo kroz pouzdanost, brzinu i inteligenciju.",
     "weightsSummary": "pouzdanost {reliability}% · brzina {speed}% · Inteligencija {intelligence}%",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} kérés e hónapban"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Nem mért modellek felfedezése",
+    "exploreHint": "A megbízhatósági/sebességi adatok nélküli modellek 10% eséllyel kipróbálásra kerülnek, hogy mintákat gyűjtsenek.",
     "title": "Útvonaltervezési stratégia",
     "description": "Válassz egy útvonaltervezési stratégiát. Manuális módban húzni kell a sorrend beállításához; A többi stratégia élő eredmény alapján vezet a megbízhatóság, sebesség és intelligencia terén.",
     "weightsSummary": "megbízhatóság {reliability}% · sebesség {speed}% · Intelligencia {intelligence}%",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} kérés e hónapban"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Útvonaltervezési stratégia",
     "description": "Válassz egy útvonaltervezési stratégiát. Manuális módban húzni kell a sorrend beállításához; A többi stratégia élő eredmény alapján vezet a megbízhatóság, sebesség és intelligencia terén.",
     "weightsSummary": "megbízhatóság {reliability}% · sebesség {speed}% · Intelligencia {intelligence}%",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Jelajahi model yang belum terukur",
+    "exploreHint": "Beri model tanpa data keandalan/kecepatan peluang 10% untuk dicoba agar mengumpulkan sampel.",
     "title": "Strategi perutean",
     "description": "Pilih strategi perutean. Dalam mode Manual Anda menyeret untuk mengatur urutan; strategi lainnya dirutekan berdasarkan skor langsung dalam hal keandalan, kecepatan, dan kecerdasan.",
     "weightsSummary": "keandalan {reliability}% · kecepatan {speed}% · kecerdasan {intelligence}%",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategi perutean",
     "description": "Pilih strategi perutean. Dalam mode Manual Anda menyeret untuk mengatur urutan; strategi lainnya dirutekan berdasarkan skor langsung dalam hal keandalan, kecepatan, dan kecerdasan.",
     "weightsSummary": "keandalan {reliability}% · kecepatan {speed}% · kecerdasan {intelligence}%",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "arịrịọ {count} ọnwa a"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Atụmatụ ụzọ",
     "description": "Họrọ atụmatụ ụzọ ụzọ. Na ntuziaka ntuziaka ị na-adọkpụrụ ka ịtọ usoro; Atụmatụ ụzọ ndị ọzọ site na akara ndụ gafere ntụkwasị obi, ọsọ na ọgụgụ isi.",
     "weightsSummary": "ntụkwasị obi {reliability}% · ọsọ {speed}% · ọgụgụ isi {intelligence}%",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "arịrịọ {count} ọnwa a"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Nyochaa ụdị a na-atụbeghị",
+    "exploreHint": "Nye ụdị na-enweghị data ntụkwasị obi/ọsọ ohere 10% ka a nwalee ha ka ha wee chịkọta data.",
     "title": "Atụmatụ ụzọ",
     "description": "Họrọ atụmatụ ụzọ ụzọ. Na ntuziaka ntuziaka ị na-adọkpụrụ ka ịtọ usoro; Atụmatụ ụzọ ndị ọzọ site na akara ndụ gafere ntụkwasị obi, ọsọ na ọgụgụ isi.",
     "weightsSummary": "ntụkwasị obi {reliability}% · ọsọ {speed}% · ọgụgụ isi {intelligence}%",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} rich. questo mese"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Esplora i modelli non misurati",
+    "exploreHint": "Dà ai modelli senza dati di affidabilità/velocità una probabilità del 10% di essere provati così da accumulare campioni.",
     "title": "Strategia di routing",
     "description": "Scegli una strategia di routing. In modalità Manuale trascini per impostare l'ordine; le altre strategie instradano in base al punteggio live tra affidabilità, velocità e intelligenza.",
     "weightsSummary": "affidabilità {reliability}% · velocità {speed}% · intelligenza {intelligence}%",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} rich. questo mese"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategia di routing",
     "description": "Scegli una strategia di routing. In modalità Manuale trascini per impostare l'ordine; le altre strategie instradano in base al punteggio live tra affidabilità, velocità e intelligenza.",
     "weightsSummary": "affidabilità {reliability}% · velocità {speed}% · intelligenza {intelligence}%",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "今月 {count} 件"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "ルーティング戦略",
     "description": "ルーティング戦略を選択します。手動モードでは、ドラッグして順序を設定します。他の戦略は、信頼性、スピード、インテリジェンスのライブスコアに基づいてルーティングされます。",
     "weightsSummary": "信頼性 {reliability}% · スピード {speed}% · インテリジェンス {intelligence}%",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "今月 {count} 件"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "未計測のモデルを探索",
+    "exploreHint": "信頼性・スピードのデータがないモデルに10%の確率で試行の機会を与え、サンプルを蓄積させます。",
     "title": "ルーティング戦略",
     "description": "ルーティング戦略を選択します。手動モードでは、ドラッグして順序を設定します。他の戦略は、信頼性、スピード、インテリジェンスのライブスコアに基づいてルーティングされます。",
     "weightsSummary": "信頼性 {reliability}% · スピード {speed}% · インテリジェンス {intelligence}%",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} მოთხოვნა ამ თვეში"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "გაუზომავი მოდელების შესწავლა",
+    "exploreHint": "საიმედოობის/სიჩქარის მონაცემების არმქონე მოდელებს აძლევს 10%-იან შანსს, რომ გამოიცადონ და ნიმუშები დააგროვონ.",
     "title": "მარშრუტიზაციის სტრატეგია",
     "description": "აირჩიეთ მარშრუტიზაციის სტრატეგია. ხელით რეჟიმში გადაათრევთ შეკვეთის დასაყენებლად; სხვა სტრატეგიები მარშრუტებენ პირდაპირი ქულით საიმედოობის, სიჩქარისა და ინტელექტის მიხედვით.",
     "weightsSummary": "საიმედოობა {reliability}% · სიჩქარე {speed}% · ინტელექტი {intelligence}%",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} მოთხოვნა ამ თვეში"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "მარშრუტიზაციის სტრატეგია",
     "description": "აირჩიეთ მარშრუტიზაციის სტრატეგია. ხელით რეჟიმში გადაათრევთ შეკვეთის დასაყენებლად; სხვა სტრატეგიები მარშრუტებენ პირდაპირი ქულით საიმედოობის, სიჩქარისა და ინტელექტის მიხედვით.",
     "weightsSummary": "საიმედოობა {reliability}% · სიჩქარე {speed}% · ინტელექტი {intelligence}%",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ខែនេះ {count} សំណើ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "ស្វែងរកម៉ូដែលដែលមិនទាន់វាស់វែង",
+    "exploreHint": "ផ្តល់ឱ្យម៉ូដែលដែលគ្មានទិន្នន័យភាពទុកចិត្ត/ល្បឿន ឱកាស 10% ដើម្បីសាកល្បង ដើម្បីប្រមូលគំរូ។",
     "title": "យុទ្ធសាស្ត្រផ្លូវបញ្ជូន",
     "description": "ជ្រើសរើសយុទ្ធសាស្ត្រផ្លូវចរាចរណ៍។ នៅក្នុងរបៀបដៃ អ្នកទាញដើម្បីកំណត់លំដាប់; យុទ្ធសាស្ត្រផ្សេងទៀតត្រូវបានរៀបចំតាមពិន្ទុផ្ទាល់តាមរយៈភាពទុកចិត្ត ល្បឿន និងបញ្ញា។",
     "weightsSummary": "ភាពទុកចិត្ត {reliability}% · ល្បឿន {speed}% · បញ្ញា {intelligence}%",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ខែនេះ {count} សំណើ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "យុទ្ធសាស្ត្រផ្លូវបញ្ជូន",
     "description": "ជ្រើសរើសយុទ្ធសាស្ត្រផ្លូវចរាចរណ៍។ នៅក្នុងរបៀបដៃ អ្នកទាញដើម្បីកំណត់លំដាប់; យុទ្ធសាស្ត្រផ្សេងទៀតត្រូវបានរៀបចំតាមពិន្ទុផ្ទាល់តាមរយៈភាពទុកចិត្ត ល្បឿន និងបញ្ញា។",
     "weightsSummary": "ភាពទុកចិត្ត {reliability}% · ល្បឿន {speed}% · បញ្ញា {intelligence}%",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ಈ ತಿಂಗಳು {count} ವಿನಂತಿಗಳು"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "ಅಳೆಯದ ಮಾದರಿಗಳನ್ನು ಅನ್ವೇಷಿಸಿ",
+    "exploreHint": "ವಿಶ್ವಾಸಾರ್ಹತೆ/ವೇಗ ಡೇಟಾ ಇಲ್ಲದ ಮಾದರಿಗಳಿಗೆ ಸ್ಯಾಂಪಲ್‌ಗಳನ್ನು ಸಂಗ್ರಹಿಸಲು 10% ಪ್ರಯತ್ನದ ಅವಕಾಶ ನೀಡಿ.",
     "title": "ರೂಟಿಂಗ್ ತಂತ್ರ",
     "description": "ರೂಟಿಂಗ್ ತಂತ್ರವನ್ನು ಆರಿಸಿ. ಹಸ್ತಚಾಲಿತ ಕ್ರಮದಲ್ಲಿ ನೀವು ಆದೇಶವನ್ನು ಹೊಂದಿಸಲು ಎಳೆಯಿರಿ; ವಿಶ್ವಾಸಾರ್ಹತೆ, ವೇಗ ಮತ್ತು ಬುದ್ಧಿವಂತಿಕೆಯಾದ್ಯಂತ ಲೈವ್ ಸ್ಕೋರ್ ಮೂಲಕ ಇತರ ತಂತ್ರಗಳು ಮಾರ್ಗವಾಗಿದೆ.",
     "weightsSummary": "ವಿಶ್ವಾಸಾರ್ಹತೆ {reliability}% · ವೇಗ {speed}% · ಬುದ್ಧಿವಂತಿಕೆ {intelligence}%",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ಈ ತಿಂಗಳು {count} ವಿನಂತಿಗಳು"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "ರೂಟಿಂಗ್ ತಂತ್ರ",
     "description": "ರೂಟಿಂಗ್ ತಂತ್ರವನ್ನು ಆರಿಸಿ. ಹಸ್ತಚಾಲಿತ ಕ್ರಮದಲ್ಲಿ ನೀವು ಆದೇಶವನ್ನು ಹೊಂದಿಸಲು ಎಳೆಯಿರಿ; ವಿಶ್ವಾಸಾರ್ಹತೆ, ವೇಗ ಮತ್ತು ಬುದ್ಧಿವಂತಿಕೆಯಾದ್ಯಂತ ಲೈವ್ ಸ್ಕೋರ್ ಮೂಲಕ ಇತರ ತಂತ್ರಗಳು ಮಾರ್ಗವಾಗಿದೆ.",
     "weightsSummary": "ವಿಶ್ವಾಸಾರ್ಹತೆ {reliability}% · ವೇಗ {speed}% · ಬುದ್ಧಿವಂತಿಕೆ {intelligence}%",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "이번 달 {count}건"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "라우팅 전략",
     "description": "라우팅 전략을 선택하세요. 수동 모드에서는 드래그하여 순서를 설정합니다. 다른 전략은 안정성, 속도 및 지능 전반에 걸쳐 실시간 점수를 기준으로 라우팅됩니다.",
     "weightsSummary": "신뢰성 {reliability}% · 속도 {speed}% · 지능 {intelligence}%",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "이번 달 {count}건"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "미측정 모델 탐색",
+    "exploreHint": "신뢰성/속도 데이터가 없는 모델에 10% 확률로 시도 기회를 주어 샘플을 쌓게 합니다.",
     "title": "라우팅 전략",
     "description": "라우팅 전략을 선택하세요. 수동 모드에서는 드래그하여 순서를 설정합니다. 다른 전략은 안정성, 속도 및 지능 전반에 걸쳐 실시간 점수를 기준으로 라우팅됩니다.",
     "weightsSummary": "신뢰성 {reliability}% · 속도 {speed}% · 지능 {intelligence}%",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} užkl. šį mėnesį"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Maršrutizavimo strategija",
     "description": "Pasirinkite maršrutizavimo strategiją. Rankiniame režime tempiate, kad nustatytumėte tvarką; Kitos strategijos nukreipiamos pagal gyvus rezultatus pagal patikimumą, greitį ir intelektą.",
     "weightsSummary": "Patikimumas {reliability}% · greitis {speed}% · intelektas {intelligence}%",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} užkl. šį mėnesį"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Tyrinėti neišmatuotus modelius",
+    "exploreHint": "Modeliams be patikimumo/greičio duomenų suteikiama 10 % tikimybė būti išbandytiems, kad jie sukauptų imtis.",
     "title": "Maršrutizavimo strategija",
     "description": "Pasirinkite maršrutizavimo strategiją. Rankiniame režime tempiate, kad nustatytumėte tvarką; Kitos strategijos nukreipiamos pagal gyvus rezultatus pagal patikimumą, greitį ir intelektą.",
     "weightsSummary": "Patikimumas {reliability}% · greitis {speed}% · intelektas {intelligence}%",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ഈ മാസം {count} അഭ്യർത്ഥനകൾ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "റൂട്ടിംഗ് തന്ത്രം",
     "description": "ഒരു റൂട്ടിംഗ് തന്ത്രം തിരഞ്ഞെടുക്കുക. മാനുവൽ മോഡിൽ ഓർഡർ സജ്ജീകരിക്കാൻ നിങ്ങൾ വലിച്ചിടുക; വിശ്വാസ്യത, വേഗത, ബുദ്ധി എന്നിവയിലുടനീളം തത്സമയ സ്‌കോർ വഴിയുള്ള മറ്റ് തന്ത്രങ്ങൾ.",
     "weightsSummary": "വിശ്വാസ്യത {reliability}% · വേഗത {speed}% · ബുദ്ധി {intelligence}%",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ഈ മാസം {count} അഭ്യർത്ഥനകൾ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "അളക്കാത്ത മോഡലുകൾ പര്യവേക്ഷണം ചെയ്യുക",
+    "exploreHint": "വിശ്വാസ്യത/വേഗത ഡാറ്റ ഇല്ലാത്ത മോഡലുകൾക്ക് സാമ്പിളുകൾ ശേഖരിക്കാൻ 10% പരീക്ഷണ അവസരം നൽകുക.",
     "title": "റൂട്ടിംഗ് തന്ത്രം",
     "description": "ഒരു റൂട്ടിംഗ് തന്ത്രം തിരഞ്ഞെടുക്കുക. മാനുവൽ മോഡിൽ ഓർഡർ സജ്ജീകരിക്കാൻ നിങ്ങൾ വലിച്ചിടുക; വിശ്വാസ്യത, വേഗത, ബുദ്ധി എന്നിവയിലുടനീളം തത്സമയ സ്‌കോർ വഴിയുള്ള മറ്റ് തന്ത്രങ്ങൾ.",
     "weightsSummary": "വിശ്വാസ്യത {reliability}% · വേഗത {speed}% · ബുദ്ധി {intelligence}%",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "या महिन्यात {count} विनंत्या"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "न मोजलेले मॉडेल्स एक्सप्लोर करा",
+    "exploreHint": "विश्वसनीयता/गती डेटा नसलेल्या मॉडेल्सना नमुने जमवण्यासाठी 10% चाचणीची संधी द्या.",
     "title": "राउटिंग धोरण",
     "description": "राउटिंग धोरण निवडा. मॅन्युअल मोडमध्ये तुम्ही ऑर्डर सेट करण्यासाठी ड्रॅग करता; विश्वासार्हता, वेग आणि बुद्धिमत्तेद्वारे थेट स्कोअरद्वारे इतर धोरणे मार्ग.",
     "weightsSummary": "विश्वसनीयता {reliability}% · गती {speed}% · बुद्धिमत्ता {intelligence}%",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "या महिन्यात {count} विनंत्या"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "राउटिंग धोरण",
     "description": "राउटिंग धोरण निवडा. मॅन्युअल मोडमध्ये तुम्ही ऑर्डर सेट करण्यासाठी ड्रॅग करता; विश्वासार्हता, वेग आणि बुद्धिमत्तेद्वारे थेट स्कोअरद्वारे इतर धोरणे मार्ग.",
     "weightsSummary": "विश्वसनीयता {reliability}% · गती {speed}% · बुद्धिमत्ता {intelligence}%",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategi penghalaan",
     "description": "Pilih strategi penghalaan. Dalam mod Manual anda seret untuk menetapkan susunan; Strategi lain menghala berdasarkan skor langsung merentasi kebolehpercayaan, kelajuan dan kecerdasan.",
     "weightsSummary": "kebolehpercayaan {reliability}% · kelajuan {speed}% · {intelligence}% kecerdasan",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} permintaan bulan ini"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Teroka model yang belum diukur",
+    "exploreHint": "Beri model tanpa data kebolehpercayaan/kelajuan peluang 10% untuk dicuba supaya sampel terkumpul.",
     "title": "Strategi penghalaan",
     "description": "Pilih strategi penghalaan. Dalam mod Manual anda seret untuk menetapkan susunan; Strategi lain menghala berdasarkan skor langsung merentasi kebolehpercayaan, kelajuan dan kecerdasan.",
     "weightsSummary": "kebolehpercayaan {reliability}% · kelajuan {speed}% · {intelligence}% kecerdasan",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ဤလတွင် တောင်းဆိုမှု {count} ခု"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "လမ်းကြောင်းသတ်မှတ်မှု မဟာဗျူဟာ",
     "description": "လမ်းကြောင်းသတ်မှတ်မှု မဟာဗျူဟာကို ရွေးချယ်ပါ။ Manual mode တွင် အစီအစဉ်ကို ဆွဲ၍ စီစဉ်နိုင်သည်။ အခြားမဟာဗျူဟာများမှာ ယုံကြည်စိတ်ချမှု၊ အမြန်နှုန်းနှင့် ဉာဏ်ရည်တို့အပေါ် တိုက်ရိုက်အဆင့်သတ်မှတ်ချက်ဖြင့် လမ်းညွှန်သည်။",
     "weightsSummary": "ယုံကြည်စိတ်ချမှု {reliability}% · အမြန်နှုန်း {speed}% · ဉာဏ်ရည် {intelligence}%",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ဤလတွင် တောင်းဆိုမှု {count} ခု"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "မတိုင်းတာရသေးသော မော်ဒယ်များကို စူးစမ်းရန်",
+    "exploreHint": "ယုံကြည်စိတ်ချမှု/အမြန်နှုန်း ဒေတာမရှိသော မော်ဒယ်များကို နမူနာစုဆောင်းနိုင်ရန် 10% စမ်းသပ်ခွင့် ပေးသည်။",
     "title": "လမ်းကြောင်းသတ်မှတ်မှု မဟာဗျူဟာ",
     "description": "လမ်းကြောင်းသတ်မှတ်မှု မဟာဗျူဟာကို ရွေးချယ်ပါ။ Manual mode တွင် အစီအစဉ်ကို ဆွဲ၍ စီစဉ်နိုင်သည်။ အခြားမဟာဗျူဟာများမှာ ယုံကြည်စိတ်ချမှု၊ အမြန်နှုန်းနှင့် ဉာဏ်ရည်တို့အပေါ် တိုက်ရိုက်အဆင့်သတ်မှတ်ချက်ဖြင့် လမ်းညွှန်သည်။",
     "weightsSummary": "ယုံကြည်စိတ်ချမှု {reliability}% · အမြန်နှုန်း {speed}% · ဉာဏ်ရည် {intelligence}%",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "यो महिना {count} अनुरोध"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "राउटिङ रणनीति",
     "description": "एक मार्ग रणनीति छान्नुहोस्। म्यानुअल मोडमा तपाईं अर्डर सेट गर्न तान्नुहुन्छ; अन्य रणनीतिहरू विश्वसनीयता, गति र बुद्धिमत्तामा प्रत्यक्ष स्कोर द्वारा मार्ग।",
     "weightsSummary": "विश्वसनीयता {reliability}% · गति {speed}% · बुद्धि {intelligence}%",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "यो महिना {count} अनुरोध"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "नमापिएका मोडेलहरू अन्वेषण गर्नुहोस्",
+    "exploreHint": "विश्वसनीयता/गति डेटा नभएका मोडेलहरूलाई नमूना जम्मा गर्न 10% प्रयासको मौका दिनुहोस्।",
     "title": "राउटिङ रणनीति",
     "description": "एक मार्ग रणनीति छान्नुहोस्। म्यानुअल मोडमा तपाईं अर्डर सेट गर्न तान्नुहुन्छ; अन्य रणनीतिहरू विश्वसनीयता, गति र बुद्धिमत्तामा प्रत्यक्ष स्कोर द्वारा मार्ग।",
     "weightsSummary": "विश्वसनीयता {reliability}% · गति {speed}% · बुद्धि {intelligence}%",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} verz. deze maand"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routingstrategie",
     "description": "Kies een routeringsstrategie. In de handmatige modus sleep je om de volgorde in te stellen; De andere strategieën worden via live score verzekerd over betrouwbaarheid, snelheid en intelligentie.",
     "weightsSummary": "betrouwbaarheid {reliability}% · Snelheid {speed}% · intelligentie {intelligence}%",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} verz. deze maand"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Ongemeten modellen verkennen",
+    "exploreHint": "Geeft modellen zonder betrouwbaarheids-/snelheidsgegevens 10% kans om geprobeerd te worden zodat ze steekproeven opbouwen.",
     "title": "Routingstrategie",
     "description": "Kies een routeringsstrategie. In de handmatige modus sleep je om de volgorde in te stellen; De andere strategieën worden via live score verzekerd over betrouwbaarheid, snelheid en intelligentie.",
     "weightsSummary": "betrouwbaarheid {reliability}% · Snelheid {speed}% · intelligentie {intelligence}%",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} forespørsler denne måneden"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routingstrategi",
     "description": "Velg en rutestrategi. I manuell modus drar du for å sette rekkefølgen; De andre strategiene følger live score på tvers av pålitelighet, hastighet og intelligens.",
     "weightsSummary": "Pålitelighet {reliability} % · Hastighet {speed} % · Intelligens {intelligence} %",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} forespørsler denne måneden"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Utforsk umålte modeller",
+    "exploreHint": "Gir modeller uten pålitelighets-/hastighetsdata 10 % sjanse til å bli prøvd slik at de bygger opp stikkprøver.",
     "title": "Routingstrategi",
     "description": "Velg en rutestrategi. I manuell modus drar du for å sette rekkefølgen; De andre strategiene følger live score på tvers av pålitelighet, hastighet og intelligens.",
     "weightsSummary": "Pålitelighet {reliability} % · Hastighet {speed} % · Intelligens {intelligence} %",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ଏହି ମାସରେ {count} ଅନୁରୋଧ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "ମପାଯାଇନଥିବା ମଡେଲଗୁଡ଼ିକୁ ଅନୁସନ୍ଧାନ କରନ୍ତୁ",
+    "exploreHint": "ବିଶ୍ୱସନୀୟତା/ବେଗ ତଥ୍ୟ ନଥିବା ମଡେଲଗୁଡ଼ିକୁ ନମୁନା ସଂଗ୍ରହ ପାଇଁ 10% ଚେଷ୍ଟା କରିବାର ସୁଯୋଗ ଦିଅନ୍ତୁ।",
     "title": "ରାଉଟିଂ ରଣନୀତି",
     "description": "ଏକ ରାଉଟିଂ ରଣନୀତି ବାଛନ୍ତୁ । ମାନୁଆଲ୍ ମୋଡରେ ଆପଣ ଅର୍ଡର୍ ସେଟ୍ କରିବାକୁ ଡ୍ରାଗ୍ କରନ୍ତୁ; ଅନ୍ୟ ରଣନୀତିଗୁଡ଼ିକ ବିଶ୍ୱସନୀୟତା, ଗତି ଏବଂ ବୁଦ୍ଧିମତା ମଧ୍ୟରେ ଲାଇଭ୍ ସ୍କୋର ଦ୍ୱାରା ମାର୍ଗ କରେ ।",
     "weightsSummary": "ବିଶ୍ୱସନୀୟତା {reliability}% · ବେଗ {speed}% · ଇଣ୍ଟେଲିଜେନ୍ସ {intelligence}%",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ଏହି ମାସରେ {count} ଅନୁରୋଧ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "ରାଉଟିଂ ରଣନୀତି",
     "description": "ଏକ ରାଉଟିଂ ରଣନୀତି ବାଛନ୍ତୁ । ମାନୁଆଲ୍ ମୋଡରେ ଆପଣ ଅର୍ଡର୍ ସେଟ୍ କରିବାକୁ ଡ୍ରାଗ୍ କରନ୍ତୁ; ଅନ୍ୟ ରଣନୀତିଗୁଡ଼ିକ ବିଶ୍ୱସନୀୟତା, ଗତି ଏବଂ ବୁଦ୍ଧିମତା ମଧ୍ୟରେ ଲାଇଭ୍ ସ୍କୋର ଦ୍ୱାରା ମାର୍ଗ କରେ ।",
     "weightsSummary": "ବିଶ୍ୱସନୀୟତା {reliability}% · ବେଗ {speed}% · ଇଣ୍ଟେଲିଜେନ୍ସ {intelligence}%",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ਇਸ ਮਹੀਨੇ {count} ਬੇਨਤੀਆਂ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "ਰੂਟਿੰਗ ਰਣਨੀਤੀ",
     "description": "ਇੱਕ ਰੂਟਿੰਗ ਰਣਨੀਤੀ ਚੁਣੋ। ਮੈਨੁਅਲ ਮੋਡ ਵਿੱਚ ਤੁਸੀਂ ਆਰਡਰ ਸੈੱਟ ਕਰਨ ਲਈ ਖਿੱਚਦੇ ਹੋ; ਭਰੋਸੇਯੋਗਤਾ, ਗਤੀ ਅਤੇ ਬੁੱਧੀ ਵਿੱਚ ਲਾਈਵ ਸਕੋਰ ਦੁਆਰਾ ਹੋਰ ਰਣਨੀਤੀਆਂ ਦਾ ਰੂਟ।",
     "weightsSummary": "ਭਰੋਸੇਯੋਗਤਾ {reliability}% · ਸਪੀਡ {speed}% · ਖੁਫੀਆ {intelligence}%",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ਇਸ ਮਹੀਨੇ {count} ਬੇਨਤੀਆਂ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "ਬਿਨਾਂ ਮਾਪੇ ਮਾਡਲਾਂ ਦੀ ਖੋਜ ਕਰੋ",
+    "exploreHint": "ਭਰੋਸੇਯੋਗਤਾ/ਸਪੀਡ ਡੇਟਾ ਤੋਂ ਬਿਨਾਂ ਮਾਡਲਾਂ ਨੂੰ ਨਮੂਨੇ ਇਕੱਠੇ ਕਰਨ ਲਈ 10% ਅਜ਼ਮਾਉਣ ਦਾ ਮੌਕਾ ਦਿਓ।",
     "title": "ਰੂਟਿੰਗ ਰਣਨੀਤੀ",
     "description": "ਇੱਕ ਰੂਟਿੰਗ ਰਣਨੀਤੀ ਚੁਣੋ। ਮੈਨੁਅਲ ਮੋਡ ਵਿੱਚ ਤੁਸੀਂ ਆਰਡਰ ਸੈੱਟ ਕਰਨ ਲਈ ਖਿੱਚਦੇ ਹੋ; ਭਰੋਸੇਯੋਗਤਾ, ਗਤੀ ਅਤੇ ਬੁੱਧੀ ਵਿੱਚ ਲਾਈਵ ਸਕੋਰ ਦੁਆਰਾ ਹੋਰ ਰਣਨੀਤੀਆਂ ਦਾ ਰੂਟ।",
     "weightsSummary": "ਭਰੋਸੇਯੋਗਤਾ {reliability}% · ਸਪੀਡ {speed}% · ਖੁਫੀਆ {intelligence}%",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} żąd. w tym miesiącu"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Eksploruj niezmierzone modele",
+    "exploreHint": "Daje modelom bez danych o niezawodności/prędkości 10% szansy na wypróbowanie, aby zebrały próbki.",
     "title": "Strategia routingu",
     "description": "Wybierz strategię routingu. W trybie ręcznym przeciągnij, aby ustawić kolejność; inne strategie kierują się wynikami na żywo pod względem niezawodności, szybkości i inteligencji.",
     "weightsSummary": "niezawodność {reliability}% · prędkość {speed}% · inteligencja {intelligence}%",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} żąd. w tym miesiącu"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategia routingu",
     "description": "Wybierz strategię routingu. W trybie ręcznym przeciągnij, aby ustawić kolejność; inne strategie kierują się wynikami na żywo pod względem niezawodności, szybkości i inteligencji.",
     "weightsSummary": "niezawodność {reliability}% · prędkość {speed}% · inteligencja {intelligence}%",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} sol. neste mês"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Estratégia de roteamento",
     "description": "Escolha uma estratégia de roteamento. No modo manual, arraste para definir a ordem; as demais estratégias roteiam por pontuação ao vivo de confiabilidade, velocidade e inteligência.",
     "weightsSummary": "confiabilidade {reliability}% · velocidade {speed}% · inteligência {intelligence}%",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} sol. neste mês"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Explorar modelos sem medições",
+    "exploreHint": "Dá aos modelos sem dados de confiabilidade/velocidade 10% de chance de serem testados para que acumulem amostras.",
     "title": "Estratégia de roteamento",
     "description": "Escolha uma estratégia de roteamento. No modo manual, arraste para definir a ordem; as demais estratégias roteiam por pontuação ao vivo de confiabilidade, velocidade e inteligência.",
     "weightsSummary": "confiabilidade {reliability}% · velocidade {speed}% · inteligência {intelligence}%",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} ped. este mês"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Estratégia de encaminhamento",
     "description": "Escolha uma estratégia de roteamento. No modo Manual arrasta-se para definir a ordem; As outras estratégias encaminham-se pelo resultado em tempo real através da fiabilidade, velocidade e inteligência.",
     "weightsSummary": "fiabilidade {reliability}% · velocidade {speed}% · inteligência {intelligence}%",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} ped. este mês"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Explorar modelos sem medições",
+    "exploreHint": "Dá aos modelos sem dados de fiabilidade/velocidade 10% de probabilidade de serem experimentados para que acumulem amostras.",
     "title": "Estratégia de encaminhamento",
     "description": "Escolha uma estratégia de roteamento. No modo Manual arrasta-se para definir a ordem; As outras estratégias encaminham-se pelo resultado em tempo real através da fiabilidade, velocidade e inteligência.",
     "weightsSummary": "fiabilidade {reliability}% · velocidade {speed}% · inteligência {intelligence}%",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} cereri luna aceasta"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Explorează modelele nemăsurate",
+    "exploreHint": "Oferă modelelor fără date de fiabilitate/viteză o șansă de 10% de a fi încercate, ca să acumuleze eșantioane.",
     "title": "Strategia de rutare",
     "description": "Alege o strategie de rutare. În modul Manual tragi pentru a seta ordinea; Celelalte strategii se ghidează după scorul live, în funcție de fiabilitate, viteză și inteligență.",
     "weightsSummary": "Fiabilitate {reliability}% · viteză {speed}% · Inteligență {intelligence}%",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} cereri luna aceasta"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Strategia de rutare",
     "description": "Alege o strategie de rutare. În modul Manual tragi pentru a seta ordinea; Celelalte strategii se ghidează după scorul live, în funcție de fiabilitate, viteză și inteligență.",
     "weightsSummary": "Fiabilitate {reliability}% · viteză {speed}% · Inteligență {intelligence}%",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} запр. за месяц"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Исследовать неизмеренные модели",
+    "exploreHint": "Дает моделям без данных о надежности/скорости 10% шанс быть опробованными, чтобы они накапливали выборку.",
     "title": "Стратегия маршрутизации",
     "description": "Выберите стратегию маршрутизации. В ручном режиме вы перетаскиваете, чтобы установить порядок; другие стратегии основаны на реальном счете и учитывают надежность, скорость и интеллект.",
     "weightsSummary": "надежность {reliability}% · скорость {speed}% · интеллект {intelligence}%",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} запр. за месяц"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Стратегия маршрутизации",
     "description": "Выберите стратегию маршрутизации. В ручном режиме вы перетаскиваете, чтобы установить порядок; другие стратегии основаны на реальном счете и учитывают надежность, скорость и интеллект.",
     "weightsSummary": "надежность {reliability}% · скорость {speed}% · интеллект {intelligence}%",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "මෙම මාසයේ ඉල්ලීම් {count}"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "නොමැනූ ආකෘති ගවේෂණය කරන්න",
+    "exploreHint": "විශ්වසනීයත්වය/වේගය දත්ත නොමැති ආකෘතිවලට නියැදි එකතු කර ගැනීමට 10% උත්සාහ අවස්ථාවක් දෙන්න.",
     "title": "මාර්ගගත කිරීමේ උපාය",
     "description": "මාර්ගගත කිරීමේ උපාය මාර්ගයක් තෝරන්න. අත්පොත ආකාරයෙන් ඔබ ඇණවුම සැකසීමට ඇද දමන්න; අනෙකුත් උපාය මාර්ග විශ්වසනීයත්වය, වේගය සහ බුද්ධිය හරහා සජීවී ලකුණු අනුව ගමන් කරයි.",
     "weightsSummary": "විශ්වසනීයත්වය {reliability}% · වේගය {speed}% · බුද්ධිය {intelligence}%",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "මෙම මාසයේ ඉල්ලීම් {count}"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "මාර්ගගත කිරීමේ උපාය",
     "description": "මාර්ගගත කිරීමේ උපාය මාර්ගයක් තෝරන්න. අත්පොත ආකාරයෙන් ඔබ ඇණවුම සැකසීමට ඇද දමන්න; අනෙකුත් උපාය මාර්ග විශ්වසනීයත්වය, වේගය සහ බුද්ධිය හරහා සජීවී ලකුණු අනුව ගමන් කරයි.",
     "weightsSummary": "විශ්වසනීයත්වය {reliability}% · වේගය {speed}% · බුද්ධිය {intelligence}%",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} pož. tento mesiac"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Preskúmavať nezmerané modely",
+    "exploreHint": "Dáva modelom bez údajov o spoľahlivosti/rýchlosti 10 % šancu na vyskúšanie, aby nazbierali vzorky.",
     "title": "Stratégia smerovania",
     "description": "Vyberte si stratégiu smerovania. V manuálnom režime potiahnete na nastavenie poradia; Ostatné stratégie smerujú podľa živého skóre spoľahlivosť, rýchlosť a inteligenciu.",
     "weightsSummary": "spoľahlivosť {reliability} % · rýchlosť {speed}% · inteligencia {intelligence}%",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} pož. tento mesiac"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Stratégia smerovania",
     "description": "Vyberte si stratégiu smerovania. V manuálnom režime potiahnete na nastavenie poradia; Ostatné stratégie smerujú podľa živého skóre spoľahlivosť, rýchlosť a inteligenciu.",
     "weightsSummary": "spoľahlivosť {reliability} % · rýchlosť {speed}% · inteligencia {intelligence}%",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} захтева овог месеца"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Стратегија рутирања",
     "description": "Изаберите стратегију рутирања. У ручном режиму превлачите да бисте поставили редослед; друге стратегије се крећу путем резултата уживо преко поузданости, брзине и интелигенције.",
     "weightsSummary": "поузданост {reliability}% · брзина {speed}% · интелигенција {intelligence}%",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} захтева овог месеца"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Истражи неизмерене моделе",
+    "exploreHint": "Моделима без података о поузданости/брзини даје 10% шансе да буду испробани како би прикупили узорке.",
     "title": "Стратегија рутирања",
     "description": "Изаберите стратегију рутирања. У ручном режиму превлачите да бисте поставили редослед; друге стратегије се крећу путем резултата уживо преко поузданости, брзине и интелигенције.",
     "weightsSummary": "поузданост {reliability}% · брзина {speed}% · интелигенција {intelligence}%",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} förfr. denna månad"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Utforska omätta modeller",
+    "exploreHint": "Ger modeller utan tillförlitlighets-/hastighetsdata 10 % chans att provas så att de bygger upp stickprov.",
     "title": "Routingstrategi",
     "description": "Välj en routingstrategi. I manuellt läge drar du för att ställa in ordningen; De andra strategierna styrs efter livepoäng över tillförlitlighet, hastighet och intelligens.",
     "weightsSummary": "Tillförlitlighet {reliability} % · Hastighet {speed}% · Intelligens {intelligence} %",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} förfr. denna månad"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Routingstrategi",
     "description": "Välj en routingstrategi. I manuellt läge drar du för att ställa in ordningen; De andra strategierna styrs efter livepoäng över tillförlitlighet, hastighet och intelligens.",
     "weightsSummary": "Tillförlitlighet {reliability} % · Hastighet {speed}% · Intelligens {intelligence} %",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "maombi {count} mwezi huu"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Chunguza mifano isiyopimwa",
+    "exploreHint": "Ipe mifano isiyo na data ya kuegemea/kasi nafasi ya 10% ya kujaribiwa ili ikusanye sampuli.",
     "title": "Mkakati wa uelekezaji",
     "description": "Chagua mkakati wa uelekezaji. Katika hali ya Mwongozo, buruta ili kuweka mpangilio; mikakati mingine kupitia matokeo ya moja kwa moja katika kuegemea, kasi na akili.",
     "weightsSummary": "kuegemea {reliability}% · kasi {speed}% · akili {intelligence}%",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "maombi {count} mwezi huu"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Mkakati wa uelekezaji",
     "description": "Chagua mkakati wa uelekezaji. Katika hali ya Mwongozo, buruta ili kuweka mpangilio; mikakati mingine kupitia matokeo ya moja kwa moja katika kuegemea, kasi na akili.",
     "weightsSummary": "kuegemea {reliability}% · kasi {speed}% · akili {intelligence}%",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "இந்த மாதம் {count} கோரிக்கை"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "அளவிடப்படாத மாதிரிகளை ஆராயுங்கள்",
+    "exploreHint": "நம்பகத்தன்மை/வேகத் தரவு இல்லாத மாதிரிகளுக்கு, சாம்பிள்களைச் சேகரிக்க 10% முயற்சி வாய்ப்பு வழங்கவும்.",
     "title": "ரூட்டிங் உத்தி",
     "description": "ஒரு ரூட்டிங் உத்தியைத் தேர்ந்தெடுக்கவும். கையேடு முறையில் நீங்கள் ஆர்டரை அமைக்க இழுக்கவும்; மற்ற உத்திகள் நம்பகத்தன்மை, வேகம் மற்றும் நுண்ணறிவு ஆகியவற்றில் நேரலை மதிப்பெண் மூலம் வழி.",
     "weightsSummary": "நம்பகத்தன்மை {reliability}% · வேகம் {speed}% · நுண்ணறிவு {intelligence}%",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "இந்த மாதம் {count} கோரிக்கை"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "ரூட்டிங் உத்தி",
     "description": "ஒரு ரூட்டிங் உத்தியைத் தேர்ந்தெடுக்கவும். கையேடு முறையில் நீங்கள் ஆர்டரை அமைக்க இழுக்கவும்; மற்ற உத்திகள் நம்பகத்தன்மை, வேகம் மற்றும் நுண்ணறிவு ஆகியவற்றில் நேரலை மதிப்பெண் மூலம் வழி.",
     "weightsSummary": "நம்பகத்தன்மை {reliability}% · வேகம் {speed}% · நுண்ணறிவு {intelligence}%",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ఈ నెలలో {count} అభ్యర్థనలు"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "రూటింగ్ వ్యూహం",
     "description": "రూటింగ్ వ్యూహాన్ని ఎంచుకోండి. మాన్యువల్ మోడ్‌లో మీరు ఆర్డర్‌ను సెట్ చేయడానికి లాగండి; విశ్వసనీయత, వేగం మరియు మేధస్సు అంతటా ప్రత్యక్ష స్కోర్ ద్వారా ఇతర వ్యూహాల మార్గం.",
     "weightsSummary": "విశ్వసనీయత {reliability}% · వేగం {speed}% · మేధస్సు {intelligence}%",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ఈ నెలలో {count} అభ్యర్థనలు"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "కొలవని మోడల్స్‌ను అన్వేషించండి",
+    "exploreHint": "విశ్వసనీయత/వేగం డేటా లేని మోడల్స్‌కు నమూనాలు సేకరించడానికి 10% ప్రయత్న అవకాశం ఇవ్వండి.",
     "title": "రూటింగ్ వ్యూహం",
     "description": "రూటింగ్ వ్యూహాన్ని ఎంచుకోండి. మాన్యువల్ మోడ్‌లో మీరు ఆర్డర్‌ను సెట్ చేయడానికి లాగండి; విశ్వసనీయత, వేగం మరియు మేధస్సు అంతటా ప్రత్యక్ష స్కోర్ ద్వారా ఇతర వ్యూహాల మార్గం.",
     "weightsSummary": "విశ్వసనీయత {reliability}% · వేగం {speed}% · మేధస్సు {intelligence}%",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "เดือนนี้ {count} คำขอ"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "กลยุทธ์การกำหนดเส้นทาง",
     "description": "เลือกกลยุทธ์การกำหนดเส้นทาง ในโหมดแมนนวล คุณลากเพื่อกำหนดลำดับ ส่วนกลยุทธ์อื่นๆ กำหนดเส้นทางตามคะแนนสดผ่านความน่าเชื่อถือ ความเร็ว และความชาญฉลาด",
     "weightsSummary": "ความน่าเชื่อถือ {reliability}% · ความเร็ว {speed}% · ความฉลาด {intelligence}%",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "เดือนนี้ {count} คำขอ"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "สำรวจโมเดลที่ยังไม่ได้วัดผล",
+    "exploreHint": "ให้โมเดลที่ไม่มีข้อมูลความน่าเชื่อถือ/ความเร็วมีโอกาส 10% ที่จะถูกลองใช้เพื่อสะสมตัวอย่าง",
     "title": "กลยุทธ์การกำหนดเส้นทาง",
     "description": "เลือกกลยุทธ์การกำหนดเส้นทาง ในโหมดแมนนวล คุณลากเพื่อกำหนดลำดับ ส่วนกลยุทธ์อื่นๆ กำหนดเส้นทางตามคะแนนสดผ่านความน่าเชื่อถือ ความเร็ว และความชาญฉลาด",
     "weightsSummary": "ความน่าเชื่อถือ {reliability}% · ความเร็ว {speed}% · ความฉลาด {intelligence}%",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} kahilingan ngayong buwan"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Estratehiya sa Pag-ruta",
     "description": "Pumili ng routing strategy. Sa Manual mode, i-drag mo para itakda ang order; Ang iba pang mga estratehiya ay nakabase sa live score sa reliability, bilis, at intelligence.",
     "weightsSummary": "pagiging maaasahan {reliability}% · bilis {speed}% · intelihensiya {intelligence}%",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} kahilingan ngayong buwan"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "I-explore ang mga hindi pa nasusukat na modelo",
+    "exploreHint": "Bigyan ang mga modelong walang data ng pagiging maaasahan/bilis ng 10% na tsansang masubukan para makaipon ng mga sample.",
     "title": "Estratehiya sa Pag-ruta",
     "description": "Pumili ng routing strategy. Sa Manual mode, i-drag mo para itakda ang order; Ang iba pang mga estratehiya ay nakabase sa live score sa reliability, bilis, at intelligence.",
     "weightsSummary": "pagiging maaasahan {reliability}% · bilis {speed}% · intelihensiya {intelligence}%",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "bu ay {count} istek"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Ölçülmemiş modelleri keşfet",
+    "exploreHint": "Güvenilirlik/hız verisi olmayan modellere örnek toplayabilmeleri için %10 denenme şansı verir.",
     "title": "Yönlendirme stratejisi",
     "description": "Bir yönlendirme stratejisi seçin. Manuel modda sırayı ayarlamak için sürüklersiniz; diğer stratejiler ise güvenilirlik, hız ve zeka üzerinden canlı skora göre yönlendirilir.",
     "weightsSummary": "güvenilirlik {reliability}% · hız {speed}% · zeka {intelligence}%",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "bu ay {count} istek"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Yönlendirme stratejisi",
     "description": "Bir yönlendirme stratejisi seçin. Manuel modda sırayı ayarlamak için sürüklersiniz; diğer stratejiler ise güvenilirlik, hız ve zeka üzerinden canlı skora göre yönlendirilir.",
     "weightsSummary": "güvenilirlik {reliability}% · hız {speed}% · zeka {intelligence}%",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} запитів цього місяця"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Досліджувати невиміряні моделі",
+    "exploreHint": "Дає моделям без даних про надійність/швидкість 10% шанс бути випробуваними, щоб вони накопичували вибірку.",
     "title": "Стратегія маршрутизації",
     "description": "Виберіть стратегію маршрутизації. У ручному режимі ви перетягуєте, щоб встановити порядок; інші стратегії визначають надійність, швидкість і інтелект за результатами в реальному часі.",
     "weightsSummary": "надійність {reliability}% · швидкість {speed}% · інтелект {intelligence}%",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} запитів цього місяця"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Стратегія маршрутизації",
     "description": "Виберіть стратегію маршрутизації. У ручному режимі ви перетягуєте, щоб встановити порядок; інші стратегії визначають надійність, швидкість і інтелект за результатами в реальному часі.",
     "weightsSummary": "надійність {reliability}% · швидкість {speed}% · інтелект {intelligence}%",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "اس مہینے {count} درخواستیں"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "غیر پیمائش شدہ ماڈلز دریافت کریں",
+    "exploreHint": "جن ماڈلز کے پاس اعتماد/رفتار کا ڈیٹا نہیں انہیں نمونے جمع کرنے کے لیے 10% آزمائے جانے کا موقع دیں۔",
     "title": "روٹنگ کی حکمت عملی",
     "description": "روٹنگ کی حکمت عملی کا انتخاب کریں۔ مینوئل موڈ میں آپ آرڈر سیٹ کرنے کے لیے گھسیٹتے ہیں۔ قابل اعتماد، رفتار اور ذہانت میں لائیو سکور کے ذریعے دیگر حکمت عملیوں کا راستہ۔",
     "weightsSummary": "وشوسنییتا {reliability}% · رفتار {speed}% · ذہانت {intelligence}%",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "اس مہینے {count} درخواستیں"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "روٹنگ کی حکمت عملی",
     "description": "روٹنگ کی حکمت عملی کا انتخاب کریں۔ مینوئل موڈ میں آپ آرڈر سیٹ کرنے کے لیے گھسیٹتے ہیں۔ قابل اعتماد، رفتار اور ذہانت میں لائیو سکور کے ذریعے دیگر حکمت عملیوں کا راستہ۔",
     "weightsSummary": "وشوسنییتا {reliability}% · رفتار {speed}% · ذہانت {intelligence}%",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "bu oyda {count} ta so'rov"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "O'lchanmagan modellarni o'rganish",
+    "exploreHint": "Ishonchlilik/tezlik ma'lumotlari bo'lmagan modellarga namunalar to'plashi uchun 10% sinab ko'rish imkoniyati beriladi.",
     "title": "Marshrut strategiyasi",
     "description": "Marshrutlash strategiyasini tanlang. Qo'l rejimida tartibni o'rnatish uchun sudrang; Boshqa strategiyalar ishonchlilik, tezlik va aql bo'yicha jonli hisob bilan yo'naltiriladi.",
     "weightsSummary": "ishonchlilik {reliability}% · tezlik {speed}% · razvedka {intelligence}%",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "bu oyda {count} ta so'rov"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Marshrut strategiyasi",
     "description": "Marshrutlash strategiyasini tanlang. Qo'l rejimida tartibni o'rnatish uchun sudrang; Boshqa strategiyalar ishonchlilik, tezlik va aql bo'yicha jonli hisob bilan yo'naltiriladi.",
     "weightsSummary": "ishonchlilik {reliability}% · tezlik {speed}% · razvedka {intelligence}%",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "{count} yêu cầu tháng này"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Khám phá các mô hình chưa được đo",
+    "exploreHint": "Cho các mô hình chưa có dữ liệu độ tin cậy/tốc độ 10% cơ hội được thử để tích lũy mẫu.",
     "title": "Chiến lược định tuyến",
     "description": "Chọn một chiến lược định tuyến. Ở chế độ Thủ công, bạn kéo để đặt thứ tự; các chiến lược khác định tuyến theo điểm số trực tiếp dựa trên độ tin cậy, tốc độ và trí thông minh.",
     "weightsSummary": "độ tin cậy {reliability}% · tốc độ {speed}% · trí thông minh {intelligence}%",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "{count} yêu cầu tháng này"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Chiến lược định tuyến",
     "description": "Chọn một chiến lược định tuyến. Ở chế độ Thủ công, bạn kéo để đặt thứ tự; các chiến lược khác định tuyến theo điểm số trực tiếp dựa trên độ tin cậy, tốc độ và trí thông minh.",
     "weightsSummary": "độ tin cậy {reliability}% · tốc độ {speed}% · trí thông minh {intelligence}%",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -244,8 +244,8 @@
     "usageRequestsMonth": "ìbéèrè {count} ní oṣù yìí"
   },
   "strategies": {
-    "explore": "Explore unmeasured models",
-    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
+    "explore": "Ṣawari awọn awoṣe ti a ko ti wọn",
+    "exploreHint": "Fun awọn awoṣe ti ko ni data igbẹkẹle/iyara ni anfani 10% lati dan wo ki wọn le ko apẹẹrẹ jọ.",
     "title": "Ilana ipa ọna",
     "description": "Yan ilana ipa ọna. Ni ipo Afowoyi o fa lati ṣeto aṣẹ; ọna awọn ilana miiran nipasẹ Dimegilio ifiwe kọja igbẹkẹle, iyara ati oye.",
     "weightsSummary": "igbẹkẹle {reliability}% · iyara {speed}% · oye {intelligence}%",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "ìbéèrè {count} ní oṣù yìí"
   },
   "strategies": {
+    "explore": "Explore unmeasured models",
+    "exploreHint": "Give models without reliability/speed data a 10% chance to be tried so they build samples.",
     "title": "Ilana ipa ọna",
     "description": "Yan ilana ipa ọna. Ni ipo Afowoyi o fa lati ṣeto aṣẹ; ọna awọn ilana miiran nipasẹ Dimegilio ifiwe kọja igbẹkẹle, iyara ati oye.",
     "weightsSummary": "igbẹkẹle {reliability}% · iyara {speed}% · oye {intelligence}%",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -245,7 +245,7 @@
   },
   "strategies": {
     "explore": "探索未测模型",
-    "exploreHint": "给尚无稳定/速度数据的模型 10% 的尝试机会，以便积累样本。",
+    "exploreHint": "给尚无可靠性/速度数据的模型 10% 的尝试机会，以便积累样本。",
     "title": "路由策略",
     "description": "选择路由策略。手动模式下拖动即可设置顺序；其他策略会根据可靠性、速度和智能的实时评分进行路由。",
     "weightsSummary": "可靠性 {reliability}% · 速度 {speed}% · 智能 {intelligence}%",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "本月 {count} 次请求"
   },
   "strategies": {
+    "explore": "探索未测模型",
+    "exploreHint": "给尚无稳定/速度数据的模型 10% 的尝试机会，以便积累样本。",
     "title": "路由策略",
     "description": "选择路由策略。手动模式下拖动即可设置顺序；其他策略会根据可靠性、速度和智能的实时评分进行路由。",
     "weightsSummary": "可靠性 {reliability}% · 速度 {speed}% · 智能 {intelligence}%",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -245,7 +245,7 @@
   },
   "strategies": {
     "explore": "探索未測模型",
-    "exploreHint": "給尚無穩定/速度資料的模型 10% 的嘗試機會，以便累積樣本。",
+    "exploreHint": "給尚無可靠性/速度資料的模型 10% 的嘗試機會，以便累積樣本。",
     "title": "路由策略",
     "description": "選擇路由策略。在手動模式下，拖曳即可設定順序；其他策略會根據可靠性、速度與智慧的即時分數進行路由。",
     "weightsSummary": "可靠性 {reliability}% · 速度 {speed}% · 智慧 {intelligence}%",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -244,6 +244,8 @@
     "usageRequestsMonth": "本月 {count} 次請求"
   },
   "strategies": {
+    "explore": "探索未測模型",
+    "exploreHint": "給尚無穩定/速度資料的模型 10% 的嘗試機會，以便累積樣本。",
     "title": "路由策略",
     "description": "選擇路由策略。在手動模式下，拖曳即可設定順序；其他策略會根據可靠性、速度與智慧的即時分數進行路由。",
     "weightsSummary": "可靠性 {reliability}% · 速度 {speed}% · 智慧 {intelligence}%",

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -76,8 +76,9 @@ export interface RoutingData {
   weights: RoutingWeights | null
   customWeights: RoutingWeights
   /** Exploration toggle: when on, unmeasured models get a guaranteed chance to
-   *  be tried so they build reliability/speed data (#685 follow-up). */
-  exploreEnabled?: boolean
+   *  be tried so they build reliability/speed data (#685 follow-up). Required:
+   *  the server always sends it, and the checkbox renders straight from it. */
+  exploreEnabled: boolean
   scores: (RoutingScore & { platform: string; modelId: string; displayName: string; enabled: boolean })[]
 }
 

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -75,6 +75,9 @@ export interface RoutingData {
   strategy: RoutingStrategy
   weights: RoutingWeights | null
   customWeights: RoutingWeights
+  /** Exploration toggle: when on, unmeasured models get a guaranteed chance to
+   *  be tried so they build reliability/speed data (#685 follow-up). */
+  exploreEnabled?: boolean
   scores: (RoutingScore & { platform: string; modelId: string; displayName: string; enabled: boolean })[]
 }
 

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -107,7 +107,7 @@ export default function FallbackPage() {
   })
 
   const strategyMutation = useMutation({
-    mutationFn: (payload: { strategy: RoutingStrategy; weights?: RoutingWeights }) =>
+    mutationFn: (payload: { strategy: RoutingStrategy; weights?: RoutingWeights; exploreEnabled?: boolean }) =>
       apiFetch('/api/fallback/routing', { method: 'PUT', body: JSON.stringify(payload) }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['fallback', 'routing'] }),
   })
@@ -273,6 +273,22 @@ export default function FallbackPage() {
               />
             )}
           </div>
+
+          {/* Exploration toggle: give unmeasured models a guaranteed chance to
+              be tried so they build reliability/speed data (#685 follow-up). */}
+          <label className="mt-3 inline-flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={routing?.exploreEnabled ?? false}
+              disabled={strategyMutation.isPending}
+              onChange={e => strategyMutation.mutate({ strategy, exploreEnabled: e.target.checked })}
+              className="size-3.5 accent-foreground"
+            />
+            <span>{t('strategies.explore')}</span>
+            <Tooltip text={t('strategies.exploreHint')}>
+              <span className="cursor-help underline decoration-dotted underline-offset-2">?</span>
+            </Tooltip>
+          </label>
 
           <p className="mt-2 text-xs text-muted-foreground">
             {isManual ? t('strategies.modeManualHint') : t('strategies.modeScoreHint')}

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -274,25 +274,29 @@ export default function FallbackPage() {
             )}
           </div>
 
-          {/* Exploration toggle: give unmeasured models a guaranteed chance to
-              be tried so they build reliability/speed data (#685 follow-up). */}
-          <label className="mt-3 inline-flex items-center gap-2 text-xs text-muted-foreground">
-            <input
-              type="checkbox"
-              checked={routing?.exploreEnabled ?? false}
-              disabled={strategyMutation.isPending}
-              onChange={e => strategyMutation.mutate({ strategy, exploreEnabled: e.target.checked })}
-              className="size-3.5 accent-foreground"
-            />
-            <span>{t('strategies.explore')}</span>
-            <Tooltip text={t('strategies.exploreHint')}>
-              <span className="cursor-help underline decoration-dotted underline-offset-2">?</span>
-            </Tooltip>
-          </label>
-
           <p className="mt-2 text-xs text-muted-foreground">
             {isManual ? t('strategies.modeManualHint') : t('strategies.modeScoreHint')}
           </p>
+
+          {/* Exploration toggle (#685 follow-up): footnote-level on purpose —
+              a niche knob that gives unmeasured models a guaranteed chance to
+              be tried so they build reliability/speed data. Hidden in Manual
+              mode, where routeRequest ignores it. */}
+          {!isManual && (
+            <label className="mt-2 inline-flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={routing?.exploreEnabled ?? false}
+                disabled={strategyMutation.isPending}
+                onChange={e => strategyMutation.mutate({ strategy, exploreEnabled: e.target.checked })}
+                className="size-3.5 accent-foreground"
+              />
+              <span>{t('strategies.explore')}</span>
+              <Tooltip text={t('strategies.exploreHint')}>
+                <span className="cursor-help underline decoration-dotted underline-offset-2">?</span>
+              </Tooltip>
+            </label>
+          )}
         </section>
 
         <PenaltyInspector />

--- a/server/src/__tests__/routes/fallback.test.ts
+++ b/server/src/__tests__/routes/fallback.test.ts
@@ -212,6 +212,29 @@ describe('Fallback API', () => {
     await request(app, 'PUT', '/api/fallback/routing', { strategy: 'balanced' });
   });
 
+  // Regression: the toggle state must ride on GET /routing, not just the PUT
+  // echo — the dashboard checkbox renders from the GET payload, so a missing
+  // field made it look permanently off and impossible to disable from the UI.
+  it('GET /api/fallback/routing reflects the exploration toggle set via PUT', async () => {
+    const get0 = await request(app, 'GET', '/api/fallback/routing');
+    expect(get0.body.exploreEnabled).toBe(false);
+
+    const put = await request(app, 'PUT', '/api/fallback/routing', {
+      strategy: 'balanced',
+      exploreEnabled: true,
+    });
+    expect(put.status).toBe(200);
+    expect(put.body.exploreEnabled).toBe(true);
+
+    const get1 = await request(app, 'GET', '/api/fallback/routing');
+    expect(get1.body.exploreEnabled).toBe(true);
+
+    // Restore the default so later tests start clean.
+    await request(app, 'PUT', '/api/fallback/routing', { strategy: 'balanced', exploreEnabled: false });
+    const get2 = await request(app, 'GET', '/api/fallback/routing');
+    expect(get2.body.exploreEnabled).toBe(false);
+  });
+
   it('PUT /api/fallback/routing rejects all-zero custom weights', async () => {
     const { status } = await request(app, 'PUT', '/api/fallback/routing', {
       strategy: 'custom',

--- a/server/src/__tests__/services/router-bandit.test.ts
+++ b/server/src/__tests__/services/router-bandit.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   routeRequest, refreshStatsCache, getRoutingStrategy, setRoutingStrategy, getRoutingScores,
-  getCustomWeights, setCustomWeights,
+  getCustomWeights, setCustomWeights, getExploreEnabled, setExploreEnabled, EXPLORE_MIN_SAMPLES,
 } from '../../services/router.js';
 import * as ratelimit from '../../services/ratelimit.js';
 import { getDb, initDb } from '../../db/index.js';
@@ -193,5 +193,34 @@ describe('bandit router', () => {
     expect(scores[0].reliability).toBeGreaterThan(0.9);
     expect(scores[0].score).toBeGreaterThan(0);
     expect(scores[0].score).toBeLessThanOrEqual(1);
+  });
+
+  it('exploration toggle persists and defaults to off', () => {
+    expect(getExploreEnabled()).toBe(false);
+    setExploreEnabled(true);
+    expect(getExploreEnabled()).toBe(true);
+    setExploreEnabled(false);
+    expect(getExploreEnabled()).toBe(false);
+  });
+
+  it('exploration toggle gives an unmeasured model a chance to be tried', () => {
+    // A measured model that wins every bandit draw, plus a brand-new model with
+    // no reliability/speed samples. With the toggle off the new model is never
+    // routed; with it on it must appear within a bounded number of requests.
+    addModel({ platform: 'google', modelId: 'old', name: 'Old', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'new', name: 'New', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 2 });
+    addHistory('google', 'old', { successes: 500, failures: 0, outTokens: 1000, latencyMs: 300, ttfbMs: 100 });
+    setRoutingStrategy('balanced');
+    refreshStatsCache(getDb(), true);
+
+    // Toggle off: the unmeasured model loses every draw.
+    setExploreEnabled(false);
+    const without = pickCounts(200);
+    expect(without['new'] ?? 0).toBe(0);
+
+    // Toggle on: 10% per request → over 500 requests the new model must appear.
+    setExploreEnabled(true);
+    const withExplore = pickCounts(500);
+    expect(withExplore['new'] ?? 0).toBeGreaterThan(0);
   });
 });

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -7,7 +7,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { getDb } from '../db/index.js';
-import { getAllPenalties, getRoutingScores, getRoutingStrategy, setRoutingStrategy, setCustomWeights } from '../services/router.js';
+import { getAllPenalties, getRoutingScores, getRoutingStrategy, setRoutingStrategy, setCustomWeights, getExploreEnabled, setExploreEnabled } from '../services/router.js';
 import { BANDIT_PRESETS, type RoutingStrategy } from '../services/scoring.js';
 import { parseBudget } from '../lib/budget.js';
 import { getModelGroups } from '../services/model-groups.js';
@@ -38,6 +38,8 @@ const routingSchema = z.object({
     speed: z.number().nonnegative(),
     intelligence: z.number().nonnegative(),
   }).optional(),
+  // Exploration toggle: give unmeasured models a guaranteed chance to be tried.
+  exploreEnabled: z.boolean().optional(),
 });
 
 // PUT /routing → switch strategy. Presets are just weight vectors over the three
@@ -60,7 +62,10 @@ fallbackRouter.put('/routing', (req: Request, res: Response) => {
     }
   }
   setRoutingStrategy(parsed.data.strategy as RoutingStrategy);
-  res.json({ strategy: getRoutingStrategy(), presets: BANDIT_PRESETS });
+  if (parsed.data.exploreEnabled !== undefined) {
+    setExploreEnabled(parsed.data.exploreEnabled);
+  }
+  res.json({ strategy: getRoutingStrategy(), exploreEnabled: getExploreEnabled(), presets: BANDIT_PRESETS });
 });
 
 // Get fallback chain (with dynamic penalties)

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -1478,7 +1478,7 @@ export interface RoutingScore {
   totalRequests: number; // decay-weighted observations
 }
 
-export function getRoutingScores(): { strategy: RoutingStrategy; weights: RoutingWeights | null; customWeights: RoutingWeights; scores: RoutingScore[] } {
+export function getRoutingScores(): { strategy: RoutingStrategy; weights: RoutingWeights | null; customWeights: RoutingWeights; exploreEnabled: boolean; scores: RoutingScore[] } {
   const db = getDb();
   const strategy = getRoutingStrategy();
   refreshStatsCache(db);
@@ -1516,7 +1516,10 @@ export function getRoutingScores(): { strategy: RoutingStrategy; weights: Routin
   // so the dashboard's custom-weight sliders can render even before the user
   // has saved their own — distinct from `weights`, which is null in priority
   // mode and the active preset otherwise.
-  return { strategy, weights: weightsFor(strategy), customWeights: getCustomWeights(), scores };
+  // exploreEnabled must ride along here too: the dashboard checkbox renders
+  // from GET /routing, so omitting it would make the toggle look permanently
+  // off (and impossible to turn off) after a refetch.
+  return { strategy, weights: weightsFor(strategy), customWeights: getCustomWeights(), exploreEnabled: getExploreEnabled(), scores };
 }
 
 /**

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -292,6 +292,16 @@ export function getAllPenalties(): Array<{ modelDbId: number; count: number; pen
 // ── Routing strategy (persisted) ────────────────────────────────────────────
 const STRATEGY_KEY = 'routing_strategy';
 const CUSTOM_WEIGHTS_KEY = 'routing_custom_weights';
+const EXPLORE_KEY = 'routing_explore_enabled';
+
+/** Chance per request that an unmeasured model gets tried first when the
+ *  exploration toggle is on. The bandit's Thompson sampling already explores
+ *  automatically; this guarantees a floor so models with no reliability/speed
+ *  data still get sampled instead of being starved by prior-heavy rivals. */
+export const EXPLORE_CHANCE = 0.1;
+/** A model counts as "has data" once its decay-weighted success+failure
+ *  pseudo-count reaches this many samples. */
+export const EXPLORE_MIN_SAMPLES = 5;
 const VALID_STRATEGIES: RoutingStrategy[] = ['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom'];
 
 export function getRoutingStrategy(): RoutingStrategy {
@@ -306,6 +316,18 @@ export function setRoutingStrategy(strategy: RoutingStrategy): void {
     throw new Error(`Unknown routing strategy: ${strategy}`);
   }
   setSetting(STRATEGY_KEY, strategy);
+}
+
+// ── Exploration toggle (persisted) ─────────────────────────────────────────
+// Off by default: existing routing behavior unchanged. When on, routeRequest
+// gives unmeasured models a guaranteed chance to be tried (EXPLORE_CHANCE) so
+// they acquire reliability/speed samples instead of losing every bandit draw.
+export function getExploreEnabled(): boolean {
+  return getSetting(EXPLORE_KEY) === '1';
+}
+
+export function setExploreEnabled(enabled: boolean): void {
+  setSetting(EXPLORE_KEY, enabled ? '1' : '0');
 }
 
 // ── Custom weights (persisted) ──────────────────────────────────────────────
@@ -1323,6 +1345,27 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   const chain = (prefetchedChain ?? getActiveChain(db)).filter(e => e.enabled);
 
   const sortedChain = orderChain(chain, strategy);
+
+  // Exploration toggle (#685/#707 follow-up): when enabled, give a model with
+  // no reliability/speed samples a guaranteed chance to be tried, so it stops
+  // losing every bandit draw to prior-heavy rivals. With EXPLORE_CHANCE
+  // probability, pick one unmeasured model uniformly and try it first; if it
+  // fails, the loop falls through to the scored order as usual. Only for
+  // bandit strategies — Manual is the operator's explicit order.
+  if (strategy !== 'priority' && getExploreEnabled() && Math.random() < EXPLORE_CHANCE) {
+    const unmeasured = sortedChain.filter(e => {
+      const stats = statsCache?.get(modelStatsKey(e.platform, e.model_id, e.endpoint_scope));
+      return (stats?.successes ?? 0) + (stats?.failures ?? 0) < EXPLORE_MIN_SAMPLES;
+    });
+    if (unmeasured.length > 0) {
+      const probe = unmeasured[Math.floor(Math.random() * unmeasured.length)];
+      const idx = sortedChain.findIndex(e => e.model_db_id === probe.model_db_id);
+      if (idx > 0) {
+        const [probeRow] = sortedChain.splice(idx, 1);
+        sortedChain.unshift(probeRow);
+      }
+    }
+  }
 
   // Sticky session / Explicit pinning: move preferred model to front of chain
   if (preferredModelDbId) {


### PR DESCRIPTION
## What

Issue #685 follow-up: models with no reliability/speed samples can lose every bandit draw to prior-heavy rivals and never acquire data, so custom endpoints stay blind. Add a persisted exploration toggle (default off):

- when enabled, `routeRequest` gives an unmeasured model (decay-weighted success+failure < 5) a **10% chance per request** to be tried first, falling back to the scored order on failure — Manual/priority mode is untouched;
- exposed via `GET/PUT /api/fallback/routing` as `routing_explore_enabled`, and a checkbox on the FallbackPage strategy selector with a hint tooltip;
- Thompson sampling keeps exploring automatically; the toggle only adds a **guaranteed floor** so data gets built.

## Tests

Two new cases in `router-bandit.test.ts`:
- toggle persists and defaults to off;
- an unmeasured model is never routed when off, and appears within 500 requests when on (10% per request).

router-bandit + fallback suites green (25 tests); `tsc -b` (client + server) and i18n parity pass (60 locales / 751 keys).

## Files

- `server/src/services/router.ts` — `get/setExploreEnabled`, `EXPLORE_CHANCE`, exploration hook in `routeRequest`
- `server/src/routes/fallback.ts` — expose the toggle
- `server/src/__tests__/services/router-bandit.test.ts`
- `client/src/pages/FallbackPage.tsx` — checkbox
- `client/src/lib/routing.ts` — `exploreEnabled` on RoutingData
- `client/src/i18n/locales/*` — `strategies.explore` / `exploreHint`

Refs #685