### PR TITLE
feat(keys): provider checklist status as icons with tooltips

### DIFF
--- a/client/src/components/keys/provider-checklist-section.tsx
+++ b/client/src/components/keys/provider-checklist-section.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
-import { ChevronDown, Plus } from 'lucide-react'
+import { ChevronDown, KeyRound, Plus, Unlock } from 'lucide-react'
+import { Tooltip } from '@/components/tooltip'
 import { useI18n } from '@/i18n'
 
 // Shape of GET /api/keys/providers (#543). Declared inline: the backend owns
@@ -61,26 +62,38 @@ export function ProviderChecklistSection({ onAddKey }: { onAddKey: (platform: st
       {expanded && (
         <div className="mt-2 flex flex-wrap gap-1.5">
           {unconfigured.map(p => (
-            <button
+            // The status reads as an icon, not a word: the chip row is dense and
+            // the labels repeated on every chip. The wrapper is the shared
+            // Tooltip, which opens on hover and — because focus bubbles up from
+            // the button inside it — on keyboard focus too, so the sentence the
+            // icon replaces is still one hover or one Tab away. The short label
+            // stays as sr-only text, keeping the button's accessible name.
+            <Tooltip
               key={p.platform}
-              type="button"
-              onClick={() => onAddKey(p.platform)}
-              className="inline-flex h-5 items-center gap-1 rounded-4xl border border-border px-2 text-xs font-medium whitespace-nowrap transition-all hover:bg-muted focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              text={p.keyless ? t('keys.checklistKeylessTip') : t('keys.checklistNoKeyTip')}
             >
-              <Plus className="size-3 text-muted-foreground" />
-              {p.name}
-              {p.keyless ? (
-                <span className="text-[10px] font-normal text-muted-foreground">
-                  {t('keys.checklistKeyless')}
-                </span>
-              ) : (
-                // Needs a key but none added yet — the actionable case. Amber
-                // so the "add this" providers stand out from anonymous ones.
-                <span className="text-[10px] font-normal text-amber-600 dark:text-amber-400">
-                  {t('models.noKey')}
-                </span>
-              )}
-            </button>
+              <button
+                type="button"
+                onClick={() => onAddKey(p.platform)}
+                className="inline-flex h-5 items-center gap-1 rounded-4xl border border-border px-2 text-xs font-medium whitespace-nowrap transition-all hover:bg-muted focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+              >
+                <Plus className="size-3 text-muted-foreground" />
+                {p.name}
+                {p.keyless ? (
+                  <span className="inline-flex text-muted-foreground">
+                    <Unlock className="size-3.5" aria-hidden="true" />
+                    <span className="sr-only">{t('keys.checklistKeyless')}</span>
+                  </span>
+                ) : (
+                  // Needs a key but none added yet — the actionable case. Amber
+                  // so the "add this" providers stand out from anonymous ones.
+                  <span className="inline-flex text-amber-600 dark:text-amber-400">
+                    <KeyRound className="size-3.5" aria-hidden="true" />
+                    <span className="sr-only">{t('models.noKey')}</span>
+                  </span>
+                )}
+              </button>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -319,6 +319,8 @@
     "tabProviders": "አቅራቢዎች",
     "checklistSummary": "ከ{total} አቅራቢዎች {configured} ተዋቅረዋል",
     "checklistKeyless": "ቁልፍ አያስፈልግም",
+    "checklistNoKeyTip": "እስካሁን ቁልፍ አልታከለም። ለመጨመር ጠቅ ያድርጉ።",
+    "checklistKeylessTip": "ያለ ቁልፍ ይሠራል።",
     "tabQuotaSignals": "የኮታ ምልክቶች",
     "tabApiKey": "የተዋሃደ API ቁልፍ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -319,6 +319,8 @@
     "tabProviders": "مقدمي الخدمات",
     "checklistSummary": "تم إعداد {configured} من {total} من مقدمي الخدمات",
     "checklistKeyless": "لا حاجة لمفتاح",
+    "checklistNoKeyTip": "لم تتم إضافة أي مفتاح بعد. انقر لإضافة مفتاح.",
+    "checklistKeylessTip": "يعمل بدون مفتاح.",
     "tabQuotaSignals": "إشارات الحصص",
     "tabApiKey": "مفتاح API الموحد",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -319,6 +319,8 @@
     "tabProviders": "Təchizatçılar",
     "checklistSummary": "{total} təchizatçıdan {configured} qurulub",
     "checklistKeyless": "açar tələb olunmur",
+    "checklistNoKeyTip": "Hələ açar əlavə edilməyib. Əlavə etmək üçün klikləyin.",
+    "checklistKeylessTip": "Açarsız işləyir.",
     "tabQuotaSignals": "Kvota siqnalları",
     "tabApiKey": "Birləşmiş API açarı",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -319,6 +319,8 @@
     "tabProviders": "Доставчици",
     "checklistSummary": "Настроени са {configured} от {total} доставчици",
     "checklistKeyless": "не е нужен ключ",
+    "checklistNoKeyTip": "Все още не е добавен ключ. Щракнете, за да добавите.",
+    "checklistKeylessTip": "Работи без ключ.",
     "tabQuotaSignals": "Квотни сигнали",
     "tabApiKey": "Унифициран API ключ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -319,6 +319,8 @@
     "tabProviders": "প্রদানকারী",
     "checklistSummary": "{total}টি প্রদানকারীর মধ্যে {configured}টি কনফিগার করা হয়েছে",
     "checklistKeyless": "কোনো কী প্রয়োজন নেই",
+    "checklistNoKeyTip": "এখনও কোনো কী যোগ করা হয়নি। যোগ করতে ক্লিক করুন।",
+    "checklistKeylessTip": "কী ছাড়াই কাজ করে।",
     "tabQuotaSignals": "কোটা সংকেত",
     "tabApiKey": "ইউনিফাইড API কী",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -319,6 +319,8 @@
     "tabProviders": "Poskytovatelé",
     "checklistSummary": "Nastaveno {configured} z {total} poskytovatelů",
     "checklistKeyless": "klíč není potřeba",
+    "checklistNoKeyTip": "Zatím nebyl přidán žádný klíč. Kliknutím jej přidáte.",
+    "checklistKeylessTip": "Funguje bez klíče.",
     "tabQuotaSignals": "Kvótové signály",
     "tabApiKey": "Sjednocený API klíč",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -319,6 +319,8 @@
     "tabProviders": "Udbydere",
     "checklistSummary": "{configured} af {total} udbydere er konfigureret",
     "checklistKeyless": "ingen nøgle påkrævet",
+    "checklistNoKeyTip": "Der er endnu ikke tilføjet en nøgle. Klik for at tilføje en.",
+    "checklistKeylessTip": "Virker uden nøgle.",
     "tabQuotaSignals": "Kvotesignaler",
     "tabApiKey": "Unified API nøgle",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -319,6 +319,8 @@
     "tabProviders": "Anbieter",
     "checklistSummary": "{configured} von {total} Anbietern eingerichtet",
     "checklistKeyless": "kein Schlüssel nötig",
+    "checklistNoKeyTip": "Noch kein Schlüssel hinzugefügt. Zum Hinzufügen klicken.",
+    "checklistKeylessTip": "Funktioniert ohne Schlüssel.",
     "tabQuotaSignals": "Quotensignale",
     "tabApiKey": "Einheitlicher API-Schlüssel",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -319,6 +319,8 @@
     "tabProviders": "Πάροχοι",
     "checklistSummary": "{configured} από {total} παρόχους έχουν ρυθμιστεί",
     "checklistKeyless": "δεν απαιτείται κλειδί",
+    "checklistNoKeyTip": "Δεν έχει προστεθεί κλειδί ακόμη. Κάντε κλικ για να προσθέσετε ένα.",
+    "checklistKeylessTip": "Λειτουργεί χωρίς κλειδί.",
     "tabQuotaSignals": "Σήματα ποσοστώσεων",
     "tabApiKey": "Ενοποιημένο κλειδί API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -319,6 +319,8 @@
     "tabProviders": "Providers",
     "checklistSummary": "{configured} of {total} providers configured",
     "checklistKeyless": "no key needed",
+    "checklistNoKeyTip": "No key added yet. Click to add one.",
+    "checklistKeylessTip": "Works without a key.",
     "tabQuotaSignals": "Quota signals",
     "tabApiKey": "Unified API key",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -319,6 +319,8 @@
     "tabProviders": "Proveedores",
     "checklistSummary": "{configured} de {total} proveedores configurados",
     "checklistKeyless": "no se necesita clave",
+    "checklistNoKeyTip": "Aún no se ha añadido ninguna clave. Haz clic para añadir una.",
+    "checklistKeylessTip": "Funciona sin clave.",
     "tabQuotaSignals": "Señales de cuota",
     "tabApiKey": "Clave de API unificada",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -319,6 +319,8 @@
     "tabProviders": "ارائه دهندگان",
     "checklistSummary": "{configured} از {total} ارائه‌دهنده پیکربندی شده است",
     "checklistKeyless": "بدون نیاز به کلید",
+    "checklistNoKeyTip": "هنوز کلیدی اضافه نشده است. برای افزودن کلیک کنید.",
+    "checklistKeylessTip": "بدون کلید کار می‌کند.",
     "tabQuotaSignals": "سیگنال های سهمیه ای",
     "tabApiKey": "کلید یکپارچه API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -319,6 +319,8 @@
     "tabProviders": "Palveluntarjoajat",
     "checklistSummary": "{configured}/{total} palveluntarjoajaa määritetty",
     "checklistKeyless": "avainta ei tarvita",
+    "checklistNoKeyTip": "Avainta ei ole vielä lisätty. Lisää napsauttamalla.",
+    "checklistKeylessTip": "Toimii ilman avainta.",
     "tabQuotaSignals": "Kiintiösignaalit",
     "tabApiKey": "Yhtenäinen API avain",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -319,6 +319,8 @@
     "tabProviders": "Fournisseurs",
     "checklistSummary": "{configured} fournisseurs sur {total} configurés",
     "checklistKeyless": "aucune clé requise",
+    "checklistNoKeyTip": "Aucune clé ajoutée pour l'instant. Cliquez pour en ajouter une.",
+    "checklistKeylessTip": "Fonctionne sans clé.",
     "tabQuotaSignals": "Signaux de quota",
     "tabApiKey": "Clé d'API unifiée",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -319,6 +319,8 @@
     "tabProviders": "પ્રદાતાઓ",
     "checklistSummary": "{total} માંથી {configured} પ્રદાતાઓ ગોઠવેલા છે",
     "checklistKeyless": "કીની જરૂર નથી",
+    "checklistNoKeyTip": "હજી સુધી કોઈ કી ઉમેરી નથી. ઉમેરવા માટે ક્લિક કરો.",
+    "checklistKeylessTip": "કી વિના કામ કરે છે.",
     "tabQuotaSignals": "ક્વોટા સંકેતો",
     "tabApiKey": "એકીકૃત API કી",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -319,6 +319,8 @@
     "tabProviders": "Masu bayarwa",
     "checklistSummary": "An saita {configured} daga cikin {total} masu bayarwa",
     "checklistKeyless": "ba a buƙatar maɓalli",
+    "checklistNoKeyTip": "Ba a ƙara maɓalli ba tukuna. Danna don ƙarawa.",
+    "checklistKeylessTip": "Yana aiki ba tare da maɓalli ba.",
     "tabQuotaSignals": "Alamun ƙididdiga",
     "tabApiKey": "Maɓallin API haɗe",
     "tabAnthropic": "Saukewa: Anthropic",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -319,6 +319,8 @@
     "tabProviders": "ספקים",
     "checklistSummary": "{configured} מתוך {total} ספקים הוגדרו",
     "checklistKeyless": "אין צורך במפתח",
+    "checklistNoKeyTip": "עדיין לא נוסף מפתח. לחץ כדי להוסיף.",
+    "checklistKeylessTip": "עובד ללא מפתח.",
     "tabQuotaSignals": "אותות מכסה",
     "tabApiKey": "מפתח API מאוחד",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -319,6 +319,8 @@
     "tabProviders": "प्रदाता",
     "checklistSummary": "{total} में से {configured} प्रदाता कॉन्फ़िगर किए गए",
     "checklistKeyless": "कुंजी की आवश्यकता नहीं",
+    "checklistNoKeyTip": "अभी तक कोई कुंजी नहीं जोड़ी गई। जोड़ने के लिए क्लिक करें।",
+    "checklistKeylessTip": "कुंजी के बिना काम करता है।",
     "tabQuotaSignals": "कोटा संकेत",
     "tabApiKey": "एकीकृत API कुंजी",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -319,6 +319,8 @@
     "tabProviders": "Pružatelji usluga",
     "checklistSummary": "Konfigurirano {configured} od {total} pružatelja usluga",
     "checklistKeyless": "ključ nije potreban",
+    "checklistNoKeyTip": "Ključ još nije dodan. Kliknite za dodavanje.",
+    "checklistKeylessTip": "Radi bez ključa.",
     "tabQuotaSignals": "Kvotni signali",
     "tabApiKey": "Ujedinjeni API ključ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -319,6 +319,8 @@
     "tabProviders": "Szolgáltatók",
     "checklistSummary": "{total} szolgáltatóból {configured} beállítva",
     "checklistKeyless": "nem kell kulcs",
+    "checklistNoKeyTip": "Még nincs hozzáadva kulcs. Kattintson a hozzáadáshoz.",
+    "checklistKeylessTip": "Kulcs nélkül működik.",
     "tabQuotaSignals": "Kvótajelzések",
     "tabApiKey": "Egységes API kulcs",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -319,6 +319,8 @@
     "tabProviders": "Penyedia",
     "checklistSummary": "{configured} dari {total} penyedia telah dikonfigurasi",
     "checklistKeyless": "tidak perlu kunci",
+    "checklistNoKeyTip": "Belum ada kunci yang ditambahkan. Klik untuk menambahkan.",
+    "checklistKeylessTip": "Berfungsi tanpa kunci.",
     "tabQuotaSignals": "Sinyal kuota",
     "tabApiKey": "Kunci API terpadu",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -319,6 +319,8 @@
     "tabProviders": "Ndị na-enye ihe",
     "checklistSummary": "Ahaziela {configured} n'ime {total} ndị na-enye ihe",
     "checklistKeyless": "achọghị igodo",
+    "checklistNoKeyTip": "Etinyebeghị igodo. Pịa iji tinye otu.",
+    "checklistKeylessTip": "Ọ na-arụ ọrụ na-enweghị igodo.",
     "tabQuotaSignals": "Ngosipụta oke",
     "tabApiKey": "Igodo API jikọtara ọnụ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -319,6 +319,8 @@
     "tabProviders": "Fornitori",
     "checklistSummary": "{configured} fornitori su {total} configurati",
     "checklistKeyless": "nessuna chiave richiesta",
+    "checklistNoKeyTip": "Nessuna chiave aggiunta. Clicca per aggiungerne una.",
+    "checklistKeylessTip": "Funziona senza chiave.",
     "tabQuotaSignals": "Segnali quota",
     "tabApiKey": "Chiave API unificata",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -319,6 +319,8 @@
     "tabProviders": "プロバイダー",
     "checklistSummary": "{total}件中{configured}件のプロバイダーを設定済み",
     "checklistKeyless": "キー不要",
+    "checklistNoKeyTip": "キーがまだ追加されていません。クリックして追加します。",
+    "checklistKeylessTip": "キーなしで利用できます。",
     "tabQuotaSignals": "クォータ信号",
     "tabApiKey": "統一されたAPIキー",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -319,6 +319,8 @@
     "tabProviders": "პროვაიდერები",
     "checklistSummary": "{total}-დან {configured} პროვაიდერი კონფიგურირებულია",
     "checklistKeyless": "გასაღები არ არის საჭირო",
+    "checklistNoKeyTip": "გასაღები ჯერ არ დამატებულა. დააწკაპუნეთ დასამატებლად.",
+    "checklistKeylessTip": "მუშაობს გასაღების გარეშე.",
     "tabQuotaSignals": "კვოტის სიგნალები",
     "tabApiKey": "ერთიანი API გასაღები",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -319,6 +319,8 @@
     "tabProviders": "អ្នកផ្តល់សេវា",
     "checklistSummary": "បានកំណត់រចនាសម្ព័ន្ធអ្នកផ្តល់សេវា {configured} ក្នុងចំណោម {total}",
     "checklistKeyless": "មិនត្រូវការសោ",
+    "checklistNoKeyTip": "មិនទាន់បានបន្ថែមសោនៅឡើយទេ។ ចុចដើម្បីបន្ថែម។",
+    "checklistKeylessTip": "ដំណើរការដោយមិនចាំបាច់ប្រើសោ។",
     "tabQuotaSignals": "សញ្ញាកូតា",
     "tabApiKey": "កូនសោ API រួម",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -319,6 +319,8 @@
     "tabProviders": "ಪೂರೈಕೆದಾರರು",
     "checklistSummary": "{total} ರಲ್ಲಿ {configured} ಪೂರೈಕೆದಾರರನ್ನು ಕಾನ್ಫಿಗರ್ ಮಾಡಲಾಗಿದೆ",
     "checklistKeyless": "ಕೀ ಅಗತ್ಯವಿಲ್ಲ",
+    "checklistNoKeyTip": "ಇನ್ನೂ ಯಾವುದೇ ಕೀ ಸೇರಿಸಿಲ್ಲ. ಸೇರಿಸಲು ಕ್ಲಿಕ್ ಮಾಡಿ.",
+    "checklistKeylessTip": "ಕೀ ಇಲ್ಲದೆ ಕೆಲಸ ಮಾಡುತ್ತದೆ.",
     "tabQuotaSignals": "ಕೋಟಾ ಸಂಕೇತಗಳು",
     "tabApiKey": "ಏಕೀಕೃತ API ಕೀ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -319,6 +319,8 @@
     "tabProviders": "공급자",
     "checklistSummary": "{total}개 공급자 중 {configured}개 설정됨",
     "checklistKeyless": "키 필요 없음",
+    "checklistNoKeyTip": "아직 키를 추가하지 않았습니다. 클릭하여 추가하세요.",
+    "checklistKeylessTip": "키 없이 작동합니다.",
     "tabQuotaSignals": "할당량 신호",
     "tabApiKey": "통합 API 키",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -319,6 +319,8 @@
     "tabProviders": "Tiekėjai",
     "checklistSummary": "Sukonfigūruota {configured} iš {total} tiekėjų",
     "checklistKeyless": "rakto nereikia",
+    "checklistNoKeyTip": "Raktas dar nepridėtas. Spustelėkite, kad pridėtumėte.",
+    "checklistKeylessTip": "Veikia be rakto.",
     "tabQuotaSignals": "Kvotų signalai",
     "tabApiKey": "Vieningas API raktas",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -319,6 +319,8 @@
     "tabProviders": "ദാതാക്കൾ",
     "checklistSummary": "{total}-ൽ {configured} ദാതാക്കൾ കോൺഫിഗർ ചെയ്തു",
     "checklistKeyless": "കീ ആവശ്യമില്ല",
+    "checklistNoKeyTip": "ഇതുവരെ കീ ചേർത്തിട്ടില്ല. ചേർക്കാൻ ക്ലിക്ക് ചെയ്യുക.",
+    "checklistKeylessTip": "കീ ഇല്ലാതെ പ്രവർത്തിക്കുന്നു.",
     "tabQuotaSignals": "ക്വാട്ട സിഗ്നലുകൾ",
     "tabApiKey": "ഏകീകൃത API കീ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -319,6 +319,8 @@
     "tabProviders": "प्रदाते",
     "checklistSummary": "{total} पैकी {configured} प्रदाते कॉन्फिगर केले",
     "checklistKeyless": "की आवश्यक नाही",
+    "checklistNoKeyTip": "अद्याप कोणतीही की जोडलेली नाही. जोडण्यासाठी क्लिक करा.",
+    "checklistKeylessTip": "कीशिवाय काम करते.",
     "tabQuotaSignals": "कोटा सिग्नल",
     "tabApiKey": "युनिफाइड API की",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -319,6 +319,8 @@
     "tabProviders": "Penyedia",
     "checklistSummary": "{configured} daripada {total} penyedia telah dikonfigurasi",
     "checklistKeyless": "tiada kunci diperlukan",
+    "checklistNoKeyTip": "Belum ada kunci ditambah. Klik untuk menambah.",
+    "checklistKeylessTip": "Berfungsi tanpa kunci.",
     "tabQuotaSignals": "Isyarat kuota",
     "tabApiKey": "Kunci API bersatu",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -319,6 +319,8 @@
     "tabProviders": "ပံ့ပိုးသူများ",
     "checklistSummary": "ပံ့ပိုးသူ {total} ဦးအနက် {configured} ဦး သတ်မှတ်ပြီး",
     "checklistKeyless": "ကီး မလိုအပ်ပါ",
+    "checklistNoKeyTip": "ကီး မထည့်ရသေးပါ။ ထည့်ရန် နှိပ်ပါ။",
+    "checklistKeylessTip": "ကီး မပါဘဲ အလုပ်လုပ်ပါသည်။",
     "tabQuotaSignals": "အရေအတွက် အချက်ပြချက်များ",
     "tabApiKey": "ပေါင်းစည်းထားသော API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -319,6 +319,8 @@
     "tabProviders": "प्रदायकहरू",
     "checklistSummary": "{total} मध्ये {configured} प्रदायकहरू कन्फिगर गरिएको",
     "checklistKeyless": "कुञ्जी आवश्यक छैन",
+    "checklistNoKeyTip": "अहिलेसम्म कुनै कुञ्जी थपिएको छैन। थप्न क्लिक गर्नुहोस्।",
+    "checklistKeylessTip": "कुञ्जी बिना काम गर्छ।",
     "tabQuotaSignals": "कोटा सङ्केतहरू",
     "tabApiKey": "एकीकृत API कुञ्जी",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -319,6 +319,8 @@
     "tabProviders": "Aanbieders",
     "checklistSummary": "{configured} van {total} aanbieders ingesteld",
     "checklistKeyless": "geen sleutel nodig",
+    "checklistNoKeyTip": "Nog geen sleutel toegevoegd. Klik om er een toe te voegen.",
+    "checklistKeylessTip": "Werkt zonder sleutel.",
     "tabQuotaSignals": "Quotasignalen",
     "tabApiKey": "Unified API sleutel",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -319,6 +319,8 @@
     "tabProviders": "Leverandører",
     "checklistSummary": "{configured} av {total} leverandører konfigurert",
     "checklistKeyless": "ingen nøkkel kreves",
+    "checklistNoKeyTip": "Ingen nøkkel er lagt til ennå. Klikk for å legge til en.",
+    "checklistKeylessTip": "Fungerer uten nøkkel.",
     "tabQuotaSignals": "Kvotesignaler",
     "tabApiKey": "Enhetlig API nøkkel",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -319,6 +319,8 @@
     "tabProviders": "ପ୍ରଦାନକାରୀ",
     "checklistSummary": "{total} ମଧ୍ୟରୁ {configured} ପ୍ରଦାନକାରୀ ବିନ୍ୟାସ ହୋଇଛି",
     "checklistKeyless": "କି ଆବଶ୍ୟକ ନାହିଁ",
+    "checklistNoKeyTip": "ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି କି ଯୋଡାଯାଇ ନାହିଁ। ଯୋଡିବା ପାଇଁ କ୍ଲିକ୍ କରନ୍ତୁ।",
+    "checklistKeylessTip": "କି ବିନା କାମ କରେ।",
     "tabQuotaSignals": "କୋଟା ସଙ୍କେତ",
     "tabApiKey": "ଏକୀକୃତ API କୀ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -319,6 +319,8 @@
     "tabProviders": "ਪ੍ਰਦਾਤਾ",
     "checklistSummary": "{total} ਵਿੱਚੋਂ {configured} ਪ੍ਰਦਾਤਾ ਸੰਰਚਿਤ ਕੀਤੇ ਗਏ",
     "checklistKeyless": "ਕੁੰਜੀ ਦੀ ਲੋੜ ਨਹੀਂ",
+    "checklistNoKeyTip": "ਅਜੇ ਤੱਕ ਕੋਈ ਕੁੰਜੀ ਸ਼ਾਮਲ ਨਹੀਂ ਕੀਤੀ ਗਈ। ਸ਼ਾਮਲ ਕਰਨ ਲਈ ਕਲਿੱਕ ਕਰੋ।",
+    "checklistKeylessTip": "ਕੁੰਜੀ ਤੋਂ ਬਿਨਾਂ ਕੰਮ ਕਰਦਾ ਹੈ।",
     "tabQuotaSignals": "ਕੋਟਾ ਸਿਗਨਲ",
     "tabApiKey": "ਯੂਨੀਫਾਈਡ API ਕੁੰਜੀ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -319,6 +319,8 @@
     "tabProviders": "Dostawcy",
     "checklistSummary": "Skonfigurowano {configured} z {total} dostawców",
     "checklistKeyless": "klucz niepotrzebny",
+    "checklistNoKeyTip": "Nie dodano jeszcze klucza. Kliknij, aby dodać.",
+    "checklistKeylessTip": "Działa bez klucza.",
     "tabQuotaSignals": "Sygnały kwotowe",
     "tabApiKey": "Ujednolicony klucz API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -319,6 +319,8 @@
     "tabProviders": "Provedores",
     "checklistSummary": "{configured} de {total} provedores configurados",
     "checklistKeyless": "não precisa de chave",
+    "checklistNoKeyTip": "Nenhuma chave adicionada ainda. Clique para adicionar uma.",
+    "checklistKeylessTip": "Funciona sem chave.",
     "tabQuotaSignals": "Sinais de cota",
     "tabApiKey": "Chave de API unificada",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -319,6 +319,8 @@
     "tabProviders": "Fornecedores",
     "checklistSummary": "{configured} de {total} fornecedores configurados",
     "checklistKeyless": "não requer chave",
+    "checklistNoKeyTip": "Ainda não foi adicionada nenhuma chave. Clique para adicionar uma.",
+    "checklistKeylessTip": "Funciona sem chave.",
     "tabQuotaSignals": "Sinais de quota",
     "tabApiKey": "Chave API unificada",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -319,6 +319,8 @@
     "tabProviders": "Furnizori",
     "checklistSummary": "{configured} din {total} furnizori configurați",
     "checklistKeyless": "nu necesită cheie",
+    "checklistNoKeyTip": "Nicio cheie adăugată încă. Faceți clic pentru a adăuga una.",
+    "checklistKeylessTip": "Funcționează fără cheie.",
     "tabQuotaSignals": "Semnale de cotă",
     "tabApiKey": "Cheia API unificată",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -319,6 +319,8 @@
     "tabProviders": "Провайдеры",
     "checklistSummary": "Настроено {configured} из {total} провайдеров",
     "checklistKeyless": "ключ не нужен",
+    "checklistNoKeyTip": "Ключ ещё не добавлен. Нажмите, чтобы добавить.",
+    "checklistKeylessTip": "Работает без ключа.",
     "tabQuotaSignals": "Сигналы квоты",
     "tabApiKey": "Единый ключ API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -319,6 +319,8 @@
     "tabProviders": "සපයන්නන්",
     "checklistSummary": "සපයන්නන් {total} දෙනාගෙන් {configured} ක් වින්‍යාස කර ඇත",
     "checklistKeyless": "යතුරක් අවශ්‍ය නැත",
+    "checklistNoKeyTip": "තවම යතුරක් එක් කර නැත. එක් කිරීමට ක්ලික් කරන්න.",
+    "checklistKeylessTip": "යතුරක් නොමැතිව ක්‍රියා කරයි.",
     "tabQuotaSignals": "කෝටා සංඥා",
     "tabApiKey": "ඒකාබද්ධ API යතුර",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -319,6 +319,8 @@
     "tabProviders": "Poskytovatelia",
     "checklistSummary": "Nastavených {configured} z {total} poskytovateľov",
     "checklistKeyless": "kľúč nie je potrebný",
+    "checklistNoKeyTip": "Zatiaľ nebol pridaný žiadny kľúč. Kliknutím ho pridáte.",
+    "checklistKeylessTip": "Funguje bez kľúča.",
     "tabQuotaSignals": "Kvótové signály",
     "tabApiKey": "Zjednotený API kľúč",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -319,6 +319,8 @@
     "tabProviders": "Провајдери",
     "checklistSummary": "Подешено {configured} од {total} провајдера",
     "checklistKeyless": "кључ није потребан",
+    "checklistNoKeyTip": "Кључ још није додат. Кликните да бисте га додали.",
+    "checklistKeylessTip": "Ради без кључа.",
     "tabQuotaSignals": "Квотни сигнали",
     "tabApiKey": "Обједињени кључ API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -319,6 +319,8 @@
     "tabProviders": "Leverantörer",
     "checklistSummary": "{configured} av {total} leverantörer konfigurerade",
     "checklistKeyless": "ingen nyckel krävs",
+    "checklistNoKeyTip": "Ingen nyckel har lagts till än. Klicka för att lägga till en.",
+    "checklistKeylessTip": "Fungerar utan nyckel.",
     "tabQuotaSignals": "Kvotsignaler",
     "tabApiKey": "Enhetlig API nyckel",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -319,6 +319,8 @@
     "tabProviders": "Watoa huduma",
     "checklistSummary": "Watoa huduma {configured} kati ya {total} wamesanidiwa",
     "checklistKeyless": "hakuna ufunguo unaohitajika",
+    "checklistNoKeyTip": "Bado hakuna ufunguo ulioongezwa. Bofya ili kuongeza.",
+    "checklistKeylessTip": "Hufanya kazi bila ufunguo.",
     "tabQuotaSignals": "Ishara za quota",
     "tabApiKey": "Kitufe cha umoja cha API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -319,6 +319,8 @@
     "tabProviders": "வழங்குபவர்கள்",
     "checklistSummary": "{total} இல் {configured} வழங்குபவர்கள் உள்ளமைக்கப்பட்டுள்ளனர்",
     "checklistKeyless": "விசை தேவையில்லை",
+    "checklistNoKeyTip": "இன்னும் விசை எதுவும் சேர்க்கப்படவில்லை. சேர்க்க கிளிக் செய்யவும்.",
+    "checklistKeylessTip": "விசை இல்லாமல் செயல்படும்.",
     "tabQuotaSignals": "ஒதுக்கீடு சமிக்ஞைகள்",
     "tabApiKey": "ஒருங்கிணைந்த API விசை",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -319,6 +319,8 @@
     "tabProviders": "ప్రొవైడర్లు",
     "checklistSummary": "{total}లో {configured} ప్రొవైడర్లు కాన్ఫిగర్ చేయబడ్డాయి",
     "checklistKeyless": "కీ అవసరం లేదు",
+    "checklistNoKeyTip": "ఇంకా కీ జోడించలేదు. జోడించడానికి క్లిక్ చేయండి.",
+    "checklistKeylessTip": "కీ లేకుండా పనిచేస్తుంది.",
     "tabQuotaSignals": "కోటా సంకేతాలు",
     "tabApiKey": "ఏకీకృత API కీ",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -319,6 +319,8 @@
     "tabProviders": "ผู้ให้บริการ",
     "checklistSummary": "กำหนดค่าผู้ให้บริการแล้ว {configured} จาก {total} ราย",
     "checklistKeyless": "ไม่ต้องใช้คีย์",
+    "checklistNoKeyTip": "ยังไม่ได้เพิ่มคีย์ คลิกเพื่อเพิ่ม",
+    "checklistKeylessTip": "ใช้งานได้โดยไม่ต้องใช้คีย์",
     "tabQuotaSignals": "สัญญาณโควต้า",
     "tabApiKey": "คีย์ API แบบรวม",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -319,6 +319,8 @@
     "tabProviders": "Mga Tagapagbigay",
     "checklistSummary": "{configured} sa {total} tagapagbigay ang naka-configure",
     "checklistKeyless": "hindi kailangan ng key",
+    "checklistNoKeyTip": "Wala pang key na naidagdag. I-click para magdagdag.",
+    "checklistKeylessTip": "Gumagana nang walang key.",
     "tabQuotaSignals": "Mga senyales ng quota",
     "tabApiKey": "Pinag-isang API key",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -319,6 +319,8 @@
     "tabProviders": "Sağlayıcılar",
     "checklistSummary": "{total} sağlayıcıdan {configured} tanesi yapılandırıldı",
     "checklistKeyless": "anahtar gerekmez",
+    "checklistNoKeyTip": "Henüz anahtar eklenmedi. Eklemek için tıklayın.",
+    "checklistKeylessTip": "Anahtarsız çalışır.",
     "tabQuotaSignals": "Kota sinyalleri",
     "tabApiKey": "Birleşik API anahtarı",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -319,6 +319,8 @@
     "tabProviders": "Провайдери",
     "checklistSummary": "Налаштовано {configured} із {total} провайдерів",
     "checklistKeyless": "ключ не потрібен",
+    "checklistNoKeyTip": "Ключ ще не додано. Натисніть, щоб додати.",
+    "checklistKeylessTip": "Працює без ключа.",
     "tabQuotaSignals": "Сигнали квоти",
     "tabApiKey": "Уніфікований ключ API",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -319,6 +319,8 @@
     "tabProviders": "فراہم کرنے والے",
     "checklistSummary": "{total} میں سے {configured} فراہم کنندگان ترتیب دیے گئے",
     "checklistKeyless": "کلید کی ضرورت نہیں",
+    "checklistNoKeyTip": "ابھی تک کوئی کلید شامل نہیں کی گئی۔ شامل کرنے کے لیے کلک کریں۔",
+    "checklistKeylessTip": "کلید کے بغیر کام کرتا ہے۔",
     "tabQuotaSignals": "کوٹہ سگنلز",
     "tabApiKey": "متحد API کلید",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -319,6 +319,8 @@
     "tabProviders": "Provayderlar",
     "checklistSummary": "{total} ta provayderdan {configured} tasi sozlangan",
     "checklistKeyless": "kalit kerak emas",
+    "checklistNoKeyTip": "Hali kalit qo'shilmagan. Qo'shish uchun bosing.",
+    "checklistKeylessTip": "Kalitsiz ishlaydi.",
     "tabQuotaSignals": "Kvota signallari",
     "tabApiKey": "Birlashtirilgan API kaliti",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -319,6 +319,8 @@
     "tabProviders": "Nhà cung cấp",
     "checklistSummary": "Đã cấu hình {configured} trong {total} nhà cung cấp",
     "checklistKeyless": "không cần khóa",
+    "checklistNoKeyTip": "Chưa thêm khóa nào. Nhấp để thêm.",
+    "checklistKeylessTip": "Hoạt động mà không cần khóa.",
     "tabQuotaSignals": "tín hiệu hạn ngạch",
     "tabApiKey": "Khóa API hợp nhất",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -319,6 +319,8 @@
     "tabProviders": "Awọn olupese",
     "checklistSummary": "A ti ṣètò {configured} nínú {total} olùpèsè",
     "checklistKeyless": "kò nílò kọ́kọ́rọ́",
+    "checklistNoKeyTip": "Kò sí kọ́kọ́rọ́ tí a ti fi kún un. Tẹ̀ láti fi kọ́kọ́rọ́ kún un.",
+    "checklistKeylessTip": "Ó ń ṣiṣẹ́ láìsí kọ́kọ́rọ́.",
     "tabQuotaSignals": "Quota awọn ifihan agbara",
     "tabApiKey": "Bọtini API ti iṣọkan",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -319,6 +319,8 @@
     "tabProviders": "提供方",
     "checklistSummary": "已配置 {configured}/{total} 个提供方",
     "checklistKeyless": "无需密钥",
+    "checklistNoKeyTip": "尚未添加密钥。点击添加一个。",
+    "checklistKeylessTip": "无需密钥即可使用。",
     "tabQuotaSignals": "配额信号",
     "tabApiKey": "统一 API 密钥",
     "tabAnthropic": "Anthropic",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -319,6 +319,8 @@
     "tabProviders": "提供者",
     "checklistSummary": "已設定 {configured}/{total} 個提供者",
     "checklistKeyless": "無需金鑰",
+    "checklistNoKeyTip": "尚未新增金鑰。點擊即可新增。",
+    "checklistKeylessTip": "無需金鑰即可使用。",
     "tabQuotaSignals": "配額訊號",
     "tabApiKey": "統一 API 金鑰",
     "tabAnthropic": "Anthropic",


### PR DESCRIPTION
Follow-up to #777. The amber "no key" and muted "no key needed" text labels on the provider checklist chips are now icons (KeyRound in amber, Unlock in muted) with the explanation moved to a tooltip that opens on hover and keyboard focus. The short labels remain as sr-only text so accessible names are unchanged. Tooltip copy added to all 60 locales.