### PR TITLE
fix(models): line-break provider tooltips instead of comma-cluttering them (#789)

### DIFF
--- a/client/src/components/model-combobox.tsx
+++ b/client/src/components/model-combobox.tsx
@@ -147,7 +147,7 @@ export function ModelCombobox({
                   </span>
                 )}
                 {o.sub && ((o.platforms?.length ?? 0) > 1 ? (
-                  <Tooltip text={t('models.servedBy', { providers: (o.platforms ?? []).join(', ') })}>
+                  <Tooltip text={t('models.servedBy', { providers: (o.platforms ?? []).join('\n') })}>
                     <span className="shrink-0 text-xs text-muted-foreground underline decoration-dotted underline-offset-2">{o.sub}</span>
                   </Tooltip>
                 ) : (

--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -267,7 +267,7 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   const measured = group.members.filter(m => (m.totalRequests ?? 0) > 0)
   const scoreBreakdown = group.members
     .map(m => `${memberProviderLabel(m, siblings)} ${m.score !== undefined ? m.score.toFixed(3) : '–'}`)
-    .join(' · ')
+    .join('\n')
   const vision = group.members.some(m => m.supportsVision)
   const tools = group.members.some(m => m.supportsTools)
   const quota = groupQuotaBadge(group.members, t)
@@ -287,7 +287,7 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
             <span className="font-medium text-sm">{group.label}</span>
             {solo
               ? <span className="text-xs text-muted-foreground" title={memberEndpointTitle(group.members[0], siblings)}>{memberProviderLabel(group.members[0], siblings)}</span>
-              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => memberProviderLabel(m, siblings)).join(', ') })}>
+              : <Tooltip text={t('models.servedBy', { providers: group.members.map(m => memberProviderLabel(m, siblings)).join('\n') })}>
                   <span className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: group.members.length })}</span>
                 </Tooltip>}
             {quota && (

--- a/client/src/components/tooltip.tsx
+++ b/client/src/components/tooltip.tsx
@@ -44,7 +44,7 @@ export function Tooltip({ text, children, side = 'top', className }: {
             transform: side === 'top' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
             zIndex: 9999,
           }}
-          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md"
+          className="pointer-events-none w-56 rounded-lg bg-foreground px-2.5 py-1.5 text-xs leading-snug text-background shadow-md whitespace-pre-line"
         >
           {text}
         </span>,


### PR DESCRIPTION
Closes #789

## Problem

The model-list tooltips (served-by providers and per-provider scores) joined entries with ", " / " · ", so custom labels and base URLs rendered as an unreadable wall of text.

## Fix

Each entry is now on its own line, and the shared Tooltip component renders \n via whitespace-pre-line.

- model-table.tsx: servedBy join(", ") → join("\n"); scoreBreakdown join(" · ") → join("\n")
- model-combobox.tsx: platforms join(", ") → join("\n")
- tooltip.tsx: whitespace-pre-line so the newlines render

## Verification

client tsc clean.