### PR TITLE
docs(docker): explain why a container cannot reach providers the host can (#733)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,14 @@ PORT=3001
 # ALL_PROXY=socks5h://127.0.0.1:1080
 # HTTPS_PROXY=http://proxy.corp.com:8080
 # HTTP_PROXY=http://proxy.corp.com:8080
+#
+# IN DOCKER, 127.0.0.1 IS THE CONTAINER, NOT YOUR MACHINE. If the proxy runs
+# on the host (Clash, v2rayN, sing-box, a corporate client), use the host's
+# address instead, and make sure the proxy listens on more than loopback
+# (Clash: `allow-lan: true`):
+# PROXY_URL=socks5h://host.docker.internal:7890
+# The bundled docker-compose.yml maps host.docker.internal to the host gateway
+# so this works on plain Linux Docker too, not just Docker Desktop.
 
 # Hosts that must be reached directly, bypassing the proxy above. Comma-
 # separated; a bare domain also covers its subdomains, and `*` disables the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - "${HOST_BIND:-127.0.0.1}:${PORT:-3001}:3001"
     volumes:
       - freellmapi-data:/app/server/data
+    # Makes `host.docker.internal` resolve to the host from inside the
+    # container. Docker Desktop provides it already; plain Docker on Linux does
+    # not, and without it the documented way to reach a proxy running on the
+    # host (PROXY_URL=http://host.docker.internal:7890) fails to resolve.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     healthcheck:
       test:

--- a/docs/i18n/zh-CN/docs/install.md
+++ b/docs/i18n/zh-CN/docs/install.md
@@ -70,6 +70,17 @@ docker compose up -d
 >
 > 只在你信任的网络里这么做：这个代理是单用户的，唯一的防护就是那把统一 API 密钥。
 
+> **宿主机连得上提供方，容器里却连不上？** 容器有自己独立的网络栈，所以有两件在你机器上成立的事，到了容器里并不成立：
+>
+> - **`127.0.0.1` 在容器里指的是容器自己，不是你的机器。** 如果你是通过宿主机上的代理客户端（Clash、v2rayN、sing-box，或公司代理）访问提供方，请把 FreeLLMAPI 指向宿主机：`PROXY_URL=socks5h://host.docker.internal:7890`。仓库自带的 `docker-compose.yml` 已经把 `host.docker.internal` 映射到宿主网关，所以在 Linux 上的原生 Docker 里同样可用，不只是 Docker Desktop。另外代理本身也要允许来自 loopback 以外的连接（Clash 里是 `allow-lan: true`）。
+> - **纯 IPv6 的宿主机需要在 Docker 里开启 IPv6。** 默认的 bridge 网络只有 IPv4，所以在没有 IPv4 出口的宿主机上，容器什么都连不上，连 DNS 也一样。在 `/etc/docker/daemon.json` 里加上 `"ipv6": true`、`"ip6tables": true` 和一个 `"fixed-cidr-v6"` 网段，然后重启 Docker。
+>
+> 想知道自己属于哪一种，直接问容器：
+>
+> ```bash
+> docker compose exec freellmapi node -e "fetch('https://generativelanguage.googleapis.com/').then(r=>console.log('ok',r.status)).catch(e=>console.log('fail',e.cause?.code||e.message))"
+> ```
+
 ## 本地开发
 
 **前置条件：** Node.js 20+、npm。
@@ -169,6 +180,8 @@ docker compose logs -f freellmapi
 ```
 
 容器端口默认绑定在 `127.0.0.1`（仅本机）。想从网络里的另一台机器访问仪表盘或 API，用 `HOST_BIND=0.0.0.0 docker compose up -d` 把它发布到所有网卡上。只在可信的局域网里这么做，因为这个代理是单用户的。
+
+用局域网地址走纯 HTTP 是可以直接工作的：那些只对 HTTPS 生效的安全响应头（`upgrade-insecure-requests`、`Cross-Origin-Opener-Policy`、`Origin-Agent-Cluster`）只有在请求确实经由 TLS 到达时才会发出，或者是在 loopback 上，因为浏览器本来就把 loopback 当作安全上下文。放在 HTTPS 反向代理后面时它们会自动恢复，只要代理转发了 `X-Forwarded-Proto`。如果你的部署有特殊需要，`CSP_UPGRADE_INSECURE_REQUESTS=true|false` 可以强制开关那条升级指令。
 
 SQLite 数据存放在 `freellmapi-data` 卷的 `/app/server/data` 下。升级时请保持 `.env` 里的 `ENCRYPTION_KEY` 和这个卷不变，因为提供方密钥是加密存储的。如果你的宿主机只持久化某个特定目录，可以设置 `FREEAPI_DB_PATH=/that/path/freellmapi.db`。
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -70,6 +70,17 @@ docker compose up -d
 >
 > Only do this on a trusted network: the proxy is single-user and guarded only by the unified API key.
 
+> **Providers unreachable from the container, but fine from the host?** A container has its own network stack, so two things that work on your machine do not carry over:
+>
+> - **A proxy on `127.0.0.1` is not your machine.** Inside the container, loopback is the container itself. If you reach providers through a proxy client on the host (Clash, v2rayN, sing-box, a corporate proxy), point FreeLLMAPI at the host instead: `PROXY_URL=socks5h://host.docker.internal:7890`. The bundled `docker-compose.yml` maps `host.docker.internal` to the host gateway, so this works on plain Linux Docker as well as Docker Desktop. The proxy also has to accept connections from outside loopback (in Clash, `allow-lan: true`).
+> - **An IPv6-only host needs IPv6 enabled in Docker.** The default bridge network is IPv4-only, so on a host with no IPv4 route the container cannot reach anything, DNS included. Enable it in `/etc/docker/daemon.json` with `"ipv6": true`, `"ip6tables": true` and a `"fixed-cidr-v6"` range, then restart Docker.
+>
+> To see which of these you are hitting, ask the container directly:
+>
+> ```bash
+> docker compose exec freellmapi node -e "fetch('https://generativelanguage.googleapis.com/').then(r=>console.log('ok',r.status)).catch(e=>console.log('fail',e.cause?.code||e.message))"
+> ```
+
 ## Local development
 
 **Prerequisites:** Node.js 20+, npm.


### PR DESCRIPTION
Follow-up to #733.

Nothing in the server is at fault there. The outbound path has no IPv4 pinning, IPv6 addresses are classified correctly, and transport errors deliberately do not demote or disable keys. What is at fault is our documentation, which points people straight into the trap.

**A proxy on the host.** `.env.example` suggested `PROXY_URL=socks5h://127.0.0.1:1080`. Inside a container that is the container itself, so anyone reaching providers through Clash, v2rayN, sing-box or a corporate proxy on the host gets a silent transport failure on every provider at once. The fix is `host.docker.internal`, and `docker-compose.yml` now maps it to the host gateway via `extra_hosts`, so it resolves on plain Linux Docker rather than only Docker Desktop.

**An IPv6-only host.** The default bridge network is IPv4-only, so with no IPv4 route on the host the container cannot reach anything, DNS included, until the daemon has `ipv6` and `ip6tables` turned on.

Both notes ship with a one-liner that asks the container directly which one it is hitting:

```bash
docker compose exec freellmapi node -e "fetch('https://generativelanguage.googleapis.com/').then(r=>console.log('ok',r.status)).catch(e=>console.log('fail',e.cause?.code||e.message))"
```

Mirrored into the zh-CN install guide, since that is where the reports are coming from, together with the plain-HTTP LAN paragraph that #735 added to the English page only.