### PR TITLE
Add .gitattributes to pin LF, fixing CSP hash mismatch on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Normalize line endings in the repository to LF.
+#
+# Without this, Git for Windows' default `core.autocrlf=true` checks text files
+# out with CRLF. That is not cosmetic here: server/src/app.ts pins
+# INLINE_BOOTSTRAP_SHA, the SHA-256 of the inline theme bootstrap in
+# client/index.html, and serves it in the CSP `script-src` directive. A CRLF
+# checkout changes those bytes, so the hash no longer matches the script it is
+# meant to authorize — the browser blocks the bootstrap and dark-mode users get
+# the white flash that #682 fixed. csp-inline-bootstrap.test.ts catches it, but
+# only after a Windows clone already fails two tests out of the box.
+*               text=auto eol=lf
+
+# Binary assets must never be line-ending converted.
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.webp          binary
+*.woff          binary
+*.woff2         binary
+*.ttf           binary
+*.eot           binary
+*.pdf           binary
+*.zip           binary
+*.node          binary
+*.db            binary
+
+# Windows-only scripts are fine either way, but keep them LF for consistency
+# with the rest of the tree; PowerShell reads LF without complaint.
+*.ps1           text eol=lf


### PR DESCRIPTION
## Problem

Git for Windows defaults to `core.autocrlf=true`, and the repo has no `.gitattributes`. So a clean
Windows clone checks `client/index.html` out with CRLF.

`server/src/app.ts` pins `INLINE_BOOTSTRAP_SHA` — the SHA-256 of that file's inline theme bootstrap —
and serves it in the CSP `script-src` directive. CRLF changes the hashed bytes, so the hash no longer
authorizes the script it names:

```
on-disk (CRLF)      'sha256-NhQ9t1luOLg/gJxVj+cgjX5vxl4o7owwcLBpVHf+wD8='
same content as LF  'sha256-4Mz/yZAENQGlTAAeE1WqXruXCripvlvl0s+Q9S1VS4A='   <- the value in app.ts
```

`server/src/__tests__/routes/csp-inline-bootstrap.test.ts` fails two of its four tests on a fresh
Windows clone, before any code is touched.

**This is not only a test failure.** That hash goes into the CSP header the server sends. A client
built from a CRLF checkout ships an `index.html` whose inline bootstrap the browser then blocks —
which is #682, the white-flash-on-load bug the hash exists to prevent. A release built on Windows
would reintroduce it.

## Why CI does not catch this

`.github/workflows/ci.yml` runs on `ubuntu-24.04` only. `core.autocrlf` never applies there, so the
checkout is always LF and the test always passes. The failure is invisible to CI by construction —
it only appears for contributors on Windows.

## Fix

Add a `.gitattributes` that pins `text=auto eol=lf`, with binary types excluded from conversion.

`git add --renormalize .` stages **zero** content changes — the index is already LF throughout — so
this is purely preventive and does not touch a single existing file.

## Verification

On Windows 11, Node 22.23.2, with `core.autocrlf=true` (the default that causes the bug):

1. Delete and re-checkout `client/index.html` → now LF, because of `.gitattributes`.
2. `npm run build -w client`
3. `npx vitest run src/__tests__/routes/csp-inline-bootstrap.test.ts` → **4/4 pass** (was 2/4).

Also run, all passing: `npm run test:migrations` (3/3), `client/` `npm run check:i18n`
(60 locales, 797 keys), `npm run build` across all workspaces.

## A note on the "include a test" guideline

I have deliberately not added a new test, and want to be upfront about why rather than pad the diff.

The test for this already exists — `csp-inline-bootstrap.test.ts` is exactly the guard, and it goes
from 2/4 to 4/4 with this change. A new test could not add coverage where it matters: CI runs on
Linux, where the checkout is LF regardless of whether `.gitattributes` is present, so any assertion
about line endings passes there with or without the fix.

If you would like one anyway, I am happy to add whichever you prefer — an assertion that
`.gitattributes` declares `eol=lf`, or a Windows leg in the CI matrix (which would genuinely have
caught this, and would catch the next one). Happy to do the CI matrix change as a separate PR.

## Unrelated pre-existing Windows failures

For transparency, `npm test` is not fully green on Windows on `main` for two reasons unrelated to
this change. I have left both alone to keep this PR scoped, but can open issues if useful:

- `src/__tests__/db/hardening.test.ts` asserts `mode & 0o077 === 0` on the DB and its WAL sidecars.
  Node synthesizes `0o666` on Windows and `fs.chmod` there only toggles the read-only flag, so this
  cannot pass. Worth noting it is not purely cosmetic: the owner-only restriction genuinely is not
  applied on Windows, so the guarantee that test describes does not hold there.
- `scripts/dev-bootstrap.test.mjs` spawns `powershell.exe` via `execFile` inheriting ambient `PATH`,
  so it picks up whatever `node` is first — failing against a system Node outside the engines range
  even when a supported Node is used for the actual build.
