### PR TITLE
fix(analytics): render timeline x-axis in the viewer's local timezone

### DIFF
--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -401,6 +401,22 @@ const gridStyle = 'var(--border)'
 const primaryFill = 'var(--foreground)'
 const tooltipStyle = { backgroundColor: 'var(--popover)', border: '1px solid var(--border)', borderRadius: 8, fontSize: 12 } as const
 
+// The timeline endpoint returns UTC timestamps without a zone suffix
+// ("2026-08-10T14:00:00" hourly, "2026-08-10" daily). Parse them as UTC and
+// render in the viewer's local timezone; without this the x-axis showed UTC
+// wall-clock times that disagreed with every other timestamp on the page.
+function formatTimelineTick(value: string): string {
+  if (!value) return ''
+  const iso = value.includes('T') ? `${value}Z` : `${value}T00:00:00Z`
+  const date = new Date(iso)
+  if (isNaN(date.getTime())) return value
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    ...(value.includes('T') ? { hour: '2-digit', minute: '2-digit' } : {}),
+  })
+}
+
 // Two categorical series hues, validated against the app's actual chart
 // surfaces (light card #ffffff, dark card #101010) with the dataviz palette
 // checker. Slot A (blue) = the "average / input" series; slot B (aqua) = the
@@ -591,7 +607,7 @@ export default function AnalyticsPage() {
                 <ResponsiveContainer width="100%" height={240}>
                   <LineChart data={timeline} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} tickFormatter={formatTimelineTick} />
                     <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                     <Tooltip contentStyle={tooltipStyle} />
                     <Legend wrapperStyle={{ fontSize: 12 }} iconType="line" />
@@ -612,7 +628,7 @@ export default function AnalyticsPage() {
                 <ResponsiveContainer width="100%" height={240}>
                   <LineChart data={timeline} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                     <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                    <XAxis dataKey="timestamp" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} tickFormatter={formatTimelineTick} />
                     <YAxis tick={axisStyle} tickLine={false} axisLine={false} tickFormatter={(v: number) => formatTokens(v)} />
                     <Tooltip contentStyle={tooltipStyle} formatter={(value) => formatTokens(Number(value))} />
                     <Legend wrapperStyle={{ fontSize: 12 }} iconType="line" />


### PR DESCRIPTION
## What

Fixes #761 — the Analytics timeline charts (requests over time, tokens over time) rendered the x-axis with raw UTC timestamps, disagreeing with every other timestamp on the page (detail rows already go through `formatSqliteUtcToLocalTime`).

The `/api/analytics/timeline` endpoint returns UTC buckets without a zone suffix — hourly as `2026-08-10T14:00:00`, daily as `2026-08-10` — and both `LineChart`s fed that string straight into `XAxis`.

## Changes

`client/src/pages/AnalyticsPage.tsx`:

- New `formatTimelineTick(value)` — parses the bucket timestamp as UTC (appends `Z`, or `T00:00:00Z` for date-only buckets) and formats via `toLocaleString` in the viewer's timezone: `month + day` always, plus `hour:minute` for hourly buckets. Falls back to the raw string if unparseable.
- Both timeline `XAxis` components now use `tickFormatter={formatTimelineTick}`.

## Verification

- `npx tsc -b` (client) → clean
- `npm run test -w client` → pass (incl. i18n check)

## Notes

Chart-only change; no server behavior, no i18n keys added.