### PR TITLE
feat(desktop): ship a Windows zip alongside the installer (#766)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -38,6 +38,7 @@ jobs:
             artifact: windows-installer
             glob: |
               desktop/dist-electron/*.exe
+              desktop/dist-electron/*.zip
               desktop/dist-electron/*.blockmap
               desktop/dist-electron/latest.yml
           - os: macos-latest

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -47,6 +47,9 @@ win:
     - target: nsis
       arch:
         - x64
+    - target: zip
+      arch:
+        - x64
   # electron-builder converts a >=256px PNG to .ico at build time.
   icon: assets/appicon_1024.png
 nsis:

--- a/server/src/__tests__/services/router-key-bandit.test.ts
+++ b/server/src/__tests__/services/router-key-bandit.test.ts
@@ -116,7 +116,10 @@ describe('per-key bandit selection', () => {
     addKeyHistory('groq', 'm', seasoned, { successes: 40, failures: 2 });
     refreshStatsCache(getDb(), true);
 
-    const counts = pickKeyCounts(300);
+    // Thompson sampling gives an unmeasured key a small but non-zero chance of
+    // winning each draw (~1.5% with this prior), so 300 draws flaked in CI when
+    // the fresh key lost every one. 3000 draws make that ~1e-20 instead.
+    const counts = pickKeyCounts(3000);
     expect(counts[fresh] ?? 0).toBeGreaterThan(0);
     expect(counts[seasoned] ?? 0).toBeGreaterThan(0);
   });


### PR DESCRIPTION
Adds a portable Windows x64 zip build alongside the existing nsis installer:

- `desktop/electron-builder.yml`: win target now emits both `nsis` and `zip` (x64)
- `.github/workflows/desktop-release.yml`: attaches `*.zip` to the release artifacts

Gives users a portable option that writes less to C: (no install step). Refs #766