### PR TITLE
fix(router): penalize repeated empty 'length' completions, guarantee a failover hop, and record client aborts (#751, #752)

### DIFF
--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "የተጠየቀ {model}፣ በመውደቅ አገልግሏል",
     "attempts": "ሙከራዎች",
     "filterAll": "ሁሉም",
+    "filterCanceled": "የተሰረዙ",
     "providerBreakdown": "በእያንዳንዱ አቅራቢ መከፋፈል",
     "tokensPerSec": "ቶክ / ዎች",
     "allProviders": "ሁሉም አቅራቢዎች",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "تم طلب {model}، ويتم تقديمه بطريقة احتياطية",
     "attempts": "محاولات",
     "filterAll": "الكل",
+    "filterCanceled": "ملغاة",
     "providerBreakdown": "تفصيل لكل مزود",
     "tokensPerSec": "توك/س",
     "allProviders": "جميع مقدمي الخدمة",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} tələb olundu, ehtiyat qüvvə ilə təqdim edildi",
     "attempts": "Cəhdlər",
     "filterAll": "Hamı",
+    "filterCanceled": "Ləğv edilmiş",
     "providerBreakdown": "Təminatçı üzrə bölgü",
     "tokensPerSec": "Tok/s",
     "allProviders": "Bütün təminatçılar",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Поискано {model}, обслужено като резерв",
     "attempts": "Опити",
     "filterAll": "Всички",
+    "filterCanceled": "Отменени",
     "providerBreakdown": "Разпределение на всеки доставчик",
     "tokensPerSec": "Ток/с",
     "allProviders": "Всички доставчици",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "অনুরোধ করা হয়েছে {model}, ফলব্যাক দ্বারা পরিবেশিত৷",
     "attempts": "প্রচেষ্টা",
     "filterAll": "সব",
+    "filterCanceled": "বাতিল",
     "providerBreakdown": "প্রতি-প্রদানকারী ব্রেকডাউন",
     "tokensPerSec": "টোক/সে",
     "allProviders": "সমস্ত প্রদানকারী",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Požadovaný {model}, sloužen záložní variantou",
     "attempts": "Pokusy",
     "filterAll": "Všichni",
+    "filterCanceled": "Zrušené",
     "providerBreakdown": "Rozdělení podle poskytovatele",
     "tokensPerSec": "Tok/s",
     "allProviders": "Všichni poskytovatelé",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Anmodede {model}, betjent via fallback",
     "attempts": "Forsøg",
     "filterAll": "Alle",
+    "filterCanceled": "Annullerede",
     "providerBreakdown": "Opdeling pr. udbyder",
     "tokensPerSec": "Tok/s",
     "allProviders": "Alle udbydere",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Angeforderter {model}, bereitgestellt durch Fallback",
     "attempts": "Versuche",
     "filterAll": "Alle",
+    "filterCanceled": "Abgebrochen",
     "providerBreakdown": "Aufschlüsselung nach Anbieter",
     "tokensPerSec": "Tok/s",
     "allProviders": "Alle Anbieter",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Ζητήθηκε {model}, εξυπηρετείται από εναλλακτική",
     "attempts": "Προσπάθειες",
     "filterAll": "Όλα",
+    "filterCanceled": "Ακυρωμένες",
     "providerBreakdown": "Ανάλυση ανά πάροχο",
     "tokensPerSec": "Τοκ/α",
     "allProviders": "Όλοι οι πάροχοι",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -567,6 +567,7 @@
     "requestedModelHint": "Requested {model}, served by fallback",
     "attempts": "Attempts",
     "filterAll": "All",
+    "filterCanceled": "Canceled",
     "providerBreakdown": "Per-provider breakdown",
     "tokensPerSec": "Tok/s",
     "allProviders": "All providers",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Se solicitó {model}, servido por respaldo",
     "attempts": "Intentos",
     "filterAll": "Todas",
+    "filterCanceled": "Canceladas",
     "providerBreakdown": "Desglose por proveedor",
     "tokensPerSec": "Tok/s",
     "allProviders": "Todos los proveedores",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "درخواست {model}، ارائه شده توسط بازگشت",
     "attempts": "تلاش ها",
     "filterAll": "همه",
+    "filterCanceled": "لغوشده",
     "providerBreakdown": "تفکیک هر ارائه دهنده",
     "tokensPerSec": "Tok/s",
     "allProviders": "همه ارائه دهندگان",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Pyydetty {model}, toimitettu varasuunnitelmana",
     "attempts": "Yritykset",
     "filterAll": "Kaikki",
+    "filterCanceled": "Peruutetut",
     "providerBreakdown": "Palveluntarjoajakohtainen erittely",
     "tokensPerSec": "Tok/s",
     "allProviders": "Kaikki palveluntarjoajat",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} demandé, servi par repli",
     "attempts": "Tentatives",
     "filterAll": "Toutes",
+    "filterCanceled": "Annulées",
     "providerBreakdown": "Détail par fournisseur",
     "tokensPerSec": "Tok/s",
     "allProviders": "Tous les fournisseurs",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} વિનંતી કરી, ફોલબેક દ્વારા સેવા આપવામાં આવી",
     "attempts": "પ્રયાસો",
     "filterAll": "બધા",
+    "filterCanceled": "રદ થયેલ",
     "providerBreakdown": "પ્રતિ-પ્રદાતા બ્રેકડાઉન",
     "tokensPerSec": "ટોક/સે",
     "allProviders": "બધા પ્રદાતાઓ",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Neman {model}, wanda aka yi amfani da shi ta koma baya",
     "attempts": "Ƙoƙari",
     "filterAll": "Duka",
+    "filterCanceled": "An soke",
     "providerBreakdown": "Rushewar kowane mai bayarwa",
     "tokensPerSec": "Tok/s",
     "allProviders": "Duk masu samarwa",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "מבוקש {model}, משרת על ידי גיבוי",
     "attempts": "ניסיונות",
     "filterAll": "הכל",
+    "filterCanceled": "בוטלו",
     "providerBreakdown": "פירוט לכל ספק",
     "tokensPerSec": "Tok/s",
     "allProviders": "כל הספקים",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "अनुरोधित {model}, फ़ॉलबैक द्वारा सेवा प्रदान की गई",
     "attempts": "प्रयास",
     "filterAll": "सब",
+    "filterCanceled": "रद्द",
     "providerBreakdown": "प्रति-प्रदाता टूटना",
     "tokensPerSec": "टोक/एस",
     "allProviders": "सभी प्रदाता",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Zatraženo {model}, posluženo kao rezerva",
     "attempts": "Pokušaji",
     "filterAll": "Svi",
+    "filterCanceled": "Otkazani",
     "providerBreakdown": "Raspodjela po pružatelju usluga",
     "tokensPerSec": "Tok/s",
     "allProviders": "Svi pružatelji",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Kértem {model}, tartalék kézbe szállítva",
     "attempts": "Próbálkozások",
     "filterAll": "Mind",
+    "filterCanceled": "Megszakítva",
     "providerBreakdown": "Szolgáltatónkénti bontás",
     "tokensPerSec": "Tok/s",
     "allProviders": "Minden szolgáltató",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} yang diminta, dilayani oleh fallback",
     "attempts": "Upaya",
     "filterAll": "Semua",
+    "filterCanceled": "Dibatalkan",
     "providerBreakdown": "Perincian per penyedia",
     "tokensPerSec": "Tok/dtk",
     "allProviders": "Semua penyedia",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Arịrịọ {model}, nke na-azaghachi azụ azụ",
     "attempts": "Mgbalị",
     "filterAll": "Ha niile",
+    "filterCanceled": "Ndị a kagburu",
     "providerBreakdown": "Mmebi nke onye na-eweta ya",
     "tokensPerSec": "Tok/s",
     "allProviders": "Ndị na-eweta niile",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Richiesto {model}, servito dal fallback",
     "attempts": "Tentativi",
     "filterAll": "Tutte",
+    "filterCanceled": "Annullate",
     "providerBreakdown": "Dettaglio per provider",
     "tokensPerSec": "Tok/s",
     "allProviders": "Tutti i provider",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "リクエストされた {model}、フォールバックによって提供される",
     "attempts": "試み",
     "filterAll": "すべて",
+    "filterCanceled": "キャンセル",
     "providerBreakdown": "プロバイダーごとの内訳",
     "tokensPerSec": "トク/秒",
     "allProviders": "すべてのプロバイダー",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "მოითხოვა {model}, მოწოდებული სარეზერვო საშუალებით",
     "attempts": "მცდელობები",
     "filterAll": "ყველა",
+    "filterCanceled": "გაუქმებული",
     "providerBreakdown": "თითო პროვაიდერის დაშლა",
     "tokensPerSec": "ტოკ/ს",
     "allProviders": "ყველა პროვაიდერი",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "បានស្នើសុំ {model} បម្រើដោយជម្រើសបម្រុង",
     "attempts": "ការព្យាយាម",
     "filterAll": "ទាំងអស់",
+    "filterCanceled": "បានបោះបង់",
     "providerBreakdown": "ការបែងចែកតាមអ្នកផ្តល់សេវា",
     "tokensPerSec": "តុក/វិនាទី",
     "allProviders": "អ្នកផ្តល់សេវាទាំងអស់",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "ವಿನಂತಿಸಿದ {model}, ಫಾಲ್‌ಬ್ಯಾಕ್ ಮೂಲಕ ಸೇವೆ ಸಲ್ಲಿಸಲಾಗಿದೆ",
     "attempts": "ಪ್ರಯತ್ನಗಳು",
     "filterAll": "ಎಲ್ಲಾ",
+    "filterCanceled": "ರದ್ದಾದವು",
     "providerBreakdown": "ಪ್ರತಿ-ಒದಗಿಸುವವರ ಸ್ಥಗಿತ",
     "tokensPerSec": "ಟೋಕ್/ರು",
     "allProviders": "ಎಲ್ಲಾ ಪೂರೈಕೆದಾರರು",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "대체 서비스로 제공되는 {model} 요청",
     "attempts": "시도",
     "filterAll": "모두",
+    "filterCanceled": "취소됨",
     "providerBreakdown": "공급자별 분석",
     "tokensPerSec": "톡/초",
     "allProviders": "모든 제공업체",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Prašyta {model}, aptarnauta atsarginiu būdu",
     "attempts": "Bandymai",
     "filterAll": "Visi",
+    "filterCanceled": "Atšauktos",
     "providerBreakdown": "Pasiskirstymas pagal tiekėją",
     "tokensPerSec": "Tok/s",
     "allProviders": "Visi tiekėjai",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} അഭ്യർത്ഥിച്ചു, ഫാൾബാക്ക് നൽകി",
     "attempts": "ശ്രമങ്ങൾ",
     "filterAll": "എല്ലാം",
+    "filterCanceled": "റദ്ദാക്കിയവ",
     "providerBreakdown": "ഓരോ ദാതാവിനും തകരാർ",
     "tokensPerSec": "ടോക്ക്/സെ",
     "allProviders": "എല്ലാ ദാതാക്കളും",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} ची विनंती केली, फॉलबॅकद्वारे सेवा दिली",
     "attempts": "प्रयत्न",
     "filterAll": "सर्व",
+    "filterCanceled": "रद्द",
     "providerBreakdown": "प्रति-प्रदाता ब्रेकडाउन",
     "tokensPerSec": "टोक/से",
     "allProviders": "सर्व प्रदाते",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Permintaan {model}, dilayani sebagai sandaran",
     "attempts": "Percubaan",
     "filterAll": "Semua",
+    "filterCanceled": "Dibatalkan",
     "providerBreakdown": "Pecahan setiap penyedia",
     "tokensPerSec": "Tok/s",
     "allProviders": "Semua penyedia",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "တောင်းဆိုထားသော {model}၊ fallback ဖြင့် ဝန်ဆောင်မှု",
     "attempts": "ကြိုးစားမှုများ",
     "filterAll": "အားလုံး",
+    "filterCanceled": "ပယ်ဖျက်ပြီး",
     "providerBreakdown": "ပံ့ပိုးသူအလိုက် ခွဲခြားချက်",
     "tokensPerSec": "Tok/s",
     "allProviders": "ပံ့ပိုးသူအားလုံး",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} अनुरोध गरियो, फलब्याकद्वारा सेवा गरियो",
     "attempts": "प्रयासहरू",
     "filterAll": "सबै",
+    "filterCanceled": "रद्द गरिएका",
     "providerBreakdown": "प्रत्येक प्रदायक क्रमाङ्कन",
     "tokensPerSec": "टक/एस",
     "allProviders": "सबै प्रदायकहरू",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Gevraagd {model}, bediend via reserveplan",
     "attempts": "Pogingen",
     "filterAll": "Allemaal",
+    "filterCanceled": "Geannuleerd",
     "providerBreakdown": "Uitsplitsing per aanbieder",
     "tokensPerSec": "Tok/s",
     "allProviders": "Alle aanbieders",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Bedt om {model}, betjent som reserveplan",
     "attempts": "Forsøk",
     "filterAll": "Alle",
+    "filterCanceled": "Avbrutt",
     "providerBreakdown": "Fordeling per leverandør",
     "tokensPerSec": "Tok/s",
     "allProviders": "Alle tilbydere",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} ଅନୁରୋଧ କରାଯାଇଛି, ଫଲବ୍ୟାକ୍ ଦ୍ୱାରା ପରିବେଷଣ କରାଯାଇଛି",
     "attempts": "ଉଦ୍ୟମ",
     "filterAll": "ସମସ୍ତ",
+    "filterCanceled": "ବାତିଲ",
     "providerBreakdown": "ପ୍ରତି-ପ୍ରଦାନକାରୀ ବ୍ରେକଡାଉନ୍",
     "tokensPerSec": "ଟୋକ୍ / ସେକେଣ୍ଡ",
     "allProviders": "ସମସ୍ତ ପ୍ରଦାନକାରୀ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} ਦੀ ਬੇਨਤੀ ਕੀਤੀ, ਫਾਲਬੈਕ ਦੁਆਰਾ ਸੇਵਾ ਕੀਤੀ ਗਈ",
     "attempts": "ਕੋਸ਼ਿਸ਼ਾਂ",
     "filterAll": "ਸਾਰੇ",
+    "filterCanceled": "ਰੱਦ ਕੀਤੇ",
     "providerBreakdown": "ਪ੍ਰਤੀ-ਪ੍ਰਦਾਤਾ ਟੁੱਟਣ",
     "tokensPerSec": "Tok/s",
     "allProviders": "ਸਾਰੇ ਪ੍ਰਦਾਤਾ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Żądano {model}, obsługiwane przez rezerwę",
     "attempts": "Próby",
     "filterAll": "Wszystko",
+    "filterCanceled": "Anulowane",
     "providerBreakdown": "Podział na dostawcę",
     "tokensPerSec": "Tok/s",
     "allProviders": "Wszyscy dostawcy",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Solicitado {model}, servido por fallback",
     "attempts": "Tentativas",
     "filterAll": "Todas",
+    "filterCanceled": "Canceladas",
     "providerBreakdown": "Detalhamento por provedor",
     "tokensPerSec": "Tok/s",
     "allProviders": "Todos os provedores",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Solicitado {model}, servido por recuo",
     "attempts": "Tentativas",
     "filterAll": "Todos",
+    "filterCanceled": "Canceladas",
     "providerBreakdown": "Distribuição por fornecedor",
     "tokensPerSec": "Tok/s",
     "allProviders": "Todos os prestadores",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Solicitat {model}, deservit de rezervă",
     "attempts": "Încercări",
     "filterAll": "Toate",
+    "filterCanceled": "Anulate",
     "providerBreakdown": "Defalcare pe furnizor",
     "tokensPerSec": "Tok/s",
     "allProviders": "Toți furnizorii",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Запрошен {model}, обслуживается резервным способом.",
     "attempts": "Попытки",
     "filterAll": "Все",
+    "filterCanceled": "Отменённые",
     "providerBreakdown": "Разбивка по провайдерам",
     "tokensPerSec": "Ток/с",
     "allProviders": "Все провайдеры",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} ඉල්ලන ලදී, පසුබැසීම මගින් සේවය කරන ලදී",
     "attempts": "උත්සාහයන්",
     "filterAll": "සියල්ල",
+    "filterCanceled": "අවලංගු කළ",
     "providerBreakdown": "එක්-සැපයුම්කරු බිඳ වැටීම",
     "tokensPerSec": "Tok/s",
     "allProviders": "සියලුම සපයන්නන්",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Požiadaný {model}, obsluhovaný záložnou zálohou",
     "attempts": "Pokusy",
     "filterAll": "Všetko",
+    "filterCanceled": "Zrušené",
     "providerBreakdown": "Rozdelenie podľa poskytovateľa",
     "tokensPerSec": "Tok/s",
     "allProviders": "Všetci poskytovatelia",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Захтевано {model}, сервирано резервним путем",
     "attempts": "Покушаји",
     "filterAll": "Све",
+    "filterCanceled": "Отказани",
     "providerBreakdown": "Анализа по добављачима",
     "tokensPerSec": "Ток/с",
     "allProviders": "Сви провајдери",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Begärt {model}, servat som reservplan",
     "attempts": "Försök",
     "filterAll": "Alla",
+    "filterCanceled": "Avbrutna",
     "providerBreakdown": "Uppdelning per leverantör",
     "tokensPerSec": "Tok/s",
     "allProviders": "Alla leverantörer",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Umeomba {model}, ukitolewa kwa njia mbadala",
     "attempts": "Majaribio",
     "filterAll": "Wote",
+    "filterCanceled": "Zilizoghairiwa",
     "providerBreakdown": "Uchanganuzi wa kila mtoaji",
     "tokensPerSec": "Tok/s",
     "allProviders": "Watoa huduma wote",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} கோரப்பட்டது, ஃபால்பேக் மூலம் சேவை வழங்கப்பட்டது",
     "attempts": "முயற்சிகள்",
     "filterAll": "அனைத்து",
+    "filterCanceled": "ரத்தானவை",
     "providerBreakdown": "ஒவ்வொரு வழங்குநருக்கும் முறிவு",
     "tokensPerSec": "டோக்/கள்",
     "allProviders": "அனைத்து வழங்குநர்கள்",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "ఫాల్‌బ్యాక్ ద్వారా అందించబడిన {model} అభ్యర్థించబడింది",
     "attempts": "ప్రయత్నాలు",
     "filterAll": "అన్నీ",
+    "filterCanceled": "రద్దైనవి",
     "providerBreakdown": "ప్రతి ప్రొవైడర్ బ్రేక్‌డౌన్",
     "tokensPerSec": "టోక్/లు",
     "allProviders": "అందరు ప్రొవైడర్లు",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "ร้องขอ {model} ซึ่งให้บริการโดยทางเลือก",
     "attempts": "ความพยายาม",
     "filterAll": "ทั้งหมด",
+    "filterCanceled": "ยกเลิกแล้ว",
     "providerBreakdown": "รายละเอียดต่อผู้ให้บริการ",
     "tokensPerSec": "ต๊อก/ส",
     "allProviders": "ผู้ให้บริการทั้งหมด",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Hiniling na {model}, pinagsilbihan bilang fallback",
     "attempts": "Mga Pagtatangka",
     "filterAll": "Lahat",
+    "filterCanceled": "Kanselado",
     "providerBreakdown": "Pagkakahati-hati ng bawat provider",
     "tokensPerSec": "Tok/s",
     "allProviders": "Lahat ng provider",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "İstenen {model}, yedek tarafından sunuldu",
     "attempts": "denemeler",
     "filterAll": "Hepsi",
+    "filterCanceled": "İptal edilenler",
     "providerBreakdown": "Sağlayıcı başına döküm",
     "tokensPerSec": "Tok/s",
     "allProviders": "Tüm sağlayıcılar",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Запитано {model}, обслуговується резервним способом",
     "attempts": "Спроби",
     "filterAll": "все",
+    "filterCanceled": "Скасовані",
     "providerBreakdown": "Розподіл за постачальником",
     "tokensPerSec": "Ток/с",
     "allProviders": "Всі провайдери",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} کی درخواست کی گئی، فال بیک کے ذریعے پیش کی گئی۔",
     "attempts": "کوششیں",
     "filterAll": "تمام",
+    "filterCanceled": "منسوخ شدہ",
     "providerBreakdown": "فی فراہم کنندہ کی خرابی",
     "tokensPerSec": "Tok/s",
     "allProviders": "تمام فراہم کنندگان",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Soʻralgan {model}, zaxira orqali xizmat koʻrsatadi",
     "attempts": "Urinishlar",
     "filterAll": "Hammasi",
+    "filterCanceled": "Bekor qilingan",
     "providerBreakdown": "Har bir provayder bo'yicha taqsimot",
     "tokensPerSec": "Tok/s",
     "allProviders": "Barcha provayderlar",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "{model} được yêu cầu, được cung cấp bởi dự phòng",
     "attempts": "Nỗ lực",
     "filterAll": "Tất cả",
+    "filterCanceled": "Đã hủy",
     "providerBreakdown": "Phân tích theo nhà cung cấp",
     "tokensPerSec": "Tok/giây",
     "allProviders": "Tất cả các nhà cung cấp",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "Ti beere {model}, yoo wa nipasẹ fallback",
     "attempts": "Awọn igbiyanju",
     "filterAll": "Gbogbo",
+    "filterCanceled": "Ti fagile",
     "providerBreakdown": "Pipin-olupese",
     "tokensPerSec": "Tok/s",
     "allProviders": "Gbogbo olupese",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "请求了 {model}，由回退模型提供",
     "attempts": "尝试次数",
     "filterAll": "全部",
+    "filterCanceled": "已取消",
     "providerBreakdown": "按提供方细分",
     "tokensPerSec": "词元/秒",
     "allProviders": "全部提供方",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -550,6 +550,7 @@
     "requestedModelHint": "請求了 {model}，由備援模型提供",
     "attempts": "嘗試次數",
     "filterAll": "全部",
+    "filterCanceled": "已取消",
     "providerBreakdown": "按提供者細分",
     "tokensPerSec": "Token/秒",
     "allProviders": "全部提供者",

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -187,7 +187,15 @@ interface RequestDetail extends Omit<RecentCallRow, 'attemptCount'> {
   attempts: RequestAttempt[]
 }
 
-type StatusFilter = 'all' | 'success' | 'error'
+type StatusFilter = 'all' | 'success' | 'error' | 'canceled'
+
+// 'canceled' (#752 — the client hung up mid-request) is neither success nor
+// error: neutral amber, not destructive red.
+function statusTextClass(status: string): string {
+  if (status === 'success') return 'text-muted-foreground'
+  if (status === 'canceled') return 'text-amber-600 dark:text-amber-400'
+  return 'text-destructive'
+}
 
 // First product token of the UA ("python-requests/2.32.3", "curl/8.6.0", …)
 // is enough to tell callers apart in a narrow cell; full string on hover.
@@ -310,7 +318,7 @@ function RequestDetailDialog({ requestId, onClose }: { requestId: number | null;
               <DetailField
                 label={t('common.status')}
                 value={
-                  <span className={detail.status === 'success' ? '' : 'text-destructive'}>{detail.status}</span>
+                  <span className={detail.status === 'success' ? '' : statusTextClass(detail.status)}>{detail.status}</span>
                 }
               />
               <DetailField
@@ -362,7 +370,8 @@ function RequestDetailDialog({ requestId, onClose }: { requestId: number | null;
                         <span className="font-medium">{a.platform}</span>
                         <span className="text-muted-foreground truncate" title={a.modelId}>{a.modelId}</span>
                         <Badge variant="outline">{t('analytics.keyOrdinal', { n: a.keyOrdinal })}</Badge>
-                        <Badge variant={a.outcome === 'ok' || a.outcome === 'committed' ? 'secondary' : 'destructive'}>
+                        {/* client_abort is the caller's doing, not a hop failure. */}
+                        <Badge variant={a.outcome === 'ok' || a.outcome === 'committed' ? 'secondary' : a.outcome === 'client_abort' ? 'outline' : 'destructive'}>
                           {a.outcome}
                         </Badge>
                         <span
@@ -765,6 +774,7 @@ export default function AnalyticsPage() {
                       { value: 'all', label: t('analytics.filterAll') },
                       { value: 'success', label: t('common.success') },
                       { value: 'error', label: t('analytics.errors') },
+                      { value: 'canceled', label: t('analytics.filterCanceled') },
                     ]}
                     ariaLabel={t('common.status')}
                   />
@@ -827,7 +837,7 @@ export default function AnalyticsPage() {
                             {r.requestedModel && r.requestedModel !== r.modelId ? ' *' : ''}
                           </TableCell>
                           <TableCell className="text-xs text-muted-foreground">{r.platform}</TableCell>
-                          <TableCell className={`text-xs ${r.status === 'success' ? 'text-muted-foreground' : 'text-destructive'}`} title={r.error ?? undefined}>
+                          <TableCell className={`text-xs ${statusTextClass(r.status)}`} title={r.error ?? undefined}>
                             {r.status}
                           </TableCell>
                           {/* >1 = the request burned failover hops; that is the

--- a/server/src/__tests__/lib/fallback-loop-client-abort.test.ts
+++ b/server/src/__tests__/lib/fallback-loop-client-abort.test.ts
@@ -11,7 +11,9 @@ import type { RouteResult } from '../../services/router.js';
  * the in-flight attempt with the marked error from newClientAbortError. That
  * throw must stop the ladder immediately, release the in-flight lease via the
  * existing finally, and leave NO provider-failure trace — no cooldown, no
- * skip-key entry, no logFailure row, no exhaustion render.
+ * skip-key entry, no logFailure row, no exhaustion render. What it DOES leave
+ * (#752) is a 'canceled' requests row, so the dashboard shows the request
+ * happened; stats/scoring queries exclude that status everywhere.
  */
 
 let keySeq = 900;
@@ -121,6 +123,26 @@ describe('fallback loop on client abort', () => {
     // No per-request skip state either — nothing was "tried and failed".
     expect(state.skipKeys.size).toBe(0);
     expect(state.skipModels.size).toBe(0);
+  });
+
+  it("writes a 'canceled' requests row so the abort is visible in the dashboard (#752)", async () => {
+    const state = newFallbackState();
+    const { route } = leasedRoute();
+    await runFallbackLoop(hooks(state, {
+      route: () => route,
+      dispatch: async () => { throw newClientAbortError(); },
+    }));
+
+    const row = getDb().prepare(
+      'SELECT id, platform, model_id, key_id, status, error FROM requests ORDER BY id DESC LIMIT 1',
+    ).get() as any;
+    expect(row).toMatchObject({ platform: 'fake', model_id: 'fake-model', status: 'canceled' });
+    expect(row.error).toContain('client disconnected');
+    expect(row.error).toContain('upstream request canceled');
+    // The attempt trace persists too, keyed to the canceled row — pure aborts
+    // used to leave no parent row and therefore no ladder either.
+    const attempts = getDb().prepare('SELECT outcome FROM request_attempts WHERE request_id = ?').all(row.id) as any[];
+    expect(attempts.map(a => a.outcome)).toEqual(['client_abort']);
   });
 
   it('clientGone still stops the loop before the next attempt after an ordinary failure', async () => {

--- a/server/src/__tests__/lib/fallback-loop.test.ts
+++ b/server/src/__tests__/lib/fallback-loop.test.ts
@@ -7,7 +7,11 @@ import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 // contract enforcement.
 
 const { mockCheckKeyHealth } = vi.hoisted(() => ({ mockCheckKeyHealth: vi.fn() }));
-vi.mock('../../services/health.js', () => ({ checkKeyHealth: mockCheckKeyHealth }));
+vi.mock('../../services/health.js', () => ({
+  checkKeyHealth: mockCheckKeyHealth,
+  // recordUpstreamSuccess touches this on the streak-reset test path.
+  markKeyHealthyFromRequest: vi.fn(),
+}));
 
 import { initDb, getDb } from '../../db/index.js';
 import {
@@ -15,6 +19,8 @@ import {
   newFallbackState,
   cooldownForError,
   recordRetryableFailure,
+  recordUpstreamSuccess,
+  resetEmptyCompletionStreaks,
   exhaustedRetryError,
   formatAttemptTrail,
   classifyAttemptError,
@@ -22,6 +28,7 @@ import {
   getFallbackTimeBudgetMs,
   DEFAULT_FALLBACK_TIME_BUDGET_MS,
   AUTH_FAILURE_COOLDOWN_MS,
+  EMPTY_COMPLETION_STREAK_LIMIT,
   type AttemptRecord,
   type FallbackHooks,
 } from '../../lib/fallback-loop.js';
@@ -68,6 +75,7 @@ beforeEach(() => {
   mockCheckKeyHealth.mockReset();
   mockCheckKeyHealth.mockResolvedValue('invalid');
   getDb().prepare('DELETE FROM rate_limit_cooldowns').run();
+  resetEmptyCompletionStreaks();
 });
 
 describe('isKeyAuthError (401 = key-fatal, rotate instead of 502)', () => {
@@ -189,6 +197,80 @@ describe('recordRetryableFailure skipBench exemption (reasoning truncation)', ()
   });
 });
 
+describe('empty-completion streak lifts the skipBench exemption (#751)', () => {
+  const emptyLengthErr = (route: RouteResult) =>
+    Object.assign(new Error(`empty completion from ${route.displayName}`), { skipBench: true });
+  const cooldownFor = (route: RouteResult) =>
+    getDb().prepare('SELECT 1 FROM rate_limit_cooldowns WHERE platform = ? AND key_id = ?').get('fake', route.keyId);
+
+  it('benches + penalizes from the Nth consecutive empty completion on the same model+key', () => {
+    const route = fakeRoute();
+    for (let i = 1; i < EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      expect(recordRetryableFailure(route, emptyLengthErr(route), newFallbackState())).toBe(true);
+      expect(cooldownFor(route)).toBeUndefined();
+    }
+    // Streak limit reached: the exemption lifts and the normal path runs.
+    expect(recordRetryableFailure(route, emptyLengthErr(route), newFallbackState())).toBe(false);
+    expect(cooldownFor(route)).toBeDefined();
+    expect(getAllPenalties().some(p => p.modelDbId === route.modelDbId)).toBe(true);
+  });
+
+  it('a success on the model+key resets the streak', () => {
+    const route = fakeRoute();
+    for (let i = 1; i < EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      recordRetryableFailure(route, emptyLengthErr(route), newFallbackState());
+    }
+    recordUpstreamSuccess(route, 0);
+    // The full pre-limit run is available again.
+    for (let i = 1; i < EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      expect(recordRetryableFailure(route, emptyLengthErr(route), newFallbackState())).toBe(true);
+    }
+    expect(cooldownFor(route)).toBeUndefined();
+  });
+
+  it('a normally-penalized failure resets the streak too', () => {
+    const route = fakeRoute();
+    for (let i = 1; i < EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      recordRetryableFailure(route, emptyLengthErr(route), newFallbackState());
+    }
+    // A plain 429 takes the cooldown ladder — and breaks the streak.
+    recordRetryableFailure(route, Object.assign(new Error('429 Too Many Requests'), { status: 429 }), newFallbackState());
+    getDb().prepare('DELETE FROM rate_limit_cooldowns').run();
+    for (let i = 1; i < EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      expect(recordRetryableFailure(route, emptyLengthErr(route), newFallbackState())).toBe(true);
+    }
+    expect(cooldownFor(route)).toBeUndefined();
+  });
+
+  it('format violations (skipModelForRequest) stay exempt and never accrue', () => {
+    const route = fakeRoute();
+    const formatErr = () => Object.assign(
+      new Error(`${route.displayName} ignored response_format (returned non-JSON despite json_schema)`),
+      { skipBench: true, skipModelForRequest: true },
+    );
+    for (let i = 0; i < EMPTY_COMPLETION_STREAK_LIMIT * 2; i++) {
+      expect(recordRetryableFailure(route, formatErr(), newFallbackState())).toBe(true);
+    }
+    // …and they did not pre-charge the empty-completion streak either.
+    expect(recordRetryableFailure(route, emptyLengthErr(route), newFallbackState())).toBe(true);
+    expect(cooldownFor(route)).toBeUndefined();
+  });
+
+  it('an over-the-limit empty completion counts toward the breaker', async () => {
+    const route = fakeRoute();
+    const onExhausted = vi.fn();
+    const dispatch = vi.fn(async () => { throw emptyLengthErr(route); });
+
+    await runFallbackLoop(hooksSkeleton({ maxRetries: 20, breakerLimit: 2, route: () => route, dispatch, onExhausted }));
+
+    // The first LIMIT-1 failures are exempt (invisible to the breaker); the
+    // next two count and trip the 2-limit breaker.
+    expect(dispatch).toHaveBeenCalledTimes(EMPTY_COMPLETION_STREAK_LIMIT - 1 + 2);
+    expect(onExhausted).toHaveBeenCalledTimes(1);
+    expect(onExhausted.mock.calls[0][0].status).toBe(503);
+  });
+});
+
 describe('exhaustedRetryError attempt trail + auth exhaustion', () => {
   it('all-auth attempts produce a distinct 502 provider_error body, not a rate-limit 429', () => {
     const body = exhaustedRetryError(new Error('Groq API error 401: Invalid API Key'), 20, { attempts: authRecord(3) });
@@ -275,7 +357,7 @@ describe('runFallbackLoop: auth rotation (401 is key-fatal, not request-fatal)',
 });
 
 describe('runFallbackLoop: wall-clock retry budget', () => {
-  it('stops starting new attempts once the budget is spent and reports timedOut', async () => {
+  it('always allows one failover hop, then stops and reports timedOut (#751)', async () => {
     const dispatch = vi.fn(async () => {
       await new Promise(r => setTimeout(r, 25));
       throw Object.assign(new Error('429 Too Many Requests'), { status: 429 });
@@ -288,12 +370,15 @@ describe('runFallbackLoop: wall-clock retry budget', () => {
       onExhausted,
     }));
 
-    expect(dispatch).toHaveBeenCalledTimes(1); // first attempt always runs, no second start
+    // Attempt 0 alone consumed the budget, but attempt 1 still starts — a
+    // slow-failing model must never make failover structurally impossible.
+    // Attempt 2 is where the spent budget stops the chain.
+    expect(dispatch).toHaveBeenCalledTimes(2);
     expect(onExhausted).toHaveBeenCalledTimes(1);
     const [body, info] = onExhausted.mock.calls[0];
     expect(info.timedOut).toBe(true);
     expect(body.message).toContain('retry time budget');
-    expect(info.attempts).toHaveLength(1);
+    expect(info.attempts).toHaveLength(2);
   });
 
   it('budget 0 disables the check', async () => {

--- a/server/src/__tests__/routes/analytics-requests.test.ts
+++ b/server/src/__tests__/routes/analytics-requests.test.ts
@@ -101,6 +101,18 @@ describe('GET /api/analytics/requests', () => {
     expect(successes.body.rows.map((r: any) => r.status)).toEqual(['success']);
   });
 
+  it("filters by the 'canceled' status (#752)", async () => {
+    insertCall(recentUtcTimestamp(8).sql, '10.0.0.1', 'ua', 'success');
+    insertCall(recentUtcTimestamp(9).sql, '10.0.0.1', 'ua', 'canceled');
+
+    const canceled = await request(app, '/api/analytics/requests?range=7d&status=canceled');
+    expect(canceled.status).toBe(200);
+    expect(canceled.body.total).toBe(1);
+    expect(canceled.body.rows.map((r: any) => r.status)).toEqual(['canceled']);
+    // ...and canceled rows still show up unfiltered.
+    expect((await request(app, '/api/analytics/requests?range=7d')).body.total).toBe(2);
+  });
+
   it('filters by platform, and combines with the status filter', async () => {
     insertCall(recentUtcTimestamp(8).sql, '10.0.0.1', 'ua', 'success', 'groq');
     insertCall(recentUtcTimestamp(9).sql, '10.0.0.1', 'ua', 'error', 'groq');

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -169,6 +169,27 @@ describe('Analytics API', () => {
     expect(body.lifetimeTotalRequests).toBe(3);
   });
 
+  it("counts 'canceled' rows in totals but in no success/error rate (#752)", async () => {
+    vi.useRealTimers();
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'success', 100, 50, 12, null);
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'error', 30, 0, 9, 'boom');
+    logRequest('groq', 'llama-3.3-70b-versatile', 0, 'canceled', 0, 0, 800,
+      'client disconnected after 0.8s; upstream request canceled');
+
+    const summary = await request(app, '/api/analytics/summary?range=24h');
+    expect(summary.status).toBe(200);
+    expect(summary.body.totalRequests).toBe(3); // the canceled request happened
+    expect(summary.body.successRate).toBe(50);  // 1 of 2 decided — not 1 of 3
+
+    const byModel = await request(app, '/api/analytics/by-model?range=24h');
+    expect(byModel.body[0].requests).toBe(3);
+    expect(byModel.body[0].successRate).toBe(50);
+
+    const byPlatform = await request(app, '/api/analytics/by-platform?range=24h');
+    expect(byPlatform.body[0].successRate).toBe(50);
+    expect(byPlatform.body[0].errorCount).toBe(1); // canceled is not an error
+  });
+
   it('prices savings at the served model paid-equivalent rate', async () => {
     // groq/llama-3.3-70b-versatile is mapped at $0.10/M in, $0.32/M out
     // (db/model-pricing.ts): 10M in + 5M out → 1.00 + 1.60 = $2.60

--- a/server/src/__tests__/routes/fallback-hardening.test.ts
+++ b/server/src/__tests__/routes/fallback-hardening.test.ts
@@ -29,7 +29,7 @@ const { createApp } = await import('../../app.js');
 const { initDb, getDb, getUnifiedApiKey } = await import('../../db/index.js');
 const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy, getAllPenalties } = await import('../../services/router.js');
-const { msUntilNextUtcMidnight } = await import('../../lib/fallback-loop.js');
+const { msUntilNextUtcMidnight, resetEmptyCompletionStreaks, EMPTY_COMPLETION_STREAK_LIMIT } = await import('../../lib/fallback-loop.js');
 
 async function post(app: Express, path: string, body: any, key: string) {
   const server = app.listen(0);
@@ -97,6 +97,7 @@ describe('fallback hardening (items 3, 4, 5, 6)', () => {
     db.prepare('DELETE FROM rate_limit_cooldowns').run();
     db.prepare('DELETE FROM rate_limit_usage').run();
     db.prepare('DELETE FROM requests').run();
+    resetEmptyCompletionStreaks();
   });
 
   afterEach(() => {
@@ -181,7 +182,30 @@ describe('fallback hardening (items 3, 4, 5, 6)', () => {
     expect(cooldownRowFor(firstModel)).toBeUndefined();
   });
 
-  it('item 5: the wall-clock budget stops retries and returns the rich exhaustion error', async () => {
+  it('item 4 bound (#751): consecutive empty-length completions bench the model+key at the streak limit', async () => {
+    // One empty-length turn is reasoning truncation; the Nth in a row on the
+    // same model+key is a broken model. Each request here fails over to a
+    // healthy sibling, but the streak accrues on the FIRST model.
+    let firstModel = '';
+    for (let i = 1; i <= EMPTY_COMPLETION_STREAK_LIMIT; i++) {
+      chatCompletion.mockReset();
+      chatCompletion
+        .mockResolvedValueOnce(emptyWithFinish('length'))
+        .mockResolvedValueOnce(GOOD_RESULT);
+      const { status } = await post(app, '/v1/chat/completions', {
+        messages: [{ role: 'user', content: `empty streak request ${i}` }],
+      }, key);
+      expect(status).toBe(200); // every request still failed over and served
+      firstModel = chatCompletion.mock.calls[0][2] as string;
+      if (i < EMPTY_COMPLETION_STREAK_LIMIT) {
+        expect(cooldownRowFor(firstModel)).toBeUndefined(); // still exempt
+      }
+    }
+    // The limit-th consecutive empty completion finally benches it.
+    expect(cooldownRowFor(firstModel)).toBeDefined();
+  });
+
+  it('item 5: the wall-clock budget allows one failover hop, then stops with the rich exhaustion error', async () => {
     process.env.FALLBACK_TIME_BUDGET_MS = '1';
     chatCompletion.mockImplementation(async () => {
       await new Promise(r => setTimeout(r, 15)); // ensure the budget is spent after attempt 0
@@ -193,10 +217,12 @@ describe('fallback hardening (items 3, 4, 5, 6)', () => {
     }, key);
 
     expect(status).toBe(429);
-    expect(chatCompletion).toHaveBeenCalledTimes(1); // the first attempt always runs; no second start
+    // The first attempt always runs, and so does the first RETRY even on a
+    // spent budget (#751) — attempt 2 is where the chain stops.
+    expect(chatCompletion).toHaveBeenCalledTimes(2);
     expect(body.error.message).toContain('retry time budget');
     expect(body.error.message).toContain('Attempt trail:');
-    expect(headers.get('x-fallback-attempts')).toBe('1');
+    expect(headers.get('x-fallback-attempts')).toBe('2');
   });
 
   it('item 6: /v1/chat/completions logs estimated tokens when the provider omits usage', async () => {

--- a/server/src/__tests__/services/router-speed-scoring.test.ts
+++ b/server/src/__tests__/services/router-speed-scoring.test.ts
@@ -142,6 +142,26 @@ describe('speed scoring: timeouts count against speed (#619)', () => {
     const fast = scores.find(s => s.modelId === 'fast')!;
     expect(refusing.reliability).toBeLessThan(fast.reliability);
   });
+
+  it("a 'canceled' row (#752 — client hung up) affects neither speed nor reliability", () => {
+    addModel({ platform: 'google', modelId: 'steady', name: 'Steady', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'hungup', name: 'HungUp', priority: 2 });
+    for (const [platform, modelId] of [['google', 'steady'], ['groq', 'hungup']] as const) {
+      addRequests(platform, modelId, { count: 40, status: 'success', outTokens: 100, latencyMs: 1000, ttfbMs: 200 });
+    }
+    // Long-latency canceled rows would read as timeouts/failures if counted.
+    addRequests('groq', 'hungup', {
+      count: 20, status: 'canceled', outTokens: 0, latencyMs: 120_000,
+      error: 'client disconnected after 120.0s; upstream request canceled',
+    });
+
+    refreshStatsCache(getDb(), true);
+    expect(speedOf('hungup')).toBeCloseTo(speedOf('steady'), 10);
+    const { scores } = getRoutingScores();
+    const hungup = scores.find(s => s.modelId === 'hungup')!;
+    const steady = scores.find(s => s.modelId === 'steady')!;
+    expect(hungup.reliability).toBeCloseTo(steady.reliability, 10);
+  });
 });
 
 describe('observed speed_rank writeback (#619)', () => {

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -49,7 +49,7 @@ import { noteModelRetirementSignal } from '../services/model-retirement.js';
 import { getSetting } from '../db/index.js';
 import { newBreaker, recordBreakerFailure } from './guardrails.js';
 import { getRequestTrace, newRequestTrace, runWithRequestTrace, type AttemptOutcome, type RequestTrace } from './attempt-trace.js';
-import { persistRequestAttempts } from './request-log.js';
+import { logRequest, persistRequestAttempts } from './request-log.js';
 
 // Every surface caps failover hops at the same number.
 export const FALLBACK_MAX_RETRIES = 20;
@@ -57,9 +57,13 @@ export const FALLBACK_MAX_RETRIES = 20;
 // ── Wall-clock retry budget ──────────────────────────────────────────────────
 // Serial failover has no time bound of its own: the observed worst case was a
 // 38.8s TTFB over 11 attempts, and the theoretical worst is maxRetries x the
-// per-attempt HTTP timeout. The budget is checked before STARTING each retry
-// (the first attempt always runs), so one slow attempt is never aborted
-// mid-flight — it just becomes the last one. 0 disables the budget entirely.
+// per-attempt HTTP timeout. The budget is checked before STARTING each retry,
+// so one slow attempt is never aborted mid-flight — it just becomes the last
+// one. The first attempt always runs, and so does the FIRST retry: when
+// attempt 0 alone consumes the whole budget (a slow-failing model), refusing
+// attempt 1 would make failover structurally impossible for exactly the
+// requests that need it (#751). The budget stops attempts >= 2 only.
+// 0 disables the budget entirely.
 // Precedence mirrors the response cache: the settings-table value wins when
 // present (runtime-tunable), then the env var, then the default.
 // TODO(fallback-v2): AbortController hedging so a stalled attempt can be
@@ -153,6 +157,40 @@ export function cooldownDecisionForError(route: RouteResult, err: any): Cooldown
   );
 }
 
+// ── Empty-completion streak (issue #751) ─────────────────────────────────────
+// The skipBench exemption below assumes an empty 'length' completion is
+// REQUEST behavior (this turn's max_tokens spent on hidden reasoning). A
+// model+key that produces them consecutively is broken, not unlucky — with an
+// unconditional exemption it stayed penalty-free forever while failing every
+// request routed to it. At the streak limit the exemption lifts and the
+// failure takes the normal cooldown/penalty/limit-learning path (and counts
+// toward the breaker). Format violations (skipModelForRequest) never accrue:
+// they are model behavior for THIS request's response_format, not key health.
+export const EMPTY_COMPLETION_STREAK_LIMIT = 3;
+const emptyCompletionStreaks = new Map<string, number>(); // "platform:modelId:keyId"
+
+export function resetEmptyCompletionStreaks(): void {
+  emptyCompletionStreaks.clear();
+}
+
+// Advance (or break) the streak for this failure and report whether the
+// skipBench exemption still holds. Called exactly once per retryable failure,
+// from recordRetryableFailure; the loop reuses its returned decision for the
+// breaker so the two consumers can never disagree.
+function consumeSkipBenchExemption(route: RouteResult, err: any): boolean {
+  const key = `${route.platform}:${route.modelId}:${route.keyId}`;
+  if (err?.skipBench !== true) {
+    // A normally-penalized failure breaks the streak: the cooldown ladder is
+    // already handling whatever is wrong with this model+key.
+    emptyCompletionStreaks.delete(key);
+    return false;
+  }
+  if (err?.skipModelForRequest === true) return true;
+  const streak = (emptyCompletionStreaks.get(key) ?? 0) + 1;
+  emptyCompletionStreaks.set(key, streak);
+  return streak < EMPTY_COMPLETION_STREAK_LIMIT;
+}
+
 /**
  * Apply the full per-key failure bookkeeping shared by every surface after a
  * retryable failure:
@@ -172,11 +210,17 @@ export function cooldownDecisionForError(route: RouteResult, err: any): Cooldown
  * finish_reason 'length') still fails over — the key is skipped for THIS
  * request — but is NOT a provider-health signal, so no cooldown, no model
  * penalty, and no limit-learning are recorded. Benching those was costing
- * healthy models a 90s cooldown + a scorer penalty per truncated turn.
+ * healthy models a 90s cooldown + a scorer penalty per truncated turn. The
+ * exemption is streak-bounded (#751): from the EMPTY_COMPLETION_STREAK_LIMITth
+ * consecutive empty completion on the same model+key it stops applying, until
+ * a success (or a normally-penalized failure) resets the streak.
+ *
+ * Returns whether the skipBench exemption held for this failure, so the loop
+ * can keep the breaker in lockstep with the bench decision.
  *
  * Callers add the just-failed key to skipKeys via this function (do not pre-add).
  */
-export function recordRetryableFailure(route: RouteResult, err: any, state: FallbackState): void {
+export function recordRetryableFailure(route: RouteResult, err: any, state: FallbackState): boolean {
   // `skipModelForRequest: true` = the failure is MODEL behavior, not key
   // state (ignored response_format, JSON truncated at max_tokens): a sibling
   // key would reproduce it exactly, so rule out the whole model for this
@@ -194,7 +238,7 @@ export function recordRetryableFailure(route: RouteResult, err: any, state: Fall
   // sibling keys counts as the single observation it is.
   noteModelRetirementSignal(route, err, getRequestTrace());
   state.skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
-  if (err?.skipBench === true) return;
+  if (consumeSkipBenchExemption(route, err)) return true;
   const decision = cooldownDecisionForError(route, err);
   setCooldown(route.platform, route.modelId, route.keyId, decision.durationMs, decision.source);
   // Model-level penalty only when no sibling key can still serve (#454).
@@ -202,6 +246,7 @@ export function recordRetryableFailure(route: RouteResult, err: any, state: Fall
     recordRateLimitHit(route.modelDbId);
   }
   learnLimitFromError(route.modelDbId, err);
+  return false;
 }
 
 // ── Upstream 401 handling (key-fatal, not request-fatal) ─────────────────────
@@ -252,6 +297,9 @@ export function recordUpstreamSuccess(route: RouteResult, rateLimitTokens: numbe
   recordRequest(route.platform, route.modelId, route.keyId);
   recordTokens(route.platform, route.modelId, route.keyId, rateLimitTokens);
   recordSuccess(route.modelDbId);
+  // A served request proves the model+key can complete: the empty-completion
+  // streak (#751) starts over.
+  emptyCompletionStreaks.delete(`${route.platform}:${route.modelId}:${route.keyId}`);
   // A served request is the strongest possible evidence the key works, so clear
   // any stale 'error' status left by an earlier transport blip instead of waiting
   // for the next health pass to make the key routable again.
@@ -452,7 +500,7 @@ export function exhaustedRetryError(lastError: any, maxRetries?: number, ctx?: E
   const attempts = ctx?.attempts ?? [];
   const trail = attempts.length > 0 ? ` Attempt trail: ${formatAttemptTrail(attempts)}.` : '';
   const budgetNote = ctx?.timedOut
-    ? ` (stopped early: retry time budget ${Math.round((ctx.budgetMs ?? 0) / 1000)}s exceeded — the attempt in flight is never aborted mid-flight, the budget only stops STARTING further retries; raise FALLBACK_TIME_BUDGET_MS or the fallback_time_budget_ms setting to allow a longer failover chain)`
+    ? ` (stopped early: retry time budget ${Math.round((ctx.budgetMs ?? 0) / 1000)}s exceeded — the attempt in flight is never aborted mid-flight and one failover hop is always allowed, the budget only stops STARTING further retries; raise FALLBACK_TIME_BUDGET_MS or the fallback_time_budget_ms setting to allow a longer failover chain)`
     : '';
   const everyAttempt = (cls: AttemptErrorClass | ReadonlySet<AttemptErrorClass>): boolean =>
     attempts.length > 0 && attempts.every(a => (cls instanceof Set ? cls.has(a.errorClass) : a.errorClass === cls));
@@ -748,7 +796,8 @@ export async function runFallbackLoop(hooks: FallbackHooks): Promise<void> {
   // report back the row ids it writes without any surface changing. The flush
   // runs after the loop returns — i.e. after the response is finished — so it
   // never sits on the client's latency path, and it is a no-op when no
-  // `requests` row was written (pure client aborts).
+  // `requests` row was written (a pure abort writes its own 'canceled' row,
+  // so its trace persists too).
   const trace = newRequestTrace();
   try {
     await runWithRequestTrace(trace, () => runFallbackLoopAttempts(hooks, trace));
@@ -807,9 +856,12 @@ async function runFallbackLoopAttempts(hooks: FallbackHooks, trace: RequestTrace
     }
 
     // Wall-clock budget: refuse to START another retry once spent. The first
-    // attempt always runs; a slow attempt is never aborted mid-flight (that is
-    // the TODO(fallback-v2) hedging work), it just becomes the last one.
-    if (attempt > 0 && budgetMs > 0 && Date.now() - startedAt >= budgetMs) {
+    // attempt always runs, and so does the first RETRY — when attempt 0 alone
+    // consumed the budget, refusing attempt 1 would make failover impossible
+    // for exactly the slow-failing models that need it (#751). A slow attempt
+    // is never aborted mid-flight (that is the TODO(fallback-v2) hedging
+    // work), it just becomes the last one.
+    if (attempt > 1 && budgetMs > 0 && Date.now() - startedAt >= budgetMs) {
       hooks.onExhausted(
         exhaustedRetryError(lastError, maxRetries, { attempts, timedOut: true, budgetMs }),
         { attempts, timedOut: true },
@@ -867,10 +919,15 @@ async function runFallbackLoopAttempts(hooks: FallbackHooks, trace: RequestTrace
       // waiting, and there is no socket to render anything to. The finally
       // below still frees the in-flight lease.
       if (isClientAbortError(err)) {
+        const elapsedMs = Date.now() - startedAt;
         console.log(`[FallbackLoop] client disconnected mid-attempt on ${route.platform}/${route.modelId} — upstream canceled, stopping without benching`);
-        // Trace only: persisted iff an earlier failure already wrote a
-        // `requests` row (the requests table records nothing for a pure abort,
-        // and the trace stays consistent with that).
+        // Visibility row (#752): a pure abort used to leave NOTHING in the
+        // requests table, so the dashboard showed no trace of the request.
+        // Status 'canceled' is neither success nor failure — every stats/
+        // scoring query excludes it — and this row is also the parent the
+        // attempt-trace batch below keys to.
+        logRequest(route.platform, route.modelId, route.keyId, 'canceled', 0, 0, elapsedMs,
+          `client disconnected after ${(elapsedMs / 1000).toFixed(1)}s; upstream request canceled`);
         traceAttempt('client_abort');
         return;
       }
@@ -886,17 +943,19 @@ async function runFallbackLoopAttempts(hooks: FallbackHooks, trace: RequestTrace
         continue;
       }
       if (isRetryableError(err)) {
-        recordRetryableFailure(route, err, hooks.state);
+        const exempt = recordRetryableFailure(route, err, hooks.state);
         const errorClass = classifyAttemptError(err);
         attempts.push({ platform: route.platform, modelId: route.modelId, keyOrdinal: keyOrdinal(route), errorClass });
         traceAttempt(errorClass, err);
         lastError = err;
-        // skipBench failures (format ignored, hidden-reasoning truncation) are
-        // model behavior, not provider health — recordRetryableFailure already
-        // skips the cooldown/penalty for them, and they must not count toward
-        // the "pool looks unhealthy" breaker either: three prose answers to a
-        // json_schema request say nothing about whether candidate four is up.
-        if (err?.skipBench !== true && stopIfBreakerTripped()) return;
+        // A still-exempt skipBench failure (format ignored, hidden-reasoning
+        // truncation under the streak limit) is model behavior, not provider
+        // health — recordRetryableFailure skipped the cooldown/penalty for it,
+        // and it must not count toward the "pool looks unhealthy" breaker
+        // either: three prose answers to a json_schema request say nothing
+        // about whether candidate four is up. Once the empty-completion streak
+        // lifts the exemption (#751), the failure counts everywhere.
+        if (!exempt && stopIfBreakerTripped()) return;
         continue;
       }
       traceAttempt(classifyAttemptError(err), err);

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -34,6 +34,11 @@ function setSettingIfMissing(db: LogTx, key: string, value: string): void {
 // is logged identically. Lives in a neutral lib module to avoid an import cycle
 // between the fusion service and the proxy route that both call it.
 //
+// Status is 'success', 'error', or 'canceled' (#752 — the client hung up
+// mid-attempt). A canceled request counts toward request totals — it happened —
+// but toward NEITHER success nor error: rates and scoring must read
+// success/(success+error), never success/total.
+//
 // In addition to the raw row, we update two durable aggregates so analytics
 // totals survive the raw-row prune (REQUEST_ANALYTICS_MAX_ROWS):
 //   - request_hourly: per-hour bucket counts and tokens (max window = 30d).
@@ -113,9 +118,10 @@ export function logRequest(
 // mid-stream error row, or the last per-attempt failure row). Called once per
 // request by the fallback loop AFTER the response is finished, so the write is
 // off the client's latency path. Zero-failure single-attempt successes write
-// exactly one 'ok' row; a trace with no parent row (e.g. a client abort before
-// any attempt was logged) writes nothing — consistent with the `requests`
-// table, which records nothing for those either.
+// exactly one 'ok' row. A trace with no parent row writes nothing — since the
+// fallback loop logs a 'canceled' row for pure client aborts (#752), that is
+// now only the loop-top stop paths, whose failed attempts each wrote their own
+// row already.
 export function persistRequestAttempts(trace: RequestTrace): void {
   if (trace.records.length === 0 || trace.lastRequestRowId == null) return;
   try {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -42,6 +42,7 @@ function readAggregateSince(since: string) {
     SELECT
       COALESCE(SUM(total_requests), 0) as total_requests,
       COALESCE(SUM(success_count), 0) as success_count,
+      COALESCE(SUM(error_count), 0) as error_count,
       COALESCE(SUM(input_tokens), 0) as total_input_tokens,
       COALESCE(SUM(output_tokens), 0) as total_output_tokens,
       MIN(hour) as first_request_at
@@ -50,6 +51,7 @@ function readAggregateSince(since: string) {
   `).get(aggregateSince) as {
     total_requests: number;
     success_count: number;
+    error_count: number;
     total_input_tokens: number;
     total_output_tokens: number;
     first_request_at: string | null;
@@ -80,7 +82,11 @@ analyticsRouter.get('/summary', (req: Request, res: Response) => {
   // is the source of truth for headline numbers.
   const aggregate = readAggregateSince(since);
   const totalRequests = aggregate.total_requests ?? 0;
-  const successRate = totalRequests > 0 ? (aggregate.success_count / totalRequests) * 100 : 0;
+  // Success rate over success+error only: a 'canceled' request (#752 — client
+  // hung up) still counts in the totals but is neither a success nor a
+  // failure, so it must not dilute the rate.
+  const decidedRequests = (aggregate.success_count ?? 0) + (aggregate.error_count ?? 0);
+  const successRate = decidedRequests > 0 ? (aggregate.success_count / decidedRequests) * 100 : 0;
 
   // Avg latency is only meaningful at the raw row level; the hourly bucket
   // doesn't preserve it. Fall back to a 0/null when no recent raw rows exist.
@@ -201,7 +207,8 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
       r.model_id,
       m.display_name,
       COUNT(*) as requests,
-      SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
+      -- Rate over success+error only: 'canceled' (#752) is neither.
+      SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / NULLIF(SUM(CASE WHEN r.status <> 'canceled' THEN 1 ELSE 0 END), 0) as success_rate,
       AVG(r.latency_ms) as avg_latency_ms,
       SUM(r.input_tokens) as total_input_tokens,
       SUM(r.output_tokens) as total_output_tokens,
@@ -222,7 +229,8 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
     modelId: r.model_id,
     displayName: r.display_name ?? r.model_id,
     requests: r.requests,
-    successRate: Math.round(r.success_rate * 10) / 10,
+    // success_rate is NULL when every row in the group was canceled.
+    successRate: Math.round((r.success_rate ?? 0) * 10) / 10,
     avgLatencyMs: Math.round(r.avg_latency_ms),
     totalInputTokens: r.total_input_tokens ?? 0,
     totalOutputTokens: r.total_output_tokens ?? 0,
@@ -243,7 +251,7 @@ analyticsRouter.get('/by-platform', (req: Request, res: Response) => {
       platform,
       COUNT(*) as requests,
       COUNT(latency_ms) as latency_count,
-      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
+      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / NULLIF(SUM(CASE WHEN status <> 'canceled' THEN 1 ELSE 0 END), 0) as success_rate,
       AVG(latency_ms) as avg_latency_ms,
       AVG(ttfb_ms) as avg_ttfb_ms,
       SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
@@ -279,7 +287,7 @@ analyticsRouter.get('/by-platform', (req: Request, res: Response) => {
     return {
       platform: r.platform,
       requests: r.requests,
-      successRate: Math.round(r.success_rate * 10) / 10,
+      successRate: Math.round((r.success_rate ?? 0) * 10) / 10,
       avgLatencyMs: Math.round(r.avg_latency_ms),
       p95LatencyMs: p95Row ? Math.round(p95Row.latency_ms) : null,
       avgTtfbMs: r.avg_ttfb_ms != null ? Math.round(r.avg_ttfb_ms) : null,
@@ -300,7 +308,7 @@ analyticsRouter.get('/by-client', (req: Request, res: Response) => {
     SELECT
       COALESCE(client_agent, 'unknown') AS client_agent,
       COUNT(*) AS requests,
-      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) AS success_rate,
+      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / NULLIF(SUM(CASE WHEN status <> 'canceled' THEN 1 ELSE 0 END), 0) AS success_rate,
       AVG(latency_ms) AS avg_latency_ms,
       SUM(input_tokens) AS total_input_tokens,
       SUM(output_tokens) AS total_output_tokens,
@@ -336,7 +344,7 @@ analyticsRouter.get('/by-key', (req: Request, res: Response) => {
       k.label as label,
       k.platform as platform,
       COUNT(*) as requests,
-      SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate,
+      SUM(CASE WHEN r.status = 'success' THEN 1 ELSE 0 END) * 100.0 / NULLIF(SUM(CASE WHEN r.status <> 'canceled' THEN 1 ELSE 0 END), 0) as success_rate,
       AVG(r.latency_ms) as avg_latency_ms,
       SUM(r.input_tokens) as total_input_tokens,
       SUM(r.output_tokens) as total_output_tokens
@@ -355,7 +363,7 @@ analyticsRouter.get('/by-key', (req: Request, res: Response) => {
     label: r.label ?? null,
     platform: r.platform ?? null,
     requests: r.requests,
-    successRate: Math.round(r.success_rate * 10) / 10,
+    successRate: Math.round((r.success_rate ?? 0) * 10) / 10,
     avgLatencyMs: Math.round(r.avg_latency_ms),
     totalInputTokens: r.total_input_tokens ?? 0,
     totalOutputTokens: r.total_output_tokens ?? 0,
@@ -500,8 +508,8 @@ analyticsRouter.get('/requests', (req: Request, res: Response) => {
   // Optional filters. Both are validated (whitelist / shape) and applied as
   // bound parameters; absent filters keep the default behavior identical.
   const status = req.query.status as string | undefined;
-  if (status !== undefined && status !== 'success' && status !== 'error') {
-    res.status(400).json({ error: "invalid status filter (expected 'success' or 'error')" });
+  if (status !== undefined && status !== 'success' && status !== 'error' && status !== 'canceled') {
+    res.status(400).json({ error: "invalid status filter (expected 'success', 'error' or 'canceled')" });
     return;
   }
   // Platform ids are short slugs ('groq', 'pt-custom_1'); anything else is a

--- a/server/src/routes/mcp.ts
+++ b/server/src/routes/mcp.ts
@@ -137,10 +137,11 @@ function usageSummary(args: Record<string, unknown>): unknown {
   const totals = db.prepare(`
     SELECT COALESCE(SUM(total_requests), 0) AS requests,
            COALESCE(SUM(success_count), 0) AS successes,
+           COALESCE(SUM(error_count), 0) AS errors,
            COALESCE(SUM(input_tokens), 0) AS input_tokens,
            COALESCE(SUM(output_tokens), 0) AS output_tokens
     FROM request_hourly WHERE hour >= ?
-  `).get(since.slice(0, 13) + ':00:00') as { requests: number; successes: number; input_tokens: number; output_tokens: number };
+  `).get(since.slice(0, 13) + ':00:00') as { requests: number; successes: number; errors: number; input_tokens: number; output_tokens: number };
   const topModels = db.prepare(`
     SELECT platform, model_id, COUNT(*) AS requests,
            SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS successes
@@ -150,7 +151,8 @@ function usageSummary(args: Record<string, unknown>): unknown {
   return {
     range,
     requests: totals.requests,
-    success_rate: totals.requests > 0 ? Math.round((totals.successes / totals.requests) * 1000) / 10 : null,
+    // Over success+error only: 'canceled' rows (#752) are neither.
+    success_rate: totals.successes + totals.errors > 0 ? Math.round((totals.successes / (totals.successes + totals.errors)) * 1000) / 10 : null,
     input_tokens: totals.input_tokens,
     output_tokens: totals.output_tokens,
     top_models: topModels,

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -529,12 +529,14 @@ function decayWeight(ageDays: number): number {
   return Math.pow(0.5, Math.max(0, ageDays) / HALF_LIFE_DAYS);
 }
 
-// SQL predicate for "this row is a timed-out request" (#619). `requests.status`
-// only ever holds 'success' or 'error' — a timeout is an error row whose text
-// carries one of the shared timeout markers (lib/error-classify.ts), which is
-// also what the failover attempt trail classifies on. The markers are
-// hard-coded lowercase identifiers from our own source, never user input, so
-// interpolating them into the LIKE list is safe.
+// SQL predicate for "this row is a timed-out request" (#619). A timeout is an
+// error row whose text carries one of the shared timeout markers
+// (lib/error-classify.ts), which is also what the failover attempt trail
+// classifies on. 'canceled' rows (#752 — client hung up) never reach this
+// predicate: the stats query below filters them out entirely, because a
+// vanished client says nothing about the model's reliability or speed. The
+// markers are hard-coded lowercase identifiers from our own source, never
+// user input, so interpolating them into the LIKE list is safe.
 const IS_TIMEOUT_SQL = `(status != 'success' AND (${
   TIMEOUT_ERROR_MARKERS.map(m => `LOWER(COALESCE(error, '')) LIKE '%${m}%'`).join(' OR ')
 }))`;
@@ -570,7 +572,7 @@ export function refreshStatsCache(db: Db, force = false): void {
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN 1 ELSE 0 END) AS timeouts,
       SUM(CASE WHEN ${IS_TIMEOUT_SQL} THEN MIN(MAX(latency_ms, 0), ${TIMEOUT_LATENCY_CAP_MS}) ELSE 0 END) AS timeout_lat
     FROM requests
-    WHERE created_at >= ?
+    WHERE created_at >= ? AND status <> 'canceled'
     GROUP BY platform, model_id, key_id, age_days
   `).all(since) as Array<{
     platform: string; model_id: string; key_id: number | null; age_days: number; total: number; successes: number;


### PR DESCRIPTION
Fixes #751: consecutive empty finish_reason='length' completions lift the skipBench exemption after 3 per model+key (reset on success), and the wall-clock retry budget now always allows one failover hop even when attempt 0 consumed it.

Fixes #752: pure client aborts write a 'canceled' requests row (counted in totals, excluded from every success/error rate and from speed/reliability scoring) and render neutrally in the dashboard; no-retry/no-bench behavior for vanished clients is unchanged.