### PR TITLE
fix(keys): drop the unverified 100K/day claim from the AnyAPI picker label

### DIFF
--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -54,7 +54,11 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'navy', label: 'NavyAI (free key)', url: 'https://api.navy' },
   { value: 'nara', label: 'NaraRouter (free key)', url: 'https://router.bynara.id' },
   { value: 'sealion', label: 'SEA-LION (free key)', url: 'https://sea-lion.ai' },
-  { value: 'anyapi', label: 'AnyAPI (free key, 100K tokens/day)', url: 'https://anyapi.ai' },
+  // AnyAPI advertises 100K tokens/day free, but live testing on 2026-08-10
+  // could not get a single free-tier request served (see
+  // CATALOG-ANYAPI-SMOKE-2026-08-10 in the ops repo). No quota claim until
+  // their free tier demonstrably works.
+  { value: 'anyapi', label: 'AnyAPI (free key)', url: 'https://anyapi.ai' },
   { value: 'modelscope', label: 'ModelScope (free key, needs Aliyun cn binding)', url: 'https://modelscope.cn/my/myaccesstoken' },
   { value: 'aihorde', label: 'AI Horde (no key needed, slow)', url: 'https://aihorde.net/register', keyless: true },
 ]


### PR DESCRIPTION
Live testing on 2026-08-10 could not get a single AnyAPI free-tier request served (13 listed :free models: 7 hard 404, 6 permanent 429, zero cost billed, AnyChat also failing). The provider stays registered, but the picker should not advertise a daily quota we could not observe. No catalog rows are being added.