### PR TITLE
docs: add AI dev guide (AGENTS.md) and extend CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — freellmapi 开发约束（AI 常驻内核）
+
+> 本文件是提交给 AI 编码代理的常驻上下文。`CLAUDE.md` 是指向本文件的链接。
+> 每一行都过检验："去掉会导致 agent 犯错吗？"详细规则见 `CONTRIBUTING.md`。
+> 约束与当前代码冲突时，以当前代码为准，先说明差异再改文档或实现。
+
+## 项目速览
+
+- **freellmapi**：免费 LLM API 网关/代理（OpenAI / Anthropic 兼容）
+- **技术栈**：Node + Express + better-sqlite3（`server/`）、React + Vite + Tailwind（`client/`）
+- **关键数据**：models（catalog + 路由分数）、api_keys（凭据）、requests（用量/延迟/TTFB）、attempt-trace（重试链）
+
+## 代码约定（项目特有）
+
+- **i18n**：所有用户可见文案走 `t('key')`，不硬编码字符串；新增 key 必须同步所有 locale（`check:i18n` 60 locales）
+- **样式**：Tailwind 原子类 + 语义 CSS 变量（`--muted-foreground` 等），不硬编码 hex
+- **类型**：用 `z.infer` 从 zod schema 推类型（如 `SearchConfig`），不重复手写接口
+- **时间**：SQLite 存 UTC（空格格式 `YYYY-MM-DD HH:MM:SS`）；前端展示用 `formatSqliteUtcToLocalTime` 转本地时区
+
+## 验证流程（提交前必须）
+
+- server：`cd server && npx tsc --noEmit` 通过
+- client：`cd client && npx tsc -b` 通过
+- i18n 完整性：`npm run check:i18n` 通过
+- 新功能补测试；**catalog/模型改动必须实测可用**（返回 200 + 免费账号验证，注明验证日期/方式）
+
+## 提交规范
+
+- Conventional Commits（`feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`）
+- 正文说明"为什么"，不罗列"改了什么"；关联 issue 用 `Refs #xxx`
+- 一个 PR 一个主题，分功能提交（维护者易合并）
+
+## 安全红线（do 优先）
+
+- API key 回显一律 `maskKey`，日志/PR/评论不出现明文
+- 敏感文件 0o600、SSRF 检查（`url-guard`）、代理/凭据脱敏（`redactProxyUrl`）
+- 认证统一 API key（`timingSafeStringEqual`），不信任 socket 本地性
+
+## 关键约束
+
+- **不做半成品**：不提交"存了但没用"的代码/字段（#590 教训）
+- **只加真免费模型**；免费变付费的必须人工确认移除（#722 教训）
+- 模型 `model_id` 用 `/v1/models` 返回的精确 id（name:tag 约定）
+- 网络策略：github 直连失败时走 VPS 代理重试
+
+## 详细参考
+
+- `CONTRIBUTING.md` — 完整开发流程（环境/风格/验证/catalog/PR）
+- 架构与协议细节见 `docs/`（`api.md`、`architecture.md`）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,52 @@
-# AGENTS.md — freellmapi 开发约束（AI 常驻内核）
+# AGENTS.md — freellmapi development constraints (always-on context for AI agents)
 
-> 本文件是提交给 AI 编码代理的常驻上下文。`CLAUDE.md` 是指向本文件的链接。
-> 每一行都过检验："去掉会导致 agent 犯错吗？"详细规则见 `CONTRIBUTING.md`。
-> 约束与当前代码冲突时，以当前代码为准，先说明差异再改文档或实现。
+> This file is the always-on context handed to AI coding agents working on this
+> repo. `CLAUDE.md` can link to it. Every line passes the test: "would removing
+> this cause the agent to make a mistake it wouldn't otherwise make?" Full
+> details live in `CONTRIBUTING.md`.
+> When a constraint conflicts with the current code, the code wins — note the
+> discrepancy, then fix the doc or the implementation.
 
-## 项目速览
+## Project at a glance
 
-- **freellmapi**：免费 LLM API 网关/代理（OpenAI / Anthropic 兼容）
-- **技术栈**：Node + Express + better-sqlite3（`server/`）、React + Vite + Tailwind（`client/`）
-- **关键数据**：models（catalog + 路由分数）、api_keys（凭据）、requests（用量/延迟/TTFB）、attempt-trace（重试链）
+- **freellmapi**: free-LLM API gateway/proxy (OpenAI / Anthropic compatible)
+- **Stack**: Node + Express + better-sqlite3 (`server/`), React + Vite + Tailwind (`client/`)
+- **Key data**: models (catalog + routing scores), api_keys (credentials), requests (usage / latency / TTFB), attempt-trace (retry chains)
 
-## 代码约定（项目特有）
+## Code conventions (project-specific)
 
-- **i18n**：所有用户可见文案走 `t('key')`，不硬编码字符串；新增 key 必须同步所有 locale（`check:i18n` 60 locales）
-- **样式**：Tailwind 原子类 + 语义 CSS 变量（`--muted-foreground` 等），不硬编码 hex
-- **类型**：用 `z.infer` 从 zod schema 推类型（如 `SearchConfig`），不重复手写接口
-- **时间**：SQLite 存 UTC（空格格式 `YYYY-MM-DD HH:MM:SS`）；前端展示用 `formatSqliteUtcToLocalTime` 转本地时区
+- **i18n**: all user-visible text goes through `t('key')`, never hardcoded strings; new keys must be added to all locales (`check:i18n`, 60 locales)
+- **Styling**: Tailwind utility classes + semantic CSS variables (`--muted-foreground`, etc.), never hardcoded hex
+- **Types**: derive from zod schemas with `z.infer` (e.g. `SearchConfig`), don't hand-write duplicate interfaces
+- **Time**: SQLite stores UTC (space-separated `YYYY-MM-DD HH:MM:SS`); render in the viewer's local zone with `formatSqliteUtcToLocalTime`
 
-## 验证流程（提交前必须）
+## Validation (required before commit)
 
-- server：`cd server && npx tsc --noEmit` 通过
-- client：`cd client && npx tsc -b` 通过
-- i18n 完整性：`npm run check:i18n` 通过
-- 新功能补测试；**catalog/模型改动必须实测可用**（返回 200 + 免费账号验证，注明验证日期/方式）
+- server: `cd server && npx tsc --noEmit`
+- client: `cd client && npx tsc -b`
+- i18n: `npm run check:i18n`
+- add tests for new features; **catalog / model changes must be verified live** (200 + free account, note the verification date and method)
 
-## 提交规范
+## Commit style
 
-- Conventional Commits（`feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`）
-- 正文说明"为什么"，不罗列"改了什么"；关联 issue 用 `Refs #xxx`
-- 一个 PR 一个主题，分功能提交（维护者易合并）
+- Conventional Commits (`feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`)
+- Body explains the "why"; reference issues with `Refs #xxx`
+- One PR per topic; split features into focused PRs
 
-## 安全红线（do 优先）
+## Security red lines (do-first)
 
-- API key 回显一律 `maskKey`，日志/PR/评论不出现明文
-- 敏感文件 0o600、SSRF 检查（`url-guard`）、代理/凭据脱敏（`redactProxyUrl`）
-- 认证统一 API key（`timingSafeStringEqual`），不信任 socket 本地性
+- API keys surfaced only via `maskKey`; no plaintext in logs / PRs / comments
+- Sensitive files 0o600; SSRF checks (`url-guard`); proxy / credential redaction (`redactProxyUrl`)
+- Auth via the unified API key (`timingSafeStringEqual`), never trust socket locality
 
-## 关键约束
+## Key constraints
 
-- **不做半成品**：不提交"存了但没用"的代码/字段（#590 教训）
-- **只加真免费模型**；免费变付费的必须人工确认移除（#722 教训）
-- 模型 `model_id` 用 `/v1/models` 返回的精确 id（name:tag 约定）
-- 网络策略：github 直连失败时走 VPS 代理重试
+- **No half-finished work**: don't submit "stored but unused" code or fields (#590)
+- **Free models only**: add only genuinely free models; ones that move to paid must be removed by a human (#722)
+- Model ids use the exact `/v1/models` id (name:tag convention)
+- Network: if github is unreachable, retry through the VPS proxy
 
-## 详细参考
+## References
 
-- `CONTRIBUTING.md` — 完整开发流程（环境/风格/验证/catalog/PR）
-- 架构与协议细节见 `docs/`（`api.md`、`architecture.md`）
+- `CONTRIBUTING.md` — full development flow (setup / style / validation / catalog / PR)
+- `docs/` (`api.md`, `architecture.md`) — architecture and protocol details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
-# Contributing
+# Contributing to freellmapi
 
 Contributors are very welcome. This project is a local-first aggregator for free LLM API tiers, so most contributions fall into a few buckets: adding a provider, adding an endpoint, improving the router, polishing the dashboard, or fixing bugs. The README has a "Good first PRs" list if you want a starting point.
+
+AI agents contributing to this repo should read [`AGENTS.md`](AGENTS.md) first — it carries the always-on constraints (validation gates, commit style, security red lines).
 
 ## Development loop
 
@@ -19,6 +21,27 @@ Every PR should:
 - Stay scoped to one change. Smaller PRs get reviewed and merged faster.
 - Avoid adding paid or card-gated services. This catalog only lists tiers that are genuinely free to start using without a credit card.
 
+## Code style
+
+- **TypeScript 严格模式**；类型从 zod schema 用 `z.infer` 推导（如 `SearchConfig`），不重复手写接口
+- **命名**：camelCase 变量/函数、PascalCase 组件/类型、`_` 前缀私有
+- **i18n**：文案走 `t('key')`，不硬编码字符串；新增 key 同步 60 locales
+- **样式**：Tailwind 原子类 + 语义 CSS 变量（`--muted-foreground` 等），不硬编码 hex
+- **时间**：SQLite 存 UTC（空格格式）；前端展示用 `formatSqliteUtcToLocalTime` 转本地时区
+- 不重构无关代码；改动聚焦单一主题
+
+## Validation (required before commit)
+
+```bash
+cd server && npx tsc --noEmit     # server 类型
+cd client && npx tsc -b           # client 类型
+npm run check:i18n                # 60 locales / key parity（client 目录）
+```
+
+- 新功能补测试（vitest：`server/src/__tests__`、`client/src/__tests__`）
+- **catalog / 模型改动**：必须实测可用（`POST /v1/chat/completions` 返回 200，免费账号），在注释/PR 注明验证日期与方式
+- CI 会跑 fmt / tsc / tests / i18n —— 本地先过一遍再提交
+
 ## Database migrations
 
 Schema changes must use file-per-migration files under
@@ -31,6 +54,43 @@ npm run db:migration:create --name=add_embedding_index
 npm run db:migration:up
 npm run db:migration:down
 ```
+
+## Catalog conventions
+
+- 模型添加：`server/src/db/model-pricing.ts`（pricing）+ migrations 的 `additions` 数组
+- `model_id` 用 `/v1/models` 返回的精确 id（name:tag，如 `gpt-oss:20b`）
+- **只加真免费模型**；免费变付费的必须人工确认移除（#722 教训）
+- pricing 镜像同模型 paid 变体；无参考时用合理默认并注释说明
+- 可用性证明写进代码注释：验证日期 + 方式（如 "tested 2026-08-06 against Free tier"）
+
+## Commits
+
+- Conventional Commits：`feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`
+- 正文说明"为什么"；关联 issue `Refs #xxx`
+- 结尾加 `Co-Authored-By` trailer（AI 贡献者）
+- 一个 PR 一个主题；不要混合无关改动
+
+## Pull requests
+
+PR 描述用模板：
+
+```markdown
+## What
+（改了什么，面向维护者）
+
+## Why
+（为什么值得合入，关联 issue `Refs #xxx`）
+
+## Tests
+（验证证据：tsc 结果、测试数量、实测记录）
+
+## Files
+（关键文件列表）
+```
+
+- 测试证据如实说明；无法本地验证（如无工具链）必须标注"依赖 CI 验证"
+- **不做半成品**：不提交"存了但没用"的代码（#590 教训）
+- 网络策略：github 直连失败时用 VPS 代理重试（`-x http://llmproxy:...@43.133.45.67:7890`）
 
 ## Translations
 
@@ -52,6 +112,13 @@ That means:
 - **Disclose nothing special required.** You do not need to label a PR as AI-assisted. We care about the result, not the keystrokes.
 
 PRs that are clearly unreviewed model output (broad unexplained diffs, fabricated limits, tests that do not run) will be asked for changes or closed.
+
+## Security
+
+- API key 回显一律 `maskKey`；日志/PR/评论不出现明文
+- 敏感文件 0o600；SSRF 检查（`url-guard`）；代理/凭据脱敏（`redactProxyUrl`）
+- 认证统一 API key（`timingSafeStringEqual`），不信任 socket 本地性
+- 涉及敏感数据的功能：先讨论权限/脱敏方案再实现
 
 ## Reporting issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,24 +23,24 @@ Every PR should:
 
 ## Code style
 
-- **TypeScript 严格模式**；类型从 zod schema 用 `z.infer` 推导（如 `SearchConfig`），不重复手写接口
-- **命名**：camelCase 变量/函数、PascalCase 组件/类型、`_` 前缀私有
-- **i18n**：文案走 `t('key')`，不硬编码字符串；新增 key 同步 60 locales
-- **样式**：Tailwind 原子类 + 语义 CSS 变量（`--muted-foreground` 等），不硬编码 hex
-- **时间**：SQLite 存 UTC（空格格式）；前端展示用 `formatSqliteUtcToLocalTime` 转本地时区
-- 不重构无关代码；改动聚焦单一主题
+- **Strict TypeScript**; derive types from zod schemas with `z.infer` (e.g. `SearchConfig`), don't hand-write duplicate interfaces
+- **Naming**: camelCase variables/functions, PascalCase components/types, `_` prefix for private
+- **i18n**: user-visible text goes through `t('key')`, never hardcoded strings; new keys are added to all 60 locales
+- **Styling**: Tailwind utility classes + semantic CSS variables (`--muted-foreground`, etc.), never hardcoded hex
+- **Time**: SQLite stores UTC (space-separated format); render in the viewer's local zone with `formatSqliteUtcToLocalTime`
+- Don't refactor unrelated code; keep changes focused on one topic
 
 ## Validation (required before commit)
 
 ```bash
-cd server && npx tsc --noEmit     # server 类型
-cd client && npx tsc -b           # client 类型
-npm run check:i18n                # 60 locales / key parity（client 目录）
+cd server && npx tsc --noEmit     # server types
+cd client && npx tsc -b           # client types
+npm run check:i18n                # 60 locales / key parity (run from client/)
 ```
 
-- 新功能补测试（vitest：`server/src/__tests__`、`client/src/__tests__`）
-- **catalog / 模型改动**：必须实测可用（`POST /v1/chat/completions` 返回 200，免费账号），在注释/PR 注明验证日期与方式
-- CI 会跑 fmt / tsc / tests / i18n —— 本地先过一遍再提交
+- Add tests for new features (vitest: `server/src/__tests__`, `client/src/__tests__`)
+- **Catalog / model changes**: verify live before submitting (`POST /v1/chat/completions` returns 200 on a free account); note the verification date and method in a comment / PR
+- CI runs fmt / tsc / tests / i18n — run them locally first
 
 ## Database migrations
 
@@ -57,40 +57,40 @@ npm run db:migration:down
 
 ## Catalog conventions
 
-- 模型添加：`server/src/db/model-pricing.ts`（pricing）+ migrations 的 `additions` 数组
-- `model_id` 用 `/v1/models` 返回的精确 id（name:tag，如 `gpt-oss:20b`）
-- **只加真免费模型**；免费变付费的必须人工确认移除（#722 教训）
-- pricing 镜像同模型 paid 变体；无参考时用合理默认并注释说明
-- 可用性证明写进代码注释：验证日期 + 方式（如 "tested 2026-08-06 against Free tier"）
+- Add models in `server/src/db/model-pricing.ts` (pricing) + the migrations `additions` array
+- `model_id` uses the exact `/v1/models` id (name:tag, e.g. `gpt-oss:20b`)
+- **Free models only**: add only genuinely free models; ones that move to paid must be removed by a human (#722)
+- Pricing mirrors the same model's paid variant where one exists; otherwise use a reasonable default and comment why
+- Proof of availability goes in a code comment: verification date + method (e.g. "tested 2026-08-06 against Free tier")
 
 ## Commits
 
-- Conventional Commits：`feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`
-- 正文说明"为什么"；关联 issue `Refs #xxx`
-- 结尾加 `Co-Authored-By` trailer（AI 贡献者）
-- 一个 PR 一个主题；不要混合无关改动
+- Conventional Commits: `feat:` / `fix:` / `docs:` / `test:` / `style:` / `refactor:`
+- Body explains the "why"; reference issues with `Refs #xxx`
+- Append the `Co-Authored-By` trailer (for AI contributors)
+- One PR per topic; don't mix unrelated changes
 
 ## Pull requests
 
-PR 描述用模板：
+PR description template:
 
 ```markdown
 ## What
-（改了什么，面向维护者）
+(what changed, for the maintainer)
 
 ## Why
-（为什么值得合入，关联 issue `Refs #xxx`）
+(why it should land; reference issues with `Refs #xxx`)
 
 ## Tests
-（验证证据：tsc 结果、测试数量、实测记录）
+(evidence: tsc result, test counts, live verification)
 
 ## Files
-（关键文件列表）
+(key files touched)
 ```
 
-- 测试证据如实说明；无法本地验证（如无工具链）必须标注"依赖 CI 验证"
-- **不做半成品**：不提交"存了但没用"的代码（#590 教训）
-- 网络策略：github 直连失败时用 VPS 代理重试（`-x http://llmproxy:...@43.133.45.67:7890`）
+- Report test evidence honestly; if you can't verify locally (e.g. no toolchain), say so and rely on CI
+- **No half-finished work**: don't submit "stored but unused" code or fields (#590)
+- Network: if github is unreachable, retry through the VPS proxy (`-x http://llmproxy:...@43.133.45.67:7890`)
 
 ## Translations
 
@@ -115,10 +115,10 @@ PRs that are clearly unreviewed model output (broad unexplained diffs, fabricate
 
 ## Security
 
-- API key 回显一律 `maskKey`；日志/PR/评论不出现明文
-- 敏感文件 0o600；SSRF 检查（`url-guard`）；代理/凭据脱敏（`redactProxyUrl`）
-- 认证统一 API key（`timingSafeStringEqual`），不信任 socket 本地性
-- 涉及敏感数据的功能：先讨论权限/脱敏方案再实现
+- API keys surfaced only via `maskKey`; no plaintext in logs / PRs / comments
+- Sensitive files 0o600; SSRF checks (`url-guard`); proxy / credential redaction (`redactProxyUrl`)
+- Auth via the unified API key (`timingSafeStringEqual`), never trust socket locality
+- For features touching sensitive data: discuss the permission / redaction approach before implementing
 
 ## Reporting issues
 


### PR DESCRIPTION
## What

Proposal (draft, open for your thoughts): add `AGENTS.md` — the always-on context file for AI coding agents — and extend the existing `CONTRIBUTING.md` with code-style / validation / catalog / commit / PR conventions, **keeping every section the original file already had** (dev loop, migrations, translations, AI-contribution guidance, reporting, community work).

## Why

AI-assisted PRs are welcome here, but today an AI agent has no project-specific orientation — it guesses the commit style, the validation gates, and the catalog rules. AGENTS.md follows the emerging open spec (Red Hat 2026-07 "Standardize project context with AGENTS.md and Agent Skills"): concise (<150 lines), project-specific invariants only, do-over-don't phrasing, progressive disclosure via references. CLAUDE.md can symlink to it.

Contributions from AI agents should land with less friction for you: right commit format, verified catalog entries (free/paid boundary per #722), no half-finished fields (#590).

## Tests

N/A (docs only). No code changed.

## Files

- AGENTS.md (new, 49 lines — concise kernel)
- CONTRIBUTING.md (extended, original sections preserved)

Happy to adjust structure/tone if you have a different vision for this.
