### PR TITLE
feat(proxy): auto-detect system-wide proxy settings as a last-resort fallback (#353)

### DIFF
--- a/server/src/__tests__/lib/proxy.test.ts
+++ b/server/src/__tests__/lib/proxy.test.ts
@@ -17,6 +17,8 @@ import {
   withKeyProxy,
   probeProxyUrl,
   DEFAULT_PROXY_PROBE_TARGET,
+  parseScutilProxy,
+  parseRegProxy,
 } from '../../lib/proxy.js';
 
 // Every env var the proxy config reads, in both the upper- and lower-case
@@ -831,5 +833,57 @@ describe('probeProxyUrl (#863)', () => {
     const result = await probeProxyUrl(undefined, { timeoutMs: 250 });
 
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('system proxy detection parsers (#353)', () => {
+  it('parses macOS scutil HTTP proxy output', () => {
+    const out = [
+      '<dictionary> {',
+      '  HTTPEnable : 1',
+      '  HTTPPort : 7890',
+      '  HTTPProxy : 127.0.0.1',
+      '  SOCKSEnable : 0',
+      '  SOCKSProxy : 127.0.0.1',
+      '  SOCKSPort : 1080',
+      '}',
+    ].join('\n');
+    expect(parseScutilProxy(out)).toEqual({ url: '127.0.0.1:7890', source: 'system(macOS)' });
+  });
+
+  it('falls back to macOS SOCKS when HTTP is disabled', () => {
+    const out = [
+      '<dictionary> {',
+      '  HTTPEnable : 0',
+      '  HTTPProxy : 127.0.0.1',
+      '  SOCKSEnable : 1',
+      '  SOCKSProxy : 127.0.0.1',
+      '  SOCKSPort : 1080',
+      '}',
+    ].join('\n');
+    expect(parseScutilProxy(out)).toEqual({ url: 'socks5://127.0.0.1:1080', source: 'system(macOS)' });
+  });
+
+  it('returns none when macOS proxy is disabled', () => {
+    const out = ['<dictionary> {', '  HTTPEnable : 0', '  SOCKSEnable : 0', '}'].join('\n');
+    expect(parseScutilProxy(out)).toEqual({ url: '', source: 'none' });
+  });
+
+  it('parses Windows registry ProxyEnable + bare ProxyServer', () => {
+    const enable = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyEnable    REG_DWORD    0x1\n';
+    const server = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyServer    REG_SZ    127.0.0.1:7890\n';
+    expect(parseRegProxy(enable, server)).toEqual({ url: '127.0.0.1:7890', source: 'system(Windows)' });
+  });
+
+  it('parses Windows registry per-scheme ProxyServer (http=…;https=…)', () => {
+    const enable = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyEnable    REG_DWORD    0x1\n';
+    const server = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyServer    REG_SZ    http=proxy.corp:8080;https=proxy.corp:8443\n';
+    expect(parseRegProxy(enable, server)).toEqual({ url: 'proxy.corp:8080', source: 'system(Windows)' });
+  });
+
+  it('returns none when Windows proxy is disabled', () => {
+    const enable = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyEnable    REG_DWORD    0x0\n';
+    const server = 'HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\n    ProxyServer    REG_SZ    127.0.0.1:7890\n';
+    expect(parseRegProxy(enable, server)).toEqual({ url: '', source: 'none' });
   });
 });

--- a/server/src/lib/proxy.ts
+++ b/server/src/lib/proxy.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import https from 'https';
+import { execFileSync } from 'node:child_process';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { assertProviderUrlAllowed } from './url-guard.js';
 
@@ -89,7 +90,88 @@ function resolveProxySource(dbValue: string): { url: string; source: string } {
     const value = readEnv(name);
     if (value) return { url: value, source: name };
   }
+
+  // #353: last resort — read the system-wide proxy settings (macOS System
+  // Settings / Windows Internet Options / GNOME desktop) so the app works
+  // without duplicating the OS config. Best-effort: every failure here just
+  // falls through to the direct (no-proxy) path.
+  const system = detectSystemProxy();
+  if (system.url) return system;
   return { url: '', source: 'none' };
+}
+
+/**
+ * Read the OS-wide proxy configuration. Synchronous and best-effort: never
+ * throws, returns '' when the platform is unsupported or the command fails.
+ *
+ * - macOS: `scutil --proxy` (System Settings → Network → Proxies)
+ * - Windows: Internet Options registry (ProxyEnable + ProxyServer)
+ * - Linux: GNOME gsettings (the most common desktop), manual mode only
+ */
+export function detectSystemProxy(): { url: string; source: string } {
+  try {
+    if (process.platform === 'darwin') {
+      const out = execFileSync('scutil', ['--proxy'], { encoding: 'utf8', timeout: 2000 });
+      return parseScutilProxy(out);
+    }
+    if (process.platform === 'win32') {
+      const enable = execFileSync(
+        'reg', ['query', 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings', '/v', 'ProxyEnable'],
+        { encoding: 'utf8', timeout: 2000 },
+      );
+      const server = execFileSync(
+        'reg', ['query', 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings', '/v', 'ProxyServer'],
+        { encoding: 'utf8', timeout: 2000 },
+      );
+      return parseRegProxy(enable, server);
+    }
+    if (process.platform === 'linux') {
+      return parseGsettingsProxy();
+    }
+  } catch {
+    // fall through to no-proxy
+  }
+  return { url: '', source: 'none' };
+}
+
+/** Parse `scutil --proxy` output: HTTPEnable/HTTPProxy/HTTPPort first, then SOCKS. */
+export function parseScutilProxy(out: string): { url: string; source: string } {
+  const kv = (key: string) => out.match(new RegExp(`^\\s*${key}\\s*:\\s*(.+)$`, 'm'))?.[1]?.trim();
+  const httpEnabled = kv('HTTPEnable') === '1';
+  const httpHost = kv('HTTPProxy');
+  const httpPort = kv('HTTPPort') || '80';
+  if (httpEnabled && httpHost) {
+    return { url: `${httpHost}:${httpPort}`, source: 'system(macOS)' };
+  }
+  const socksEnabled = kv('SOCKSEnable') === '1';
+  const socksHost = kv('SOCKSProxy');
+  const socksPort = kv('SOCKSPort') || '1080';
+  if (socksEnabled && socksHost) {
+    return { url: `socks5://${socksHost}:${socksPort}`, source: 'system(macOS)' };
+  }
+  return { url: '', source: 'none' };
+}
+
+/** Parse Windows registry output; ProxyServer may be "host:port" or "http=…;https=…". */
+export function parseRegProxy(enableOut: string, serverOut: string): { url: string; source: string } {
+  // reg query prints: `    ProxyEnable    REG_DWORD    0x1`
+  if (!/ProxyEnable\s+REG_DWORD\s+0x1/.test(enableOut)) return { url: '', source: 'none' };
+  const m = serverOut.match(/ProxyServer\s+REG_SZ\s+(.+)$/m);
+  if (!m) return { url: '', source: 'none' };
+  const raw = m[1].trim();
+  const http = raw.split(';').find(p => p.startsWith('http='))?.slice('http='.length) ?? raw;
+  if (!http) return { url: '', source: 'none' };
+  return { url: http, source: 'system(Windows)' };
+}
+
+/** GNOME desktop proxy in manual mode (gsettings). */
+function parseGsettingsProxy(): { url: string; source: string } {
+  const mode = execFileSync('gsettings', ['get', 'org.gnome.system.proxy', 'mode'], { encoding: 'utf8', timeout: 2000 }).trim();
+  if (mode !== "'manual'") return { url: '', source: 'none' };
+  const host = execFileSync('gsettings', ['get', 'org.gnome.system.proxy.http', 'host'], { encoding: 'utf8', timeout: 2000 }).trim().replace(/^'|'$/g, '');
+  const port = execFileSync('gsettings', ['get', 'org.gnome.system.proxy.http', 'port'], { encoding: 'utf8', timeout: 2000 }).trim();
+  if (!host || !port) return { url: '', source: 'none' };
+  return { url: `${host}:${port}`, source: 'system(GNOME)' };
 }
 
 /**


### PR DESCRIPTION
Closes #353

## Problem

The proxy source chain was PROXY_URL → dashboard setting → env vars, so users had to duplicate their OS proxy config in the app. On macOS these are configured once in System Settings; on Linux via the desktop environment; on Windows via Internet Options.

## Fix

Adds a best-effort OS detection at the END of the chain, so the app works without manual configuration when nothing else is set.

- `detectSystemProxy()`: synchronous, never throws — macOS `scutil --proxy`, Windows Internet Options registry (`ProxyEnable`/`ProxyServer`), Linux GNOME gsettings (manual mode)
- `parseScutilProxy` / `parseRegProxy`: pure parsers, unit-tested (HTTP-first, SOCKS fallback, per-scheme `http=…;https=…` registry form)
- `resolveProxySource`: falls through to OS detection when PROXY_URL / dashboard / env vars are all unset

## Verification

- server `tsc` clean
- proxy suite 74/74 pass (6 new parser cases)