### PR TITLE
feat: AI model intelligence, multimodal fallback, multi-user, and modularity (#760 #811 #812 #813 #814 #763 #267 #824)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -271,3 +271,23 @@ and `config.json` (window/theme/port/LAN preferences). Copy both to move an
 install. For the server (non-desktop) deployment, the equivalent state is the
 `.env` file and the SQLite DB at `server/data/freeapi.db` (or wherever
 `FREEAPI_DB_PATH` points).
+
+## FAQ: password reset and logs
+
+**Where are the logs?**
+The router writes to stdout of the process that runs it — the terminal you
+launched `freellmapi` / the server in, or the desktop app's own console. The
+one-time codes described below appear there.
+
+**I forgot my password — how do I reset it?**
+On the login screen, click **Forgot password?** to generate a reset code. The
+code is printed to the **server logs** (see above) — open them, copy the code,
+paste it into the form, and set a new password. The dashboard account is the
+email + password you chose during the initial setup.
+
+**Desktop app: there is no password.**
+The desktop build has no user-set password — it signs the dashboard in
+automatically with a hidden local account, so you are never prompted for one.
+If you still see a password prompt for exporting or copying a full key, update
+to a build that includes PR #810 (the desktop server skips that re-verification
+for local requests).

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -26,6 +26,7 @@ const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endpoint_ho
 const KEY_MODEL_SCOPE_FILENAME = '20260805_000001_key_model_scope.ts';
 const CLIENT_PROFILES_FILENAME = '20260805_000002_client_profiles.ts';
 const API_KEY_PROXY_FILENAME = '20260810_000001_api_key_proxy.ts';
+const OPENCODE_MULTIMODAL_CURATION_FILENAME = '20260811_000001_opencode_multimodal_curation.ts';
 
 interface SchemaRow {
   type: string;
@@ -98,6 +99,7 @@ describe('migration round trip', () => {
         KEY_MODEL_SCOPE_FILENAME,
         CLIENT_PROFILES_FILENAME,
         API_KEY_PROXY_FILENAME,
+        OPENCODE_MULTIMODAL_CURATION_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/lib/vision-fallback.test.ts
+++ b/server/src/__tests__/lib/vision-fallback.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fallbackAnalyzeImages } from '../../lib/vision-fallback.js';
+import type { ChatMessage } from '@freellmapi/shared/types.js';
+
+// #813: multimodal gateway tests — text pass-through, visual pass-through
+// (no image → unchanged), non-visual fallback (Qwen VL analysis replaces the
+// image blocks), fallback failure (keeps original messages), and image
+// removal (the target call never receives image blocks).
+
+// These are referenced inside the vi.mock factories, so they must be declared
+// before the mocks (vitest hoists vi.mock above the imports; the factories run
+// at import time, by which point these are initialized).
+const mockKeyRow: { encrypted_key: string; iv: string; auth_tag: string } = {
+  encrypted_key: 'enc', iv: 'iv', auth_tag: 'tag',
+};
+let mockAnalysis: string | null = 'a detailed description of the image';
+
+vi.mock('../../db/index.js', () => ({
+  getDb: vi.fn(() => ({
+    prepare: () => ({ get: () => mockKeyRow }),
+  })),
+}));
+
+vi.mock('../../lib/crypto.js', () => ({
+  decrypt: vi.fn(() => 'opencode-key'),
+}));
+
+vi.mock('../../providers/index.js', () => ({
+  getProvider: vi.fn(() => ({
+    chatCompletion: async () => ({
+      choices: [{ message: { content: mockAnalysis } }],
+    }),
+  })),
+}));
+
+import { getDb } from '../../db/index.js';
+import { decrypt } from '../../lib/crypto.js';
+import { getProvider } from '../../providers/index.js';
+
+beforeEach(() => {
+  mockAnalysis = 'a detailed description of the image';
+});
+
+afterEach(() => {
+  // Reset call records AND the mockReturnValueOnce queue — a test that sets a
+  // once-value without consuming it (the text-only case) would otherwise leak
+  // it into the next test's first getProvider call.
+  vi.resetAllMocks();
+  // Restore the module factory's default implementations after resetAllMocks
+  // wiped them.
+  vi.mocked(getDb).mockImplementation(() => ({
+    prepare: () => ({ get: () => mockKeyRow }),
+  }));
+  vi.mocked(decrypt).mockImplementation(() => 'opencode-key');
+  vi.mocked(getProvider).mockImplementation(() => ({
+    chatCompletion: async () => ({
+      choices: [{ message: { content: mockAnalysis } }],
+    }),
+  }));
+});
+
+function imageMessage(): ChatMessage {
+  return {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'what is this?' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } },
+    ],
+  };
+}
+
+describe('fallbackAnalyzeImages (#812/#813)', () => {
+  it('passes text-only messages through unchanged', async () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'hello' }];
+    const out = await fallbackAnalyzeImages(messages);
+    expect(out).toBe(messages); // same reference = untouched
+  });
+
+  it('replaces image blocks with the analysis text (image removal)', async () => {
+    const out = await fallbackAnalyzeImages([imageMessage()]);
+    expect(out).not.toBeNull();
+    expect(out[0].content).toEqual([
+      { type: 'text', text: '[Image analysis: a detailed description of the image]' },
+    ]);
+    // No image_url block survives — the target call is text-only.
+    const text = JSON.stringify(out[0].content);
+    expect(text).not.toContain('image_url');
+    expect(text).not.toContain('image/png');
+  });
+
+  it('keeps the original messages when the provider is absent', async () => {
+    vi.mocked(getProvider).mockReturnValueOnce(undefined as never);
+    const out = await fallbackAnalyzeImages([imageMessage()]);
+    expect(out).toEqual([imageMessage()]);
+  });
+
+  it('keeps the original messages when the analysis fails', async () => {
+    mockAnalysis = null; // provider returns an empty/missing content
+    const out = await fallbackAnalyzeImages([imageMessage()]);
+    expect(out).toEqual([imageMessage()]);
+  });
+
+  it('keeps the original messages when no opencode key is configured', async () => {
+    vi.mocked(getDb).mockReturnValueOnce({
+      prepare: () => ({ get: () => undefined }),
+    } as never);
+    const out = await fallbackAnalyzeImages([imageMessage()]);
+    expect(out).toEqual([imageMessage()]);
+  });
+
+  it('does not call the provider for text-only messages', async () => {
+    const spy = vi.fn();
+    vi.mocked(getProvider).mockReturnValueOnce({ chatCompletion: spy } as never);
+    await fallbackAnalyzeImages([{ role: 'user', content: 'plain text' }]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('uses the decrypted opencode key and Qwen VL model', async () => {
+    const spy = vi.fn(async () => ({
+      choices: [{ message: { content: 'ok' } }],
+    }));
+    vi.mocked(getProvider).mockReturnValueOnce({ chatCompletion: spy } as never);
+    await fallbackAnalyzeImages([imageMessage()]);
+    expect(spy).toHaveBeenCalledWith('opencode-key', expect.any(Array), 'qwen-vl-plus-free');
+    expect(decrypt).toHaveBeenCalledWith('enc', 'iv', 'tag');
+  });
+});

--- a/server/src/__tests__/services/modules.test.ts
+++ b/server/src/__tests__/services/modules.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  registerModule,
+  getModules,
+  getModule,
+  isModuleEnabled,
+  enableModule,
+  disableModule,
+  initBuiltinModules,
+} from '../../services/modules.js';
+
+// #763: the pluggable-module registry. Tests cover registration (idempotent,
+// last-wins), querying (in order), the enable/disable surface (persisted to
+// the module's setting key, absent = disabled) and the builtin compression
+// module. The registry keeps process-global state, so tests reset it by
+// re-registering known modules and clearing the settings store between cases.
+
+const settingStore = new Map<string, string>();
+vi.mock('../../db/index.js', () => ({
+  getSetting: (key: string) => settingStore.get(key),
+  setSetting: (key: string, value: string) => { settingStore.set(key, value); },
+}));
+
+beforeEach(() => {
+  settingStore.clear();
+  // Re-seed a deterministic registry for each test (registration is
+  // process-global and last-wins, so a fresh set keeps cases isolated).
+  registerModule({ id: 'alpha', name: 'Alpha', description: 'test module', settingKey: 'alpha_enabled' });
+  registerModule({ id: 'beta', name: 'Beta', description: 'test module', settingKey: 'beta_enabled' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('module registry (#763)', () => {
+  it('lists modules in registration order', () => {
+    const ids = getModules().map(m => m.id);
+    expect(ids).toEqual(['alpha', 'beta']);
+  });
+
+  it('returns a module by id, or undefined for an unknown id', () => {
+    expect(getModule('alpha')?.name).toBe('Alpha');
+    expect(getModule('nope')).toBeUndefined();
+  });
+
+  it('re-registering an id replaces the earlier module (last wins)', () => {
+    registerModule({ id: 'alpha', name: 'Alpha v2', description: 'updated', settingKey: 'alpha_enabled' });
+    expect(getModule('alpha')?.name).toBe('Alpha v2');
+    expect(getModules()).toHaveLength(2); // no duplicate entry
+  });
+});
+
+describe('enable / disable surface (#763)', () => {
+  it('is disabled by default when the setting key is absent', () => {
+    expect(isModuleEnabled('alpha')).toBe(false);
+  });
+
+  it('enable persists "1" and flips the flag', () => {
+    expect(enableModule('alpha')).toBe(true);
+    expect(settingStore.get('alpha_enabled')).toBe('1');
+    expect(isModuleEnabled('alpha')).toBe(true);
+  });
+
+  it('disable persists "0" and flips the flag back', () => {
+    enableModule('alpha');
+    expect(disableModule('alpha')).toBe(true);
+    expect(settingStore.get('alpha_enabled')).toBe('0');
+    expect(isModuleEnabled('alpha')).toBe(false);
+  });
+
+  it('reads "0" from the store as disabled even without disable()', () => {
+    settingStore.set('alpha_enabled', '0');
+    expect(isModuleEnabled('alpha')).toBe(false);
+  });
+
+  it('returns false for unknown modules and writes nothing', () => {
+    expect(enableModule('ghost')).toBe(false);
+    expect(disableModule('ghost')).toBe(false);
+    expect(settingStore.has('ghost_enabled')).toBe(false);
+  });
+});
+
+describe('builtin modules (#763)', () => {
+  it('registers compression with its own setting key', () => {
+    initBuiltinModules();
+    const compression = getModule('compression');
+    expect(compression?.name).toBe('Prompt compression');
+    expect(compression?.settingKey).toBe('compression_enabled');
+    expect(isModuleEnabled('compression')).toBe(false);
+    expect(enableModule('compression')).toBe(true);
+    expect(isModuleEnabled('compression')).toBe(true);
+  });
+});

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -21,6 +21,7 @@ import * as customEndpointHostLabels from '../migrations/20260802_000001_custom_
 import * as keyModelScope from '../migrations/20260805_000001_key_model_scope.js';
 import * as clientProfiles from '../migrations/20260805_000002_client_profiles.js';
 import * as apiKeyProxy from '../migrations/20260810_000001_api_key_proxy.js';
+import * as opencodeMultimodalCuration from '../migrations/20260811_000001_opencode_multimodal_curation.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -54,6 +55,7 @@ export const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endp
 export const KEY_MODEL_SCOPE_FILENAME = '20260805_000001_key_model_scope.ts';
 export const CLIENT_PROFILES_FILENAME = '20260805_000002_client_profiles.ts';
 export const API_KEY_PROXY_FILENAME = '20260810_000001_api_key_proxy.ts';
+export const OPENCODE_MULTIMODAL_CURATION_FILENAME = '20260811_000001_opencode_multimodal_curation.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -78,4 +80,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: KEY_MODEL_SCOPE_FILENAME, module: keyModelScope },
   { filename: CLIENT_PROFILES_FILENAME, module: clientProfiles },
   { filename: API_KEY_PROXY_FILENAME, module: apiKeyProxy },
+  { filename: OPENCODE_MULTIMODAL_CURATION_FILENAME, module: opencodeMultimodalCuration },
 ];

--- a/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
+++ b/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
@@ -18,6 +18,15 @@ import type { Db } from '../types.js';
  * baseline, then up again and compares full snapshots — an AUTOINCREMENT id
  * would drift between the two ups and fail that comparison. 90xxxxx sits far
  * above the legacy baseline's id range, so no collision is possible.
+ *
+ * Two invariants are kept:
+ *   - every catalog row has exactly one fallback_config entry (idempotency
+ *     test), so the new models seed their fallback_config rows here too —
+ *     again with FIXED ids for the same roundtrip-snapshot reason;
+ *   - display names must not normalize into an existing model's group after
+ *     stripProviderSuffix (a trailing "(...)" parenthetical is stripped), or
+ *     the unified-id resolution would merge these video entries into google's
+ *     "Gemini 2.5 Pro" / "Gemini 2.5 Flash" groups and change their routing.
  */
 export function up(db: Db): void {
   const insert = db.prepare(`
@@ -27,17 +36,28 @@ export function up(db: Db): void {
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
   `);
   const additions: Array<[number, string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
-    [900001, 'opencode', 'qwen-vl-plus-free',      'Qwen VL Plus (OpenCode Zen, vision)',   8, 3, 'Large',    20, 200, null, null, 'promo (trial)', 131072],
-    [900002, 'opencode', 'gemini-2.5-flash-video', 'Gemini 2.5 Flash (video analysis)',     5, 5, 'Large',    15, 100, null, null, 'promo (trial)', 1048576],
-    [900003, 'opencode', 'gemini-2.5-pro-video',   'Gemini 2.5 Pro (video analysis)',       2, 2, 'Frontier', 10, 100, null, null, 'promo (trial)', 2097152],
+    [900001, 'opencode', 'qwen-vl-plus-free',      'Qwen VL Plus Vision',         8, 3, 'Large',    20, 200, null, null, 'promo (trial)', 131072],
+    [900002, 'opencode', 'gemini-2.5-flash-video', 'Gemini 2.5 Flash Video',      5, 5, 'Large',    15, 100, null, null, 'promo (trial)', 1048576],
+    [900003, 'opencode', 'gemini-2.5-pro-video',   'Gemini 2.5 Pro Video',        2, 2, 'Frontier', 10, 100, null, null, 'promo (trial)', 2097152],
   ];
   const apply = db.transaction(() => {
     for (const a of additions) insert.run(...a);
+    // Every model row needs exactly one fallback_config entry; seed the new
+    // rows at the end of the existing chain (maxPriority + offset), same as
+    // legacy_baseline's backfillFallback, but with FIXED ids so the roundtrip
+    // up/down/up snapshot comparison stays stable.
+    const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+    const addFb = db.prepare('INSERT OR IGNORE INTO fallback_config (id, model_db_id, priority, enabled) VALUES (?, ?, ?, 1)');
+    additions.forEach((a, i) => addFb.run(910001 + i, a[0], maxPriority + i + 1));
   });
   apply();
 }
 
 export function down(db: Db): void {
+  db.prepare(`
+    DELETE FROM fallback_config
+    WHERE model_db_id BETWEEN 900001 AND 900003
+  `).run();
   db.prepare(`
     DELETE FROM models
     WHERE id BETWEEN 900001 AND 900003

--- a/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
+++ b/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
@@ -1,0 +1,45 @@
+import type { Db } from '../types.js';
+
+/**
+ * #811: curated multimodal OpenCode models.
+ *
+ * OpenCode users need pinned coding + multimodal choices plus a capability-
+ * first auto route. This seeds a small curated set of vision/video-capable
+ * models on the opencode platform:
+ *   - qwen-vl-plus-free: the Qwen VL vision analysis model used by the
+ *     multimodal gateway for image requests aimed at non-visual targets;
+ *   - gemini-2.5-flash-video / gemini-2.5-pro-video: explicitly selectable
+ *     short-video analysis entries.
+ *
+ * All marked supports_vision=1; the existing auto route keeps every enabled
+ * model eligible, so nothing else changes.
+ *
+ * The seeded rows use FIXED ids: the roundtrip test migrates up, down to
+ * baseline, then up again and compares full snapshots — an AUTOINCREMENT id
+ * would drift between the two ups and fail that comparison. 90xxxxx sits far
+ * above the legacy baseline's id range, so no collision is possible.
+ */
+export function up(db: Db): void {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO models
+      (id, platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+       rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window, supports_vision)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+  `);
+  const additions: Array<[number, string, string, string, number, number, string, number | null, number | null, number | null, number | null, string, number | null]> = [
+    [900001, 'opencode', 'qwen-vl-plus-free',      'Qwen VL Plus (OpenCode Zen, vision)',   8, 3, 'Large',    20, 200, null, null, 'promo (trial)', 131072],
+    [900002, 'opencode', 'gemini-2.5-flash-video', 'Gemini 2.5 Flash (video analysis)',     5, 5, 'Large',    15, 100, null, null, 'promo (trial)', 1048576],
+    [900003, 'opencode', 'gemini-2.5-pro-video',   'Gemini 2.5 Pro (video analysis)',       2, 2, 'Frontier', 10, 100, null, null, 'promo (trial)', 2097152],
+  ];
+  const apply = db.transaction(() => {
+    for (const a of additions) insert.run(...a);
+  });
+  apply();
+}
+
+export function down(db: Db): void {
+  db.prepare(`
+    DELETE FROM models
+    WHERE id BETWEEN 900001 AND 900003
+  `).run();
+}

--- a/server/src/lib/vision-fallback.ts
+++ b/server/src/lib/vision-fallback.ts
@@ -1,0 +1,107 @@
+import { getDb } from '../db/index.js';
+import { decrypt } from './crypto.js';
+import { getProvider } from '../providers/index.js';
+import { contentHasImage } from './content.js';
+import type { ChatMessage } from '@freellmapi/shared/types.js';
+
+/**
+ * #812: capability-aware multimodal fallback.
+ *
+ * A user may pin a NON-visual coding model (e.g. DeepSeek V4 Flash) and still
+ * send an image: routing that request to a vision model would break the pin,
+ * and sending the image blocks to the non-visual model would either 400 or be
+ * silently dropped. Instead we run a Qwen VL pre-analysis on the image, then
+ * forward ONLY the resulting text to the originally requested model — the
+ * target call never receives image blocks (acceptance criteria #3/#4).
+ *
+ * The Qwen VL model is the curated opencode/qwen-vl-plus-free entry seeded by
+ * migration 20260811_000001_opencode_multimodal_curation. Requires an opencode
+ * API key to be configured; without one the request is left untouched and the
+ * caller keeps its existing no-vision handling.
+ */
+
+const QWEN_VL_PLATFORM = 'opencode';
+const QWEN_VL_MODEL = 'qwen-vl-plus-free';
+const IMAGE_ANALYSIS_SYSTEM_PROMPT =
+  'Describe the image(s) in this message in detail: what is depicted, any text/UI elements, ' +
+  'and anything relevant to a coding or data-analysis task. Output plain text only.';
+
+/** Extract the first image URL from the last user message (best-effort). */
+function firstImageUrl(messages: ChatMessage[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const content = messages[i].content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as { type?: string; image_url?: unknown };
+      if (b.type !== 'image_url' && b.type !== 'image') continue;
+      if (typeof b.image_url === 'string') return b.image_url;
+      if (b.image_url && typeof b.image_url === 'object') {
+        const url = (b.image_url as { url?: unknown }).url;
+        if (typeof url === 'string') return url;
+      }
+    }
+  }
+  return null;
+}
+
+/** The decrypted opencode key, or null when none is configured. */
+function opencodeKey(): string | null {
+  const row = getDb().prepare(
+    "SELECT encrypted_key, iv, auth_tag FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown') LIMIT 1",
+  ).get(QWEN_VL_PLATFORM) as { encrypted_key: string; iv: string; auth_tag: string } | undefined;
+  if (!row) return null;
+  try {
+    return decrypt(row.encrypted_key, row.iv, row.auth_tag);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pre-analyze images in `messages` with Qwen VL and return messages with the
+ * image blocks replaced by the analysis text. Returns the original messages
+ * unchanged when there is no image, no Qwen VL key, or the analysis fails —
+ * the caller keeps its existing behaviour (e.g. no-vision error) in those
+ * cases.
+ */
+export async function fallbackAnalyzeImages(messages: ChatMessage[]): Promise<ChatMessage[]> {
+  const hasImage = messages.some(m => contentHasImage(m.content));
+  if (!hasImage) return messages;
+
+  const imageUrl = firstImageUrl(messages);
+  const key = opencodeKey();
+  if (!imageUrl || !key) return messages;
+
+  const provider = getProvider(QWEN_VL_PLATFORM);
+  if (!provider) return messages;
+
+  const analysisMessages: ChatMessage[] = [
+    { role: 'system', content: IMAGE_ANALYSIS_SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Analyze the following image:' },
+        { type: 'image_url', image_url: { url: imageUrl } },
+      ],
+    },
+  ];
+
+  try {
+    const result = await provider.chatCompletion(key, analysisMessages, QWEN_VL_MODEL);
+    const analysis = result.choices?.[0]?.message?.content;
+    if (!analysis || typeof analysis !== 'string' || !analysis.trim()) return messages;
+
+    // Replace the image-bearing message's content with a text block carrying
+    // the analysis; strip every image block so the target call is text-only.
+    return messages.map(m => {
+      if (!Array.isArray(m.content) || !contentHasImage(m.content)) return m;
+      return {
+        ...m,
+        content: [{ type: 'text', text: `[Image analysis: ${analysis.trim()}]` }],
+      };
+    });
+  } catch {
+    return messages;
+  }
+}

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -213,6 +213,10 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
       SUM(r.input_tokens) as total_input_tokens,
       SUM(r.output_tokens) as total_output_tokens,
       SUM(CASE WHEN r.requested_model = r.model_id THEN 1 ELSE 0 END) as pinned_requests,
+      -- #760 P1 benchmarks: time-to-first-byte (streaming) and latency spread.
+      AVG(r.ttfb_ms) as avg_ttfb_ms,
+      MIN(r.latency_ms) as min_latency_ms,
+      MAX(r.latency_ms) as max_latency_ms,
       SUM(CASE WHEN r.status = 'success' THEN
         r.input_tokens  * COALESCE(m.paid_input_per_m,  ?) / 1000000.0 +
         r.output_tokens * COALESCE(m.paid_output_per_m, ?) / 1000000.0
@@ -232,6 +236,11 @@ analyticsRouter.get('/by-model', (req: Request, res: Response) => {
     // success_rate is NULL when every row in the group was canceled.
     successRate: Math.round((r.success_rate ?? 0) * 10) / 10,
     avgLatencyMs: Math.round(r.avg_latency_ms),
+    // #760 P1: benchmark surface — stream TTFB plus the latency spread so the
+    // UI can answer "is this model slow today" without digging into traces.
+    avgTtfbMs: Math.round(r.avg_ttfb_ms ?? 0),
+    minLatencyMs: Math.round(r.min_latency_ms ?? 0),
+    maxLatencyMs: Math.round(r.max_latency_ms ?? 0),
     totalInputTokens: r.total_input_tokens ?? 0,
     totalOutputTokens: r.total_output_tokens ?? 0,
     // Requests this model served because the client pinned it by name.

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,6 +14,7 @@ import {
 } from '../services/auth.js';
 import { setupCodeMatches, clearSetupCode } from '../lib/setup-code.js';
 import { generateResetCode, resetCodeMatches, clearResetCode } from '../lib/reset-code.js';
+import { requireAuth } from '../middleware/requireAuth.js';
 
 export const authRouter = Router();
 
@@ -273,4 +274,28 @@ authRouter.post('/reset-password', (req: Request, res: Response) => {
   }
   clearResetCode();
   res.json({ success: true });
+});
+
+// ── Multi-user (#267): add additional dashboard accounts ────────────────────
+// The first account is claimed via /setup (one-time). Any further account is
+// created here by an already-authenticated user, so a family/NAS install can
+// hand each member their own login instead of sharing one dashboard session.
+// Minimal viable slice: accounts only (each user gets their own session on
+// login); per-user unified API keys / workspaces are the next increment.
+authRouter.post('/users', requireAuth, (req: Request, res: Response) => {
+  const parsed = credentialsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
+    return;
+  }
+  try {
+    const user = createUser(parsed.data.email, parsed.data.password);
+    res.status(201).json({ id: user.userId, email: user.email, message: 'Account created. They can sign in with these credentials.' });
+  } catch (err: any) {
+    if (err?.code === 'email_taken') {
+      res.status(409).json({ error: { message: err.message, type: 'email_taken' } });
+      return;
+    }
+    res.status(500).json({ error: { message: err?.message ?? 'Failed to create account', type: 'server_error' } });
+  }
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -18,6 +18,7 @@ import { rescueInlineToolCalls, startsWithDialectMarker, couldBecomeDialectMarke
 import { getContextHandoffMode, recordIncomingMessages, maybeInjectContextHandoff, recordSuccessfulModel, hasPriorModel, HANDOFF_MAX_TOKENS } from '../services/context-handoff.js';
 import { isFusionModel, runFusion, fusionConfigSchema, FusionError, FUSION_MODEL_ID } from '../services/fusion.js';
 import { isRetryableError, isPaymentRequiredError, isModelNotFoundError, isModelAccessForbiddenError, isClientAbortError, newClientAbortError } from '../lib/error-classify.js';
+import { fallbackAnalyzeImages } from '../lib/vision-fallback.js';
 import { logRequest } from '../lib/request-log.js';
 import { observeServedModel } from '../lib/served-model.js';
 import { parseCacheDirective, cacheActive, isCacheableTemperature, computeCacheKey, getCachedResponse, storeCachedResponse } from '../services/cache.js';
@@ -1406,14 +1407,24 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // heuristic above (text-only) can't see.
   const hasImage = messageHasImage(messages);
   if (hasImage && !hasEnabledVisionModel()) {
-    res.status(422).json({
-      error: {
-        message: 'This request includes an image, but no vision-capable model is enabled. Enable a vision model (e.g. Gemini 2.5 Flash, Llama 4 Scout) in the Fallback Chain.',
-        type: 'invalid_request_error',
-        code: 'no_vision_model',
-      },
-    });
-    return;
+    // #812: capability-aware multimodal fallback — before rejecting, try a
+    // Qwen VL pre-analysis of the image and forward only its text to the
+    // originally requested (non-visual) model. When the analysis succeeds the
+    // target call never receives image blocks; otherwise keep the existing
+    // no-vision error.
+    const analyzed = await fallbackAnalyzeImages(messages);
+    if (analyzed !== messages) {
+      messages = analyzed;
+    } else {
+      res.status(422).json({
+        error: {
+          message: 'This request includes an image, but no vision-capable model is enabled. Enable a vision model (e.g. Gemini 2.5 Flash, Llama 4 Scout) in the Fallback Chain.',
+          type: 'invalid_request_error',
+          code: 'no_vision_model',
+        },
+      });
+      return;
+    }
   }
   const IMAGE_TOKEN_ESTIMATE = 1000;
   const imageCount = messages.reduce((n, m) =>

--- a/server/src/services/modules.ts
+++ b/server/src/services/modules.ts
@@ -1,0 +1,77 @@
+import { getSetting, setSetting } from '../db/index.js';
+
+/**
+ * #763: sub-feature modularization — a tiny, dependency-free pluggable-module
+ * registry so composable features (compression, an opt-in paid-model module,
+ * future experimental ones) share one uniform enable/disable surface.
+ *
+ * Modules are just objects with an id, a display name, a one-line description
+ * and an enable/disable pair persisted to a settings key. There is no plugin
+ * loading, no dynamic code — the point is a single registry the dashboard and
+ * the router can query, so opt-in features don't each invent their own toggle.
+ */
+
+export interface FeatureModule {
+  /** Stable identifier, e.g. 'compression'. */
+  id: string;
+  /** Display name shown in the dashboard. */
+  name: string;
+  /** One-line description for the settings list. */
+  description: string;
+  /** Setting key that holds the enabled flag ('1'/'0', absent = false). */
+  settingKey: string;
+}
+
+const modules = new Map<string, FeatureModule>();
+
+/** Register a feature module (idempotent — last registration wins). */
+export function registerModule(module: FeatureModule): void {
+  modules.set(module.id, module);
+}
+
+/** All registered modules, in registration order. */
+export function getModules(): FeatureModule[] {
+  return [...modules.values()];
+}
+
+/** A module by id, or undefined when not registered. */
+export function getModule(id: string): FeatureModule | undefined {
+  return modules.get(id);
+}
+
+/** Whether the module is currently enabled. */
+export function isModuleEnabled(id: string): boolean {
+  const module = modules.get(id);
+  if (!module) return false;
+  return getSetting(module.settingKey) === '1';
+}
+
+/** Enable a module. Returns true when it was registered, false otherwise. */
+export function enableModule(id: string): boolean {
+  const module = modules.get(id);
+  if (!module) return false;
+  setSetting(module.settingKey, '1');
+  return true;
+}
+
+/** Disable a module. Returns true when it was registered, false otherwise. */
+export function disableModule(id: string): boolean {
+  const module = modules.get(id);
+  if (!module) return false;
+  setSetting(module.settingKey, '0');
+  return true;
+}
+
+/**
+ * Compression is the flagship opt-in module (#763): it rewrites outbound
+ * requests to save tokens, and is gated by the dashboard toggle. Registering
+ * it here exposes the uniform interface without touching its config code.
+ */
+export function initBuiltinModules(): void {
+  registerModule({
+    id: 'compression',
+    name: 'Prompt compression',
+    description: 'Rewrites outbound requests to use fewer tokens (lossless / standard / aggressive modes).',
+    settingKey: 'compression_enabled',
+  });
+}

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -18,7 +18,7 @@ import {
   BANDIT_PRESETS, DEFAULT_STRATEGY, type RoutingStrategy, type RoutingWeights,
   reliabilityPosterior, expectedReliability, sampleBeta,
   speedScore, intelligenceScore, intelligenceComposite, headroomFactor, rateLimitFactor, combineScore,
-  observedSpeedRank, TIMEOUT_LATENCY_CAP_MS,
+  timeOfDayWeights, observedSpeedRank, TIMEOUT_LATENCY_CAP_MS,
 } from './scoring.js';
 import { TIMEOUT_ERROR_MARKERS } from '../lib/error-classify.js';
 import { applyModelWeightOverride, getModelWeightOverrides } from './model-weight-overrides.js';
@@ -840,11 +840,11 @@ function scoreChainEntry(
   const headroom = headroomFactor(stats?.monthlyUsedTokens ?? 0, budget);
   const rl = rateLimitFactor(getPenalty(entry.model_db_id));
 
-  // Per-model env overrides (#738) scale the final score so a slow or
-  // poor-quality model is demoted without being disabled outright — a manual
-  // 'priority' chain can still select it.
+  // #760 P2: dynamic ranking — shift speed→reliability weight during local
+  // peak hours (18:00–06:00) when free relays are congested.
   const score = applyModelWeightOverride(
-    combineScore({ reliability, speed, intelligence, headroom, rateLimit: rl }, weights),
+    combineScore({ reliability, speed, intelligence, headroom, rateLimit: rl },
+      timeOfDayWeights(weights, new Date().getHours())),
     entry.model_id,
   );
   return { axes: { reliability, speed, intelligence }, headroom, rateLimit: rl, score };

--- a/server/src/services/scoring.ts
+++ b/server/src/services/scoring.ts
@@ -275,3 +275,26 @@ export function combineScore(inputs: ScoreInputs, weights: RoutingWeights): numb
       weights.intelligence * inputs.intelligence) / wSum;
   return base * inputs.headroom * inputs.rateLimit;
 }
+
+// #760 P2: dynamic ranking — time-of-day-aware weight adjustment.
+//
+// Free-tier relays are most congested in the local evening; a raw speed score
+// measured off-peak can claim a model is "fastest" when it is the slowest at
+// 20:00. During peak hours we shift weight from speed to reliability so the
+// ranking reflects the measured reliability-weighted choice instead of a
+// stale off-peak snapshot. `hour` is 0-23 local time. Returns the original
+// weights unchanged outside peak hours (so tests and off-peak behaviour are
+// unaffected).
+export function timeOfDayWeights(weights: RoutingWeights, hour: number): RoutingWeights {
+  const peak = hour >= 18 || hour < 6; // 18:00–06:00 local
+  if (!peak) return weights;
+  const speedCut = weights.speed * 0.4;
+  if (speedCut <= 0) return weights;
+  // Move the cut weight to reliability (it is what guards against a congested
+  // relay); intelligence stays untouched.
+  return {
+    reliability: weights.reliability + speedCut,
+    speed: weights.speed - speedCut,
+    intelligence: weights.intelligence,
+  };
+}


### PR DESCRIPTION
Batch of independent sub-features, each reviewable separately:

## #760 — AI model intelligence (P1+P2)
- **Benchmarks**: `/api/analytics/by-model` now returns a benchmark surface — `avgTtfbMs` + `min/max latency` spread — so the UI can answer "is this model slow today" without digging into traces
- **Dynamic ranking**: `timeOfDayWeights()` shifts speed→reliability weight during local peak hours (18:00–06:00) when free relays are congested; off-peak behaviour is unchanged

## #811/#812/#813/#814 — multimodal gateway
- Migration `20260811_000001_opencode_multimodal_curation`: curated opencode multimodal models — Qwen VL + two Gemini video-analysis entries (fixed ids for roundtrip stability)
- `lib/vision-fallback.ts`: Qwen VL pre-analysis replaces image blocks with text before a non-visual target call (image removal — the target never receives image blocks)
- `proxy.ts`: capability-aware fallback runs before the no-vision rejection; `vision-fallback.test.ts` covers pass-through / fallback / failure / removal (7 cases)

## #763 — modularity
`services/modules.ts`: a dependency-free pluggable-module registry (register / enable / disable / isEnabled), with compression registered as the flagship module.

## #267 — multi-user (minimal slice)
`POST /api/auth/users` (requireAuth) lets an authenticated user create additional dashboard accounts — each signs in with their own session. Per-user API keys/workspaces are the next increment.

## #824 — docs
FAQ section on password reset, forgot-password reset codes (server logs), logs location, and the desktop no-password build.

## Verification
- server `tsc` clean
- vision-fallback 7/7; roundtrip + registry-drift + scoring 40/40