### PR TITLE
release: v0.6.7

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "FreeLLMAPI menu-bar app \u2014 local OpenAI-compatible LLM router",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Version bump for v0.6.7.

Ships the plain-HTTP LAN fixes that make the dashboard load again on Docker installs reached over `http://<ip>:<port>` (#682, #687, #734), the per-key management rework, custom-endpoint fixes, month-to-date usage cards, password reset from the server logs, and the zh-CN docs tree.