### PR TITLE
fix(proxy): timestamp TTFB at the first reasoning_content token

### DIFF
--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -119,6 +119,46 @@ describe('proxy stream turn-integrity', () => {
     expect(rows[1].status).toBe('success');
   });
 
+  it('records TTFB at the first reasoning_content chunk, not at first visible text (#764)', async () => {
+    // A reasoning model streams thinking before any visible answer. The proxy
+    // must timestamp TTFB at that first reasoning token — waiting for the
+    // first real text would include the whole thinking window and make the
+    // model look ~0 speed. The upstream emits reasoning at t≈0 and the answer
+    // text ~250ms later, so the two candidate timestamps are far apart.
+    const encoder = new TextEncoder();
+    const reasoningChunk = { id: 'c1', object: 'chat.completion.chunk', created: 1, model: 'm', choices: [{ index: 0, delta: { role: 'assistant', reasoning_content: 'let me think about this', content: null }, finish_reason: null }] };
+    const origFetch = global.fetch;
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (!urlStr.includes('api.groq.com')) return origFetch(url as any, init);
+      const upstreamBody = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(encoder.encode(sse(reasoningChunk)));
+          await new Promise(r => setTimeout(r, 250));
+          controller.enqueue(encoder.encode(sse(textChunk('The answer.'), finishChunk('stop'), '[DONE]')));
+          controller.close();
+        },
+      });
+      return new Response(upstreamBody, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    });
+
+    const r = await request(app, '/v1/chat/completions', {
+      stream: true, messages: [{ role: 'user', content: 'ttfb reasoning timing test' }],
+    });
+    expect(r.status).toBe(200);
+    // The reasoning trace is forwarded to the client as well.
+    const fs = frames(r.text);
+    expect(fs.some(f => (f.choices?.[0]?.delta as any)?.reasoning_content)).toBe(true);
+
+    const rows = getDb().prepare('SELECT ttfb_ms, latency_ms FROM requests').all() as any[];
+    expect(rows[0].ttfb_ms).not.toBeNull();
+    // Reasoning arrived at t≈0, answer text at t≈250ms: TTFB must be well
+    // below the thinking window. Before the fix it measured ~250ms (the first
+    // visible text), so this asserts the reasoning token counts.
+    expect(rows[0].ttfb_ms).toBeLessThan(150);
+    expect(rows[0].ttfb_ms).toBeGreaterThanOrEqual(0);
+  });
+
   it('synthesizes finish_reason tool_calls and ids for a stream that ends without a terminal reason', async () => {
     // minimax/command-r live shape: valid tool_call deltas, then [DONE] with
     // no finish_reason chunk at all.

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -1711,7 +1711,10 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
 
         const flushHeaders = () => {
           if (headerSent) return;
-          ttfbMs = Date.now() - start;
+          // TTFB is captured at the first token (which for reasoning models is
+          // reasoning_content, see the text.length === 0 branch below); a later
+          // flush must never overwrite that earlier timestamp (#764).
+          if (ttfbMs === null) ttfbMs = Date.now() - start;
           res.setHeader('Content-Type', 'text/event-stream');
           res.setHeader('Cache-Control', 'no-cache');
           res.setHeader('Connection', 'keep-alive');
@@ -1801,6 +1804,16 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             const text = typeof choice.delta?.content === 'string' ? choice.delta.content : '';
 
             if (text.length === 0) {
+              // Reasoning models stream reasoning_content BEFORE any visible
+              // text. That thinking is the model's first output token, so it
+              // must count toward TTFB — otherwise the recorded TTFB includes
+              // the whole thinking window (or stays null on long-thinking
+              // timeouts) and reasoning models show ~0 speed (#764). Headers
+              // stay held until real payload, so a thinking-only dead turn
+              // can still fail over invisibly.
+              if (ttfbMs === null && typeof choice.delta?.reasoning_content === 'string' && choice.delta.reasoning_content.length > 0) {
+                ttfbMs = Date.now() - start;
+              }
               // Role preamble / keep-alive: hold until first payload decides
               // the mode, forward afterwards. tool_calls and finish_reason are
               // stripped — both are re-emitted complete at the end (OpenRouter


### PR DESCRIPTION
## What

Fixes #764 — reasoning models showed ~0 speed in analytics because TTFB was timestamped at the first **visible text**, not the first token.

**Root cause.** In the streaming loop, `flushHeaders()` (which stamps `ttfbMs`) only ran when real answer text arrived. Reasoning models (GLM-5.2, claude-opus-5, DeepSeek thinking) stream `reasoning_content` first with empty `content`, so:
- the recorded TTFB included the whole thinking window (a 2-minute thinking model looked like a 2-minute TTFB), or
- stayed `null` when a long-thinking stream timed out before its first answer.

**Fix.**
- `proxy.ts`: when a delta carries non-empty `reasoning_content` and `ttfbMs` is still null, stamp `ttfbMs = Date.now() - start` **without flushing headers** — the hold-until-first-payload failover semantics stay intact, so a thinking-only dead turn still fails over invisibly.
- `flushHeaders()` now only stamps `ttfbMs` when it is still null, so a later flush never overwrites the earlier reasoning timestamp.

## Tests

New stream-integrity test: the upstream emits `reasoning_content` at t≈0 and the answer text 250ms later; the recorded `ttfb_ms` must be well below the thinking window (before the fix it measured ~250ms — the first visible text). It also asserts the reasoning trace is forwarded to the client.

- `proxy-stream-integrity.test.ts`: 14/14 green (incl. the new case)
- `tsc -b`: clean

Refs #764
