### PR TITLE
release: v0.6.9

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
Version bump for the v0.6.9 release: searchable provider picker (#728), custom fetch-models detail hints (#729), visible intelligence-rank override (#727), SOCKS timeout guard fix (#726).