### PR TITLE
fix(responses,shared): report reasoning_tokens truthfully (#764)

### DIFF
--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -153,6 +153,29 @@ describe('POST /v1/responses (#96)', () => {
     // ttfb must be the reasoning-head moment (well before the text token that
     // triggers the commit), not the flush time ≈ latency.
     expect(rows[0].ttfb_ms).toBeLessThan(rows[0].latency_ms - 250);
+    // The completed Response reports the thinking tokens truthfully instead of
+    // a hardcoded 0: 'thinking hard…' is 14 chars → ceil(14/4) = 4.
+    const completed = text.split('event: response.completed')[1];
+    const payload = JSON.parse(completed.slice(completed.indexOf('{')));
+    expect(payload.response.usage.output_tokens_details.reasoning_tokens).toBe(4);
+  });
+
+  it('non-stream: reports reasoning_tokens from the provider usage when advertised', async () => {
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'answer', reasoning_content: 'thinking' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 6, total_tokens: 9, completion_tokens_details: { reasoning_tokens: 2 } },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }));
+
+    const { status, text } = await post(app, '/v1/responses', { input: 'hi', stream: false }, key);
+    expect(status).toBe(200);
+    const body = JSON.parse(text);
+    expect(body.usage.output_tokens_details.reasoning_tokens).toBe(2);
   });
 
   it('stream: tool-call deltas produce function_call events with assembled arguments', async () => {

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -258,6 +258,7 @@ export function buildResponseObject(opts: {
   toolCalls: ChatToolCall[];
   promptTokens: number;
   completionTokens: number;
+  reasoningTokens?: number;
 }) {
   const output: any[] = [];
   if (opts.text.length > 0) {
@@ -292,7 +293,7 @@ export function buildResponseObject(opts: {
       input_tokens: opts.promptTokens,
       input_tokens_details: { cached_tokens: 0 },
       output_tokens: opts.completionTokens,
-      output_tokens_details: { reasoning_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: opts.reasoningTokens ?? 0 },
       total_tokens: opts.promptTokens + opts.completionTokens,
     },
   };
@@ -539,6 +540,10 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         // tool-call accumulator keyed by the provider's tool_call index
         const toolAcc = new Map<number, { outputIndex: number; itemId: string; callId: string; name: string; args: string }>();
         let totalOutputTokens = 0;
+        // #764: thinking tokens are tracked separately so the final Response
+        // object can report `output_tokens_details.reasoning_tokens` truthfully
+        // instead of a hardcoded 0.
+        let totalReasoningTokens = 0;
         // #764: ttfb = first token of ANY kind (content or reasoning), recorded
         // in the pump loop; commit() only backfills streams that never produced
         // one. This path previously logged no ttfb at all, so Analytics showed
@@ -632,6 +637,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             }
             if (text) {
               totalOutputTokens += Math.ceil((text.length + reasoning.length) / 4);
+              if (reasoning.length > 0) totalReasoningTokens += Math.ceil(reasoning.length / 4);
               if (dialectMode === 'passthrough') {
                 if (msgItemId === null) openTextItem('');
                 sse('response.output_text.delta', {
@@ -654,6 +660,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             } else if (reasoning.length > 0) {
               // #764: thinking-only chunk (no visible text yet) — count tokens.
               totalOutputTokens += Math.ceil(reasoning.length / 4);
+              totalReasoningTokens += Math.ceil(reasoning.length / 4);
             }
 
             // Tool-call deltas → function_call item + argument deltas.
@@ -772,6 +779,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
           const finalResponse = buildResponseObject({
             id: responseId, model: route.modelId, text: msgText,
             toolCalls: finalToolCalls, promptTokens: estimatedInputTokens, completionTokens: totalOutputTokens,
+            reasoningTokens: totalReasoningTokens,
           });
           sse('response.completed', { response: finalResponse });
           res.end();
@@ -857,6 +865,10 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       // provider omits `usage`.
       const completionTokens = result.usage?.completion_tokens
         ?? Math.ceil((text.length + completionReasoningText(result).length) / 4);
+      // #764: report reasoning_tokens truthfully — the provider's own count
+      // when advertised, else the same chars/4 estimate of the thinking text.
+      const reasoningTokens = result.usage?.completion_tokens_details?.reasoning_tokens
+        ?? Math.ceil(completionReasoningText(result).length / 4);
 
       // Empty completion → fail over via the shared loop (see the streaming
       // path); finish_reason 'length' skips the cooldown/penalty.
@@ -896,7 +908,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
       setFallbackHeaders(res, attempt, attemptLog);
       res.json(buildResponseObject({
         id: responseId, model: route.modelId, text, toolCalls,
-        promptTokens, completionTokens,
+        promptTokens, completionTokens, reasoningTokens,
       }));
 
       traceRouteEvent('Responses', {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -359,6 +359,11 @@ export interface TokenUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  // OpenAI-standard breakdown some providers advertise alongside the totals.
+  // Optional because many free-tier endpoints omit it; the proxy falls back
+  // to its chars/4 estimate when absent. (#764)
+  completion_tokens_details?: { reasoning_tokens?: number };
+  prompt_tokens_details?: { cached_tokens?: number };
 }
 
 export interface ChatCompletionResponse {


### PR DESCRIPTION
## What
/v1/responses 此前把 output_tokens_details.reasoning_tokens 硬编码为 0。两条路径都如实上报思维 token。

## Change
- buildResponseObject 接受可选 reasoningTokens，替代常量 0
- 流式路径：totalReasoningTokens 按 chars/4 累计每个 reasoning_content 帧（text 帧与纯思考帧都计）
- 非流式路径：优先用 provider 声明的 completion_tokens_details.reasoning_tokens，缺失时回退 chars/4 估算
- shared TokenUsage 增加可选的 OpenAI 标准 breakdown 字段（completion_tokens_details / prompt_tokens_details）

## Tests
- 流式：response.completed 的 reasoning_tokens 等于思考文本 chars/4 计数（'thinking hard…' 14 字符 → 4）
- 非流式：provider 声明 reasoning_tokens 时如实透传（2）
responses.test.ts 16/16 通过，tsc 干净。

## Notes
与 hedging（#778 拆分出的另一块）拆开独立提交，按作者建议单独 review。