### PR TITLE
fix(classify): only treat an end-of-life phrase as definitive on a gone-shaped status

### DIFF
--- a/server/src/__tests__/services/model-retirement.test.ts
+++ b/server/src/__tests__/services/model-retirement.test.ts
@@ -81,6 +81,36 @@ describe('modelRetirementSignal (conservative end-of-life detection — #634)', 
     ))).toBe('definitive');
   });
 
+  // 'definitive' skips the corroboration gate and disables the model on ONE
+  // response, so the phrase must not be load-bearing by itself: a rate-limit
+  // or server-error body can quote a retirement notice (about this model or
+  // another) without the model being gone.
+  it('ignores an end-of-life phrase when the status does not agree the model is gone', () => {
+    expect(modelRetirementSignal(Object.assign(
+      new Error('Rate limit exceeded. Note: llama-3.1-8b reaches end of life on 2026-12-01'),
+      { status: 429 },
+    ))).toBeNull();
+    expect(modelRetirementSignal(Object.assign(
+      new Error('Internal server error: upstream pool has been decommissioned'),
+      { status: 500 },
+    ))).toBeNull();
+    expect(modelRetirementSignal(Object.assign(
+      new Error('Bad request: the v1 endpoint has been sunset, use v2'),
+      { status: 400 },
+    ))).toBeNull();
+  });
+
+  it('still fires when a gone-shaped status carries the phrase', () => {
+    expect(modelRetirementSignal(Object.assign(
+      new Error('API error 410: this model has been retired'),
+      { status: 410 },
+    ))).toBe('definitive');
+    expect(modelRetirementSignal(Object.assign(
+      new Error('API error 404: this model has been decommissioned'),
+      { status: 404 },
+    ))).toBe('definitive');
+  });
+
   it('treats a 404 that clearly says the model is gone as probable (needs corroboration)', () => {
     expect(modelRetirementSignal(Object.assign(
       new Error('OpenRouter API error 404: this model is no longer available'),

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -449,7 +449,13 @@ export function modelRetirementSignal(err: any): ModelRetirementConfidence | nul
   const msg = (err?.message ?? '').toLowerCase();
   const status = typeof err?.status === 'number' ? err.status : 0;
   const gone = status === 410 || /\berror 410\b/.test(msg) || /\b410 gone\b/.test(msg);
-  if (gone || END_OF_LIFE_PHRASES.some(phrase => msg.includes(phrase))) return 'definitive';
+  // An end-of-life phrase is only definitive when the status agrees the model
+  // is not there. On its own it is just text, and 'definitive' skips the
+  // corroboration gate in noteModelRetirementSignal — so a 429 or 500 whose
+  // body happens to mention a retirement (an advisory notice, a status-page
+  // quote, a message about a DIFFERENT model) disabled a live model on one
+  // response. Unmatched here means it falls through and teaches nothing.
+  if (gone || (isModelNotFoundError(err) && END_OF_LIFE_PHRASES.some(phrase => msg.includes(phrase)))) return 'definitive';
   if (!isModelNotFoundError(err)) return null;
   return MODEL_GONE_PHRASES.some(phrase => msg.includes(phrase)) ? 'probable' : null;
 }


### PR DESCRIPTION
`modelRetirementSignal` (`lib/error-classify.ts`) matched `END_OF_LIFE_PHRASES` against the message of **any** error:

```ts
if (gone || END_OF_LIFE_PHRASES.some(phrase => msg.includes(phrase))) return 'definitive';
```

`'definitive'` is not a hint. In `services/model-retirement.ts`, only `'probable'` goes through the `confirmObservation` corroboration gate — `'definitive'` disables the model immediately, on a single response:

```ts
const confidence = modelRetirementSignal(err);
if (!confidence) return false;
const key = modelStatsKey(...);
if (confidence === 'probable' && !confirmObservation(key, requestToken)) return false;
// → retireCatalogModelUpstream(...)
```

So one 429 or 500 whose body happens to contain `end of life`, `has been retired`, `has been decommissioned`, or `has been sunset` permanently retired a healthy model. That is not a hypothetical shape — providers put end-of-life advisories in rate-limit bodies ("Rate limit exceeded. Note: X reaches end of life on …"), quote status pages in 5xx text, and mention one model's retirement in a message served for a different model.

## The change

An end-of-life phrase is definitive only when the status also agrees the model is not there, reusing the existing predicate:

```ts
if (gone || (isModelNotFoundError(err) && END_OF_LIFE_PHRASES.some(phrase => msg.includes(phrase)))) return 'definitive';
```

The existing behaviour that "the wording alone is definitive even when the provider picks a 404" is unchanged, since 404 satisfies `isModelNotFoundError`. #634's NVIDIA 410 case is unchanged.

## Why not demote to `'probable'` instead

Because the entire failure class is *a body quoting retirement language while the model is fine*. Feeding that into the corroboration counter would re-create the same bug at lower confidence — two unlucky rate-limit bodies instead of one. An unmatched phrase now falls through the next line (`if (!isModelNotFoundError(err)) return null;`) and teaches nothing, which is the conservative reading #634 asked for.

## Tests

Two cases added to the existing `modelRetirementSignal` describe block: a 429, a 500 and a 400 each carrying an end-of-life phrase now return `null`; a 410 and a 404 carrying one still return `'definitive'`.

Full server suite green: 205 files, 2247 passed, 8 skipped.