### PR TITLE
fix(desktop): bump Electron 33 to 38.8.6 for macOS 26 Tahoe window/tray rendering (#807)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ server/data/
 .env.local
 .DS_Store
 
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Personal deployment scripts (contain keys/credentials — kept local)
 deploy-pi.sh
 update-hermes.sh

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },
@@ -14,7 +14,7 @@
         "@electron/rebuild": "^3.7.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.0.0",
-        "electron": "^33.0.0",
+        "electron": "^38.8.6",
         "electron-builder": "^25.1.8",
         "esbuild": "^0.24.0",
         "typescript": "^5.8.0",
@@ -3141,15 +3141,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.4.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
-      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "version": "38.8.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.8.6.tgz",
+      "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^20.9.0",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -3213,16 +3213,6 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
-      }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
       }
     },
     "node_modules/emoji-regex": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -31,7 +31,7 @@
     "@electron/rebuild": "^3.7.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.0.0",
-    "electron": "^33.0.0",
+    "electron": "^38.8.6",
     "electron-builder": "^25.1.8",
     "esbuild": "^0.24.0",
     "typescript": "^5.8.0",


### PR DESCRIPTION
Closes #807

## Problem

On macOS 26 (Tahoe), the desktop app's process and API run fine but the window and tray icon never render. The packaged app ships Electron 33.4.11 (2024), which predates Tahoe; the Tahoe-specific window shadow / vibrancy / tray rendering fixes landed in Electron 38+ (electron#48398 cornerMask GPU fix, electron#10079 bump to 38.2.2).

## Fix

Bump `desktop/package.json` electron from `^33.0.0` to `^38.8.6`, bringing in the Tahoe compatibility fixes.

## Verification

Local binary download was blocked by network TLS errors (could not fetch the Electron 38 binary), so the build is verified by CI on this PR. Type-check and tests are unchanged in scope (single dependency bump).