### PR TITLE
fix(agents/models): line-break provider tooltips instead of comma-cluttering them (#789)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ server/data/
 .env.local
 .DS_Store
 
+# TypeScript incremental build cache
+*.tsbuildinfo
+
 # Personal deployment scripts (contain keys/credentials — kept local)
 deploy-pi.sh
 update-hermes.sh

--- a/client/src/components/model-combobox.tsx
+++ b/client/src/components/model-combobox.tsx
@@ -147,7 +147,7 @@ export function ModelCombobox({
                   </span>
                 )}
                 {o.sub && ((o.platforms?.length ?? 0) > 1 ? (
-                  <Tooltip text={t('models.servedBy', { providers: (o.platforms ?? []).join(', ') })}>
+                  <Tooltip text={t('models.servedBy', { providers: (o.platforms ?? []).join('\n') })}>
                     <span className="shrink-0 text-xs text-muted-foreground underline decoration-dotted underline-offset-2">{o.sub}</span>
                   </Tooltip>
                 ) : (

--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -267,7 +267,7 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   const measured = group.members.filter(m => (m.totalRequests ?? 0) > 0)
   const scoreBreakdown = group.members
     .map(m => `${memberProviderLabel(m, siblings)} ${m.score !== undefined ? m.score.toFixed(3) : '–'}`)
-    .join(' · ')
+    .join('\n')
   const vision = group.members.some(m => m.supportsVision)
   const tools = group.members.some(m => m.supportsTools)
   const quota = groupQuotaBadge(group.members, t)
@@ -287,7 +287,7 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
             <span className="font-medium text-sm">{group.label}</span>
             {solo
               ? <span className="text-xs text-muted-foreground" title={memberEndpointTitle(group.members[0], siblings)}>{memberProviderLabel(group.members[0], siblings)}</span>
-              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => memberProviderLabel(m, siblings)).join(', ') })}>
+              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => memberProviderLabel(m, siblings)).join('\n') })}>
                   <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: group.members.length })}</span>
                 </Tooltip>}
             {quota && (

--- a/client/src/components/tooltip.tsx
+++ b/client/src/components/tooltip.tsx
@@ -44,7 +44,7 @@ export function Tooltip({ text, children, side = 'top', className }: {
             transform: side === 'top' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
             zIndex: 9999,
           }}
-          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md"
+          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md whitespace-pre-line"
         >
           {text}
         </span>,


### PR DESCRIPTION
## What
#789：provider 过多的 tooltip 文本挤成一长串逗号连接，难以阅读。

## Change
- tooltip 容器支持 `whitespace-pre-line`，多 provider 用换行（`\n`）分隔而不是逗号
- model-combobox / model-table 的 servedBy 与 score breakdown tooltip 改为逐行展示
- 附带：AgentIcon 无品牌图标时使用 lettermark 兜底（atomcode/mimo 用品牌色）