### PR TITLE
feat(providers): add AMD AI Developer Program (Lemonade) as an OpenAI-compatible platform (#781)

### DIFF
--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -44,6 +44,7 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'llm7', label: 'LLM7 (anon ok)', url: 'https://llm7.io' },
   { value: 'huggingface', label: 'HuggingFace Router', url: 'https://huggingface.co/settings/tokens' },
   { value: 'opencode', label: 'OpenCode Zen (free key)', url: 'https://opencode.ai/auth' },
+  { value: 'amd', label: 'AMD (Lemonade)', url: 'https://developer.amd.com/playbooks/lemonade-getting-started' },
   { value: 'agnes', label: 'Agnes AI (free key)', url: 'https://platform.agnes-ai.com' },
   { value: 'reka', label: 'Reka (free key)', url: 'https://platform.reka.ai' },
   { value: 'siliconflow', label: 'SiliconFlow (image + TTS)', url: 'https://siliconflow.com' },

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -96,6 +96,8 @@ export const PREFIX_MAP: Record<string, string> = {
   XFYUN_: 'xfyun',
   SPARK_: 'xfyun',
   IFLYTEK_: 'xfyun',
+  AMD_: 'amd',
+  LEMONADE_: 'amd',
 };
 
 export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
@@ -134,6 +136,9 @@ export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
   'any-api': 'anyapi',
   qianfan: 'qianfan',
   baidu: 'qianfan',
+  amd: 'amd',
+  lemonade: 'amd',
+  'lemonade-server': 'amd',
   ernie: 'qianfan',
   volcengine: 'volcengine',
   volc: 'volcengine',

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -209,6 +209,18 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://opencode.ai/zen/v1',
 }));
 
+// AMD AI Developer Program (#781) — OpenAI-compatible endpoint served by
+// Lemonade Server (https://developer.amd.com/playbooks/lemonade-getting-started),
+// the AMD local/cloud AI inference gateway. Defaults to the local Lemonade
+// endpoint; Developer Cloud users point base_url at their provisioned
+// vLLM instance. Keyless rows work with the anonymous local server.
+register(new OpenAICompatProvider({
+  platform: 'amd',
+  name: 'AMD (Lemonade)',
+  baseUrl: 'http://localhost:13305/api/v1',
+  keyless: true,
+}));
+
 // OVHcloud AI Endpoints — OpenAI-compatible. Two free modes: anonymous
 // (documented 2 req/min per IP per model — observed even stricter across
 // models in practice) and authenticated (400 req/min), but an API key

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -214,6 +214,10 @@ register(new OpenAICompatProvider({
 // the AMD local/cloud AI inference gateway. Defaults to the local Lemonade
 // endpoint; Developer Cloud users point base_url at their provisioned
 // vLLM instance. Keyless rows work with the anonymous local server.
+// Free-tier note: the bundled Lemonade Server is a self-hosted local gateway
+// (no card, no recurring quota claim from AMD for the local path); Developer
+// Cloud provisioning is a free program but per-instance, so no recurring
+// daily/monthly free quota is asserted here per the #274 standard.
 register(new OpenAICompatProvider({
   platform: 'amd',
   name: 'AMD (Lemonade)',

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -33,7 +33,7 @@ const PLATFORMS = [
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
   'routeway', 'bazaarlink', 'ainative', 'aion', 'anyapi', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'unorouter', 'xkiro', 'modelscope',
-  'qianfan', 'volcengine', 'longcat', 'xfyun', 'aihorde', 'custom',
+  'qianfan', 'volcengine', 'longcat', 'xfyun', 'amd', 'aihorde', 'custom',
 ] as const;
 
 const ALLOWED_IMPORT_EXTENSIONS = new Set(['.env', '.json', '.jsonc', '.md', '.txt', '.csv']);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -99,6 +99,9 @@ export type Platform =
   // models (FLUX.1-schnell image, CosyVoice2 TTS) routed via services/media.ts;
   // chat is supported too. Key from siliconflow.com (no card).
   | 'siliconflow'
+  // AMD AI Developer Program (#781) — OpenAI-compatible endpoint served by
+  // Lemonade Server (local default) or a provisioned Developer Cloud vLLM.
+  | 'amd'
   // Routeway — OpenAI-compatible aggregator. Free ':free' models ($0) on a
   // rate-limited pool (~5 rpm observed); requires a browser User-Agent (CF
   // blocks others). Key from routeway.ai (no card).


### PR DESCRIPTION
Closes #781

## What

AMD's AI Developer Program (developer.amd.com/ai-developer-program) serves inference through Lemonade Server — an OpenAI-compatible gateway (local default `http://localhost:13305/api/v1`; Developer Cloud users point `base_url` at their provisioned vLLM instance). This registers it as a first-class platform so AMD models can be added via the normal key flow.

## Changes

- `server/src/routes/keys.ts`: add `'amd'` to the PLATFORMS allowlist
- `server/src/providers/index.ts`: register AMD (Lemonade) OpenAICompatProvider
- `shared/types.ts`: add `'amd'` to the Platform union
- `client/src/components/keys/shared.tsx`: add AMD picker option

## Verification

- server `tsc` clean, client `tsc` clean
- keys / providers suites 98/98 pass