### PR TITLE
feat(keys): import model lists with -TOOLS/-VISION suffixes from pasted env blocks (#382)

### DIFF
--- a/client/src/components/keys/import-keys-section.tsx
+++ b/client/src/components/keys/import-keys-section.tsx
@@ -82,7 +82,9 @@ export function ImportKeysSection({ onImported }: { onImported?: () => void } = 
       // The dialog closes on success, so surface the imported/failed counts as
       // a toast.
       if (onImported) {
-        toast.success(t('keys.importResult', { imported: data.imported, failed: data.errors.length }))
+        toast.success((data.modelsRegistered ?? 0) > 0
+          ? t('keys.importResultWithModels', { imported: data.imported, models: data.modelsRegistered, failed: data.errors.length })
+          : t('keys.importResult', { imported: data.imported, failed: data.errors.length }))
         onImported()
       }
     },
@@ -95,6 +97,7 @@ export function ImportKeysSection({ onImported }: { onImported?: () => void } = 
       keyValue: row.keyValue,
       platform: row.platform,
       ...(row.baseUrl ? { baseUrl: row.baseUrl } : {}),
+      ...(row.models?.length ? { models: row.models } : {}),
     }))
 
   function updateRow(index: number, patch: Partial<ImportRow>) {
@@ -195,6 +198,11 @@ export function ImportKeysSection({ onImported }: { onImported?: () => void } = 
                         {row.isDuplicate && (
                           <span className="shrink-0 rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
                             {t('keys.duplicate')}
+                          </span>
+                        )}
+                        {(row.models?.length ?? 0) > 0 && (
+                          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                            {t('keys.importModelCount', { count: row.models!.length })}
                           </span>
                         )}
                       </div>

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -450,6 +450,8 @@
     "duplicate": "ማባዛት",
     "duplicatesFound": "{count} የተባዙ(ዎች) ተገኝተዋል - ቀድሞውኑ አሉ እና ይዘለላሉ።",
     "importResult": "ከውጭ የመጡ {imported}; {failed} አልተሳካም።",
+    "importModelCount": "+{count} ሞዴሎች",
+    "importResultWithModels": "ከውጭ የመጡ {imported}; {models} ሞዴሎች ተመዝግበዋል; {failed} አልተሳካም።",
     "confirmRemove": "አረጋግጥ?",
     "quotaSignalsTitle": "የኮታ ምልክቶች",
     "quotaSignalsEmptyTitle": "እስካሁን ምንም የኮታ ምልከታ የለም።",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -450,6 +450,8 @@
     "duplicate": "مكررة",
     "duplicatesFound": "تم اكتشاف تكرارات {count} - موجودة بالفعل وسيتم تخطيها.",
     "importResult": "المستوردة {imported}. فشل {failed}.",
+    "importModelCount": "+{count} نماذج",
+    "importResultWithModels": "المستوردة {imported}؛ تم تسجيل {models} من النماذج؛ فشل {failed}.",
     "confirmRemove": "تأكيد؟",
     "quotaSignalsTitle": "إشارات الحصص",
     "quotaSignalsEmptyTitle": "لا توجد ملاحظات الحصص حتى الآن",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -450,6 +450,8 @@
     "duplicate": "Təkrarlanan",
     "duplicatesFound": "{count} təkrar(lar) aşkar edilib — artıq mövcuddur və atlanacaq.",
     "importResult": "İdxal {imported}; uğursuz {failed}.",
+    "importModelCount": "+{count} model",
+    "importResultWithModels": "İdxal {imported}; {models} model qeydə alındı; uğursuz {failed}.",
     "confirmRemove": "Təsdiqləyək?",
     "quotaSignalsTitle": "Kvota siqnalları",
     "quotaSignalsEmptyTitle": "Hələ kvota müşahidəsi yoxdur",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -450,6 +450,8 @@
     "duplicate": "Дубликат",
     "duplicatesFound": "{count} открити дубликати — вече съществуват и ще бъдат пропуснати.",
     "importResult": "Внесени {imported}; провалил {failed}.",
+    "importModelCount": "+{count} модела",
+    "importResultWithModels": "Внесени {imported}; регистрирани {models} модела; провалил {failed}.",
     "confirmRemove": "Потвърждавате ли?",
     "quotaSignalsTitle": "Квотни сигнали",
     "quotaSignalsEmptyTitle": "Все още няма наблюдение на квотите",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -450,6 +450,8 @@
     "duplicate": "ডুপ্লিকেট",
     "duplicatesFound": "{count} সদৃশ (গুলি) সনাক্ত করা হয়েছে — ইতিমধ্যেই বিদ্যমান এবং এড়িয়ে যাওয়া হবে৷",
     "importResult": "আমদানি করা {imported}; ব্যর্থ {failed}.",
+    "importModelCount": "+{count}টি মডেল",
+    "importResultWithModels": "আমদানি করা {imported}; {models}টি মডেল নিবন্ধিত হয়েছে; ব্যর্থ {failed}.",
     "confirmRemove": "নিশ্চিত?",
     "quotaSignalsTitle": "কোটা সংকেত",
     "quotaSignalsEmptyTitle": "এখনও কোন কোটা পর্যবেক্ষণ",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikát",
     "duplicatesFound": "{count} detekované duplicity — už existují a budou přeskočeny.",
     "importResult": "Dovážené {imported}; neuspěl {failed}.",
+    "importModelCount": "+{count} modelů",
+    "importResultWithModels": "Dovážené {imported}; zaregistrováno {models} modelů; neuspěl {failed}.",
     "confirmRemove": "Potvrdit?",
     "quotaSignalsTitle": "Kvótové signály",
     "quotaSignalsEmptyTitle": "Zatím žádná pozorování kvót",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "{count} dublat opdaget — eksisterer allerede og vil blive sprunget over.",
     "importResult": "Importerede {imported}; fejlede {failed}.",
+    "importModelCount": "+{count} modeller",
+    "importResultWithModels": "Importerede {imported}; registrerede {models} modeller; fejlede {failed}.",
     "confirmRemove": "Bekræfte?",
     "quotaSignalsTitle": "Kvotesignaler",
     "quotaSignalsEmptyTitle": "Ingen kvoteobservationer endnu",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplizieren",
     "duplicatesFound": "{count} Duplikat(e) erkannt – sind bereits vorhanden und werden übersprungen.",
     "importResult": "Importiert {imported}; fehlgeschlagen {failed}.",
+    "importModelCount": "+{count} Modelle",
+    "importResultWithModels": "Importiert {imported}; {models} Modelle registriert; fehlgeschlagen {failed}.",
     "confirmRemove": "Bestätigen?",
     "quotaSignalsTitle": "Quotensignale",
     "quotaSignalsEmptyTitle": "Noch keine Quotenbeobachtungen",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -450,6 +450,8 @@
     "duplicate": "Αντιγραφή",
     "duplicatesFound": "{count} εντοπίστηκαν διπλότυπα — υπάρχουν ήδη και θα παραλειφθούν.",
     "importResult": "Εισαγόμενα {imported}; απέτυχε {failed}.",
+    "importModelCount": "+{count} μοντέλα",
+    "importResultWithModels": "Εισαγόμενα {imported}; καταχωρήθηκαν {models} μοντέλα; απέτυχε {failed}.",
     "confirmRemove": "Επιβεβαιώνω?",
     "quotaSignalsTitle": "Σήματα ποσοστώσεων",
     "quotaSignalsEmptyTitle": "Δεν υπάρχουν ακόμη παρατηρήσεις σχετικά με τις ποσοστώσεις",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -472,6 +472,8 @@
     "duplicate": "Duplicate",
     "duplicatesFound": "{count} duplicate(s) detected — already exist and will be skipped.",
     "importResult": "Imported {imported}; failed {failed}.",
+    "importModelCount": "+{count} models",
+    "importResultWithModels": "Imported {imported}; registered {models} models; failed {failed}.",
     "confirmRemove": "Confirm?",
     "quotaSignalsTitle": "Quota signals",
     "quotaSignalsEmptyTitle": "No quota observations yet",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicado",
     "duplicatesFound": "{count} duplicado(s) detectado(s) — ya existen y se omitirán.",
     "importResult": "Importados {imported}; fallidos {failed}.",
+    "importModelCount": "+{count} modelos",
+    "importResultWithModels": "Importados {imported}; {models} modelos registrados; fallidos {failed}.",
     "confirmRemove": "¿Confirmar?",
     "quotaSignalsTitle": "Señales de cuota",
     "quotaSignalsEmptyTitle": "Aún no hay observaciones de cuota",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -450,6 +450,8 @@
     "duplicate": "تکراری",
     "duplicatesFound": "{count} تکراری شناسایی شد - از قبل وجود دارد و از آن صرفنظر خواهد شد.",
     "importResult": "{imported} وارداتی؛ ناموفق {failed}.",
+    "importModelCount": "+{count} مدل",
+    "importResultWithModels": "{imported} وارداتی؛ {models} مدل ثبت شد؛ ناموفق {failed}.",
     "confirmRemove": "تایید کرد؟",
     "quotaSignalsTitle": "سیگنال های سهمیه ای",
     "quotaSignalsEmptyTitle": "هنوز مشاهدات سهمیه ای وجود ندارد",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -450,6 +450,8 @@
     "duplicate": "Kaksoiskappale",
     "duplicatesFound": "{count} kaksoiskappaleet havaittu — ne ovat jo olemassa ja ne ohitetaan.",
     "importResult": "Tuotu {imported}; epäonnistui {failed}.",
+    "importModelCount": "+{count} mallia",
+    "importResultWithModels": "Tuotu {imported}; rekisteröity {models} mallia; epäonnistui {failed}.",
     "confirmRemove": "Vahvistaa?",
     "quotaSignalsTitle": "Kiintiösignaalit",
     "quotaSignalsEmptyTitle": "Ei vielä kiintiöhavaintoja",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -450,6 +450,8 @@
     "duplicate": "Doublon",
     "duplicatesFound": "{count} doublon(s) détecté(s) — existent déjà et seront ignorés.",
     "importResult": "Importés : {imported}. Échecs : {failed}.",
+    "importModelCount": "+{count} modèles",
+    "importResultWithModels": "Importés : {imported}. Modèles enregistrés : {models}. Échecs : {failed}.",
     "confirmRemove": "Confirmer ?",
     "quotaSignalsTitle": "Signaux de quota",
     "quotaSignalsEmptyTitle": "Aucune observation de quota pour le moment",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -450,6 +450,8 @@
     "duplicate": "ડુપ્લિકેટ",
     "duplicatesFound": "{count} ડુપ્લિકેટ(ઓ) મળી આવ્યા છે — પહેલેથી જ અસ્તિત્વમાં છે અને તેને છોડવામાં આવશે.",
     "importResult": "આયાત કરેલ {imported}; નિષ્ફળ {failed}.",
+    "importModelCount": "+{count} મોડેલ",
+    "importResultWithModels": "આયાત કરેલ {imported}; {models} મોડેલ નોંધાયેલ; નિષ્ફળ {failed}.",
     "confirmRemove": "પુષ્ટિ કરો?",
     "quotaSignalsTitle": "ક્વોટા સંકેતો",
     "quotaSignalsEmptyTitle": "હજુ સુધી કોઈ ક્વોટા અવલોકનો નથી",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -450,6 +450,8 @@
     "duplicate": "Kwafi",
     "duplicatesFound": "{count} Kwafi(s) gano - ya riga ya wanzu kuma za a tsallake.",
     "importResult": "Shigo da {imported}; ya kasa {failed}.",
+    "importModelCount": "+{count} samfura",
+    "importResultWithModels": "Shigo da {imported}; an yi rajistar samfura {models}; ya kasa {failed}.",
     "confirmRemove": "Tabbatar?",
     "quotaSignalsTitle": "Alamun ƙididdiga",
     "quotaSignalsEmptyTitle": "Babu abin lura tukuna",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -450,6 +450,8 @@
     "duplicate": "כפיל",
     "duplicatesFound": "{count} שזוהו כפילויות — כבר קיימות ויידלגו עליהן.",
     "importResult": "{imported} מיובא; נכשל {failed}.",
+    "importModelCount": "+{count} מודלים",
+    "importResultWithModels": "{imported} מיובא; {models} מודלים נרשמו; נכשל {failed}.",
     "confirmRemove": "לאשר?",
     "quotaSignalsTitle": "אותות מכסה",
     "quotaSignalsEmptyTitle": "עדיין אין תצפיות על מכסות",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -450,6 +450,8 @@
     "duplicate": "डुप्लिकेट",
     "duplicatesFound": "{count} डुप्लिकेट का पता चला - पहले से मौजूद है और छोड़ दिया जाएगा।",
     "importResult": "आयातित {imported}; विफल {failed}.",
+    "importModelCount": "+{count} मॉडल",
+    "importResultWithModels": "आयातित {imported}; {models} मॉडल पंजीकृत; विफल {failed}.",
     "confirmRemove": "पुष्टि करें?",
     "quotaSignalsTitle": "कोटा संकेत",
     "quotaSignalsEmptyTitle": "अभी तक कोई कोटा अवलोकन नहीं",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "{count} otkriveni duplikati — već postoje i bit će preskočeni.",
     "importResult": "Uvezena {imported}; nije {failed}.",
+    "importModelCount": "+{count} modela",
+    "importResultWithModels": "Uvezena {imported}; registrirano {models} modela; nije {failed}.",
     "confirmRemove": "Potvrditi?",
     "quotaSignalsTitle": "Kvotni signali",
     "quotaSignalsEmptyTitle": "Još nema opažanja o kvotama",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikátum",
     "duplicatesFound": "{count} duplikát(ok) észleltek — már léteznek, és kihagyják őket.",
     "importResult": "Importált {imported}; {failed} sikertelen.",
+    "importModelCount": "+{count} modell",
+    "importResultWithModels": "Importált {imported}; {models} modell regisztrálva; {failed} sikertelen.",
     "confirmRemove": "Megerősíteni?",
     "quotaSignalsTitle": "Kvótajelzések",
     "quotaSignalsEmptyTitle": "Még nincs kvótamegfigyelés",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "{count} duplikat terdeteksi — sudah ada dan akan dilewati.",
     "importResult": "{imported} yang diimpor; gagal {failed}.",
+    "importModelCount": "+{count} model",
+    "importResultWithModels": "{imported} yang diimpor; {models} model terdaftar; gagal {failed}.",
     "confirmRemove": "Konfirmasi?",
     "quotaSignalsTitle": "Sinyal kuota",
     "quotaSignalsEmptyTitle": "Belum ada observasi kuota",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -450,6 +450,8 @@
     "duplicate": "Megharịa",
     "duplicatesFound": "Achọpụtara {count} oyiri - adịlarị ma a ga-awụpụ.",
     "importResult": "Bubata {imported}; {failed} dara.",
+    "importModelCount": "+{count} ụdị",
+    "importResultWithModels": "Bubata {imported}; edebanyere ụdị {models}; {failed} dara.",
     "confirmRemove": "Kwenye?",
     "quotaSignalsTitle": "Ngosipụta oke",
     "quotaSignalsEmptyTitle": "Onweghi ihe nlebanya oke",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicato",
     "duplicatesFound": "{count} duplicato/i rilevato/i — già esistente/i e verrà/no saltato/i.",
     "importResult": "Importati {imported}; falliti {failed}.",
+    "importModelCount": "+{count} modelli",
+    "importResultWithModels": "Importati {imported}; registrati {models} modelli; falliti {failed}.",
     "confirmRemove": "Confermi?",
     "quotaSignalsTitle": "Segnali di quota",
     "quotaSignalsEmptyTitle": "Ancora nessuna osservazione di quota",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -450,6 +450,8 @@
     "duplicate": "重複",
     "duplicatesFound": "{count} の重複が検出されました - すでに存在するため、スキップされます。",
     "importResult": "{imported}をインポートしました。 {failed} に失敗しました。",
+    "importModelCount": "+{count}モデル",
+    "importResultWithModels": "{imported}をインポートしました。{models}モデルを登録しました。 {failed} に失敗しました。",
     "confirmRemove": "確認しますか？",
     "quotaSignalsTitle": "クォータ信号",
     "quotaSignalsEmptyTitle": "クォータの観測はまだありません",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -450,6 +450,8 @@
     "duplicate": "დუბლიკატი",
     "duplicatesFound": "აღმოჩენილია {count} დუბლიკატი(ები) — უკვე არსებობს და გამოტოვებული იქნება.",
     "importResult": "იმპორტირებული {imported}; წარუმატებელი {failed}.",
+    "importModelCount": "+{count} მოდელი",
+    "importResultWithModels": "იმპორტირებული {imported}; დარეგისტრირებული {models} მოდელი; წარუმატებელი {failed}.",
     "confirmRemove": "დადასტურება?",
     "quotaSignalsTitle": "კვოტის სიგნალები",
     "quotaSignalsEmptyTitle": "კვოტებზე დაკვირვება ჯერ არ არის",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -450,6 +450,8 @@
     "duplicate": "ចម្លង",
     "duplicatesFound": "{count} — មានរួចហើយ ហើយនឹងត្រូវរំលង។",
     "importResult": "នាំចូល {imported}; បរាជ័យ {failed}។",
+    "importModelCount": "+{count} ម៉ូដែល",
+    "importResultWithModels": "នាំចូល {imported}; បានចុះឈ្មោះម៉ូដែល {models}; បរាជ័យ {failed}។",
     "confirmRemove": "បញ្ជាក់?",
     "quotaSignalsTitle": "សញ្ញាកូតា",
     "quotaSignalsEmptyTitle": "មិនទាន់មានការសង្កេតកូតា",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -450,6 +450,8 @@
     "duplicate": "ನಕಲು",
     "duplicatesFound": "{count} ನಕಲಿ(ಗಳು) ಪತ್ತೆಯಾಗಿದೆ - ಈಗಾಗಲೇ ಅಸ್ತಿತ್ವದಲ್ಲಿದೆ ಮತ್ತು ಬಿಟ್ಟುಬಿಡಲಾಗುತ್ತದೆ.",
     "importResult": "ಆಮದು {imported}; ವಿಫಲವಾಗಿದೆ {failed}.",
+    "importModelCount": "+{count} ಮಾದರಿಗಳು",
+    "importResultWithModels": "ಆಮದು {imported}; {models} ಮಾದರಿಗಳು ನೋಂದಾಯಿಸಲಾಗಿದೆ; ವಿಫಲವಾಗಿದೆ {failed}.",
     "confirmRemove": "ದೃಢೀಕರಿಸುವುದೇ?",
     "quotaSignalsTitle": "ಕೋಟಾ ಸಂಕೇತಗಳು",
     "quotaSignalsEmptyTitle": "ಇನ್ನೂ ಯಾವುದೇ ಕೋಟಾ ಅವಲೋಕನಗಳಿಲ್ಲ",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -450,6 +450,8 @@
     "duplicate": "중복",
     "duplicatesFound": "{count} 중복이 감지되었습니다. 이미 존재하며 건너뜁니다.",
     "importResult": "수입된 {imported}; {failed}에 실패했습니다.",
+    "importModelCount": "+{count}개 모델",
+    "importResultWithModels": "수입된 {imported}; {models}개 모델 등록됨; {failed}에 실패했습니다.",
     "confirmRemove": "확인하시겠습니까?",
     "quotaSignalsTitle": "할당량 신호",
     "quotaSignalsEmptyTitle": "아직 할당량 관찰이 없습니다.",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -450,6 +450,8 @@
     "duplicate": "Dublikatas",
     "duplicatesFound": "{count} aptikti dublikatai — jau egzistuoja ir bus praleisti.",
     "importResult": "Importuota {imported}; Nepavyko {failed}.",
+    "importModelCount": "+{count} modeliai",
+    "importResultWithModels": "Importuota {imported}; užregistruota {models} modelių; Nepavyko {failed}.",
     "confirmRemove": "Patvirtinti?",
     "quotaSignalsTitle": "Kvotų signalai",
     "quotaSignalsEmptyTitle": "Kvotos laikymosi dar nėra",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -450,6 +450,8 @@
     "duplicate": "ഡ്യൂപ്ലിക്കേറ്റ്",
     "duplicatesFound": "{count} ഡ്യൂപ്ലിക്കേറ്റ്(കൾ) കണ്ടെത്തി - ഇതിനകം നിലവിലുണ്ട്, അത് ഒഴിവാക്കപ്പെടും.",
     "importResult": "ഇറക്കുമതി ചെയ്ത {imported}; {failed} പരാജയപ്പെട്ടു.",
+    "importModelCount": "+{count} മോഡലുകൾ",
+    "importResultWithModels": "ഇറക്കുമതി ചെയ്ത {imported}; {models} മോഡലുകൾ രജിസ്റ്റർ ചെയ്തു; {failed} പരാജയപ്പെട്ടു.",
     "confirmRemove": "സ്ഥിരീകരിക്കണോ?",
     "quotaSignalsTitle": "ക്വാട്ട സിഗ്നലുകൾ",
     "quotaSignalsEmptyTitle": "ഇതുവരെ ക്വാട്ട നിരീക്ഷണങ്ങളൊന്നുമില്ല",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -450,6 +450,8 @@
     "duplicate": "डुप्लिकेट",
     "duplicatesFound": "{count} डुप्लिकेट आढळले — आधीपासून अस्तित्वात आहेत आणि वगळले जातील.",
     "importResult": "आयातित {imported}; अयशस्वी {failed}.",
+    "importModelCount": "+{count} मॉडेल",
+    "importResultWithModels": "आयातित {imported}; {models} मॉडेल नोंदणीकृत; अयशस्वी {failed}.",
     "confirmRemove": "पुष्टी करायची?",
     "quotaSignalsTitle": "कोटा सिग्नल",
     "quotaSignalsEmptyTitle": "अद्याप कोटा निरीक्षणे नाहीत",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "{count} pendua yang dikesan — sudah wujud dan akan diabaikan.",
     "importResult": "{imported} import; gagal {failed}.",
+    "importModelCount": "+{count} model",
+    "importResultWithModels": "{imported} import; {models} model didaftarkan; gagal {failed}.",
     "confirmRemove": "Sahkan?",
     "quotaSignalsTitle": "Isyarat kuota",
     "quotaSignalsEmptyTitle": "Tiada pemerhatian kuota lagi",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -450,6 +450,8 @@
     "duplicate": "မိတ္တူ",
     "duplicatesFound": "{count} တူညီမှုများ ရှာဖွေတွေ့ရှိပြီး ရှိပြီးသားဖြစ်ပြီး ကျော်လွှားသွားမည်ဖြစ်သည်။",
     "importResult": "တင်သွင်းထားသော {imported}; {failed} မအောင်မြင်ခဲ့ပါ။",
+    "importModelCount": "+{count} မော်ဒယ်",
+    "importResultWithModels": "တင်သွင်းထားသော {imported}; မော်ဒယ် {models} ခု မှတ်ပုံတင်ပြီး; {failed} မအောင်မြင်ခဲ့ပါ။",
     "confirmRemove": "အတည်ပြုပါသလား?",
     "quotaSignalsTitle": "အရေအတွက် အချက်ပြချက်များ",
     "quotaSignalsEmptyTitle": "အရေအတွက် စောင့်ကြည့်မှု မရှိသေးပါ",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -450,6 +450,8 @@
     "duplicate": "नक्कल गर्नुहोस्",
     "duplicatesFound": "{count} नक्कली पत्ता लगाइयो - पहिले नै अवस्थित छ र फड्काइनेछ ।",
     "importResult": "आयात गरिएका {imported}; असफल {failed} ।",
+    "importModelCount": "+{count} मोडेल",
+    "importResultWithModels": "आयात गरिएका {imported}; {models} मोडेल दर्ता गरियो; असफल {failed} ।",
     "confirmRemove": "पुष्टि गर्नुहुन्छ?",
     "quotaSignalsTitle": "कोटा सङ्केतहरू",
     "quotaSignalsEmptyTitle": "अहिले सम्म कोटा अवलोकन छैन",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicate",
     "duplicatesFound": "{count} duplicaat(en) die worden gedetecteerd — bestaan al en zullen worden overgeslagen.",
     "importResult": "Geïmporteerde {imported}; Mislukt {failed}.",
+    "importModelCount": "+{count} modellen",
+    "importResultWithModels": "Geïmporteerde {imported}; {models} modellen geregistreerd; Mislukt {failed}.",
     "confirmRemove": "Bevestigen?",
     "quotaSignalsTitle": "Quotasignalen",
     "quotaSignalsEmptyTitle": "Nog geen quota-observaties",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "{count} duplikat(er) oppdaget — eksisterer allerede og vil bli hoppet over.",
     "importResult": "Importerte {imported}; mislyktes {failed}.",
+    "importModelCount": "+{count} modeller",
+    "importResultWithModels": "Importerte {imported}; registrerte {models} modeller; mislyktes {failed}.",
     "confirmRemove": "Bekreft?",
     "quotaSignalsTitle": "Kvotesignaler",
     "quotaSignalsEmptyTitle": "Ingen kvoteobservasjoner ennå",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -450,6 +450,8 @@
     "duplicate": "ନକଲ",
     "duplicatesFound": "{count} ନକଲ(ଗୁଡିକ) ଚିହ୍ନଟ ହୋଇଛି — ପୂର୍ବରୁ ବିଦ୍ୟମାନ ଏବଂ ସ୍କିପ୍ ହେବ।",
     "importResult": "ଆମଦାନୀ ହୋଇଥିବା {imported}; {failed} ବିଫଳ ହୋଇଛି।",
+    "importModelCount": "+{count} ମଡେଲ",
+    "importResultWithModels": "ଆମଦାନୀ ହୋଇଥିବା {imported}; {models} ମଡେଲ ପଞ୍ଜୀକୃତ ହୋଇଛି; {failed} ବିଫଳ ହୋଇଛି।",
     "confirmRemove": "ନିଶ୍ଚିତ କରିବେ?",
     "quotaSignalsTitle": "କୋଟା ସଙ୍କେତ",
     "quotaSignalsEmptyTitle": "ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି କୋଟା ପର୍ଯ୍ୟବେକ୍ଷଣ ହୋଇନାହିଁ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -450,6 +450,8 @@
     "duplicate": "ਡੁਪਲੀਕੇਟ",
     "duplicatesFound": "{count} ਡੁਪਲੀਕੇਟ ਖੋਜੇ ਗਏ ਹਨ — ਪਹਿਲਾਂ ਹੀ ਮੌਜੂਦ ਹਨ ਅਤੇ ਛੱਡ ਦਿੱਤੇ ਜਾਣਗੇ।",
     "importResult": "ਆਯਾਤ ਕੀਤਾ {imported}; ਅਸਫਲ {failed}।",
+    "importModelCount": "+{count} ਮਾਡਲ",
+    "importResultWithModels": "ਆਯਾਤ ਕੀਤਾ {imported}; {models} ਮਾਡਲ ਰਜਿਸਟਰ ਕੀਤੇ; ਅਸਫਲ {failed}।",
     "confirmRemove": "ਪੁਸ਼ਟੀ ਕਰੋ?",
     "quotaSignalsTitle": "ਕੋਟਾ ਸਿਗਨਲ",
     "quotaSignalsEmptyTitle": "ਅਜੇ ਕੋਈ ਕੋਟਾ ਨਿਰੀਖਣ ਨਹੀਂ ਹੈ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikat",
     "duplicatesFound": "Wykryto duplikaty {count} — już istnieją i zostaną pominięte.",
     "importResult": "Zaimportowano {imported}; nie powiodło się {failed}.",
+    "importModelCount": "+{count} modeli",
+    "importResultWithModels": "Zaimportowano {imported}; zarejestrowano {models} modeli; nie powiodło się {failed}.",
     "confirmRemove": "Potwierdzić?",
     "quotaSignalsTitle": "Sygnały kwotowe",
     "quotaSignalsEmptyTitle": "Nie ma jeszcze żadnych obserwacji kwot",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicado",
     "duplicatesFound": "{count} duplicado(s) detectado(s) — já existem e serão ignorados.",
     "importResult": "Importados {imported}; falharam {failed}.",
+    "importModelCount": "+{count} modelos",
+    "importResultWithModels": "Importados {imported}; {models} modelos registrados; falharam {failed}.",
     "confirmRemove": "Confirmar?",
     "quotaSignalsTitle": "Sinais de cota",
     "quotaSignalsEmptyTitle": "Ainda sem observações de cota",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicado",
     "duplicatesFound": "{count} duplicado(s) detetado — já existem e serão saltados.",
     "importResult": "{imported} importados; Falhou {failed}.",
+    "importModelCount": "+{count} modelos",
+    "importResultWithModels": "{imported} importados; {models} modelos registados; Falhou {failed}.",
     "confirmRemove": "Confirmar?",
     "quotaSignalsTitle": "Sinais de quota",
     "quotaSignalsEmptyTitle": "Ainda não há observações de quotas",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicat",
     "duplicatesFound": "{count} duplicate detectate — există deja și vor fi sărite.",
     "importResult": "Importați {imported}; A eșuat {failed}.",
+    "importModelCount": "+{count} modele",
+    "importResultWithModels": "Importați {imported}; {models} modele înregistrate; A eșuat {failed}.",
     "confirmRemove": "Confirmă?",
     "quotaSignalsTitle": "Semnale de cotă",
     "quotaSignalsEmptyTitle": "Încă nu am observat cotele",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -450,6 +450,8 @@
     "duplicate": "Дублировать",
     "duplicatesFound": "Обнаружены дубликаты {count} — они уже существуют и будут пропущены.",
     "importResult": "Импортирован {imported}; не удалось {failed}.",
+    "importModelCount": "+{count} моделей",
+    "importResultWithModels": "Импортирован {imported}; зарегистрировано {models} моделей; не удалось {failed}.",
     "confirmRemove": "Подтвердить?",
     "quotaSignalsTitle": "Сигналы квоты",
     "quotaSignalsEmptyTitle": "Наблюдений за квотами пока нет",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -450,6 +450,8 @@
     "duplicate": "අනුපිටපත් කරන්න",
     "duplicatesFound": "{count} අනුපිටපත්(ය) අනාවරණය විය - දැනටමත් පවතින අතර මඟ හරිනු ඇත.",
     "importResult": "ආනයනය කරන ලද {imported}; අසාර්ථක {failed}.",
+    "importModelCount": "+{count} ආකෘති",
+    "importResultWithModels": "ආනයනය කරන ලද {imported}; ආකෘති {models} ලියාපදිංචි විය; අසාර්ථක {failed}.",
     "confirmRemove": "තහවුරු කරන්නද?",
     "quotaSignalsTitle": "කෝටා සංඥා",
     "quotaSignalsEmptyTitle": "තවම කෝටා නිරීක්ෂණ නොමැත",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplikát",
     "duplicatesFound": "{count} detegované duplikáty — už existujú a budú preskočené.",
     "importResult": "Dovážané {imported}; {failed} zlyhal.",
+    "importModelCount": "+{count} modelov",
+    "importResultWithModels": "Dovážané {imported}; zaregistrovaných {models} modelov; {failed} zlyhal.",
     "confirmRemove": "Potvrdiť?",
     "quotaSignalsTitle": "Kvótové signály",
     "quotaSignalsEmptyTitle": "Zatiaľ žiadne pozorovania kvót",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -450,6 +450,8 @@
     "duplicate": "Дупликат",
     "duplicatesFound": "{count} дупликати су откривени — већ постоје и биће прескочени.",
     "importResult": "Импортед {imported}; неуспешно {failed}.",
+    "importModelCount": "+{count} модела",
+    "importResultWithModels": "Импортед {imported}; регистровано {models} модела; неуспешно {failed}.",
     "confirmRemove": "Потврдите?",
     "quotaSignalsTitle": "Квотни сигнали",
     "quotaSignalsEmptyTitle": "Још нема запажања квота",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -450,6 +450,8 @@
     "duplicate": "Duplicat",
     "duplicatesFound": "{count} dubblett upptäckt — finns redan och kommer att hoppas över.",
     "importResult": "Importerade {imported}; Misslyckades {failed}.",
+    "importModelCount": "+{count} modeller",
+    "importResultWithModels": "Importerade {imported}; registrerade {models} modeller; Misslyckades {failed}.",
     "confirmRemove": "Bekräfta?",
     "quotaSignalsTitle": "Kvotsignaler",
     "quotaSignalsEmptyTitle": "Inga kvotobservationer än",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -450,6 +450,8 @@
     "duplicate": "Nakala",
     "duplicatesFound": "Nakala mbili za {count} zimetambuliwa - tayari zipo na zitarukwa.",
     "importResult": "Zilizoingizwa {imported}; imeshindwa {failed}.",
+    "importModelCount": "+{count} miundo",
+    "importResultWithModels": "Zilizoingizwa {imported}; miundo {models} imesajiliwa; imeshindwa {failed}.",
     "confirmRemove": "Thibitisha?",
     "quotaSignalsTitle": "Ishara za quota",
     "quotaSignalsEmptyTitle": "Bado hakuna uchunguzi wa kiasi",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -450,6 +450,8 @@
     "duplicate": "நகல்",
     "duplicatesFound": "{count} நகல்(கள்) கண்டறியப்பட்டது - ஏற்கனவே உள்ளது மற்றும் தவிர்க்கப்படும்.",
     "importResult": "இறக்குமதி செய்யப்பட்ட {imported}; தோல்வி {failed}.",
+    "importModelCount": "+{count} மாடல்கள்",
+    "importResultWithModels": "இறக்குமதி செய்யப்பட்ட {imported}; {models} மாடல்கள் பதிவு செய்யப்பட்டன; தோல்வி {failed}.",
     "confirmRemove": "உறுதிப்படுத்தவா?",
     "quotaSignalsTitle": "ஒதுக்கீடு சமிக்ஞைகள்",
     "quotaSignalsEmptyTitle": "இன்னும் ஒதுக்கீடு கண்காணிப்புகள் இல்லை",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -450,6 +450,8 @@
     "duplicate": "నకిలీ",
     "duplicatesFound": "{count} నకిలీ(లు) కనుగొనబడ్డాయి - ఇప్పటికే ఉనికిలో ఉన్నాయి మరియు దాటవేయబడతాయి.",
     "importResult": "దిగుమతి చేయబడిన {imported}; {failed} విఫలమైంది.",
+    "importModelCount": "+{count} మోడల్స్",
+    "importResultWithModels": "దిగుమతి చేయబడిన {imported}; {models} మోడల్స్ నమోదు చేయబడ్డాయి; {failed} విఫలమైంది.",
     "confirmRemove": "నిర్ధారించాలా?",
     "quotaSignalsTitle": "కోటా సంకేతాలు",
     "quotaSignalsEmptyTitle": "ఇంకా కోటా పరిశీలనలు లేవు",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -450,6 +450,8 @@
     "duplicate": "ทำซ้ำ",
     "duplicatesFound": "ตรวจพบรายการซ้ำ {count} — มีอยู่แล้วและจะถูกข้าม",
     "importResult": "นำเข้า {imported}; {failed} ล้มเหลว",
+    "importModelCount": "+{count} โมเดล",
+    "importResultWithModels": "นำเข้า {imported}; ลงทะเบียน {models} โมเดล; {failed} ล้มเหลว",
     "confirmRemove": "ยืนยัน?",
     "quotaSignalsTitle": "สัญญาณโควต้า",
     "quotaSignalsEmptyTitle": "ยังไม่มีการสังเกตโควต้า",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -450,6 +450,8 @@
     "duplicate": "kopyahin",
     "duplicatesFound": "{count} duplicate(s) na natukoy — umiiral na at malalaktawan na.",
     "importResult": "Imported {imported}; nabigong {failed}.",
+    "importModelCount": "+{count} na modelo",
+    "importResultWithModels": "Imported {imported}; nairehistro ang {models} na modelo; nabigong {failed}.",
     "confirmRemove": "Kumpirmahin?",
     "quotaSignalsTitle": "Mga senyales ng quota",
     "quotaSignalsEmptyTitle": "Wala pang obserbasyon sa quota",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -450,6 +450,8 @@
     "duplicate": "Çoğalt",
     "duplicatesFound": "{count} kopya(lar) algılandı — zaten mevcut ve atlanacak.",
     "importResult": "İçe aktarılan {imported}; başarısız oldu {failed}.",
+    "importModelCount": "+{count} model",
+    "importResultWithModels": "İçe aktarılan {imported}; {models} model kaydedildi; başarısız oldu {failed}.",
     "confirmRemove": "Onaylıyor musun?",
     "quotaSignalsTitle": "Kota sinyalleri",
     "quotaSignalsEmptyTitle": "Henüz kota gözlemi yok",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -450,6 +450,8 @@
     "duplicate": "дублікат",
     "duplicatesFound": "Виявлено дублікати {count} — уже існують і їх буде пропущено.",
     "importResult": "Імпортований {imported}; не вдалося {failed}.",
+    "importModelCount": "+{count} моделей",
+    "importResultWithModels": "Імпортований {imported}; зареєстровано {models} моделей; не вдалося {failed}.",
     "confirmRemove": "Підтвердити?",
     "quotaSignalsTitle": "Сигнали квоти",
     "quotaSignalsEmptyTitle": "Спостережень щодо квот ще немає",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -450,6 +450,8 @@
     "duplicate": "نقل",
     "duplicatesFound": "{count} ڈپلیکیٹ کا پتہ چلا — پہلے سے موجود ہے اور اسے چھوڑ دیا جائے گا۔",
     "importResult": "درآمد شدہ {imported}؛ ناکام {failed}۔",
+    "importModelCount": "+{count} ماڈلز",
+    "importResultWithModels": "درآمد شدہ {imported}؛ {models} ماڈلز رجسٹر ہوئے؛ ناکام {failed}۔",
     "confirmRemove": "تصدیق کریں؟",
     "quotaSignalsTitle": "کوٹہ سگنلز",
     "quotaSignalsEmptyTitle": "ابھی تک کوئی کوٹہ مشاہدہ نہیں ہوا۔",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -450,6 +450,8 @@
     "duplicate": "Dublikat",
     "duplicatesFound": "{count} dublikat(lar)i aniqlandi — allaqachon mavjud va oʻtkazib yuboriladi.",
     "importResult": "Import qilingan {imported}; muvaffaqiyatsiz {failed}.",
+    "importModelCount": "+{count} model",
+    "importResultWithModels": "Import qilingan {imported}; {models} model ro'yxatga olindi; muvaffaqiyatsiz {failed}.",
     "confirmRemove": "Tasdiqlansinmi?",
     "quotaSignalsTitle": "Kvota signallari",
     "quotaSignalsEmptyTitle": "Hozircha kvotalar kuzatilmagan",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -450,6 +450,8 @@
     "duplicate": "trùng lặp",
     "duplicatesFound": "Đã phát hiện thấy (các) bản sao {count} - đã tồn tại và sẽ bị bỏ qua.",
     "importResult": "{imported} nhập khẩu; {failed} không thành công.",
+    "importModelCount": "+{count} mô hình",
+    "importResultWithModels": "{imported} nhập khẩu; đã đăng ký {models} mô hình; {failed} không thành công.",
     "confirmRemove": "Xác nhận?",
     "quotaSignalsTitle": "tín hiệu hạn ngạch",
     "quotaSignalsEmptyTitle": "Chưa có quan sát hạn ngạch",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -450,6 +450,8 @@
     "duplicate": "Ṣe pidánpidán",
     "duplicatesFound": "{count} àdáwòkọ(s) ti ri - tẹlẹ tẹlẹ ati pe yoo jẹ foo.",
     "importResult": "Gbe wọle {imported}; kuna {failed}.",
+    "importModelCount": "+{count} awoṣe",
+    "importResultWithModels": "Gbe wọle {imported}; forukọsilẹ awoṣe {models}; kuna {failed}.",
     "confirmRemove": "Jẹrisi?",
     "quotaSignalsTitle": "Quota awọn ifihan agbara",
     "quotaSignalsEmptyTitle": "Ko si awọn akiyesi ipin sibẹsibẹ",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -450,6 +450,8 @@
     "duplicate": "重复",
     "duplicatesFound": "检测到 {count} 个重复项 — 已存在，将被跳过。",
     "importResult": "已导入 {imported} 个；失败 {failed} 个。",
+    "importModelCount": "+{count} 个模型",
+    "importResultWithModels": "已导入 {imported} 个；已注册 {models} 个模型；失败 {failed} 个。",
     "confirmRemove": "确认？",
     "quotaSignalsTitle": "配额信号",
     "quotaSignalsEmptyTitle": "暂无配额观测数据",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -450,6 +450,8 @@
     "duplicate": "重複",
     "duplicatesFound": "偵測到 {count} 個重複項 — 已存在，將被跳過。",
     "importResult": "已匯入 {imported} 個；失敗 {failed} 個。",
+    "importModelCount": "+{count} 個模型",
+    "importResultWithModels": "已匯入 {imported} 個；已註冊 {models} 個模型；失敗 {failed} 個。",
     "confirmRemove": "確認？",
     "quotaSignalsTitle": "配額訊號",
     "quotaSignalsEmptyTitle": "尚無配額觀測資料",

--- a/server/src/__tests__/lib/key-parser-models.test.ts
+++ b/server/src/__tests__/lib/key-parser-models.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { parseKeysFromFile, parseModelList } from '../../lib/key-parser.js';
+
+// #382: a paste can declare the models a custom endpoint serves next to its
+// key, either as CUSTOM_<n>_MODELS beside the paired CUSTOM_<n>_* lines or as
+// <PREFIX>_CUSTOM_MODELS beside <PREFIX>_BASE_URL + <PREFIX>_API_KEY/_KEY.
+
+describe('parseModelList (#382)', () => {
+  it('splits on commas and strips trailing capability suffixes', () => {
+    expect(parseModelList('llama3, qwen3-TOOLS,pixtral-VISION')).toEqual([
+      { id: 'llama3' },
+      { id: 'qwen3', supportsTools: true },
+      { id: 'pixtral', supportsVision: true },
+    ]);
+  });
+
+  it('accepts both suffixes in either order', () => {
+    expect(parseModelList('m1-TOOLS-VISION,m2-VISION-TOOLS')).toEqual([
+      { id: 'm1', supportsTools: true, supportsVision: true },
+      { id: 'm2', supportsTools: true, supportsVision: true },
+    ]);
+  });
+
+  it('never touches a TOOLS/VISION that is not trailing', () => {
+    expect(parseModelList('qwen-TOOLS-preview,llama-VISION-8b')).toEqual([
+      { id: 'qwen-TOOLS-preview' },
+      { id: 'llama-VISION-8b' },
+    ]);
+  });
+
+  it('treats lowercase suffixes as part of the model id', () => {
+    expect(parseModelList('devstral-tools,moondream-vision')).toEqual([
+      { id: 'devstral-tools' },
+      { id: 'moondream-vision' },
+    ]);
+  });
+
+  it('drops blanks and dedupes ids after stripping', () => {
+    expect(parseModelList('a, ,a-TOOLS,')).toEqual([{ id: 'a' }]);
+  });
+});
+
+describe('model lists in .env pastes (#382)', () => {
+  it('attaches CUSTOM_<n>_MODELS to its own endpoint only', () => {
+    const env = [
+      'CUSTOM_1_BASE_URL=http://relay-a.example/v1',
+      'CUSTOM_1_KEY=sk-a',
+      'CUSTOM_1_MODELS=llama3,qwen3-TOOLS',
+      'CUSTOM_2_BASE_URL=http://relay-b.example/v1',
+      'CUSTOM_2_KEY=sk-b',
+    ].join('\n');
+    const result = parseKeysFromFile(env, 'keys.env');
+    expect(result.keys).toEqual([
+      {
+        rawKey: 'CUSTOM_1_KEY=sk-a',
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: 'http://relay-a.example/v1',
+        models: [{ id: 'llama3' }, { id: 'qwen3', supportsTools: true }],
+      },
+      {
+        rawKey: 'CUSTOM_2_KEY=sk-b',
+        prefix: 'CUSTOM_',
+        platform: 'custom',
+        baseUrl: 'http://relay-b.example/v1',
+      },
+    ]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('folds <PREFIX>_BASE_URL + <PREFIX>_API_KEY + <PREFIX>_CUSTOM_MODELS into a custom endpoint', () => {
+    const env = [
+      'MYRELAY_BASE_URL=http://myrelay.example/v1',
+      'MYRELAY_API_KEY=sk-relay',
+      'MYRELAY_CUSTOM_MODELS=deepseek-v3,text-embedding-qwen',
+    ].join('\n');
+    const result = parseKeysFromFile(env, 'keys.env');
+    expect(result.keys).toEqual([
+      expect.objectContaining({
+        rawKey: 'MYRELAY_API_KEY=sk-relay',
+        platform: 'custom',
+        baseUrl: 'http://myrelay.example/v1',
+        models: [{ id: 'deepseek-v3' }, { id: 'text-embedding-qwen' }],
+      }),
+    ]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('accepts <PREFIX>_KEY as the key spelling', () => {
+    const env = [
+      'MYRELAY_BASE_URL=http://myrelay.example/v1',
+      'MYRELAY_KEY=sk-relay',
+      'MYRELAY_CUSTOM_MODELS=deepseek-v3',
+    ].join('\n');
+    const result = parseKeysFromFile(env, 'keys.env');
+    expect(result.keys).toEqual([
+      expect.objectContaining({
+        platform: 'custom',
+        baseUrl: 'http://myrelay.example/v1',
+        models: [{ id: 'deepseek-v3' }],
+      }),
+    ]);
+  });
+
+  it('leaves a <PREFIX>_BASE_URL pair alone when no models line makes it endpoint-defining', () => {
+    const env = [
+      'MYRELAY_BASE_URL=http://myrelay.example/v1',
+      'MYRELAY_API_KEY=sk-relay',
+    ].join('\n');
+    const result = parseKeysFromFile(env, 'keys.env');
+    expect(result.keys.every(k => k.platform !== 'custom')).toBe(true);
+  });
+
+  it('consumes and reports a models line with nothing to attach to', () => {
+    const env = [
+      'CUSTOM_1_MODELS=llama3',
+      'ORPHAN_CUSTOM_MODELS=qwen',
+    ].join('\n');
+    const result = parseKeysFromFile(env, 'keys.env');
+    // The list values must never fall through and be mistaken for key material.
+    expect(result.keys).toEqual([]);
+    expect(result.skipped).toEqual([
+      expect.stringContaining('CUSTOM_1_MODELS'),
+      expect.stringContaining('ORPHAN_CUSTOM_MODELS'),
+    ]);
+  });
+});

--- a/server/src/__tests__/routes/keys-import-models.test.ts
+++ b/server/src/__tests__/routes/keys-import-models.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { mintDashboardToken } from '../helpers/auth.js';
+
+// #382, remaining gap: an imported custom endpoint can carry the models it
+// serves. Chat ids go through the same registration POST /custom runs;
+// ids that look like embedding models go through the embeddings path, probing
+// the endpoint for dimensions only when the model is not already on record.
+
+const realFetch = globalThis.fetch;
+
+let dashToken = '';
+
+async function post(app: Express, path: string, body: unknown) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${dashToken}` },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: json as any };
+}
+
+async function previewFile(app: Express, filename: string, content: string) {
+  const server = app.listen(0);
+  const addr = server.address() as { port: number };
+  const form = new FormData();
+  form.append('files', new Blob([content], { type: 'text/plain' }), filename);
+  const res = await realFetch(`http://127.0.0.1:${addr.port}/api/keys/preview`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${dashToken}` },
+    body: form,
+  });
+  const json = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: json as any };
+}
+
+function embeddingResponse(dimensions: number) {
+  return new Response(JSON.stringify({
+    data: [{ index: 0, embedding: Array(dimensions).fill(0.1) }],
+    usage: { prompt_tokens: 1 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+}
+
+function customModels() {
+  return getDb().prepare(
+    "SELECT model_id, supports_tools, supports_vision, key_id, endpoint_scope FROM models WHERE platform = 'custom' ORDER BY model_id",
+  ).all() as Array<{ model_id: string; supports_tools: number; supports_vision: number; key_id: number; endpoint_scope: string }>;
+}
+
+function customEmbeddings() {
+  return getDb().prepare(
+    "SELECT model_id, family, dimensions, key_id FROM embedding_models WHERE platform = 'custom' ORDER BY model_id",
+  ).all() as Array<{ model_id: string; family: string; dimensions: number; key_id: number }>;
+}
+
+describe('POST /api/keys/import-selected — model lists (#382)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  beforeEach(() => {
+    const db = getDb();
+    db.prepare("DELETE FROM fallback_config WHERE model_db_id IN (SELECT id FROM models WHERE platform = 'custom')").run();
+    db.prepare("DELETE FROM models WHERE platform = 'custom'").run();
+    db.prepare("DELETE FROM embedding_models WHERE platform = 'custom'").run();
+    db.prepare('DELETE FROM api_keys').run();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('registers chat models bound to the imported endpoint, with the parsed flags', async () => {
+    const { status, body } = await post(app, '/api/keys/import-selected', {
+      keys: [{
+        keyName: 'My Relay',
+        keyValue: 'sk-relay-123',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+        models: [
+          { id: 'llama3' },
+          { id: 'qwen3', supportsTools: true, supportsVision: true },
+        ],
+      }],
+    });
+
+    expect(status).toBe(200);
+    expect(body.imported).toBe(1);
+    expect(body.modelsRegistered).toBe(2);
+    expect(body.errors).toEqual([]);
+
+    const keyRow = getDb().prepare("SELECT id FROM api_keys WHERE platform = 'custom'").get() as { id: number };
+    expect(customModels()).toEqual([
+      // Flags left unset take the registration defaults (tools 1, vision 0).
+      expect.objectContaining({ model_id: 'llama3', supports_tools: 1, supports_vision: 0, key_id: keyRow.id, endpoint_scope: 'https://relay.example.com/v1' }),
+      expect.objectContaining({ model_id: 'qwen3', supports_tools: 1, supports_vision: 1, key_id: keyRow.id }),
+    ]);
+  });
+
+  it('routes ids that look like embedding models through the embeddings path', async () => {
+    const fetchMock = vi.fn(async () => embeddingResponse(768));
+    globalThis.fetch = fetchMock as any;
+
+    const { body } = await post(app, '/api/keys/import-selected', {
+      keys: [{
+        keyName: 'My Relay',
+        keyValue: 'sk-relay-123',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+        models: [{ id: 'text-embedding-qwen' }, { id: 'chat-1' }],
+      }],
+    });
+
+    expect(body.imported).toBe(1);
+    expect(body.modelsRegistered).toBe(2);
+    expect(body.errors).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(customModels().map(m => m.model_id)).toEqual(['chat-1']);
+    expect(customEmbeddings()).toEqual([
+      expect.objectContaining({ model_id: 'text-embedding-qwen', family: 'text-embedding-qwen', dimensions: 768 }),
+    ]);
+  });
+
+  it('records a failed embedding probe as a per-model error and keeps the rest', async () => {
+    globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as any;
+
+    const { body } = await post(app, '/api/keys/import-selected', {
+      keys: [{
+        keyName: 'My Relay',
+        keyValue: 'sk-relay-123',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+        models: [{ id: 'text-embedding-qwen' }, { id: 'chat-1' }],
+      }],
+    });
+
+    // The key itself and the chat model still import; only the unprobeable
+    // embedding model is reported.
+    expect(body.imported).toBe(1);
+    expect(body.modelsRegistered).toBe(1);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].key).toContain('text-embedding-qwen');
+    expect(customEmbeddings()).toEqual([]);
+    expect(customModels().map(m => m.model_id)).toEqual(['chat-1']);
+  });
+
+  it('is idempotent on re-import and reuses stored embedding dimensions', async () => {
+    const fetchMock = vi.fn(async () => embeddingResponse(768));
+    globalThis.fetch = fetchMock as any;
+
+    const payload = {
+      keys: [{
+        keyName: 'My Relay',
+        keyValue: 'sk-relay-123',
+        platform: 'custom',
+        baseUrl: 'https://relay.example.com/v1',
+        models: [{ id: 'text-embedding-qwen' }, { id: 'chat-1' }],
+      }],
+    };
+    await post(app, '/api/keys/import-selected', payload);
+    const { body } = await post(app, '/api/keys/import-selected', payload);
+
+    expect(body.errors).toEqual([]);
+    expect(customModels()).toHaveLength(1);
+    expect(customEmbeddings()).toHaveLength(1);
+    const db = getDb();
+    expect(db.prepare("SELECT COUNT(*) AS n FROM api_keys WHERE platform = 'custom'").get()).toEqual({ n: 1 });
+    const modelDbId = (db.prepare("SELECT id FROM models WHERE platform = 'custom'").get() as { id: number }).id;
+    expect(db.prepare('SELECT COUNT(*) AS n FROM fallback_config WHERE model_db_id = ?').get(modelDbId)).toEqual({ n: 1 });
+    // The second import found the dimensions on record — no second probe.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores model lists on catalog-platform rows', async () => {
+    const { body } = await post(app, '/api/keys/import-selected', {
+      keys: [{
+        keyName: 'GROQ_API_KEY',
+        keyValue: 'gsk-test-123',
+        platform: 'groq',
+        models: [{ id: 'llama3' }],
+      }],
+    });
+
+    expect(body.imported).toBe(1);
+    expect(body.modelsRegistered).toBe(0);
+    expect(customModels()).toEqual([]);
+  });
+
+  it('carries models from /preview so the dialog can pass them back', async () => {
+    const env = [
+      'CUSTOM_1_BASE_URL=https://relay.example.com/v1',
+      'CUSTOM_1_KEY=sk-relay-123',
+      'CUSTOM_1_MODELS=llama3,qwen3-TOOLS',
+    ].join('\n');
+
+    const { status, body } = await previewFile(app, 'keys.env', env);
+    expect(status).toBe(200);
+    const custom = body.keys.find((k: any) => k.detectedPlatform === 'custom');
+    expect(custom).toBeTruthy();
+    expect(custom.models).toEqual([{ id: 'llama3' }, { id: 'qwen3', supportsTools: true }]);
+  });
+});

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -1,3 +1,12 @@
+/** One model id from a `*_MODELS` list (#382). A capability flag is set only
+ *  when the paste declared it via a trailing `-TOOLS` / `-VISION` suffix;
+ *  unset means "no opinion" so registration keeps its own defaults. */
+export interface ParsedModelEntry {
+  id: string;
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+}
+
 export interface ParsedKey {
   rawKey: string;
   prefix: string;
@@ -7,6 +16,9 @@ export interface ParsedKey {
    *  by the formats that can carry it (export JSON, CSV, and the paired
    *  CUSTOM_<n>_BASE_URL / CUSTOM_<n>_KEY convention in .env). */
   baseUrl?: string;
+  /** Custom endpoints only: models declared beside the key via
+   *  CUSTOM_<n>_MODELS / <PREFIX>_CUSTOM_MODELS (#382). */
+  models?: ParsedModelEntry[];
 }
 
 /** A key/value pair on its way to becoming a ParsedKey. `platform` and
@@ -17,6 +29,7 @@ interface KeyPair {
   value: string;
   platform?: string;
   baseUrl?: string;
+  models?: ParsedModelEntry[];
 }
 
 export interface ParseResult {
@@ -379,28 +392,124 @@ export function parseAuthJson(content: string): ParseResult {
 }
 
 /**
+ * Parse a comma-separated model list (#382). Trailing `-TOOLS` / `-VISION`
+ * suffixes — either order, possibly both — strip off the stored id and set the
+ * matching capability flag. Trailing ONLY: a TOOLS/VISION inside the id is
+ * part of the id, and the suffixes are uppercase by convention so a real model
+ * id ending in `-tools` is never mangled.
+ */
+export function parseModelList(value: string): ParsedModelEntry[] {
+  const entries: ParsedModelEntry[] = [];
+  const seen = new Set<string>();
+  for (const raw of value.split(',')) {
+    let id = raw.trim();
+    let tools: boolean | undefined;
+    let vision: boolean | undefined;
+    for (;;) {
+      if (id.endsWith('-TOOLS')) { tools = true; id = id.slice(0, -'-TOOLS'.length); }
+      else if (id.endsWith('-VISION')) { vision = true; id = id.slice(0, -'-VISION'.length); }
+      else break;
+    }
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    entries.push({
+      id,
+      ...(tools !== undefined ? { supportsTools: tools } : {}),
+      ...(vision !== undefined ? { supportsVision: vision } : {}),
+    });
+  }
+  return entries;
+}
+
+interface CustomEnvFold {
+  pairs: KeyPair[];
+  skipped: string[];
+}
+
+/**
  * Fold the paired CUSTOM_<n>_BASE_URL / CUSTOM_<n>_KEY lines the .env export
  * writes back into one custom key carrying its endpoint. A plain `CUSTOM_KEY=`
  * with no URL beside it stays unpaired and is skipped downstream, which is the
  * honest outcome: there is no endpoint to attach it to.
+ *
+ * Model lists ride the same conventions (#382): `CUSTOM_<n>_MODELS=` attaches
+ * to the CUSTOM_<n> pair, and `<PREFIX>_CUSTOM_MODELS=` turns a
+ * `<PREFIX>_BASE_URL` + `<PREFIX>_API_KEY` (or `<PREFIX>_KEY`) pair in the
+ * same paste into a custom endpoint carrying those models. A bare
+ * `<PREFIX>_BASE_URL` without a models line beside it keeps its old meaning —
+ * only the explicit models declaration makes the trio endpoint-defining.
+ * A models line that pairs with nothing is consumed and reported, never
+ * imported as if its value were a key.
  */
-function pairCustomEndpointEnv(pairs: Array<{ key: string; value: string }>): KeyPair[] {
+function pairCustomEndpointEnv(pairs: Array<{ key: string; value: string }>): CustomEnvFold {
   const baseUrls = new Map<string, string>();
+  const modelLists = new Map<string, ParsedModelEntry[]>();
+  const prefixModels = new Map<string, ParsedModelEntry[]>();
   for (const { key, value } of pairs) {
-    const m = key.toUpperCase().match(/^CUSTOM_(.+)_BASE_URL$/);
-    if (m && value.trim()) baseUrls.set(m[1]!, value.trim());
+    const upper = key.toUpperCase();
+    let m = upper.match(/^CUSTOM_(.+)_BASE_URL$/);
+    if (m && value.trim()) { baseUrls.set(m[1]!, value.trim()); continue; }
+    m = upper.match(/^CUSTOM_(.+)_MODELS$/);
+    if (m) { modelLists.set(m[1]!, parseModelList(value)); continue; }
+    m = upper.match(/^(.+)_CUSTOM_MODELS$/);
+    if (m) prefixModels.set(m[1]!, parseModelList(value));
   }
-  if (baseUrls.size === 0) return pairs;
+  const prefixUrls = new Map<string, string>();
+  for (const { key, value } of pairs) {
+    const m = key.toUpperCase().match(/^(.+)_BASE_URL$/);
+    if (m && prefixModels.has(m[1]!) && value.trim()) prefixUrls.set(m[1]!, value.trim());
+  }
+  if (baseUrls.size === 0 && modelLists.size === 0 && prefixModels.size === 0) {
+    return { pairs, skipped: [] };
+  }
 
   const out: KeyPair[] = [];
+  const attachedLists = new Set<string>();
+  const attachedPrefixes = new Set<string>();
   for (const pair of pairs) {
     const upper = pair.key.toUpperCase();
     if (/^CUSTOM_.+_BASE_URL$/.test(upper)) continue; // consumed above
-    const keyMatch = upper.match(/^CUSTOM_(.+)_KEY$/);
-    const baseUrl = keyMatch ? baseUrls.get(keyMatch[1]!) : undefined;
-    out.push(baseUrl ? { ...pair, platform: 'custom', baseUrl } : pair);
+    if (/^CUSTOM_.+_MODELS$/.test(upper) || /^.+_CUSTOM_MODELS$/.test(upper)) continue; // consumed above
+    const urlMatch = upper.match(/^(.+)_BASE_URL$/);
+    if (urlMatch && prefixUrls.has(urlMatch[1]!)) continue; // consumed above
+
+    const customMatch = upper.match(/^CUSTOM_(.+)_KEY$/);
+    const customUrl = customMatch ? baseUrls.get(customMatch[1]!) : undefined;
+    if (customMatch && customUrl) {
+      const models = modelLists.get(customMatch[1]!);
+      if (models !== undefined) attachedLists.add(customMatch[1]!);
+      out.push({ ...pair, platform: 'custom', baseUrl: customUrl, ...(models?.length ? { models } : {}) });
+      continue;
+    }
+
+    // Both spellings can name the endpoint prefix (`X_API_KEY` → X, but also
+    // `X_API_KEY` → X_API when the paste used X_API_BASE_URL), so try each.
+    const prefixCandidates = [upper.match(/^(.+)_API_KEY$/), upper.match(/^(.+)_KEY$/)];
+    let folded = false;
+    for (const candidate of prefixCandidates) {
+      const prefixUrl = candidate ? prefixUrls.get(candidate[1]!) : undefined;
+      if (!candidate || !prefixUrl) continue;
+      // A second key line for the same prefix is another credential of the
+      // pool; the model list attaches once.
+      const models = attachedPrefixes.has(candidate[1]!) ? undefined : prefixModels.get(candidate[1]!);
+      attachedPrefixes.add(candidate[1]!);
+      out.push({ ...pair, platform: 'custom', baseUrl: prefixUrl, ...(models?.length ? { models } : {}) });
+      folded = true;
+      break;
+    }
+    if (folded) continue;
+
+    out.push(pair);
   }
-  return out;
+
+  const skipped: string[] = [];
+  for (const n of modelLists.keys()) {
+    if (!attachedLists.has(n)) skipped.push(`CUSTOM_${n}_MODELS: no CUSTOM_${n}_BASE_URL / CUSTOM_${n}_KEY pair to attach to`);
+  }
+  for (const p of prefixModels.keys()) {
+    if (!attachedPrefixes.has(p)) skipped.push(`${p}_CUSTOM_MODELS: needs ${p}_BASE_URL and ${p}_API_KEY (or ${p}_KEY) in the same paste`);
+  }
+  return { pairs: out, skipped };
 }
 
 function extractPrefix(key: string): string {
@@ -431,12 +540,16 @@ function toParsedKeys(pairs: KeyPair[]): ParseResult {
   const keys: ParsedKey[] = [];
   const skipped: string[] = [];
 
-  for (const { key, value, platform: statedPlatform, baseUrl } of pairs) {
+  for (const { key, value, platform: statedPlatform, baseUrl, models } of pairs) {
     const prefix = extractPrefix(key);
     const platform = statedPlatform ?? detectPlatform(prefix);
 
     if (platform) {
-      keys.push({ rawKey: `${key}=${value}`, prefix, platform, ...(baseUrl ? { baseUrl } : {}) });
+      keys.push({
+        rawKey: `${key}=${value}`, prefix, platform,
+        ...(baseUrl ? { baseUrl } : {}),
+        ...(models?.length ? { models } : {}),
+      });
       continue;
     }
 
@@ -448,6 +561,12 @@ function toParsedKeys(pairs: KeyPair[]): ParseResult {
   }
 
   return { keys, skipped };
+}
+
+function parseEnvText(text: string): ParseResult {
+  const folded = pairCustomEndpointEnv(parseDotEnv(text));
+  const result = toParsedKeys(folded.pairs);
+  return { keys: result.keys, skipped: [...result.skipped, ...folded.skipped] };
 }
 
 export function parseKeysFromFile(content: string, filename: string): ParseResult {
@@ -467,7 +586,7 @@ export function parseKeysFromFile(content: string, filename: string): ParseResul
     try {
       parsed = JSON.parse(clean);
     } catch {
-      return toParsedKeys(pairCustomEndpointEnv(parseDotEnv(text)));
+      return parseEnvText(text);
     }
     if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) && 'credential_pool' in parsed) {
       return parseAuthJson(clean);
@@ -479,5 +598,5 @@ export function parseKeysFromFile(content: string, filename: string): ParseResul
     return toParsedKeys(parseCsv(text));
   }
 
-  return toParsedKeys(pairCustomEndpointEnv(parseDotEnv(text)));
+  return parseEnvText(text);
 }

--- a/server/src/routes/embeddings.ts
+++ b/server/src/routes/embeddings.ts
@@ -4,11 +4,12 @@ import { z } from 'zod';
 import { getDb, setSetting } from '../db/index.js';
 import { decrypt, maskKey } from '../lib/crypto.js';
 import { deleteUnusedCustomEndpointKey } from '../lib/custom-provider-cleanup.js';
-import { resolveCustomEndpointKey, customEndpointKeyIds } from '../services/custom-endpoint.js';
+import { resolveCustomEndpointKey } from '../services/custom-endpoint.js';
 import {
   listEmbeddingModels,
   getDefaultFamily,
   probeEmbeddingDimensions,
+  registerCustomEmbeddingModel,
   EmbeddingsError,
   type EmbeddingModelRow,
 } from '../services/embeddings.js';
@@ -123,69 +124,34 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
     return;
   }
 
-  const sibling = db.prepare(`
-    SELECT dimensions
-      FROM embedding_models
-     WHERE family = ?
-       AND NOT (platform = 'custom' AND model_id = ?)
-     LIMIT 1
-  `).get(family, modelId) as { dimensions: number } | undefined;
-  if (sibling && sibling.dimensions !== dimensions) {
-    res.status(400).json({
-      error: {
-        message: `Embedding family '${family}' is ${sibling.dimensions} dimensions, but '${modelId}' returned ${dimensions}. Use a new family name.`,
-      },
-    });
-    return;
-  }
-
   const upsert = db.transaction(() => {
     // A new secret for a known endpoint is an ADDITIONAL credential, never a
     // replacement for the stored one (#619).
     const { keyId, storedKey: storedKeyForMask } = resolveCustomEndpointKey(db, baseUrl, providedKey, label);
-    const endpointKeyIds = customEndpointKeyIds(db, keyId);
-
-    const existingModel = db.prepare(`
-      SELECT id, priority, key_id
-        FROM embedding_models
-       WHERE platform = 'custom' AND model_id = ?
-       LIMIT 1
-    `).get(modelId) as { id: number; priority: number; key_id: number | null } | undefined;
-    // A model already on this endpoint keeps the key it has; only a move to a
-    // different endpoint re-binds it.
-    const bindKeyId = existingModel?.key_id != null && endpointKeyIds.has(existingModel.key_id)
-      ? existingModel.key_id
-      : keyId;
-    const priority = existingModel?.priority ?? (
-      (db.prepare('SELECT COALESCE(MAX(priority), 0) AS maxPriority FROM embedding_models WHERE family = ?')
-        .get(family) as { maxPriority: number }).maxPriority + 1
-    );
-
-    if (existingModel) {
-      db.prepare(`
-        UPDATE embedding_models
-           SET family = ?,
-               display_name = COALESCE(?, display_name),
-               dimensions = ?,
-               max_input_tokens = ?,
-               priority = ?,
-               enabled = 1,
-               quota_label = ?,
-               key_id = ?
-         WHERE id = ?
-      `).run(family, submittedName, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, bindKeyId, existingModel.id);
-      return { modelDbId: existingModel.id, keyId, storedKeyForMask };
-    }
-
-    const model = db.prepare(`
-      INSERT INTO embedding_models
-        (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
-      VALUES (?, 'custom', ?, ?, ?, ?, ?, 1, ?, ?)
-    `).run(family, modelId, submittedName ?? modelId, dimensions, parsed.data.maxInputTokens ?? null, priority, quotaLabel, bindKeyId);
-    return { modelDbId: Number(model.lastInsertRowid), keyId, storedKeyForMask };
+    const { modelDbId } = registerCustomEmbeddingModel(db, {
+      keyId,
+      modelId,
+      displayName: submittedName,
+      family,
+      dimensions,
+      maxInputTokens: parsed.data.maxInputTokens ?? null,
+      quotaLabel,
+    });
+    return { modelDbId, keyId, storedKeyForMask };
   });
 
-  const result = upsert();
+  // A family-dimension conflict aborts the transaction, so a rejected submit
+  // leaves no half-registered key row behind.
+  let result: { modelDbId: number; keyId: number; storedKeyForMask: string };
+  try {
+    result = upsert();
+  } catch (err: any) {
+    if (err instanceof EmbeddingsError) {
+      res.status(err.status).json({ error: { message: err.message } });
+      return;
+    }
+    throw err;
+  }
   const storedName = (db.prepare('SELECT display_name FROM embedding_models WHERE id = ?')
     .get(result.modelDbId) as { display_name: string }).display_name;
   res.status(201).json({

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -14,7 +14,9 @@ import { getActiveCooldownsForKeys, clearCooldownsForKey } from '../services/rat
 import { resolveCustomEndpointKey, customEndpointKeyIds, siblingEndpointKeyId, endpointHasCredential } from '../services/custom-endpoint.js';
 import { customModelSeed } from '../services/custom-model-seed.js';
 import { discoverEndpointModels, probeEndpointModel, ModelDiscoveryError } from '../services/model-discovery.js';
+import { probeEmbeddingDimensions, registerCustomEmbeddingModel } from '../services/embeddings.js';
 import { endpointScopeForBaseUrl, normalizeBaseUrl } from '../lib/endpoint-scope.js';
+import type { Db } from '../db/types.js';
 
 export const keysRouter = Router();
 
@@ -66,6 +68,13 @@ const importKeySchema = z.object({
   // A custom row names an ENDPOINT, so it only means something with the URL
   // the export file carried alongside it (#687).
   baseUrl: z.string().optional(),
+  // Models declared beside a custom endpoint in the paste (#382). Ignored for
+  // catalog platforms — their model lists come from the catalog, not the file.
+  models: z.array(z.object({
+    id: z.string().min(1),
+    supportsTools: z.boolean().optional(),
+    supportsVision: z.boolean().optional(),
+  })).max(200).optional(),
 });
 
 function handleUploadError(err: any, res: Response, next: NextFunction): boolean {
@@ -642,6 +651,164 @@ function resolveEndpointRef(ref: { keyId?: number; baseUrl?: string }): CustomEn
   return { baseUrl: requestedBaseUrl, keyId: rows[0]?.id ?? null, storedKey: null };
 }
 
+interface CustomChatModelEntry {
+  modelId: string;
+  displayName: string | null;
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+}
+
+interface RegisteredCustomModel {
+  modelDbId: number;
+  model: string;
+  displayName: string;
+  supportsTools: boolean;
+  supportsVision: boolean;
+  created: boolean;
+}
+
+/**
+ * Register chat models bound to a custom endpoint's key — the shared write
+ * path behind POST /custom and the bulk key importer (#382). Runs inside the
+ * caller's transaction.
+ */
+function registerCustomChatModels(db: Db, baseUrl: string, keyId: number, entries: CustomChatModelEntry[]): RegisteredCustomModel[] {
+  const endpointKeyIds = customEndpointKeyIds(db, keyId);
+  // The identity discriminator for every row registered in this call (#651).
+  const endpointScope = endpointScopeForBaseUrl(baseUrl);
+  // Unknown ≠ worst: seed the routing ranks at the catalog median so a new
+  // custom model is explored instead of buried at intelligence 0 (#488).
+  const seed = customModelSeed(db);
+
+  const registered: RegisteredCustomModel[] = [];
+  for (const { modelId, displayName, supportsTools, supportsVision } of entries) {
+    // Register each model bound to THIS endpoint's key. Custom models carry no
+    // rate limits and sort last in the intelligence preset (size_label tier).
+    // Identity is per endpoint (#651): the same model id on a DIFFERENT relay
+    // is a separate row with its own enabled flag, ranks and stats, instead of
+    // silently rebinding the other endpoint's row as it used to. A model
+    // already on THIS endpoint keeps the key it has, so adding a second
+    // credential doesn't re-bind it (#619).
+    // Capability flags: an unset flag binds NULL so COALESCE picks the insert
+    // default (tools 1, vision 0) on a new row and preserves the existing
+    // value on re-registration. (#470) An omitted display name binds NULL the
+    // same way — it falls back to the model id on a new row and leaves a name
+    // already on the row alone, so the bulk re-registration behind "Fetch
+    // models" (which posts bare ids) can't wipe names the operator set.
+    const bound = db.prepare(
+      "SELECT key_id FROM models WHERE platform = 'custom' AND model_id = ? AND endpoint_scope = ?",
+    ).get(modelId, endpointScope) as { key_id: number | null } | undefined;
+    const created = bound === undefined;
+    const bindKeyId = bound?.key_id != null && endpointKeyIds.has(bound.key_id) ? bound.key_id : keyId;
+    const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
+    const visionParam = supportsVision === undefined ? null : (supportsVision ? 1 : 0);
+    // The seed applies on INSERT only: DO UPDATE deliberately leaves the rank
+    // columns alone so re-registering a model (or bulk-adding alongside it)
+    // never rewrites ranks the operator has since tuned by hand.
+    db.prepare(`
+      INSERT INTO models
+        (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+         rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, key_id,
+         supports_tools, supports_vision, source, endpoint_scope)
+      VALUES ('custom', @modelId, COALESCE(@displayName, @modelId), @intelligenceRank, @speedRank, @sizeLabel,
+         NULL, NULL, NULL, NULL, '', NULL, 1, @keyId,
+         COALESCE(@tools, 1), COALESCE(@vision, 0), 'user', @endpointScope)
+      ON CONFLICT(platform, model_id, endpoint_scope)
+      DO UPDATE SET
+        display_name = COALESCE(@displayName, display_name),
+        key_id = excluded.key_id,
+        enabled = 1,
+        supports_tools = COALESCE(@tools, supports_tools),
+        supports_vision = COALESCE(@vision, supports_vision)
+    `).run({
+      modelId, displayName, keyId: bindKeyId, tools: toolsParam, vision: visionParam,
+      intelligenceRank: seed.intelligenceRank, speedRank: seed.speedRank, sizeLabel: seed.sizeLabel,
+      endpointScope,
+    });
+
+    // Read back rather than echo the submitted values: an omitted display name
+    // or capability flag resolves in SQL, so the row is the only place that
+    // knows what this model is actually called now.
+    const modelRow = db.prepare(
+      "SELECT id, display_name, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ? AND endpoint_scope = ?",
+    ).get(modelId, endpointScope) as { id: number; display_name: string; supports_tools: number; supports_vision: number };
+
+    // Append to the fallback chain if not already present.
+    const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
+    if (!inChain) {
+      const max = db.prepare('SELECT COALESCE(MAX(priority), 0) AS m FROM fallback_config').get() as { m: number };
+      db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(modelRow.id, max.m + 1);
+    }
+    ensureModelInProfiles(db, modelRow.id);
+
+    registered.push({
+      modelDbId: modelRow.id,
+      model: modelId,
+      displayName: modelRow.display_name,
+      supportsTools: modelRow.supports_tools === 1,
+      supportsVision: modelRow.supports_vision === 1,
+      created,
+    });
+  }
+
+  return registered;
+}
+
+/**
+ * Models attached to an imported custom endpoint (#382). Ids that look like
+ * embedding models go through the embeddings path — it needs a dimension, so
+ * reuse the stored one when the model is already registered and probe the
+ * endpoint (as POST /api/embeddings/custom does) only for a new id. Everything
+ * else registers as a chat model. A failure registers as a per-model error and
+ * skips that model only: the key import itself has already succeeded.
+ */
+async function registerImportedModels(
+  db: Db,
+  baseUrl: string,
+  keyId: number,
+  apiKey: string,
+  keyName: string,
+  models: Array<{ id: string; supportsTools?: boolean; supportsVision?: boolean }>,
+  errors: Array<{ key: string; error: string }>,
+): Promise<number> {
+  const chat = models.filter(m => !/embedding/i.test(m.id));
+  const embeds = models.filter(m => /embedding/i.test(m.id));
+  let registered = 0;
+
+  if (chat.length > 0) {
+    const entries = chat.map(m => ({
+      modelId: m.id,
+      displayName: null,
+      supportsTools: m.supportsTools,
+      supportsVision: m.supportsVision,
+    }));
+    registered += db.transaction(() => registerCustomChatModels(db, baseUrl, keyId, entries))().length;
+  }
+
+  for (const m of embeds) {
+    try {
+      const existing = db.prepare(
+        "SELECT dimensions FROM embedding_models WHERE platform = 'custom' AND model_id = ?",
+      ).get(m.id) as { dimensions: number } | undefined;
+      const dimensions = existing?.dimensions ?? await probeEmbeddingDimensions(baseUrl, apiKey, m.id);
+      registerCustomEmbeddingModel(db, {
+        keyId,
+        modelId: m.id,
+        displayName: null,
+        family: m.id,
+        dimensions,
+        maxInputTokens: null,
+        quotaLabel: 'custom endpoint',
+      });
+      registered++;
+    } catch (err: any) {
+      errors.push({ key: `${keyName}: ${m.id}`, error: err?.message ?? 'embedding registration failed' });
+    }
+  }
+
+  return registered;
+}
+
 // SSRF guard (#440): a base_url is the one user-controlled outbound target.
 // Cloud metadata / link-local addresses are rejected outright; private ranges
 // too when FREEAPI_BLOCK_PRIVATE_PROVIDER_URLS is set. Re-checked at request
@@ -894,84 +1061,7 @@ keysRouter.post('/custom', async (req: Request, res: Response) => {
     const { keyId, storedKey: storedKeyForMask } = resolveCustomEndpointKey(
       db, baseUrl, providedKey, label, endpoint.keyId ?? undefined,
     );
-    const endpointKeyIds = customEndpointKeyIds(db, keyId);
-    // The identity discriminator for every row registered in this call (#651).
-    const endpointScope = endpointScopeForBaseUrl(baseUrl);
-    // Unknown ≠ worst: seed the routing ranks at the catalog median so a new
-    // custom model is explored instead of buried at intelligence 0 (#488).
-    const seed = customModelSeed(db);
-
-    const registered: { modelDbId: number; model: string; displayName: string; supportsTools: boolean; supportsVision: boolean; created: boolean }[] = [];
-    for (const { modelId, displayName, supportsTools, supportsVision } of entries) {
-      // Register each model bound to THIS endpoint's key. Custom models carry no
-      // rate limits and sort last in the intelligence preset (size_label tier).
-      // Identity is per endpoint (#651): the same model id on a DIFFERENT relay
-      // is a separate row with its own enabled flag, ranks and stats, instead of
-      // silently rebinding the other endpoint's row as it used to. A model
-      // already on THIS endpoint keeps the key it has, so adding a second
-      // credential doesn't re-bind it (#619).
-      // Capability flags: an unset flag binds NULL so COALESCE picks the insert
-      // default (tools 1, vision 0) on a new row and preserves the existing
-      // value on re-registration. (#470) An omitted display name binds NULL the
-      // same way — it falls back to the model id on a new row and leaves a name
-      // already on the row alone, so the bulk re-registration behind "Fetch
-      // models" (which posts bare ids) can't wipe names the operator set.
-      const bound = db.prepare(
-        "SELECT key_id FROM models WHERE platform = 'custom' AND model_id = ? AND endpoint_scope = ?",
-      ).get(modelId, endpointScope) as { key_id: number | null } | undefined;
-      const created = bound === undefined;
-      const bindKeyId = bound?.key_id != null && endpointKeyIds.has(bound.key_id) ? bound.key_id : keyId;
-      const toolsParam = supportsTools === undefined ? null : (supportsTools ? 1 : 0);
-      const visionParam = supportsVision === undefined ? null : (supportsVision ? 1 : 0);
-      // The seed applies on INSERT only: DO UPDATE deliberately leaves the rank
-      // columns alone so re-registering a model (or bulk-adding alongside it)
-      // never rewrites ranks the operator has since tuned by hand.
-      db.prepare(`
-        INSERT INTO models
-          (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
-           rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, enabled, key_id,
-           supports_tools, supports_vision, source, endpoint_scope)
-        VALUES ('custom', @modelId, COALESCE(@displayName, @modelId), @intelligenceRank, @speedRank, @sizeLabel,
-           NULL, NULL, NULL, NULL, '', NULL, 1, @keyId,
-           COALESCE(@tools, 1), COALESCE(@vision, 0), 'user', @endpointScope)
-        ON CONFLICT(platform, model_id, endpoint_scope)
-        DO UPDATE SET
-          display_name = COALESCE(@displayName, display_name),
-          key_id = excluded.key_id,
-          enabled = 1,
-          supports_tools = COALESCE(@tools, supports_tools),
-          supports_vision = COALESCE(@vision, supports_vision)
-      `).run({
-        modelId, displayName, keyId: bindKeyId, tools: toolsParam, vision: visionParam,
-        intelligenceRank: seed.intelligenceRank, speedRank: seed.speedRank, sizeLabel: seed.sizeLabel,
-        endpointScope,
-      });
-
-      // Read back rather than echo the submitted values: an omitted display name
-      // or capability flag resolves in SQL, so the row is the only place that
-      // knows what this model is actually called now.
-      const modelRow = db.prepare(
-        "SELECT id, display_name, supports_tools, supports_vision FROM models WHERE platform = 'custom' AND model_id = ? AND endpoint_scope = ?",
-      ).get(modelId, endpointScope) as { id: number; display_name: string; supports_tools: number; supports_vision: number };
-
-      // Append to the fallback chain if not already present.
-      const inChain = db.prepare('SELECT 1 FROM fallback_config WHERE model_db_id = ?').get(modelRow.id);
-      if (!inChain) {
-        const max = db.prepare('SELECT COALESCE(MAX(priority), 0) AS m FROM fallback_config').get() as { m: number };
-        db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)').run(modelRow.id, max.m + 1);
-      }
-      ensureModelInProfiles(db, modelRow.id);
-
-      registered.push({
-        modelDbId: modelRow.id,
-        model: modelId,
-        displayName: modelRow.display_name,
-        supportsTools: modelRow.supports_tools === 1,
-        supportsVision: modelRow.supports_vision === 1,
-        created,
-      });
-    }
-
+    const registered = registerCustomChatModels(db, baseUrl, keyId, entries);
     return { keyId, registered, storedKeyForMask };
   });
 
@@ -1012,6 +1102,7 @@ keysRouter.post('/import', (req: Request, res: Response, next: NextFunction) => 
       const imported: Array<{ keyName: string; platform: string }> = [];
       const skipped = [...result.skipped];
       const errors: Array<{ key: string; error: string }> = [];
+      let modelsRegistered = 0;
       // One SSRF verdict per endpoint, not per key: a pooled endpoint (#619)
       // brings several keys to the same URL and each check costs a DNS lookup.
       const urlVerdicts = new Map<string, { allowed: boolean; reason?: string }>();
@@ -1053,8 +1144,14 @@ keysRouter.post('/import', (req: Request, res: Response, next: NextFunction) => 
             // the resolver as "no key submitted" so it stores the sentinel once
             // instead of treating 'no-key' as a real secret.
             const secret = keyValue.trim() === 'no-key' ? undefined : keyValue.trim() || undefined;
-            resolveCustomEndpointKey(getDb(), baseUrl, secret, keyName);
+            const db = getDb();
+            const resolved = resolveCustomEndpointKey(db, baseUrl, secret, keyName);
             imported.push({ keyName, platform: 'custom' });
+            if (parsedKey.models?.length) {
+              modelsRegistered += await registerImportedModels(
+                db, baseUrl, resolved.keyId, resolved.storedKey, keyName, parsedKey.models, errors,
+              );
+            }
           } catch (insertErr) {
             errors.push({ key: keyName, error: (insertErr as Error).message });
           }
@@ -1079,6 +1176,7 @@ keysRouter.post('/import', (req: Request, res: Response, next: NextFunction) => 
         skipped,
         errors,
         total: result.keys.length + result.skipped.length,
+        modelsRegistered,
       });
     } catch (handlerErr: any) {
       res.status(handlerErr.status ?? 500).json({ error: { message: handlerErr.message } });
@@ -1097,7 +1195,11 @@ keysRouter.post('/preview', (req: Request, res: Response, next: NextFunction) =>
         return;
       }
 
-      const keys: Array<{ keyName: string; keyValue: string; detectedPlatform: string | null; prefix: string; baseUrl?: string; isDuplicate: boolean }> = [];
+      const keys: Array<{
+        keyName: string; keyValue: string; detectedPlatform: string | null; prefix: string;
+        baseUrl?: string; models?: Array<{ id: string; supportsTools?: boolean; supportsVision?: boolean }>;
+        isDuplicate: boolean;
+      }> = [];
       const skipped: string[] = [];
 
       // Build a set of existing decrypted key values for duplicate detection
@@ -1125,8 +1227,10 @@ keysRouter.post('/preview', (req: Request, res: Response, next: NextFunction) =>
             prefix: parsedKey.prefix,
             // Without this the dialog can show a custom row but never restore
             // it — the endpoint it belongs to would be lost between the two
-            // calls the dashboard actually makes (#687).
+            // calls the dashboard actually makes (#687). Models ride the same
+            // round trip (#382).
             ...(parsedKey.baseUrl ? { baseUrl: parsedKey.baseUrl } : {}),
+            ...(parsedKey.models?.length ? { models: parsedKey.models } : {}),
             isDuplicate,
           });
         }
@@ -1149,6 +1253,7 @@ keysRouter.post('/import-selected', async (req: Request, res: Response) => {
 
   let imported = 0;
   let duplicateSkipped = 0;
+  let modelsRegistered = 0;
   const errors: Array<{ key: string; error: string }> = [];
 
   // Build a set of existing decrypted key values for duplicate detection
@@ -1195,8 +1300,13 @@ keysRouter.post('/import-selected', async (req: Request, res: Response) => {
         // through the resolver (not a raw INSERT) keeps endpoint pooling
         // intact, so re-importing does not duplicate the row (#619).
         const secret = key.keyValue.trim() === 'no-key' ? undefined : key.keyValue.trim() || undefined;
-        resolveCustomEndpointKey(db, baseUrl, secret, keyName);
+        const resolved = resolveCustomEndpointKey(db, baseUrl, secret, keyName);
         imported++;
+        if (key.models?.length) {
+          modelsRegistered += await registerImportedModels(
+            db, baseUrl, resolved.keyId, resolved.storedKey, keyName, key.models, errors,
+          );
+        }
       } catch (err) {
         errors.push({ key: keyName, error: (err as Error).message });
       }
@@ -1223,6 +1333,7 @@ keysRouter.post('/import-selected', async (req: Request, res: Response) => {
     skipped: [],
     errors,
     total: parsed.data.keys.length,
+    modelsRegistered,
   });
 });
 

--- a/server/src/services/embeddings.ts
+++ b/server/src/services/embeddings.ts
@@ -11,6 +11,8 @@ import { getDb, getSetting } from '../db/index.js';
 import { getClientContext } from '../lib/client-context.js';
 import { decrypt } from '../lib/crypto.js';
 import { proxyFetch } from '../lib/proxy.js';
+import { customEndpointKeyIds } from './custom-endpoint.js';
+import type { Db } from '../db/types.js';
 
 export interface EmbeddingModelRow {
   id: number;
@@ -170,6 +172,82 @@ export async function probeEmbeddingDimensions(baseUrl: string, key: string, mod
     throw new EmbeddingsError('upstream returned malformed embeddings', 502);
   }
   return vector.length;
+}
+
+export interface CustomEmbeddingRegistration {
+  keyId: number;
+  modelId: string;
+  displayName: string | null;
+  family: string;
+  dimensions: number;
+  maxInputTokens: number | null;
+  quotaLabel: string;
+}
+
+/**
+ * Upsert one custom embedding model bound to an endpoint credential — the
+ * shared write path behind POST /api/embeddings/custom and the bulk key
+ * importer (#382). Throws EmbeddingsError(400) when the family already exists
+ * at a different dimension: vectors from mismatched spaces must never mix, so
+ * the caller has to pick a new family name instead.
+ */
+export function registerCustomEmbeddingModel(db: Db, reg: CustomEmbeddingRegistration): { modelDbId: number; created: boolean } {
+  const sibling = db.prepare(`
+    SELECT dimensions
+      FROM embedding_models
+     WHERE family = ?
+       AND NOT (platform = 'custom' AND model_id = ?)
+     LIMIT 1
+  `).get(reg.family, reg.modelId) as { dimensions: number } | undefined;
+  if (sibling && sibling.dimensions !== reg.dimensions) {
+    throw new EmbeddingsError(
+      `Embedding family '${reg.family}' is ${sibling.dimensions} dimensions, but '${reg.modelId}' returned ${reg.dimensions}. Use a new family name.`,
+      400,
+    );
+  }
+
+  const endpointKeyIds = customEndpointKeyIds(db, reg.keyId);
+  const existingModel = db.prepare(`
+    SELECT id, priority, key_id
+      FROM embedding_models
+     WHERE platform = 'custom' AND model_id = ?
+     LIMIT 1
+  `).get(reg.modelId) as { id: number; priority: number; key_id: number | null } | undefined;
+  // A model already on this endpoint keeps the key it has; only a move to a
+  // different endpoint re-binds it.
+  const bindKeyId = existingModel?.key_id != null && endpointKeyIds.has(existingModel.key_id)
+    ? existingModel.key_id
+    : reg.keyId;
+  const priority = existingModel?.priority ?? (
+    (db.prepare('SELECT COALESCE(MAX(priority), 0) AS maxPriority FROM embedding_models WHERE family = ?')
+      .get(reg.family) as { maxPriority: number }).maxPriority + 1
+  );
+
+  // `display_name` is optional: a new model takes its id, and a model already
+  // on record keeps the name it has instead of being reset by a submit that
+  // simply left the field blank (#704).
+  if (existingModel) {
+    db.prepare(`
+      UPDATE embedding_models
+         SET family = ?,
+             display_name = COALESCE(?, display_name),
+             dimensions = ?,
+             max_input_tokens = ?,
+             priority = ?,
+             enabled = 1,
+             quota_label = ?,
+             key_id = ?
+       WHERE id = ?
+    `).run(reg.family, reg.displayName, reg.dimensions, reg.maxInputTokens, priority, reg.quotaLabel, bindKeyId, existingModel.id);
+    return { modelDbId: existingModel.id, created: false };
+  }
+
+  const model = db.prepare(`
+    INSERT INTO embedding_models
+      (family, platform, model_id, display_name, dimensions, max_input_tokens, priority, enabled, quota_label, key_id)
+    VALUES (?, 'custom', ?, ?, ?, ?, ?, 1, ?, ?)
+  `).run(reg.family, reg.modelId, reg.displayName ?? reg.modelId, reg.dimensions, reg.maxInputTokens, priority, reg.quotaLabel, bindKeyId);
+  return { modelDbId: Number(model.lastInsertRowid), created: true };
 }
 
 async function callProvider(row: EmbeddingModelRow, credential: ProviderCredential, inputs: string[], dimensions?: number): Promise<ProviderCallResult> {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,14 @@
 // ---- Platform & Model Types ----
 
+/** A model declared beside a custom endpoint in an import file (#382). A
+ *  capability flag is present only when the paste declared it via a trailing
+ *  -TOOLS / -VISION suffix. */
+export interface ImportModelEntry {
+  id: string;
+  supportsTools?: boolean;
+  supportsVision?: boolean;
+}
+
 export interface PreviewKey {
   keyName: string;
   keyValue: string;
@@ -7,6 +16,8 @@ export interface PreviewKey {
   prefix: string;
   /** Custom endpoints only: the upstream URL the export file carried (#687). */
   baseUrl?: string;
+  /** Custom endpoints only: models to register alongside the key (#382). */
+  models?: ImportModelEntry[];
   isDuplicate?: boolean;
 }
 
@@ -15,6 +26,7 @@ export interface ImportKey {
   keyValue: string;
   platform: string;
   baseUrl?: string;
+  models?: ImportModelEntry[];
 }
 
 export interface PreviewResponse {
@@ -33,6 +45,8 @@ export interface ImportSelectedResponse {
   skipped: string[];
   errors: Array<{ key: string; error: string }>;
   total: number;
+  /** Models registered for imported custom endpoints (#382). */
+  modelsRegistered: number;
 }
 
 // Active platforms — must match server/src/providers/index.ts and


### PR DESCRIPTION
The key importer now attaches CUSTOM_<n>_MODELS / <PREFIX>_CUSTOM_MODELS lists to their endpoint, strips trailing -TOOLS/-VISION into capability flags, splits embedding ids to the embeddings path, and registers everything through the existing helpers. Closes #382.