### PR TITLE
fix(tooltip): dismiss lingering tooltips on pointerdown and Escape (#826)

### DIFF
--- a/client/src/components/tooltip.tsx
+++ b/client/src/components/tooltip.tsx
@@ -24,12 +24,18 @@ export function Tooltip({ text, children, side = 'top', className }: {
   }
   const hide = () => setCoords(null)
 
-  // #826: a modal (copy-key / model-scope dialog) opening on top of the
-  // trigger swallows the mouseleave, so the tooltip state survives the dialog
-  // and the black box lingers after it closes. While visible, also hide on any
-  // mousemove that leaves the trigger's rect (with a small tolerance to avoid
-  // flicker at the edge) — the pointer-events-none tooltip itself never
-  // intercepts events, so this is the reliable cleanup.
+  // #826: a hover tooltip lingers after a dialog (copy full key / model
+  // scope) is opened on top of its trigger and closed again — the mouse never
+  // actually leaves the trigger, so `mouseleave` never fires and the tooltip
+  // stays until the pointer happens to cross another hot-zone. Two
+  // complementary cleanups, both only attached while a tooltip is showing:
+  //  - hide on any mousemove that leaves the trigger's rect (with a small
+  //    tolerance to avoid flicker at the edge) — the pointer-events-none
+  //    tooltip itself never intercepts events, so this is the reliable
+  //    cleanup when the pointer actually moves away;
+  //  - hide on any pointerdown (covers the click that opens the dialog) and
+  //    on Escape (the dialog's own close key), so a tooltip can't outlive the
+  //    popup that covered it even if the pointer never moves.
   useEffect(() => {
     if (!coords) return
     const onMove = (e: MouseEvent) => {
@@ -40,8 +46,18 @@ export function Tooltip({ text, children, side = 'top', className }: {
         && e.clientY >= r.top - 4 && e.clientY <= r.bottom + 4
       if (!inside) hide()
     }
+    const onPointerDown = () => hide()
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') hide()
+    }
     document.addEventListener('mousemove', onMove)
-    return () => document.removeEventListener('mousemove', onMove)
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
   }, [coords])
 
   return (


### PR DESCRIPTION
## What
修复 #826：hover tooltip 在弹窗（copy full key / model scope）打开再关闭后会残留，直到鼠标恰好划过其他热区。

## Why
tooltip 通过 portal 渲染到 document.body，弹窗盖住触发元素打开再关闭时，鼠标从未真正离开触发元素，`mouseleave` 不会触发，tooltip 就一直挂着；残留期间鼠标触发新热区时新旧 tooltip 还会叠加。

## Fix
- tooltip 可见期间监听全局 `pointerdown`（覆盖打开弹窗的那次点击）与 `Escape`（弹窗自身关闭键），任一触发即隐藏
- 监听仅在 tooltip 显示时挂载，无常驻全局 handler 开销

## Tests
client tsc 干净；无现成 tooltip 测试，改动为纯展示层。