### PR TITLE
fix(cli): resolve --model against the unfiltered catalog before launching

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,6 +38,8 @@
     "dist/index.d.ts",
     "dist/config-files.js",
     "dist/config-files.d.ts",
+    "dist/models.js",
+    "dist/models.d.ts",
     "dist/tools.js",
     "dist/tools.d.ts",
     "dist/types.js",

--- a/cli/src/index.test.ts
+++ b/cli/src/index.test.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { claudeLaunchEnv, codexArgs, parseArgs } from './index.js';
+import { claudeLaunchEnv, codexArgs, parseArgs, resolvePinnedModel } from './index.js';
+import { UnknownModelError } from './models.js';
 import type { CatalogModel } from './types.js';
 
 describe('CLI arguments and launchers', () => {
@@ -108,6 +109,58 @@ describe('CLI arguments and launchers', () => {
     expect(env.ANTHROPIC_AUTH_TOKEN).toBe('unified-key');
     expect(env.PATH).toBe('/usr/bin');
     expect(JSON.stringify(env)).not.toContain('real-anthropic');
+  });
+
+  describe('resolvePinnedModel', () => {
+    const available: CatalogModel[] = [{ id: 'auto' }, { id: 'fast-coder', available: true }];
+    const full: CatalogModel[] = [...available, { id: 'benched', available: false }];
+
+    function collect(): { warnings: string[]; warn: (message: string) => void } {
+      const warnings: string[] = [];
+      return { warnings, warn: message => { warnings.push(message); } };
+    }
+
+    it('is silent for an available pinned model', () => {
+      const { warnings, warn } = collect();
+      expect(resolvePinnedModel('fast-coder', { available, full }, warn)?.id).toBe('fast-coder');
+      expect(warnings).toEqual([]);
+    });
+
+    it('warns but still resolves a registered-but-unavailable model', () => {
+      const { warnings, warn } = collect();
+      expect(resolvePinnedModel('benched', { available, full }, warn))
+        .toMatchObject({ id: 'benched', unavailable: true });
+      expect(warnings.join()).toContain('not currently available');
+    });
+
+    it('WARNS when the unfiltered roster could not be fetched', () => {
+      // Silently degrading to the filtered roster would reinstate exactly the
+      // ambiguity this pair of fetches removes: the user would see a quota
+      // problem reported as a typo, with nothing saying the check was weaker.
+      const { warnings, warn } = collect();
+      resolvePinnedModel(
+        'fast-coder',
+        { available, full: available, degradedReason: 'HTTP 400' },
+        warn,
+      );
+      expect(warnings.join()).toContain('could not fetch the unfiltered model catalog');
+      expect(warnings.join()).toContain('HTTP 400');
+    });
+
+    it('still reports an id in neither roster as unknown, degraded or not', () => {
+      const { warn } = collect();
+      expect(() => resolvePinnedModel('nope', { available, full }, warn))
+        .toThrow(UnknownModelError);
+    });
+
+    it('does nothing at all when no model was pinned', () => {
+      // Nothing to warn about: the launcher picks from the filtered roster,
+      // where there is no unknown-vs-unavailable ambiguity to lose.
+      const { warnings, warn } = collect();
+      expect(resolvePinnedModel(undefined, { available, full, degradedReason: 'x' }, warn))
+        .toBeUndefined();
+      expect(warnings).toEqual([]);
+    });
   });
 
   it('passes a complete Responses provider to Codex', () => {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,7 @@ import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { applyGeneratedFiles, printDryRunDiff } from './config-files.js';
 import { getTool, tools } from './tools.js';
+import { resolveLaunchModel } from './models.js';
 import type { CatalogModel, GenerateContext } from './types.js';
 
 interface CliOptions {
@@ -104,10 +105,10 @@ async function promptForKey(): Promise<string> {
   }
 }
 
-async function catalog(url: string, apiKey: string): Promise<CatalogModel[]> {
+async function catalog(url: string, apiKey: string, availableOnly = true): Promise<CatalogModel[]> {
   let response: Response;
   try {
-    response = await fetch(`${rootUrl(url)}/v1/models?available=true`, {
+    response = await fetch(`${rootUrl(url)}/v1/models${availableOnly ? '?available=true' : ''}`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(10_000),
     });
@@ -129,6 +130,27 @@ async function catalog(url: string, apiKey: string): Promise<CatalogModel[]> {
   const models = body.data ?? [];
   if (!models.length) throw new Error('The live catalog returned no models');
   return models;
+}
+
+/**
+ * The available-only roster plus the unfiltered one.
+ *
+ * Only the unfiltered roster can distinguish "no such model" from "that model
+ * exists but is out of quota right now", and reporting the second as the first
+ * turns a rate limit into a spurious typo error. The unfiltered fetch is
+ * best-effort: an older gateway that ignores the parameter, or any failure,
+ * degrades to the filtered roster rather than blocking a launch.
+ */
+async function catalogs(
+  url: string,
+  apiKey: string,
+): Promise<{ available: CatalogModel[]; full: CatalogModel[] }> {
+  const available = await catalog(url, apiKey);
+  try {
+    return { available, full: await catalog(url, apiKey, false) };
+  } catch {
+    return { available, full: available };
+  }
 }
 
 function help(): string {
@@ -153,13 +175,22 @@ async function setup(command: string, options: CliOptions): Promise<void> {
   const tool = getTool(command.replace(/^setup-/, ''));
   if (!tool) throw new Error(`Unknown setup command '${command}'`);
   const apiKey = options.apiKey ?? await promptForKey();
-  const models = await catalog(options.url, apiKey);
+  const { available, full } = await catalogs(options.url, apiKey);
+  // --model was parsed but never reached the generators, so `setup-x --model y`
+  // silently wrote whatever primaryModel() preferred. Validate it against the
+  // unfiltered catalog (so an out-of-quota model is not reported as a typo)
+  // and thread it through.
+  const requestedModelId = options.model
+    ? resolveLaunchModel(options.model, available, full).id
+    : undefined;
+  warnIfUnavailable(options.model, available, full);
   const context: GenerateContext = {
     url: rootUrl(options.url),
     apiKey,
     profile: options.profile,
-    models,
+    models: available,
     homeDir: os.homedir(),
+    requestedModelId,
   };
   const generation = tool.generate(context);
 
@@ -221,14 +252,10 @@ export function claudeLaunchEnv(
   models: CatalogModel[],
   baseEnv: NodeJS.ProcessEnv = process.env,
   homeDir = os.homedir(),
+  fullCatalog: CatalogModel[] = models,
 ): NodeJS.ProcessEnv {
-  const selected = options.model
-    ?? models.find(model => model.id !== 'auto' && model.available !== false)?.id
-    ?? 'auto';
-  const selectedModel = models.find(model => model.id === selected);
-  const contextWindow = selectedModel?.context_window
-    ?? selectedModel?.context_length
-    ?? 128_000;
+  const resolved = resolveLaunchModel(options.model, models, fullCatalog);
+  const selected = resolved.id;
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   // Never leak the user's real Anthropic credentials to the gateway.
   delete env.ANTHROPIC_API_KEY;
@@ -243,23 +270,52 @@ export function claudeLaunchEnv(
     }
     env.CLAUDE_CONFIG_DIR = directory;
   }
-  return Object.assign(env, {
+  Object.assign(env, {
     ANTHROPIC_BASE_URL: rootUrl(options.url),
     ANTHROPIC_AUTH_TOKEN: apiKey,
     ANTHROPIC_MODEL: selected,
     ANTHROPIC_DEFAULT_OPUS_MODEL: selected,
     ANTHROPIC_DEFAULT_SONNET_MODEL: selected,
     ANTHROPIC_DEFAULT_HAIKU_MODEL: selected,
-    CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(contextWindow),
     CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY: '1',
   });
+  // Only pin the compaction window when the catalog actually published one.
+  // The old `?? 128_000` invented a number for every model with no stated
+  // window, and a wrong window is worse than none: too high and Claude Code
+  // compacts after the gateway has already rejected the request, too low and
+  // it compacts a conversation that still fits. Absent, Claude Code applies
+  // its own default.
+  if (resolved.contextWindow !== undefined) {
+    env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = String(resolved.contextWindow);
+  } else {
+    delete env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+  }
+  return env;
 }
 
 async function launchClaude(options: CliOptions): Promise<number> {
   const apiKey = options.apiKey ?? await promptForKey();
-  const models = await catalog(options.url, apiKey);
-  const env = claudeLaunchEnv(options, apiKey, models);
+  const { available, full } = await catalogs(options.url, apiKey);
+  const env = claudeLaunchEnv(options, apiKey, available, process.env, os.homedir(), full);
+  warnIfUnavailable(options.model, available, full);
   return runChild('claude', [], env);
+}
+
+/** A pinned model that is registered but not servable right now is a launch we
+ *  should still make — the router may recover it mid-session — but never one we
+ *  should make silently. */
+function warnIfUnavailable(
+  requested: string | undefined,
+  available: CatalogModel[],
+  full: CatalogModel[],
+): void {
+  if (!requested) return;
+  const resolved = resolveLaunchModel(requested, available, full);
+  if (!resolved.unavailable) return;
+  process.stderr.write(
+    `freellmapi: '${resolved.id}' is registered but not currently available `
+    + '(out of quota, cooling down, or its key is disabled). Launching anyway.\n',
+  );
 }
 
 export function codexArgs(url: string, selected: string): string[] {
@@ -276,10 +332,9 @@ export function codexArgs(url: string, selected: string): string[] {
 
 async function launchCodex(options: CliOptions): Promise<number> {
   const apiKey = options.apiKey ?? await promptForKey();
-  const models = await catalog(options.url, apiKey);
-  const selected = options.model
-    ?? models.find(model => model.id !== 'auto' && model.available !== false)?.id
-    ?? 'auto';
+  const { available, full } = await catalogs(options.url, apiKey);
+  const selected = resolveLaunchModel(options.model, available, full).id;
+  warnIfUnavailable(options.model, available, full);
   const env = { ...process.env, FREELLMAPI_API_KEY: apiKey };
   const args = codexArgs(options.url, selected);
   return runChild('codex', args, env);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,7 +9,7 @@ import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { applyGeneratedFiles, printDryRunDiff } from './config-files.js';
 import { getTool, tools } from './tools.js';
-import { resolveLaunchModel } from './models.js';
+import { resolveLaunchModel, type ResolvedModel } from './models.js';
 import type { CatalogModel, GenerateContext } from './types.js';
 
 interface CliOptions {
@@ -132,6 +132,15 @@ async function catalog(url: string, apiKey: string, availableOnly = true): Promi
   return models;
 }
 
+export interface Catalogs {
+  available: CatalogModel[];
+  full: CatalogModel[];
+  /** Why the unfiltered fetch failed. Set means `full` is really the FILTERED
+   *  roster, so "unknown model" and "out of quota" can no longer be told
+   *  apart — the exact ambiguity this pair of fetches exists to remove. */
+  degradedReason?: string;
+}
+
 /**
  * The available-only roster plus the unfiltered one.
  *
@@ -139,18 +148,61 @@ async function catalog(url: string, apiKey: string, availableOnly = true): Promi
  * exists but is out of quota right now", and reporting the second as the first
  * turns a rate limit into a spurious typo error. The unfiltered fetch is
  * best-effort: an older gateway that ignores the parameter, or any failure,
- * degrades to the filtered roster rather than blocking a launch.
+ * degrades to the filtered roster rather than blocking a launch — but it
+ * RECORDS that it degraded, so the degradation can be reported instead of
+ * silently reinstating the ambiguity.
  */
-async function catalogs(
-  url: string,
-  apiKey: string,
-): Promise<{ available: CatalogModel[]; full: CatalogModel[] }> {
+export async function catalogs(url: string, apiKey: string): Promise<Catalogs> {
   const available = await catalog(url, apiKey);
   try {
     return { available, full: await catalog(url, apiKey, false) };
-  } catch {
-    return { available, full: available };
+  } catch (error) {
+    return {
+      available,
+      full: available,
+      degradedReason: error instanceof Error ? error.message : String(error),
+    };
   }
+}
+
+/**
+ * Resolve a pinned `--model` ONCE, and say out loud anything that makes the
+ * verdict less than certain.
+ *
+ * One resolution feeding both the id that gets pinned and the warning the user
+ * reads, so the two can never disagree. Returns undefined when nothing was
+ * pinned — the launcher then picks from the filtered roster, where there is no
+ * ambiguity to lose and so nothing to warn about.
+ */
+export function resolvePinnedModel(
+  requested: string | undefined,
+  rosters: Catalogs,
+  warn: (message: string) => void = message => process.stderr.write(message),
+): ResolvedModel | undefined {
+  if (!requested) return undefined;
+
+  // Reported, never silent: degrading to the filtered roster is exactly the
+  // state in which an out-of-quota model gets called a typo, so the user has
+  // to be told which roster the verdict below came from.
+  if (rosters.degradedReason) {
+    warn(
+      `freellmapi: could not fetch the unfiltered model catalog (${rosters.degradedReason}). `
+      + `Checking '${requested}' against the available-only roster instead — a model that `
+      + 'exists but is out of quota may be reported as unknown.\n',
+    );
+  }
+
+  const resolved = resolveLaunchModel(requested, rosters.available, rosters.full);
+  // A pinned model that is registered but not servable right now is a launch we
+  // should still make — the router may recover it mid-session — but never one
+  // we should make silently.
+  if (resolved.unavailable) {
+    warn(
+      `freellmapi: '${resolved.id}' is registered but not currently available `
+      + '(out of quota, cooling down, or its key is disabled). Launching anyway.\n',
+    );
+  }
+  return resolved;
 }
 
 function help(): string {
@@ -175,20 +227,17 @@ async function setup(command: string, options: CliOptions): Promise<void> {
   const tool = getTool(command.replace(/^setup-/, ''));
   if (!tool) throw new Error(`Unknown setup command '${command}'`);
   const apiKey = options.apiKey ?? await promptForKey();
-  const { available, full } = await catalogs(options.url, apiKey);
+  const rosters = await catalogs(options.url, apiKey);
   // --model was parsed but never reached the generators, so `setup-x --model y`
   // silently wrote whatever primaryModel() preferred. Validate it against the
   // unfiltered catalog (so an out-of-quota model is not reported as a typo)
   // and thread it through.
-  const requestedModelId = options.model
-    ? resolveLaunchModel(options.model, available, full).id
-    : undefined;
-  warnIfUnavailable(options.model, available, full);
+  const requestedModelId = resolvePinnedModel(options.model, rosters)?.id;
   const context: GenerateContext = {
     url: rootUrl(options.url),
     apiKey,
     profile: options.profile,
-    models: available,
+    models: rosters.available,
     homeDir: os.homedir(),
     requestedModelId,
   };
@@ -295,27 +344,16 @@ export function claudeLaunchEnv(
 
 async function launchClaude(options: CliOptions): Promise<number> {
   const apiKey = options.apiKey ?? await promptForKey();
-  const { available, full } = await catalogs(options.url, apiKey);
-  const env = claudeLaunchEnv(options, apiKey, available, process.env, os.homedir(), full);
-  warnIfUnavailable(options.model, available, full);
-  return runChild('claude', [], env);
-}
-
-/** A pinned model that is registered but not servable right now is a launch we
- *  should still make — the router may recover it mid-session — but never one we
- *  should make silently. */
-function warnIfUnavailable(
-  requested: string | undefined,
-  available: CatalogModel[],
-  full: CatalogModel[],
-): void {
-  if (!requested) return;
-  const resolved = resolveLaunchModel(requested, available, full);
-  if (!resolved.unavailable) return;
-  process.stderr.write(
-    `freellmapi: '${resolved.id}' is registered but not currently available `
-    + '(out of quota, cooling down, or its key is disabled). Launching anyway.\n',
+  const rosters = await catalogs(options.url, apiKey);
+  // Resolved here for the warning; claudeLaunchEnv resolves again to build the
+  // environment. Both are pure calls over the same two rosters, so they cannot
+  // reach different verdicts — keeping claudeLaunchEnv a side-effect-free env
+  // builder is worth more than eliding the second call.
+  resolvePinnedModel(options.model, rosters);
+  const env = claudeLaunchEnv(
+    options, apiKey, rosters.available, process.env, os.homedir(), rosters.full,
   );
+  return runChild('claude', [], env);
 }
 
 export function codexArgs(url: string, selected: string): string[] {
@@ -332,9 +370,11 @@ export function codexArgs(url: string, selected: string): string[] {
 
 async function launchCodex(options: CliOptions): Promise<number> {
   const apiKey = options.apiKey ?? await promptForKey();
-  const { available, full } = await catalogs(options.url, apiKey);
-  const selected = resolveLaunchModel(options.model, available, full).id;
-  warnIfUnavailable(options.model, available, full);
+  const rosters = await catalogs(options.url, apiKey);
+  const selected = (
+    resolvePinnedModel(options.model, rosters)
+    ?? resolveLaunchModel(undefined, rosters.available, rosters.full)
+  ).id;
   const env = { ...process.env, FREELLMAPI_API_KEY: apiKey };
   const args = codexArgs(options.url, selected);
   return runChild('codex', args, env);

--- a/cli/src/models.test.ts
+++ b/cli/src/models.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { UnknownModelError, contextWindowOf, defaultModelId, resolveLaunchModel } from './models.js';
+import type { CatalogModel } from './types.js';
+
+// The distinction this module exists for: the CLI's catalog() fetches
+// `?available=true`, so absence from that roster means EITHER "no such model"
+// OR "exists, out of quota right now". Only the unfiltered roster separates
+// them, and conflating them reports a healthy pinned model as a typo the
+// moment its provider rate-limits.
+
+const AVAILABLE: CatalogModel[] = [
+  { id: 'auto' },
+  { id: 'fast-coder', available: true, context_window: 131072 },
+];
+
+const FULL: CatalogModel[] = [
+  ...AVAILABLE,
+  { id: 'benched-model', available: false, context_window: 32768 },
+  { id: 'no-window-model', available: true },
+];
+
+describe('resolveLaunchModel', () => {
+  it('accepts a model that is registered but not currently servable', () => {
+    const resolved = resolveLaunchModel('benched-model', AVAILABLE, FULL);
+    expect(resolved.id).toBe('benched-model');
+    expect(resolved.unavailable).toBe(true);
+    expect(resolved.contextWindow).toBe(32768);
+  });
+
+  it('rejects a model that is in neither roster', () => {
+    expect(() => resolveLaunchModel('no-such-model', AVAILABLE, FULL))
+      .toThrow(UnknownModelError);
+  });
+
+  it('suggests near-matches on an unknown id rather than only refusing', () => {
+    expect(() => resolveLaunchModel('coder', AVAILABLE, FULL))
+      .toThrow(/fast-coder/);
+  });
+
+  it('reports an available model as available', () => {
+    expect(resolveLaunchModel('fast-coder', AVAILABLE, FULL))
+      .toMatchObject({ id: 'fast-coder', unavailable: false, contextWindow: 131072 });
+  });
+
+  it('leaves the context window undefined when the catalog publishes none', () => {
+    // Not 128000. An unpublished window is a different fact from a known one,
+    // and inventing a number is how the launcher pinned a wrong compaction
+    // threshold for every model whose provider states no window.
+    expect(resolveLaunchModel('no-window-model', AVAILABLE, FULL).contextWindow)
+      .toBeUndefined();
+  });
+
+  it('serves `auto` even though the router never lists it as a catalog row', () => {
+    expect(resolveLaunchModel('auto', [], [])).toMatchObject({ id: 'auto', unavailable: false });
+  });
+
+  it('falls back to the filtered roster when the unfiltered one is unavailable', () => {
+    // Degraded mode: an older gateway ignoring ?available=true, or a failed
+    // second fetch. A known-good id must still resolve.
+    expect(resolveLaunchModel('fast-coder', AVAILABLE).id).toBe('fast-coder');
+  });
+});
+
+describe('defaultModelId', () => {
+  it('prefers a concrete servable model over auto, so the session names its model', () => {
+    expect(defaultModelId(AVAILABLE)).toBe('fast-coder');
+  });
+
+  it('falls back to auto when nothing concrete is servable', () => {
+    expect(defaultModelId([{ id: 'auto' }, { id: 'x', available: false }])).toBe('auto');
+  });
+});
+
+describe('contextWindowOf', () => {
+  it('accepts either catalog spelling and undefined for neither', () => {
+    expect(contextWindowOf({ id: 'a', context_window: 1000 })).toBe(1000);
+    expect(contextWindowOf({ id: 'b', context_length: 2000 })).toBe(2000);
+    expect(contextWindowOf({ id: 'c' })).toBeUndefined();
+    expect(contextWindowOf({ id: 'd', context_window: null })).toBeUndefined();
+  });
+});

--- a/cli/src/models.ts
+++ b/cli/src/models.ts
@@ -1,0 +1,81 @@
+// Resolving a model id against the catalog, for the launchers.
+//
+// The subtlety this module exists for: `catalog()` fetches `/v1/models` with
+// `?available=true`, so a model missing from that response has TWO possible
+// meanings — it does not exist, or it exists and is merely out of quota right
+// now. Treating absence as "unknown model" reports a healthy pinned model as a
+// typo the moment its provider hits a rate limit. Only the UNFILTERED roster
+// can tell those apart, so `--model` is validated against that.
+
+import type { CatalogModel } from './types.js';
+
+export interface ResolvedModel {
+  id: string;
+  /** Context window in tokens, or undefined when the catalog does not publish
+   *  one. Undefined is a fact — an unpublished window is not the same as a
+   *  known 128k, and callers must not invent one. */
+  contextWindow?: number;
+  /** The catalog lists this model but it is not currently servable. */
+  unavailable: boolean;
+}
+
+export class UnknownModelError extends Error {}
+
+export function contextWindowOf(model: CatalogModel): number | undefined {
+  return model.context_window ?? model.context_length ?? undefined;
+}
+
+/**
+ * The launcher's default when the caller did not pin one: the first servable
+ * concrete model, falling back to `auto`.
+ *
+ * Deliberately NOT the same default as the setup generators, which prefer
+ * `auto`. A generated config file is long-lived and should let the router
+ * choose per request; a launch pins one id into ANTHROPIC_MODEL for the whole
+ * session, and naming a concrete model there is what makes the session's model
+ * visible and reproducible. Unifying the two silently changes what
+ * `freellmapi launch` runs.
+ */
+export function defaultModelId(models: CatalogModel[]): string {
+  return models.find(model => model.id !== 'auto' && model.available !== false)?.id ?? 'auto';
+}
+
+/**
+ * Resolve the model a launcher should pin.
+ *
+ * `available` is the filtered roster the CLI already fetches; `full` is the
+ * unfiltered one. Pass the same array twice only when the unfiltered roster
+ * could not be fetched — the caller then loses the ability to distinguish an
+ * unknown id from an unavailable one, which is exactly the ambiguity this
+ * function exists to remove.
+ */
+export function resolveLaunchModel(
+  requested: string | undefined,
+  available: CatalogModel[],
+  full: CatalogModel[] = available,
+): ResolvedModel {
+  const id = requested ?? defaultModelId(available);
+  const known = full.find(model => model.id === id) ?? available.find(model => model.id === id);
+
+  if (!known) {
+    // `auto` is served by the router itself and need not appear in any roster.
+    if (id === 'auto') return { id, unavailable: false };
+    const suggestions = full
+      .map(model => model.id)
+      .filter(candidate => candidate.includes(id) || id.includes(candidate))
+      .slice(0, 5);
+    throw new UnknownModelError(
+      `No model '${id}' in this gateway's catalog.`
+      + (suggestions.length ? ` Did you mean: ${suggestions.join(', ')}?` : '')
+      + ' Run `freellmapi list-models` to see what is registered.',
+    );
+  }
+
+  return {
+    id,
+    contextWindow: contextWindowOf(known),
+    // Absent from the filtered roster but present in the full one = registered
+    // but not servable right now (quota, cooldown, a disabled key).
+    unavailable: known.available === false || !available.some(model => model.id === id),
+  };
+}

--- a/cli/src/tools.test.ts
+++ b/cli/src/tools.test.ts
@@ -49,6 +49,24 @@ describe('tool generators', () => {
     });
   }
 
+  it('honours an explicit --model instead of the default-model heuristic', () => {
+    // `--model` was parsed into CliOptions and then dropped: it never reached
+    // GenerateContext, so `setup-claude --model X` wrote whatever
+    // primaryModel() preferred and said nothing about ignoring the flag.
+    const pinned = { ...context, requestedModelId: 'reasoning-model' };
+    const claude = tools.find(tool => tool.id === 'claude')!.generate(pinned);
+    expect(JSON.stringify(claude.files)).toContain('reasoning-model');
+  });
+
+  it('pins a requested model that the available-roster does not carry', () => {
+    // Validated against the UNFILTERED catalog upstream, so an id missing from
+    // ctx.models here is registered-but-out-of-quota, not a typo. Writing a
+    // different model into the user's config would be the wrong repair.
+    const pinned = { ...context, requestedModelId: 'benched-model' };
+    const claude = tools.find(tool => tool.id === 'claude')!.generate(pinned);
+    expect(JSON.stringify(claude.files)).toContain('benched-model');
+  });
+
   it('setup-codex with a named profile has stable golden output', () => {
     const generation = tools.find(tool => tool.id === 'codex')!
       .generate({ ...context, profile: 'work' });

--- a/cli/src/tools.ts
+++ b/cli/src/tools.ts
@@ -14,7 +14,13 @@ function v1Url(url: string): string {
   return `${rootUrl(url)}/v1`;
 }
 
-function primaryModel(models: CatalogModel[]): CatalogModel {
+function primaryModel(models: CatalogModel[], requestedId?: string): CatalogModel {
+  // An explicit --model wins over every heuristic below. It is validated
+  // against the UNFILTERED catalog before we get here, so an id absent from
+  // `models` (the available-only roster) is a real, registered model that is
+  // merely out of quota right now — pin it anyway rather than silently writing
+  // a different model into the user's config.
+  if (requestedId) return models.find(model => model.id === requestedId) ?? { id: requestedId };
   // `auto` — the router picking the best model per request — is the whole
   // point of the gateway and the right default for a generated config. Never
   // fall back to `fusion` (multi-model fan-out) by accident.
@@ -44,7 +50,7 @@ function yamlString(value: string): string {
 }
 
 function claude(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const directory = ctx.profile === 'default'
     ? path.join(ctx.homeDir, '.claude')
     : path.join(ctx.homeDir, '.claude', 'profiles', ctx.profile);
@@ -76,7 +82,7 @@ function claude(ctx: GenerateContext): Generation {
 }
 
 function codex(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const compact = Math.max(16_000, Math.floor(contextWindow(model) * 0.9));
   const providerTable = [
     '[model_providers.freellmapi]',
@@ -129,7 +135,7 @@ function codex(ctx: GenerateContext): Generation {
 }
 
 function cline(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   return {
     files: [{
       path: path.join(ctx.homeDir, '.cline', 'data', 'settings', 'providers.json'),
@@ -163,7 +169,7 @@ function cline(ctx: GenerateContext): Generation {
 }
 
 function continueDev(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   return {
     files: [{
       path: path.join(ctx.homeDir, '.continue', 'config.yaml'),
@@ -192,7 +198,7 @@ function continueDev(ctx: GenerateContext): Generation {
 }
 
 function aider(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   return {
     files: [{
       path: path.join(ctx.homeDir, '.aider.conf.yml'),
@@ -244,7 +250,7 @@ function opencode(ctx: GenerateContext): Generation {
 }
 
 function goose(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const models = catalogModels(ctx.models).map(entry => ({
     name: entry.id,
     context_limit: contextWindow(entry),
@@ -291,7 +297,7 @@ function goose(ctx: GenerateContext): Generation {
 }
 
 function qwen(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const dir = path.join(ctx.homeDir, '.qwen');
   const models = catalogModels(ctx.models).map(entry => ({
     id: entry.id,
@@ -332,7 +338,7 @@ function qwen(ctx: GenerateContext): Generation {
 }
 
 function roo(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const importPath = path.join(ctx.homeDir, '.roo', 'freellmapi.json');
   return {
     files: [{
@@ -359,7 +365,7 @@ function roo(ctx: GenerateContext): Generation {
 }
 
 function kilo(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   const models = Object.fromEntries(catalogModels(ctx.models).map(entry => [
     entry.id,
     {
@@ -443,7 +449,7 @@ function cursor(ctx: GenerateContext): Generation {
 }
 
 function generic(ctx: GenerateContext): Generation {
-  const model = primaryModel(ctx.models);
+  const model = primaryModel(ctx.models, ctx.requestedModelId);
   return {
     files: [],
     notes: [

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -20,6 +20,9 @@ export interface GenerateContext {
   profile: string;
   models: CatalogModel[];
   homeDir: string;
+  /** An explicit `--model`. Overrides each generator's default-model
+   *  heuristic; validated against the unfiltered catalog by the caller. */
+  requestedModelId?: string;
 }
 
 export interface Generation {


### PR DESCRIPTION
## The ambiguity

`catalog()` fetches `/v1/models?available=true`, so a model absent from that roster has **two** possible meanings: it does not exist, or it exists and is out of quota right now. The CLI treated them alike — and picked the wrong half. A pinned model reads as a typo the moment its provider rate-limits.

`resolveLaunchModel()` (new `cli/src/models.ts`) validates against the **unfiltered** roster and makes "registered but not currently available" its own outcome: the launch proceeds with a warning on stderr, because the router may recover the model mid-session, but it never proceeds silently.

The unfiltered fetch is best-effort — any failure degrades to the filtered roster rather than blocking a launch, so an older gateway that ignores the parameter still works.

## Two defects fall out of the same seam

**`--model` never reached the setup generators.** It was parsed into `CliOptions` and then dropped, so `setup-claude --model X` wrote whatever `primaryModel()` preferred and said nothing about ignoring the flag. It now threads through `GenerateContext` as `requestedModelId` and overrides the per-generator heuristic. A requested id missing from the available roster is still pinned — it was validated against the full catalog upstream, so it is out-of-quota, not a typo, and substituting a different model would be the wrong repair.

**`?? 128_000` was invented for any model publishing no window** and pinned as `CLAUDE_CODE_AUTO_COMPACT_WINDOW`. A wrong window is worse than none: too high and the client compacts after the gateway has already rejected the request; too low and it compacts a conversation that still fits. The variable is now absent when the catalog states nothing, and the client applies its own default.

## One thing deliberately not unified

The launcher's default stays "first servable concrete model", **not** the setup generators' preference for `auto`. A generated config is long-lived and should let the router choose per request; a launch pins one id into `ANTHROPIC_MODEL` for the whole session, where naming a concrete model is what makes that session reproducible. `models.ts` documents why they differ — I unified them by accident first, and two existing tests caught it.

## Testing

New `cli/src/models.test.ts` (10 cases) covers the unavailable-vs-unknown split, the `auto` special case, the degraded single-roster path, and the undefined-window contract. Two cases added to `tools.test.ts` for `--model` reaching the generators.

Windows-local: **41 passed, 15 failed**. Those 15 are the pre-existing POSIX-separator assertions in `tools.test.ts` (`expected '\home\tester\...' to be '/home/tester/...'`), identical on unmodified `main` on this machine and green on Linux CI. Verified by diffing failing-test names against a stashed baseline.