### PR TITLE
fix(responses): align /v1/responses shim with the official Responses API spec

### DIFF
--- a/server/src/__tests__/routes/responses-translate.test.ts
+++ b/server/src/__tests__/routes/responses-translate.test.ts
@@ -52,6 +52,52 @@ describe('Responses → chat translation (#96)', () => {
     expect(msgs[0]).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'sunny' });
   });
 
+  it('merges an assistant message item with its following function_call items into one turn', () => {
+    const msgs = toChatMessages({
+      input: [
+        { type: 'message', role: 'assistant', content: 'Let me check.' },
+        { type: 'function_call', call_id: 'call_1', name: 'get_weather', arguments: '{"city":"SF"}' },
+        { type: 'function_call', call_id: 'call_2', name: 'get_time', arguments: '{}' },
+      ],
+    } as any);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: 'Let me check.',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"SF"}' } },
+          { id: 'call_2', type: 'function', function: { name: 'get_time', arguments: '{}' } },
+        ],
+      },
+    ]);
+  });
+
+  it('merges an empty assistant item with its following function_call items (content null)', () => {
+    const msgs = toChatMessages({
+      input: [
+        { type: 'message', role: 'assistant', content: [] },
+        { type: 'function_call', call_id: 'call_1', name: 'get_weather', arguments: '{}' },
+      ],
+    } as any);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{}' } }],
+      },
+    ]);
+  });
+
+  it('drops empty assistant message items (no tool_calls)', () => {
+    const msgs = toChatMessages({
+      input: [
+        { type: 'message', role: 'assistant', content: [] },
+        { type: 'message', role: 'user', content: 'hi' },
+      ],
+    } as any);
+    expect(msgs).toEqual([{ role: 'user', content: 'hi' }]);
+  });
+
   it('skips computer_call / computer_call_output / reasoning / local_shell_call input items', () => {
     const msgs = toChatMessages({
       input: [

--- a/server/src/__tests__/routes/responses-translate.test.ts
+++ b/server/src/__tests__/routes/responses-translate.test.ts
@@ -98,6 +98,38 @@ describe('Responses → chat translation (#96)', () => {
     expect(msgs).toEqual([{ role: 'user', content: 'hi' }]);
   });
 
+  it('hoists system/developer messages to the start of the conversation', () => {
+    const msgs = toChatMessages({
+      input: [
+        { type: 'message', role: 'user', content: 'hi' },
+        { type: 'message', role: 'developer', content: 'mid-conversation system' },
+        { type: 'message', role: 'user', content: 'again' },
+      ],
+    } as any);
+    expect(msgs).toEqual([
+      { role: 'system', content: 'mid-conversation system' },
+      { role: 'user', content: 'hi' },
+      { role: 'user', content: 'again' },
+    ]);
+  });
+
+  it('keeps instructions first, then hoisted system messages in order', () => {
+    const msgs = toChatMessages({
+      instructions: 'You are terse.',
+      input: [
+        { type: 'message', role: 'user', content: 'hi' },
+        { type: 'message', role: 'developer', content: 'rule 2' },
+        { type: 'message', role: 'developer', content: 'rule 3' },
+      ],
+    } as any);
+    expect(msgs).toEqual([
+      { role: 'system', content: 'You are terse.' },
+      { role: 'system', content: 'rule 2' },
+      { role: 'system', content: 'rule 3' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
   it('skips computer_call / computer_call_output / reasoning / local_shell_call input items', () => {
     const msgs = toChatMessages({
       input: [

--- a/server/src/__tests__/routes/responses-translate.test.ts
+++ b/server/src/__tests__/routes/responses-translate.test.ts
@@ -4,6 +4,8 @@ import {
   toChatTools,
   toChatToolChoice,
   buildResponseObject,
+  responsesInputHasImage,
+  responsesInputRequestsComputerUse,
 } from '../../routes/responses.js';
 
 describe('Responses → chat translation (#96)', () => {
@@ -48,6 +50,35 @@ describe('Responses → chat translation (#96)', () => {
       input: [{ type: 'function_call_output', call_id: 'call_1', output: 'sunny' }],
     } as any);
     expect(msgs[0]).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'sunny' });
+  });
+
+  it('skips computer_call / computer_call_output / reasoning / local_shell_call input items', () => {
+    const msgs = toChatMessages({
+      input: [
+        { type: 'computer_call', call_id: 'cc_1', action: { type: 'click', coordinate: [1, 2] } },
+        { type: 'computer_call_output', call_id: 'cc_1', output: [{ type: 'computer_screenshot', image_url: 'data:image/png;base64,AA==' }] },
+        { type: 'reasoning', summary: [{ type: 'summary_text', text: 'thinking' }] },
+        { type: 'local_shell_call', call_id: 'ls_1', action: { type: 'bash', command: 'ls' } },
+        { type: 'message', role: 'user', content: 'what now?' },
+      ],
+    } as any);
+    expect(msgs).toEqual([{ role: 'user', content: 'what now?' }]);
+  });
+
+  it('detects computer-use requests from tools and computer_call items', () => {
+    expect(responsesInputRequestsComputerUse({ tools: [{ type: 'computer' }] } as any)).toBe(true);
+    expect(responsesInputRequestsComputerUse({ tools: [{ type: 'computer_use_preview' }] } as any)).toBe(true);
+    expect(responsesInputRequestsComputerUse({ tools: [{ type: 'function', name: 'f' }] } as any)).toBe(false);
+    expect(responsesInputRequestsComputerUse({
+      input: [{ type: 'computer_call', call_id: 'cc_1', action: { type: 'click' } }],
+    } as any)).toBe(true);
+    expect(responsesInputRequestsComputerUse({ input: 'plain text' } as any)).toBe(false);
+  });
+
+  it('detects screenshots inside computer_call_output.output as image input', () => {
+    expect(responsesInputHasImage({
+      input: [{ type: 'computer_call_output', call_id: 'cc_1', output: [{ type: 'computer_screenshot', image_url: 'data:image/png;base64,AA==' }] }],
+    } as any)).toBe(true);
   });
 
   it('converts flat Responses tools to nested chat tools', () => {

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -171,6 +171,36 @@ describe('POST /v1/responses (#96)', () => {
     expect(text).toContain('"arguments":"{\\"city\\":\\"SF\\"}"');
   });
 
+  // The Responses streaming SDK indexes snapshot.output by output_index and
+  // crashes on a collision (an output_text delta with the same index as a
+  // function_call item). Models that stream tool_calls BEFORE any closing text
+  // (GLM/Qwen on this surface) used to leave the text item stuck at index 0
+  // while the function_call owned 0 too. Every output item must claim a dense,
+  // unique index.
+  it('stream: keeps output_index unique when tool_calls precede the text item', async () => {
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() { throw new Error('nope'); },
+      async *streamChatCompletion() {
+        yield { id: 'c', object: 'chat.completion.chunk', created: 0, model: 'fake-model', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{"ci' } }] }, finish_reason: null }] };
+        yield { id: 'c', object: 'chat.completion.chunk', created: 0, model: 'fake-model', choices: [{ index: 0, delta: { tool_calls: [{ index: 0, type: 'function', function: { arguments: 'ty":"SF"}' } }] }, finish_reason: null }] };
+        yield { id: 'c', object: 'chat.completion.chunk', created: 0, model: 'fake-model', choices: [{ index: 0, delta: { content: 'done' }, finish_reason: null }] };
+        yield { id: 'c', object: 'chat.completion.chunk', created: 0, model: 'fake-model', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      },
+    }));
+
+    const { text } = await post(app, '/v1/responses', { input: 'do it', stream: true }, key);
+    const indices: number[] = [...text.matchAll(/"output_index":(\d+)/g)].map((m) => Number(m[1]));
+    expect(indices.length).toBeGreaterThan(0);
+    // tool_calls + text = two distinct items, so both 0 AND 1 must appear and
+    // the function_call item must not share the text item's index.
+    expect(new Set(indices)).toContain(0);
+    expect(new Set(indices)).toContain(1);
+    // the closing text delta must reference the text item (index 1), not 0
+    const textDelta = text.split('event: response.output_text.delta')[1];
+    expect(textDelta).toContain('"output_index":1');
+    expect(textDelta).toContain('"delta":"done"');
+  });
+
   it('routes built-in Responses tools through tool-capable models', async () => {
     mockRouteRequest.mockClear();
     mockRouteRequest.mockReturnValue(fakeRoute({

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -201,6 +201,41 @@ describe('POST /v1/responses (#96)', () => {
     expect(textDelta).toContain('"delta":"done"');
   });
 
+  it('rejects computer-use requests with a clear 422 before translation', async () => {
+    mockRouteRequest.mockClear();
+    const { status, text } = await post(app, '/v1/responses', {
+      input: 'control the computer',
+      tools: [{ type: 'computer_use_preview', name: 'computer' }],
+    }, key);
+    expect(status).toBe(422);
+    const body = JSON.parse(text);
+    expect(body.error.code).toBe('no_computer_use_model');
+    expect(body.error.type).toBe('invalid_request_error');
+    expect(mockRouteRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts computer_call_output round-trip items without 400 (validation leniency)', async () => {
+    mockRouteRequest.mockReturnValue(fakeRoute({
+      async chatCompletion() {
+        return {
+          id: 'c', object: 'chat.completion', created: 0, model: 'fake-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        };
+      },
+      async *streamChatCompletion() { /* unused */ },
+    }));
+
+    const { status, text } = await post(app, '/v1/responses', {
+      input: [
+        { type: 'reasoning', summary: [{ type: 'summary_text', text: 'planning' }] },
+        { type: 'message', role: 'user', content: 'what is the weather?' },
+      ],
+    }, key);
+    expect(status).toBe(200);
+    expect(JSON.parse(text).output_text).toBe('ok');
+  });
+
   it('routes built-in Responses tools through tool-capable models', async () => {
     mockRouteRequest.mockClear();
     mockRouteRequest.mockReturnValue(fakeRoute({

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -534,9 +534,16 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         requestedModel: attempt === 0 ? requestedModelLabel : undefined,
       });
       if (stream) {
+        // Every output item (message text + each function_call) claims the next
+        // free index. OpenAI's streaming SDK indexes snapshot.output by
+        // output_index, so indices MUST be dense & unique — reusing 0 for the
+        // text item after a tool-call item had already taken it makes the SDK
+        // crash on `snapshot.output[output_index]` (#96, Codex computer-use).
         let outputIndex = 0;
         let msgItemId: string | null = null;
         let msgText = '';
+        // output_index of the open text item (valid while msgItemId !== null).
+        let textOutputIndex = 0;
         // tool-call accumulator keyed by the provider's tool_call index
         const toolAcc = new Map<number, { outputIndex: number; itemId: string; callId: string; name: string; args: string }>();
         let totalOutputTokens = 0;
@@ -578,19 +585,24 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         };
 
         // Open the text output item and stream `text` as its first delta.
+        // The text item takes the next free output index (it is NOT always 0 —
+        // when the model emits tool_calls first, the function_call items own
+        // the low indices). Every later text delta/done must reference this
+        // same index or the SDK snapshot lookup misroutes the deltas.
         const openTextItem = (text: string) => {
           commit();
           msgItemId = newId('msg');
+          textOutputIndex = outputIndex++;
           sse('response.output_item.added', {
-            output_index: outputIndex,
+            output_index: textOutputIndex,
             item: { id: msgItemId, type: 'message', status: 'in_progress', role: 'assistant', content: [] },
           });
           sse('response.content_part.added', {
-            item_id: msgItemId, output_index: outputIndex, content_index: 0,
+            item_id: msgItemId, output_index: textOutputIndex, content_index: 0,
             part: { type: 'output_text', text: '', annotations: [] },
           });
           if (text) {
-            sse('response.output_text.delta', { item_id: msgItemId, output_index: outputIndex, content_index: 0, delta: text });
+            sse('response.output_text.delta', { item_id: msgItemId, output_index: textOutputIndex, content_index: 0, delta: text });
             msgText += text;
           }
         };
@@ -636,7 +648,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
               if (dialectMode === 'passthrough') {
                 if (msgItemId === null) openTextItem('');
                 sse('response.output_text.delta', {
-                  item_id: msgItemId, output_index: 0, content_index: 0, delta: text,
+                  item_id: msgItemId, output_index: textOutputIndex, content_index: 0, delta: text,
                 });
                 msgText += text;
               } else {
@@ -665,14 +677,13 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
                 // First time we see this tool call: open a new output item.
                 commit();
                 if (msgItemId !== null && msgText.length > 0) {
-                  // close the text item (always output index 0) before starting a function_call item
-                  sse('response.output_text.done', { item_id: msgItemId, output_index: 0, content_index: 0, text: msgText });
-                  sse('response.content_part.done', { item_id: msgItemId, output_index: 0, content_index: 0, part: { type: 'output_text', text: msgText, annotations: [] } });
-                  sse('response.output_item.done', { output_index: 0, item: { id: msgItemId, type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: msgText, annotations: [] }] } });
+                  // close the text item (at its own output index) before starting a function_call item
+                  sse('response.output_text.done', { item_id: msgItemId, output_index: textOutputIndex, content_index: 0, text: msgText });
+                  sse('response.content_part.done', { item_id: msgItemId, output_index: textOutputIndex, content_index: 0, part: { type: 'output_text', text: msgText, annotations: [] } });
+                  sse('response.output_item.done', { output_index: textOutputIndex, item: { id: msgItemId, type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: msgText, annotations: [] }] } });
                   msgItemId = null;
                 }
-                outputIndex = toolAcc.size + (msgText.length > 0 ? 1 : 0);
-                acc = { outputIndex, itemId: newId('fc'), callId: tc.id || newId('call'), name: tc.function?.name ?? '', args: '' };
+                acc = { outputIndex: outputIndex++, itemId: newId('fc'), callId: tc.id || newId('call'), name: tc.function?.name ?? '', args: '' };
                 toolAcc.set(idx, acc);
                 sse('response.output_item.added', {
                   output_index: acc.outputIndex,
@@ -710,7 +721,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
                 const idx = 1000 + rescuedIdx++; // synthetic accumulator keys, past any provider index
                 commit();
                 const acc = {
-                  outputIndex: toolAcc.size + (msgText.length > 0 ? 1 : 0),
+                  outputIndex: outputIndex++,
                   itemId: newId('fc'), callId: newId('call'), name: c.name, args: c.arguments,
                 };
                 toolAcc.set(idx, acc);
@@ -752,9 +763,9 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
 
           // Finalize any open text item.
           if (msgItemId !== null) {
-            sse('response.output_text.done', { item_id: msgItemId, output_index: 0, content_index: 0, text: msgText });
-            sse('response.content_part.done', { item_id: msgItemId, output_index: 0, content_index: 0, part: { type: 'output_text', text: msgText, annotations: [] } });
-            sse('response.output_item.done', { output_index: 0, item: { id: msgItemId, type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: msgText, annotations: [] }] } });
+            sse('response.output_text.done', { item_id: msgItemId, output_index: textOutputIndex, content_index: 0, text: msgText });
+            sse('response.content_part.done', { item_id: msgItemId, output_index: textOutputIndex, content_index: 0, part: { type: 'output_text', text: msgText, annotations: [] } });
+            sse('response.output_item.done', { output_index: textOutputIndex, item: { id: msgItemId, type: 'message', status: 'completed', role: 'assistant', content: [{ type: 'output_text', text: msgText, annotations: [] }] } });
           }
           // Finalize tool-call items. Arguments are repaired against the tool's
           // parameter schema at this point (after the full string accumulated):

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -254,7 +254,10 @@ export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
     return messages;
   }
 
-  for (const item of req.input) {
+  const items = req.input;
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+
     if ('type' in item && item.type === 'function_call') {
       messages.push({
         role: 'assistant',
@@ -265,25 +268,65 @@ export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
           function: { name: item.name, arguments: item.arguments },
         }],
       });
-    } else if ('type' in item && item.type === 'function_call_output') {
+      continue;
+    }
+
+    if ('type' in item && item.type === 'function_call_output') {
       const output = typeof item.output === 'string'
         ? item.output
         : Array.isArray(item.output)
           ? partsToString(item.output as any)
           : JSON.stringify(item.output);
       messages.push({ role: 'tool', tool_call_id: item.call_id, content: output });
-    } else if ('type' in item && item.type !== 'message') {
+      continue;
+    }
+
+    if ('type' in item && item.type !== 'message') {
       // computer_call / computer_call_output / reasoning / local_shell_call:
       // no chat-message equivalent (the route 422s computer use up front).
       // Skip rather than mis-parse as a message item.
       continue;
-    } else {
-      // message item
-      const m = item as z.infer<typeof messageItemSchema>;
-      // 'developer' is the Responses-era system role.
-      const role = m.role === 'developer' ? 'system' : m.role;
-      messages.push({ role, content: partsToString(m.content) });
     }
+
+    // message item
+    const m = item as z.infer<typeof messageItemSchema>;
+    // 'developer' is the Responses-era system role.
+    const role = m.role === 'developer' ? 'system' : m.role;
+    const content = partsToString(m.content);
+
+    if (role === 'assistant') {
+      // A Responses assistant turn is a message item followed by its
+      // function_call items. Merge them into a single chat assistant message
+      // (content + tool_calls); emitting consecutive assistant turns makes
+      // Gemini map them to consecutive model turns and strict upstreams
+      // (Mistral/Cohere) 400. Drop empty assistant items — an empty turn means
+      // nothing to a chat provider. (#96)
+      const toolCalls: ChatToolCall[] = [];
+      let j = i + 1;
+      while (j < items.length && (items[j] as { type?: string }).type === 'function_call') {
+        const fc = items[j] as z.infer<typeof functionCallItemSchema>;
+        toolCalls.push({
+          id: fc.call_id,
+          type: 'function',
+          function: { name: fc.name, arguments: fc.arguments },
+        });
+        j++;
+      }
+      if (toolCalls.length > 0) {
+        messages.push({
+          role: 'assistant',
+          content: content.length > 0 ? content : null,
+          tool_calls: toolCalls,
+        });
+        i = j - 1;
+        continue;
+      }
+      if (content.length === 0) continue;
+      messages.push({ role: 'assistant', content });
+      continue;
+    }
+
+    messages.push({ role, content });
   }
 
   return messages;

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -243,16 +243,18 @@ export function responsesInputRequestsComputerUse(req: ResponsesRequest): boolea
 
 // ── Translate a Responses request → internal chat messages + options ──────
 export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
-  const messages: ChatMessage[] = [];
+  const systemMessages: ChatMessage[] = [];
 
   if (req.instructions) {
-    messages.push({ role: 'system', content: req.instructions });
+    systemMessages.push({ role: 'system', content: req.instructions });
   }
 
   if (typeof req.input === 'string') {
-    messages.push({ role: 'user', content: req.input });
-    return messages;
+    const messages = [{ role: 'user' as const, content: req.input }];
+    return [...systemMessages, ...messages];
   }
+
+  const messages: ChatMessage[] = [];
 
   const items = req.input;
   for (let i = 0; i < items.length; i++) {
@@ -294,6 +296,15 @@ export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
     const role = m.role === 'developer' ? 'system' : m.role;
     const content = partsToString(m.content);
 
+    if (role === 'system') {
+      // Hoist system/developer messages to the start of the conversation:
+      // chat providers (Gemini, Claude, Mistral) reject a system message that
+      // appears after a user turn. Codex history replay often emits developer
+      // items mid-conversation.
+      systemMessages.push({ role: 'system', content });
+      continue;
+    }
+
     if (role === 'assistant') {
       // A Responses assistant turn is a message item followed by its
       // function_call items. Merge them into a single chat assistant message
@@ -329,7 +340,7 @@ export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
     messages.push({ role, content });
   }
 
-  return messages;
+  return [...systemMessages, ...messages];
 }
 
 export function toChatTools(tools?: ResponsesRequest['tools']): ChatToolDefinition[] | undefined {

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -103,9 +103,52 @@ const functionCallOutputItemSchema = z.object({
   output: z.union([z.string(), z.array(contentPartSchema), z.record(z.string(), z.unknown())]),
 });
 
+// Remaining official ResponseInputItemParam kinds. Codex computer-use round-trips
+// `computer_call` (the model's action request) and `computer_call_output` (the
+// harness's result, incl. screenshots); multi-turn sessions also replay
+// `reasoning` / `local_shell_call` items. We accept them all so validation never
+// 400s on a standard payload; each is then either mapped (below) or dropped
+// because chat-completions upstreams have no equivalent (computer/local_shell).
+// Each schema is permissive — we only consume the fields that matter.
+const computerCallItemSchema = z.object({
+  type: z.literal('computer_call'),
+  call_id: z.string(),
+  action: z.record(z.string(), z.unknown()).optional(),
+  id: z.string().optional(),
+}).passthrough();
+
+const computerCallOutputItemSchema = z.object({
+  type: z.literal('computer_call_output'),
+  call_id: z.string(),
+  output: z.union([
+    z.string(),
+    z.array(contentPartSchema),
+    z.record(z.string(), z.unknown()),
+  ]).optional(),
+  id: z.string().optional(),
+}).passthrough();
+
+const reasoningItemSchema = z.object({
+  type: z.literal('reasoning'),
+  summary: z.union([z.string(), z.array(contentPartSchema)]).optional(),
+  content: z.union([z.string(), z.array(contentPartSchema)]).optional(),
+  id: z.string().optional(),
+}).passthrough();
+
+const localShellCallItemSchema = z.object({
+  type: z.literal('local_shell_call'),
+  call_id: z.string().optional(),
+  action: z.record(z.string(), z.unknown()).optional(),
+  id: z.string().optional(),
+}).passthrough();
+
 const inputItemSchema = z.union([
   functionCallItemSchema,
   functionCallOutputItemSchema,
+  computerCallItemSchema,
+  computerCallOutputItemSchema,
+  reasoningItemSchema,
+  localShellCallItemSchema,
   messageItemSchema,
 ]);
 
@@ -170,13 +213,32 @@ export function responsesInputHasImage(req: ResponsesRequest): boolean {
   if (typeof req.input === 'string') return false;
   for (const item of req.input) {
     const content = (item as { content?: unknown }).content;
-    if (!Array.isArray(content)) continue;
-    if (content.some((p) => {
+    if (Array.isArray(content) && content.some((p) => {
       const type = (p as { type?: string })?.type;
       return type === 'input_image' || type === 'image_url' || type === 'image';
     })) return true;
+    // computer_call_output carries screenshots under `output`, not `content`.
+    const output = (item as { output?: unknown }).output;
+    if (Array.isArray(output) && output.some((p) => {
+      const type = (p as { type?: string })?.type;
+      return type === 'input_image' || type === 'computer_screenshot' || type === 'image_url';
+    })) return true;
   }
   return false;
+}
+
+// Computer use (the Responses `computer` / `computer_use_preview` tool + its
+// computer_call/computer_call_output items) has no chat-completions equivalent:
+// the harness loop needs the model's computer_actions and screenshot context,
+// neither of which survives translation. Fail clearly (mirroring the image 422)
+// rather than silently dropping the calls and breaking the tool loop.
+export function responsesInputRequestsComputerUse(req: ResponsesRequest): boolean {
+  if ((req.tools ?? []).some((t) => t.type === 'computer' || t.type === 'computer_use_preview')) return true;
+  if (typeof req.input === 'string' || req.input == null) return false;
+  return req.input.some((item) => {
+    const type = (item as { type?: string })?.type;
+    return type === 'computer_call' || type === 'computer_call_output';
+  });
 }
 
 // ── Translate a Responses request → internal chat messages + options ──────
@@ -210,6 +272,11 @@ export function toChatMessages(req: ResponsesRequest): ChatMessage[] {
           ? partsToString(item.output as any)
           : JSON.stringify(item.output);
       messages.push({ role: 'tool', tool_call_id: item.call_id, content: output });
+    } else if ('type' in item && item.type !== 'message') {
+      // computer_call / computer_call_output / reasoning / local_shell_call:
+      // no chat-message equivalent (the route 422s computer use up front).
+      // Skip rather than mis-parse as a message item.
+      continue;
     } else {
       // message item
       const m = item as z.infer<typeof messageItemSchema>;
@@ -344,6 +411,20 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         message: 'Image input is not yet supported on /v1/responses. Use /v1/chat/completions with an image_url content part instead.',
         type: 'invalid_request_error',
         code: 'no_vision_model',
+      },
+    });
+    return;
+  }
+
+  // Computer use can't survive the chat-completions translation either (no
+  // computer tool, no screenshot context). Fail clearly instead of silently
+  // dropping the calls and breaking Codex's computer-use tool loop.
+  if (responsesInputRequestsComputerUse(reqData)) {
+    res.status(422).json({
+      error: {
+        message: 'Computer use is not yet supported on /v1/responses (the computer / computer_use_preview tool and computer_call items have no chat-completions equivalent).',
+        type: 'invalid_request_error',
+        code: 'no_computer_use_model',
       },
     });
     return;


### PR DESCRIPTION
The origin #844 without vision support
Fixes #842 (partially) — addresses the 5 highest-severity deviations. Items 6 and 7 are out of scope here.

## Fixed

- **1 — streaming `output_index` not unique** (`29e2866`): dense, unique indices across tool-call and text items in delta/done events, so the SDK's `snapshot.output[output_index]` no longer collides when a model streams tool_calls before the closing text (GLM/Qwen).
- **2 — `inputItemSchema` rejects standard item types** (`f79091f`): accept the remaining official `ResponseInputItemParam` kinds (`computer_call`, `computer_call_output`, `reasoning`, `local_shell_call`) so agent harnesses stop 400'ing at validation; `toChatMessages` skips non-message kinds instead of mis-parsing them.
- **3 — computer use cannot survive translation** (`f79091f`): detect `computer`/`computer_use_preview` tools and `computer_call` items and fail up front with a clear `422 no_computer_use_model` rather than silently dropping the calls and breaking the harness loop. `responsesInputHasImage` also detects `computer_screenshot` parts under `computer_call_output.output`.
- **4 — consecutive / empty assistant messages not normalized** (`482b70a`): merge a `message` item with the adjacent `function_call` items into a single assistant turn with `content` + `tool_calls` (the shape chat providers expect), folding tool_call ids so tool results pair correctly; drop empty assistant items with no tool_calls.
- **5 — `developer` → `system` can land mid-conversation** (`e67620f`): hoist all system/developer messages into a single leading block (instructions first, then in relative order), which Gemini/Claude/Mistral require.


## Not fixed (left for follow-up)

- **6 — `reasoning_content` dropped**, risking false empty-completion failover for thought-only outputs.
- **7 — streaming usage undercounts tool-call tokens**: text-only `totalOutputTokens`, hardcoded `cached_tokens` / `reasoning_tokens` of 0.