### PR TITLE
feat(telemetry): opt-in anonymized reliability uploader

### DIFF
--- a/server/src/__tests__/services/catalog-sync-scheduler.test.ts
+++ b/server/src/__tests__/services/catalog-sync-scheduler.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
-import { initDb } from '../../db/index.js';
+import { initDb, getDb } from '../../db/index.js';
 import { startCatalogSync, stopCatalogSync } from '../../services/catalog-sync.js';
+import {
+  collectTelemetryStats,
+  isTelemetryOptIn,
+  setTelemetryOptIn,
+  getTelemetryEndpoint,
+  setTelemetryEndpoint,
+  uploadTelemetry,
+  startTelemetryUpload,
+  cancelTelemetryUpload,
+} from '../../services/telemetry.js';
 import type { Scheduler } from '../../lib/scheduler.js';
 
 function makeScheduler() {
@@ -77,5 +87,171 @@ describe('startCatalogSync / stopCatalogSync', () => {
     startCatalogSync(s2);
     expect(after).toHaveLength(1);
     expect(every).toHaveLength(1);
+  });
+});
+
+// ── Anonymized reliability telemetry (opt-in, #685 design B1) ───────────────
+// The scheduler-registration tests above double as the harness for the
+// telemetry uploader: same Scheduler shape, same DB. Telemetry must stay
+// opt-in (nothing leaves the box by default), send only (platform, model_id,
+// counts), and never crash the scheduler on a failed upload.
+
+const realFetch = globalThis.fetch;
+
+function addRequest(opts: {
+  platform: string; modelId: string; status: string; latencyMs: number; daysAgo?: number;
+}) {
+  const created = opts.daysAgo
+    ? new Date(Date.now() - opts.daysAgo * 24 * 60 * 60 * 1000).toISOString()
+    : new Date().toISOString();
+  getDb().prepare(`
+    INSERT INTO requests (platform, model_id, status, input_tokens, output_tokens, latency_ms, created_at)
+    VALUES (?, ?, ?, 0, 0, ?, ?)
+  `).run(opts.platform, opts.modelId, opts.status, opts.latencyMs, created);
+}
+
+describe('telemetry: settings', () => {
+  beforeEach(() => {
+    // The shared in-memory DB persists settings across tests in this file, so
+    // reset the telemetry keys explicitly before each case.
+    setTelemetryOptIn(false);
+    setTelemetryEndpoint('');
+    cancelTelemetryUpload();
+  });
+
+  it('defaults to off with no endpoint', () => {
+    expect(isTelemetryOptIn()).toBe(false);
+    expect(getTelemetryEndpoint()).toBe('');
+  });
+
+  it('persists opt-in and endpoint', () => {
+    setTelemetryOptIn(true);
+    setTelemetryEndpoint('https://telemetry.example.com/v1/collect');
+    expect(isTelemetryOptIn()).toBe(true);
+    expect(getTelemetryEndpoint()).toBe('https://telemetry.example.com/v1/collect');
+  });
+});
+
+describe('telemetry: collectTelemetryStats', () => {
+  beforeEach(() => {
+    setTelemetryOptIn(true);
+    getDb().exec('DELETE FROM requests');
+  });
+
+  afterEach(() => {
+    cancelTelemetryUpload();
+    getDb().exec('DELETE FROM requests');
+  });
+
+  it('aggregates success/failure counts and mean latency per model', () => {
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'success', latencyMs: 100 });
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'success', latencyMs: 200 });
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'error', latencyMs: 3000 });
+    addRequest({ platform: 'google', modelId: 'gemini', status: 'success', latencyMs: 50 });
+
+    const stats = collectTelemetryStats(getDb());
+    const llama = stats.find(s => s.modelId === 'llama')!;
+    expect(llama).toMatchObject({ platform: 'groq', successes: 2, failures: 1 });
+    expect(llama.avgLatencyMs).toBe(150);
+    const gemini = stats.find(s => s.modelId === 'gemini')!;
+    expect(gemini).toMatchObject({ platform: 'google', successes: 1, failures: 0 });
+    expect(gemini.avgLatencyMs).toBe(50);
+  });
+
+  it('excludes requests older than the 7-day window', () => {
+    addRequest({ platform: 'groq', modelId: 'old', status: 'success', latencyMs: 100, daysAgo: 30 });
+    expect(collectTelemetryStats(getDb())).toHaveLength(0);
+  });
+});
+
+describe('telemetry: uploadTelemetry', () => {
+  beforeEach(() => {
+    setTelemetryOptIn(false);
+    setTelemetryEndpoint('');
+    getDb().exec('DELETE FROM requests');
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+    cancelTelemetryUpload();
+    getDb().exec('DELETE FROM requests');
+  });
+
+  it('sends nothing when opt-in is off', async () => {
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'success', latencyMs: 100 });
+    const mock = vi.fn(async () => new Response('ok', { status: 200 }));
+    globalThis.fetch = mock as any;
+
+    const sent = await uploadTelemetry(getDb(), 'https://telemetry.example.com/v1/collect');
+    expect(sent).toBe(false);
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs an anonymized payload to the configured endpoint', async () => {
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'success', latencyMs: 100 });
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'error', latencyMs: 500 });
+    setTelemetryOptIn(true);
+
+    const mock = vi.fn(async () => new Response('ok', { status: 200 }));
+    globalThis.fetch = mock as any;
+
+    const sent = await uploadTelemetry(getDb(), 'https://telemetry.example.com/v1/collect');
+    expect(sent).toBe(true);
+
+    const [url, init] = mock.mock.calls[0]!;
+    expect(String(url)).toBe('https://telemetry.example.com/v1/collect');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+
+    const body = JSON.parse(String((init as RequestInit).body)) as any;
+    expect(body.v).toBe(1);
+    expect(body.models).toHaveLength(1);
+    expect(body.models[0]).toMatchObject({ platform: 'groq', modelId: 'llama', successes: 1, failures: 1 });
+    expect(typeof body.models[0].avgLatencyMs).toBe('number');
+    // Privacy: only platform + model id + counts leave the box.
+    expect(JSON.stringify(body)).not.toContain('key');
+    expect(JSON.stringify(body)).not.toContain('http://');
+  });
+
+  it('returns false when the endpoint rejects the upload', async () => {
+    addRequest({ platform: 'groq', modelId: 'llama', status: 'success', latencyMs: 100 });
+    setTelemetryOptIn(true);
+    const mock = vi.fn(async () => new Response('nope', { status: 500 }));
+    globalThis.fetch = mock as any;
+
+    expect(await uploadTelemetry(getDb(), 'https://telemetry.example.com/v1/collect')).toBe(false);
+  });
+});
+
+describe('telemetry: startTelemetryUpload', () => {
+  beforeEach(() => {
+    setTelemetryOptIn(false);
+    setTelemetryEndpoint('');
+  });
+
+  afterEach(() => {
+    cancelTelemetryUpload();
+  });
+
+  it('registers a boot delay and a daily interval when opted in', () => {
+    setTelemetryOptIn(true);
+    setTelemetryEndpoint('https://telemetry.example.com/v1/collect');
+    const { scheduler, every, after } = makeScheduler();
+
+    startTelemetryUpload(scheduler, getDb());
+
+    expect(after).toHaveLength(1);
+    expect(every).toHaveLength(1);
+    expect(every[0]!.ms).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('registers nothing when opted out', () => {
+    const { scheduler, every, after } = makeScheduler();
+
+    startTelemetryUpload(scheduler, getDb());
+
+    expect(after).toHaveLength(0);
+    expect(every).toHaveLength(0);
   });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { applyProxyUrl, applyProxyEnabled, applyProxyBypass, flushProxyCache } f
 import { startWakeDetect } from './lib/wake-detect.js';
 import { startCatalogSync } from './services/catalog-sync.js';
 import { startCooldownProbe } from './services/cooldown-probe.js';
+import { startTelemetryUpload } from './services/telemetry.js';
 import { installProcessSafetyNet } from './lib/process-safety-net.js';
 import { NodeScheduler } from './lib/scheduler.js';
 import { loadConfig } from './lib/config.js';
@@ -63,6 +64,7 @@ async function main() {
     startCatalogSync(scheduler);
     startCooldownProbe(scheduler);
     startDbBackupPump(getDb(), scheduler, config.dbPath ?? undefined);
+    startTelemetryUpload(scheduler, getDb());
 
     // Post-sleep recovery: while the host was suspended (laptop lid, VM
     // pause) timers and keep-alive sockets froze, so the first requests after

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -9,6 +9,9 @@ import { getGeminiModelMap, setGeminiModelMap } from '../services/gemini-map.js'
 import { getOllamaEmulationMode } from './ollama.js';
 import { listUrlTokens, mintUrlToken, revokeUrlToken } from '../services/url-tokens.js';
 import {
+  isTelemetryOptIn, setTelemetryOptIn, getTelemetryEndpoint, setTelemetryEndpoint,
+} from '../services/telemetry.js';
+import {
   getRequestMaxTokensBudget,
   getMaxConsecutiveUpstreamFails,
   REQUEST_MAX_TOKENS_BUDGET_SETTING,
@@ -166,6 +169,31 @@ settingsRouter.put('/agent-compatibility', (req: Request, res: Response) => {
 
 settingsRouter.get('/url-tokens', (_req: Request, res: Response) => {
   res.json({ tokens: listUrlTokens() });
+});
+
+const telemetrySchema = z.object({
+  optIn: z.boolean().optional(),
+  endpoint: z.string().url('endpoint must be a valid URL').or(z.literal('')).optional(),
+}).strict();
+
+settingsRouter.get('/telemetry', (_req: Request, res: Response) => {
+  res.json({ optIn: isTelemetryOptIn(), endpoint: getTelemetryEndpoint() });
+});
+
+settingsRouter.put('/telemetry', (req: Request, res: Response) => {
+  const parsed = telemetrySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      error: {
+        message: `Invalid telemetry settings: ${parsed.error.errors.map(error => error.message).join(', ')}`,
+        type: 'invalid_request_error',
+      },
+    });
+    return;
+  }
+  if (parsed.data.optIn !== undefined) setTelemetryOptIn(parsed.data.optIn);
+  if (parsed.data.endpoint !== undefined) setTelemetryEndpoint(parsed.data.endpoint);
+  res.json({ optIn: isTelemetryOptIn(), endpoint: getTelemetryEndpoint() });
 });
 
 settingsRouter.post('/url-tokens', (req: Request, res: Response) => {

--- a/server/src/services/telemetry.ts
+++ b/server/src/services/telemetry.ts
@@ -1,0 +1,150 @@
+import type { Db } from '../db/types.js';
+import { getSetting, setSetting } from '../db/index.js';
+import type { Scheduler } from '../lib/scheduler.js';
+
+// ── Anonymized reliability telemetry (opt-in) ───────────────────────────────
+//
+// Design B1 of #685: self-hosted instances have no cross-instance quality
+// signal, so a brand-new model starts blind until local traffic accumulates.
+// This background job lets an operator OPT IN to publishing a tiny, anonymized
+// summary of what their gateway has observed — the aggregate that the
+// community-reliability prior (services/router.ts, routing_community_prior) is
+// meant to be seeded from.
+//
+// Privacy boundary (the reason this is opt-in and not on by default):
+//   - only (platform, model_id) + decay-raw success/failure counts + speed
+//     stats are sent. No keys, no request bodies, no client IPs, no base URLs;
+//   - custom endpoints are included ONLY as model ids — never their base_url;
+//   - the endpoint is a single configured URL; nothing else ever leaves the box.
+//
+// Failure handling: a failed upload logs once and waits for the next tick. It
+// never crashes the scheduler and never retries in a tight loop.
+
+/** Settings keys. */
+export const TELEMETRY_OPT_IN_KEY = 'telemetry_opt_in';
+export const TELEMETRY_ENDPOINT_KEY = 'telemetry_endpoint';
+
+/** Default aggregation window — matches the bandit's 7-day stats window. */
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/** How often the uploader runs. Daily is enough for a slowly-evolving prior. */
+export const TELEMETRY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+/** Let the server settle before the first upload (catalog-sync convention). */
+const BOOT_DELAY_MS = 30 * 1000;
+/** Bounded outbound request: this is best-effort background work. */
+const UPLOAD_TIMEOUT_MS = 15 * 1000;
+
+/** What one model contributes to the shared prior. */
+export interface TelemetryModelStat {
+  platform: string;
+  modelId: string;
+  /** Raw (non-decayed) success count over the window. */
+  successes: number;
+  /** Raw (non-decayed) failure count over the window. */
+  failures: number;
+  /** Mean latency of successful requests, ms (null when no successes). */
+  avgLatencyMs: number | null;
+}
+
+export interface TelemetryPayload {
+  v: 1;
+  sentAt: string;
+  models: TelemetryModelStat[];
+}
+
+export function isTelemetryOptIn(): boolean {
+  return getSetting(TELEMETRY_OPT_IN_KEY) === '1';
+}
+
+export function setTelemetryOptIn(enabled: boolean): void {
+  setSetting(TELEMETRY_OPT_IN_KEY, enabled ? '1' : '0');
+}
+
+export function getTelemetryEndpoint(): string {
+  return getSetting(TELEMETRY_ENDPOINT_KEY) ?? '';
+}
+
+export function setTelemetryEndpoint(url: string): void {
+  setSetting(TELEMETRY_ENDPOINT_KEY, url.trim());
+}
+
+/**
+ * Aggregate the last WINDOW_MS of requests into per-model stats. Only
+ * (platform, model_id) identity leaves the box — custom base URLs are never
+ * included. The rows are the same source the bandit scores from, so the
+ * published prior matches what the router actually sees.
+ */
+export function collectTelemetryStats(db: Db): TelemetryModelStat[] {
+  const since = new Date(Date.now() - WINDOW_MS).toISOString();
+  const rows = db.prepare(`
+    SELECT platform, model_id,
+      COUNT(*) AS total,
+      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS successes,
+      SUM(CASE WHEN status = 'success' THEN latency_ms ELSE 0 END) AS succ_lat
+    FROM requests
+    WHERE created_at >= ?
+    GROUP BY platform, model_id
+    HAVING total > 0
+  `).all(since) as Array<{
+    platform: string; model_id: string; total: number; successes: number; succ_lat: number;
+  }>;
+
+  return rows.map(r => ({
+    platform: r.platform,
+    modelId: r.model_id,
+    successes: Number(r.successes ?? 0),
+    failures: Number(r.total - (r.successes ?? 0)),
+    avgLatencyMs: (r.successes ?? 0) > 0
+      ? Math.round(Number(r.succ_lat ?? 0) / Number(r.successes))
+      : null,
+  }))
+    .filter(s => s.successes + s.failures > 0)
+    .sort((a, b) => a.platform.localeCompare(b.platform) || a.modelId.localeCompare(b.modelId));
+}
+
+/** POST the anonymized summary to the configured endpoint. Returns false on
+ *  any failure so the caller can log once and wait for the next tick. */
+export async function uploadTelemetry(db: Db, endpoint?: string): Promise<boolean> {
+  if (!isTelemetryOptIn()) return false;
+  const target = endpoint ?? getTelemetryEndpoint();
+  if (!target) return false;
+
+  const models = collectTelemetryStats(db);
+  if (models.length === 0) return true; // nothing observed yet — not an error
+
+  const payload: TelemetryPayload = { v: 1, sentAt: new Date().toISOString(), models };
+  try {
+    const res = await fetch(target, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(UPLOAD_TIMEOUT_MS),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Test hook: forget boot timer state between tests. */
+let cancelBootTimer: (() => void) | null = null;
+export function cancelTelemetryUpload(): void {
+  cancelBootTimer?.();
+  cancelBootTimer = null;
+}
+
+export function startTelemetryUpload(scheduler: Scheduler, db: Db): void {
+  if (!isTelemetryOptIn()) {
+    console.log('[Telemetry] disabled (telemetry_opt_in not set) — nothing will be uploaded.');
+    return;
+  }
+  const endpoint = getTelemetryEndpoint();
+  console.log(`[Telemetry] opt-in enabled — anonymized stats upload to ${endpoint} every ${TELEMETRY_INTERVAL_MS / 1000}s`);
+
+  const run = async (): Promise<void> => {
+    const ok = await uploadTelemetry(db);
+    if (!ok) console.warn('[Telemetry] upload failed — will retry next tick.');
+  };
+
+  cancelBootTimer = scheduler.after(BOOT_DELAY_MS, run);
+  scheduler.every(TELEMETRY_INTERVAL_MS, run, { name: 'telemetry-upload' });
+}


### PR DESCRIPTION
## What

Issue #685 design B1: self-hosted instances have no cross-instance quality signal, so a brand-new model starts blind until local traffic accumulates. This adds an **opt-in** background job that publishes a tiny, anonymized summary of what the gateway observed — the aggregate the community-reliability prior (separate PR, B3) is meant to be seeded from.

**Privacy boundary (off by default):**
- only `(platform, model_id)` + raw success/failure counts + mean latency leave the box — no keys, request bodies, client IPs, or custom base URLs;
- a single configured endpoint; nothing else ever goes out;
- a failed upload logs once and waits for the next daily tick — it never crashes the scheduler.

## Implementation

- `server/src/services/telemetry.ts` — `collectTelemetryStats` (7-day window, same source the bandit scores from) + `uploadTelemetry` (POST, 15s timeout) + `startTelemetryUpload` (boot delay + daily interval, registers nothing when opted out);
- `server/src/routes/settings.ts` — `GET/PUT /telemetry` (`optIn` + `endpoint`);
- `server/src/index.ts` — wired into the ready hook.

## Tests

14 tests in `catalog-sync-scheduler.test.ts` (reusing its scheduler harness): defaults off, persistence, aggregation + 7-day window, opt-in gate, anonymized payload shape (no key/base-url leakage), endpoint rejection, scheduler registration on/off.

Co-Authored-By: AtomCode (deepseek-v4-flash) <noreply@atomgit.com>