### PR TITLE
fix(csp/db): sync inline bootstrap hash and skip POSIX-only perms on Windows

### DIFF
--- a/server/src/__tests__/db/hardening.test.ts
+++ b/server/src/__tests__/db/hardening.test.ts
@@ -46,30 +46,36 @@ describe('database runtime hardening', () => {
     expect(jmValue.toLowerCase()).toBe('wal');
   });
 
-  it('restricts the database file to the owner', () => {
-    const dbPath = tempDbPath();
-    connectDb(dbPath);
+  it.skipIf(process.platform === 'win32', 'POSIX permission bits are not enforceable on Windows')(
+    'restricts the database file to the owner',
+    () => {
+      const dbPath = tempDbPath();
+      connectDb(dbPath);
 
-    // The DB holds encrypted provider keys and the dashboard password hash.
-    const mode = fs.statSync(dbPath).mode & 0o777;
-    expect(mode & 0o077).toBe(0);
-  });
-
-  it('restricts the WAL sidecars once they exist', () => {
-    const dbPath = tempDbPath();
-    const db = connectDb(dbPath);
-    // Force a write so -wal/-shm are created, then reconnect to chmod them.
-    db.exec('CREATE TABLE IF NOT EXISTS probe (id INTEGER PRIMARY KEY)');
-    db.exec('INSERT INTO probe (id) VALUES (1)');
-    connectDb(dbPath);
-
-    for (const suffix of ['-wal', '-shm']) {
-      const target = `${dbPath}${suffix}`;
-      if (!fs.existsSync(target)) continue;
-      const mode = fs.statSync(target).mode & 0o777;
+      // The DB holds encrypted provider keys and the dashboard password hash.
+      const mode = fs.statSync(dbPath).mode & 0o777;
       expect(mode & 0o077).toBe(0);
-    }
-  });
+    },
+  );
+
+  it.skipIf(process.platform === 'win32', 'POSIX permission bits are not enforceable on Windows')(
+    'restricts the WAL sidecars once they exist',
+    () => {
+      const dbPath = tempDbPath();
+      const db = connectDb(dbPath);
+      // Force a write so -wal/-shm are created, then reconnect to chmod them.
+      db.exec('CREATE TABLE IF NOT EXISTS probe (id INTEGER PRIMARY KEY)');
+      db.exec('INSERT INTO probe (id) VALUES (1)');
+      connectDb(dbPath);
+
+      for (const suffix of ['-wal', '-shm']) {
+        const target = `${dbPath}${suffix}`;
+        if (!fs.existsSync(target)) continue;
+        const mode = fs.statSync(target).mode & 0o777;
+        expect(mode & 0o077).toBe(0);
+      }
+    },
+  );
 
   it('works for an in-memory database without touching the filesystem', () => {
     expect(() => connectDb(':memory:')).not.toThrow();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -51,7 +51,7 @@ const DEFAULT_DASHBOARD_ORIGINS = [
 // must run before first paint. Kept as a literal so the CSP header stays a
 // constant string; csp-inline-bootstrap.test.ts recomputes it from the real
 // index.html (source and build) and fails if the two ever drift apart.
-export const INLINE_BOOTSTRAP_SHA = "'sha256-4Mz/yZAENQGlTAAeE1WqXruXCripvlvl0s+Q9S1VS4A='";
+export const INLINE_BOOTSTRAP_SHA = "'sha256-NhQ9t1luOLg/gJxVj+cgjX5vxl4o7owwcLBpVHf+wD8='";
 
 // A build asset is safe to cache forever+immutable when its URL is
 // content-addressed. Vite parks every hashed chunk (JS, CSS, fonts, images)


### PR DESCRIPTION
## What

Fixes #779 — three pre-existing test failures on a clean `origin/main` checkout.

### 1. CSP bootstrap hash drift (all platforms)

`INLINE_BOOTSTRAP_SHA` in `server/src/app.ts` served a stale hash: the inline theme/direction `<script>` in `client/index.html` was edited without regenerating it, so `script-src` blocked the bootstrap in the browser (dark-mode white-flash class of #682). The guard suite `csp-inline-bootstrap.test.ts` tripped exactly as designed.

**Fix**: regenerate the hash from the current `client/index.html` inline script and update `INLINE_BOOTSTRAP_SHA`. The suite now passes (4/4).

### 2. DB permission tests on Windows

`db/hardening.test.ts` asserted `mode & 0o077 === 0` on every platform. Windows does not enforce POSIX permission bits — `fs.stat` synthesizes modes there, so the assertion can never pass on win32.

**Fix**: gate the two permission tests with `it.skipIf(process.platform === 'win32', …)`, matching the issue's own suggestion. POSIX legs still assert the real mode; Windows is documented as non-enforceable at the OS level.

## Verification

- `vitest run csp-inline-bootstrap.test.ts` → 4 passed
- `vitest run db/hardening.test.ts` → 5 passed, 2 skipped (win32)

## Notes

No behavior change beyond the corrected CSP hash; the hardened-permissions work is tracked separately in #791 (out of scope here).