### PR TITLE
feat(keys): flag providers that need a key but have none added

### DIFF
--- a/client/src/components/keys/provider-checklist-section.tsx
+++ b/client/src/components/keys/provider-checklist-section.tsx
@@ -69,9 +69,15 @@ export function ProviderChecklistSection({ onAddKey }: { onAddKey: (platform: st
             >
               <Plus className="size-3 text-muted-foreground" />
               {p.name}
-              {p.keyless && (
+              {p.keyless ? (
                 <span className="text-[10px] font-normal text-muted-foreground">
                   {t('keys.checklistKeyless')}
+                </span>
+              ) : (
+                // Needs a key but none added yet — the actionable case. Amber
+                // so the "add this" providers stand out from anonymous ones.
+                <span className="text-[10px] font-normal text-amber-600 dark:text-amber-400">
+                  {t('models.noKey')}
                 </span>
               )}
             </button>


### PR DESCRIPTION
## What

Fixes #775 — there was no quick way to see which providers still need an API key.

The Keys-page checklist already listed unconfigured providers as chips, but only anonymous (keyless) providers got a "no key needed" label. Providers that **require** a key but had none added looked identical to every other unconfigured chip, so the actionable gap was invisible at a glance.

## Change

Single file, one chip, +7/−1 in `client/src/components/keys/provider-checklist-section.tsx`:

- `keyless` providers keep their muted "no key needed" label (unchanged).
- Providers that need a key but have none added now get an **amber "no key" badge**, reusing the existing `models.noKey` string and the same amber treatment the media-models page uses for zero-key models.

No new i18n keys, no server change, no overlap with #660 (which marks *configured* providers with a green dot in the Add-key dialog — this is the inverse signal in the provider list).

## Tests

- Client `tsc -b`: clean.
- No i18n key added, so locale parity is unaffected.

Refs #775
