### PR TITLE
fix(analytics): render timeline x-axis in the viewer's local timezone (#761)

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -12,8 +12,8 @@ export function cn(...inputs: ClassValue[]) {
 
 /** Convert a SQLite UTC datetime string into an ISO-8601 UTC string. */
 export function sqliteUtcToIso(value: string): string {
-  // Already ISO (has 'T' and a zone/offset)? Leave it alone.
-  if (value.includes('T')) return value;
+  // Already carries an explicit timezone marker (Z or ±hh:mm)? Leave it alone.
+  if (/[zZ]|[+-]\d{2}:?\d{2}$/.test(value)) return value;
   return value.replace(' ', 'T') + 'Z';
 }
 

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -546,7 +546,7 @@ export default function AnalyticsPage() {
                 <ResponsiveContainer width="100%" height={240}>
                   <LineChart data={timeline} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} tickFormatter={(v: string) => formatSqliteUtcToLocalTime(v, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })} />
                     <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                     <Tooltip contentStyle={tooltipStyle} />
                     <Legend wrapperStyle={{ fontSize: 12 }} iconType="line" />
@@ -567,7 +567,7 @@ export default function AnalyticsPage() {
                 <ResponsiveContainer width="100%" height={240}>
                   <LineChart data={timeline} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} tickFormatter={(v: string) => formatSqliteUtcToLocalTime(v, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })} />
                     <YAxis tick={axisStyle} tickLine={false} axisLine={false} tickFormatter={(v: number) => formatTokens(v)} />
                     <Tooltip contentStyle={tooltipStyle} formatter={(value) => formatTokens(Number(value))} />
                     <Legend wrapperStyle={{ fontSize: 12 }} iconType="line" />


### PR DESCRIPTION
Fixes #761. The timeline chart x-axis labeled buckets in UTC, so east-of-UTC viewers (e.g. UTC+8) saw a request made at 09:00 local under 01:00.

Two fixes:
- `sqliteUtcToIso` now appends `Z` only when the string lacks an explicit timezone marker (Z or ±hh:mm), so the timeline`s "2026-08-07T01:00:00" (T, no zone) is parsed as **UTC** rather than local — previously `new Date()` read it as local time and the conversion was wrong.
- Both "Requests over time" and "Tokens over time" XAxis now format timestamps via `formatSqliteUtcToLocalTime` (local short date + time).

Client tsc passes. Refs #761