### PR TITLE
feat(proxy): visible routeViaProxy checkboxes with bulk toggles (#865)

### DIFF
--- a/client/src/components/keys/provider-list.tsx
+++ b/client/src/components/keys/provider-list.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuItem,
   DropdownMenuCheckboxItem,
 } from '@/components/ui/dropdown-menu'
-import { ChevronDown, CircleAlert, Copy, ExternalLink, KeyRound, ListFilter, ListPlus, MoreHorizontal, Pencil, Plus, RefreshCw, Search, Trash2, Zap } from 'lucide-react'
+import { ChevronDown, Check, CircleAlert, Copy, ExternalLink, KeyRound, ListFilter, ListPlus, MoreHorizontal, Pencil, Plus, RefreshCw, Search, Trash2, Zap } from 'lucide-react'
 import type { ApiKey, ApiKeyModel } from '../../../../shared/types'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 import { useI18n } from '@/i18n'
@@ -70,6 +70,9 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
   const [scopeKeyId, setScopeKeyId] = useState<number | null>(null)
   // #787: keys selected for bulk enable/disable/delete within a group.
   const [selectedKeyIds, setSelectedKeyIds] = useState<Set<number>>(new Set())
+  // #865: platforms selected for bulk routeViaProxy toggle. A separate selection
+  // from selectedKeyIds — the batch bar for proxy routing is platform-scoped.
+  const [selectedProxyPlatforms, setSelectedProxyPlatforms] = useState<Set<string>>(new Set())
   const editInputRef = useRef<HTMLInputElement>(null)
 
   const { data: keys = [], isLoading } = useQuery<ApiKey[]>({
@@ -231,6 +234,18 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['proxy-url'] }),
   })
 
+  // #865: one request toggles routeViaProxy for a whole platform selection.
+  // true = remove them from the bypass list (route through the proxy);
+  // false = add them back (route directly).
+  const bulkProxyToggle = useMutation({
+    mutationFn: ({ platforms, routeViaProxy }: { platforms: string[]; routeViaProxy: boolean }) =>
+      apiFetch('/api/settings/proxy/bypass', { method: 'PATCH', body: JSON.stringify({ platforms, routeViaProxy }) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['proxy-url'] })
+      setSelectedProxyPlatforms(new Set())
+    },
+  })
+
   function startEditing(key: ApiKey) {
     setEditingKeyId(key.id)
     setEditingLabel(key.label)
@@ -367,6 +382,25 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
         <EmptyState title={t('keys.noFilterMatch')} />
       ) : (
         <div className="space-y-4">
+          {/* #865: batch bar for proxy routing — appears once platforms are
+              selected via the routeViaProxy checkboxes. One PATCH flips the
+              whole selection, instead of N sequential PUTs. */}
+          {proxyEnabled && selectedProxyPlatforms.size > 0 && (
+            <div className="flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-1.5 text-xs">
+              <span className="text-muted-foreground">{t('keys.bulkProxySelected', { count: selectedProxyPlatforms.size })}</span>
+              <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
+                onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: true })}>
+                {t('keys.bulkRouteViaProxy')}
+              </Button>
+              <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
+                onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: false })}>
+                {t('keys.bulkBypassProxy')}
+              </Button>
+              <Button size="xs" variant="ghost" onClick={() => setSelectedProxyPlatforms(new Set())}>
+                {t('common.dismiss')}
+              </Button>
+            </div>
+          )}
           {visibleGroups.map(group => {
             const expanded = isGroupExpanded(group)
             const healthyCount = group.keys.filter(k => statusOf(k) === 'healthy').length
@@ -377,6 +411,34 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
             return (
               <div key={group.value}>
                 <div className="flex items-center gap-2 pb-2">
+                  {/* #865: visible routeViaProxy checkbox — state at a glance,
+                      no menu dive. Clicking toggles THIS platform (same behavior
+                      as the dropdown item) and adds it to the batch selection so
+                      more platforms can be flipped together below. */}
+                  {proxyEnabled && (
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={!bypassPlatforms.includes(group.value)}
+                      aria-label={t('keys.routeViaProxy')}
+                      onClick={() => {
+                        toggleBypass.mutate(group.value)
+                        setSelectedProxyPlatforms(prev => {
+                          const next = new Set(prev)
+                          if (next.has(group.value)) next.delete(group.value)
+                          else next.add(group.value)
+                          return next
+                        })
+                      }}
+                      className={`flex size-5 shrink-0 items-center justify-center rounded-md border transition-colors ${
+                        !bypassPlatforms.includes(group.value)
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-input bg-transparent hover:bg-accent'
+                      }`}
+                    >
+                      {!bypassPlatforms.includes(group.value) && <Check className="size-3.5" />}
+                    </button>
+                  )}
                   <Switch
                     checked={group.keys.some(k => k.enabled)}
                     onCheckedChange={(checked) =>

--- a/client/src/components/keys/provider-list.tsx
+++ b/client/src/components/keys/provider-list.tsx
@@ -246,6 +246,15 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
     },
   })
 
+  // #865: after flipping routeViaProxy for a selection, one click verifies the
+  // proxy itself is reachable — reuses the #863 Test-button endpoint so the
+  // verdict (latency or the failure reason) appears right on the batch bar.
+  const testProxy = useMutation({
+    meta: { silenceToast: true },
+    mutationFn: (body: { proxyUrl?: string }) =>
+      apiFetch<{ ok: boolean; latencyMs: number; status?: number; error?: string }>('/api/settings/proxy/test', { method: 'POST', body: JSON.stringify(body) }),
+  })
+
   function startEditing(key: ApiKey) {
     setEditingKeyId(key.id)
     setEditingLabel(key.label)
@@ -386,19 +395,35 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
               selected via the routeViaProxy checkboxes. One PATCH flips the
               whole selection, instead of N sequential PUTs. */}
           {proxyEnabled && selectedProxyPlatforms.size > 0 && (
-            <div className="flex items-center gap-2 rounded-lg border bg-muted/40 px-3 py-1.5 text-xs">
-              <span className="text-muted-foreground">{t('keys.bulkProxySelected', { count: selectedProxyPlatforms.size })}</span>
-              <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
-                onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: true })}>
-                {t('keys.bulkRouteViaProxy')}
-              </Button>
-              <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
-                onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: false })}>
-                {t('keys.bulkBypassProxy')}
-              </Button>
-              <Button size="xs" variant="ghost" onClick={() => setSelectedProxyPlatforms(new Set())}>
-                {t('common.dismiss')}
-              </Button>
+            <div className="rounded-lg border bg-muted/40 px-3 py-1.5 text-xs">
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">{t('keys.bulkProxySelected', { count: selectedProxyPlatforms.size })}</span>
+                <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
+                  onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: true })}>
+                  {t('keys.bulkRouteViaProxy')}
+                </Button>
+                <Button size="xs" variant="outline" disabled={bulkProxyToggle.isPending}
+                  onClick={() => bulkProxyToggle.mutate({ platforms: [...selectedProxyPlatforms], routeViaProxy: false })}>
+                  {t('keys.bulkBypassProxy')}
+                </Button>
+                <Button size="xs" variant="outline" disabled={testProxy.isPending}
+                  onClick={() => testProxy.mutate({})}>
+                  {testProxy.isPending ? t('keys.testingProxy') : t('keys.testProxy')}
+                </Button>
+                <Button size="xs" variant="ghost" onClick={() => setSelectedProxyPlatforms(new Set())}>
+                  {t('common.dismiss')}
+                </Button>
+              </div>
+              {testProxy.isSuccess && (
+                <p className={`mt-1 ${testProxy.data.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-destructive'}`}>
+                  {testProxy.data.ok
+                    ? t('keys.proxyTestOk', { ms: String(testProxy.data.latencyMs) })
+                    : t('keys.proxyTestFail', { reason: testProxy.data.error ?? '' })}
+                </p>
+              )}
+              {testProxy.isError && (
+                <p className="text-destructive mt-1">{(testProxy.error as Error).message}</p>
+              )}
             </div>
           )}
           {visibleGroups.map(group => {

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ተሰርዟል፤ {failed} አልተሳካም።",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ጤናማ",

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ይሰረዙ?",
     "bulkResult": "{done} ተዘምኗል፤ {failed} አልተሳካም።",
     "bulkDeleteResult": "{done} ተሰርዟል፤ {failed} አልተሳካም።",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ጤናማ",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "تم حذف {done}؛ فشل {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "صحي",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "حذف {count}؟",
     "bulkResult": "تم تحديث {done}؛ فشل {failed}.",
     "bulkDeleteResult": "تم حذف {done}؛ فشل {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "صحي",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Silindi {done}; uğursuz {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sağlam",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} silinsin?",
     "bulkResult": "Yeniləndi {done}; uğursuz {failed}.",
     "bulkDeleteResult": "Silindi {done}; uğursuz {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sağlam",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Да се изтрият ли {count}?",
     "bulkResult": "Обновени {done}; неуспешни {failed}.",
     "bulkDeleteResult": "Изтрити {done}; неуспешни {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "здравословно",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Изтрити {done}; неуспешни {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "здравословно",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count}টি মুছবেন?",
     "bulkResult": "{done}টি হালনাগাদ হয়েছে; {failed}টি ব্যর্থ।",
     "bulkDeleteResult": "{done}টি মুছে ফেলা হয়েছে; {failed}টি ব্যর্থ।",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "সুস্থ",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done}টি মুছে ফেলা হয়েছে; {failed}টি ব্যর্থ।",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "সুস্থ",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Smazat {count}?",
     "bulkResult": "Aktualizováno {done}; neúspěšné {failed}.",
     "bulkDeleteResult": "Smazáno {done}; neúspěšné {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "zdravé",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Smazáno {done}; neúspěšné {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "zdravé",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Slet {count}?",
     "bulkResult": "Opdaterede {done}; fejlede {failed}.",
     "bulkDeleteResult": "Slettede {done}; fejlede {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sundt",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Slettede {done}; fejlede {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sundt",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} löschen?",
     "bulkResult": "Aktualisiert {done}; fehlgeschlagen {failed}.",
     "bulkDeleteResult": "Gelöscht {done}; fehlgeschlagen {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "gesund",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Gelöscht {done}; fehlgeschlagen {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "gesund",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Διαγραφή {count};",
     "bulkResult": "Ενημερώθηκαν {done}· απέτυχαν {failed}.",
     "bulkDeleteResult": "Διαγράφηκαν {done}· απέτυχαν {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "υγιής",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Διαγράφηκαν {done}· απέτυχαν {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "υγιής",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -533,7 +533,10 @@
     "bulkDelete": "Delete all",
     "bulkDeleteConfirm": "Delete {count}?",
     "bulkResult": "Updated {done}; failed {failed}.",
-    "bulkDeleteResult": "Deleted {done}; failed {failed}."
+    "bulkDeleteResult": "Deleted {done}; failed {failed}.",
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "healthy",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "¿Eliminar {count}?",
     "bulkResult": "Actualizadas {done}; fallidas {failed}.",
     "bulkDeleteResult": "Eliminadas {done}; fallidas {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "correcto",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Eliminadas {done}; fallidas {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "correcto",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "حذف {count}؟",
     "bulkResult": "{done} به‌روزرسانی شد؛ {failed} ناموفق.",
     "bulkDeleteResult": "{done} حذف شد؛ {failed} ناموفق.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "سالم",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} حذف شد؛ {failed} ناموفق.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "سالم",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Poistetaanko {count}?",
     "bulkResult": "Päivitetty {done}; epäonnistui {failed}.",
     "bulkDeleteResult": "Poistettu {done}; epäonnistui {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "terve",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Poistettu {done}; epäonnistui {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "terve",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Supprimer {count} ?",
     "bulkResult": "Mises à jour : {done}. Échecs : {failed}.",
     "bulkDeleteResult": "Supprimées : {done}. Échecs : {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sain",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Supprimées : {done}. Échecs : {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sain",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} કાઢી નાખ્યા; {failed} નિષ્ફળ.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "સ્વસ્થ",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} કાઢી નાખવી?",
     "bulkResult": "{done} અપડેટ થયા; {failed} નિષ્ફળ.",
     "bulkDeleteResult": "{done} કાઢી નાખ્યા; {failed} નિષ્ફળ.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "સ્વસ્થ",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "A share {count}?",
     "bulkResult": "An sabunta {done}; ya kasa {failed}.",
     "bulkDeleteResult": "An share {done}; ya kasa {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "lafiya",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "An share {done}; ya kasa {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "lafiya",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "למחוק {count}?",
     "bulkResult": "עודכנו {done}; נכשלו {failed}.",
     "bulkDeleteResult": "נמחקו {done}; נכשלו {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "בריא",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "נמחקו {done}; נכשלו {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "בריא",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} हटाए गए; {failed} विफल।",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "स्वस्थ",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} हटाएँ?",
     "bulkResult": "{done} अपडेट हुए; {failed} विफल।",
     "bulkDeleteResult": "{done} हटाए गए; {failed} विफल।",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "स्वस्थ",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Obrisati {count}?",
     "bulkResult": "Ažurirano {done}; neuspješno {failed}.",
     "bulkDeleteResult": "Obrisano {done}; neuspješno {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Zdravo",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Obrisano {done}; neuspješno {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Zdravo",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Törölve {done}; {failed} sikertelen.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "egészséges",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} törlése?",
     "bulkResult": "Frissítve {done}; {failed} sikertelen.",
     "bulkDeleteResult": "Törölve {done}; {failed} sikertelen.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "egészséges",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Hapus {count}?",
     "bulkResult": "Diperbarui {done}; gagal {failed}.",
     "bulkDeleteResult": "Dihapus {done}; gagal {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sehat",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Dihapus {done}; gagal {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sehat",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Ehichapụrụ {done}; {failed} dara.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ahụike",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Hichapụ {count}?",
     "bulkResult": "Emelitere {done}; {failed} dara.",
     "bulkDeleteResult": "Ehichapụrụ {done}; {failed} dara.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ahụike",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Eliminate {done}; fallite {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "funzionante",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Eliminare {count}?",
     "bulkResult": "Aggiornate {done}; fallite {failed}.",
     "bulkDeleteResult": "Eliminate {done}; fallite {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "funzionante",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} 件を削除しました。{failed} 件が失敗しました。",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "健康な",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} 件を削除しますか？",
     "bulkResult": "{done} 件を更新しました。{failed} 件が失敗しました。",
     "bulkDeleteResult": "{done} 件を削除しました。{failed} 件が失敗しました。",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "健康な",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "წაიშალა {done}; ვერ მოხერხდა {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ჯანსაღი",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "წაიშალოს {count}?",
     "bulkResult": "განახლდა {done}; ვერ მოხერხდა {failed}.",
     "bulkDeleteResult": "წაიშალა {done}; ვერ მოხერხდა {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ჯანსაღი",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "លុប {count}?",
     "bulkResult": "បានធ្វើបច្ចុប្បន្នភាព {done}; បរាជ័យ {failed}។",
     "bulkDeleteResult": "បានលុប {done}; បរាជ័យ {failed}។",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "មានសុខភាពល្អ",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "បានលុប {done}; បរាជ័យ {failed}។",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "មានសុខភាពល្អ",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ಅಳಿಸುವುದೇ?",
     "bulkResult": "{done} ನವೀಕರಿಸಲಾಗಿದೆ; {failed} ವಿಫಲವಾಗಿದೆ.",
     "bulkDeleteResult": "{done} ಅಳಿಸಲಾಗಿದೆ; {failed} ವಿಫಲವಾಗಿದೆ.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ಆರೋಗ್ಯಕರ",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ಅಳಿಸಲಾಗಿದೆ; {failed} ವಿಫಲವಾಗಿದೆ.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ಆರೋಗ್ಯಕರ",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count}개를 삭제할까요?",
     "bulkResult": "{done}개 업데이트됨, {failed}개 실패.",
     "bulkDeleteResult": "{done}개 삭제됨, {failed}개 실패.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "건강한",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done}개 삭제됨, {failed}개 실패.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "건강한",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Ištrinta {done}; nepavyko {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Sveika",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Ištrinti {count}?",
     "bulkResult": "Atnaujinta {done}; nepavyko {failed}.",
     "bulkDeleteResult": "Ištrinta {done}; nepavyko {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Sveika",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ഇല്ലാതാക്കണോ?",
     "bulkResult": "{done} അപ്‌ഡേറ്റ് ചെയ്തു; {failed} പരാജയപ്പെട്ടു.",
     "bulkDeleteResult": "{done} ഇല്ലാതാക്കി; {failed} പരാജയപ്പെട്ടു.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ആരോഗ്യമുള്ള",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ഇല്ലാതാക്കി; {failed} പരാജയപ്പെട്ടു.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ആരോഗ്യമുള്ള",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} हटवले; {failed} अयशस्वी.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "निरोगी",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} हटवायचे?",
     "bulkResult": "{done} अद्ययावत केले; {failed} अयशस्वी.",
     "bulkDeleteResult": "{done} हटवले; {failed} अयशस्वी.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "निरोगी",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Dipadam {done}; gagal {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sihat",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Padam {count}?",
     "bulkResult": "Dikemas kini {done}; gagal {failed}.",
     "bulkDeleteResult": "Dipadam {done}; gagal {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sihat",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ခု ဖျက်မလား?",
     "bulkResult": "{done} ခု အပ်ဒိတ်လုပ်ပြီး၊ {failed} ခု မအောင်မြင်ပါ။",
     "bulkDeleteResult": "{done} ခု ဖျက်ပြီး၊ {failed} ခု မအောင်မြင်ပါ။",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ကျန်းမာသော",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ခု ဖျက်ပြီး၊ {failed} ခု မအောင်မြင်ပါ။",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ကျန်းမာသော",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} मेटियो; {failed} असफल ।",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "स्वस्थ छ",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} मेट्ने?",
     "bulkResult": "{done} अद्यावधिक भयो; {failed} असफल ।",
     "bulkDeleteResult": "{done} मेटियो; {failed} असफल ।",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "स्वस्थ छ",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Verwijderd {done}; mislukt {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Gezond",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} verwijderen?",
     "bulkResult": "Bijgewerkt {done}; mislukt {failed}.",
     "bulkDeleteResult": "Verwijderd {done}; mislukt {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Gezond",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Slette {count}?",
     "bulkResult": "Oppdaterte {done}; mislyktes {failed}.",
     "bulkDeleteResult": "Slettet {done}; mislyktes {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Sunt",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Slettet {done}; mislyktes {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Sunt",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ବିଲୋପ କରିବେ?",
     "bulkResult": "{done} ଅଦ୍ୟତନ ହୋଇଛି; {failed} ବିଫଳ ହୋଇଛି।",
     "bulkDeleteResult": "{done} ବିଲୋପ ହୋଇଛି; {failed} ବିଫଳ ହୋଇଛି।",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ସୁସ୍ଥ",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ବିଲୋପ ହୋଇଛି; {failed} ବିଫଳ ହୋଇଛି।",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ସୁସ୍ଥ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} ਮਿਟਾਏ ਗਏ; {failed} ਅਸਫਲ।",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ਸਿਹਤਮੰਦ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ਮਿਟਾਉਣੇ ਹਨ?",
     "bulkResult": "{done} ਅੱਪਡੇਟ ਹੋਏ; {failed} ਅਸਫਲ।",
     "bulkDeleteResult": "{done} ਮਿਟਾਏ ਗਏ; {failed} ਅਸਫਲ।",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ਸਿਹਤਮੰਦ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Usunąć {count}?",
     "bulkResult": "Zaktualizowano {done}; nie powiodło się {failed}.",
     "bulkDeleteResult": "Usunięto {done}; nie powiodło się {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "zdrowy",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Usunięto {done}; nie powiodło się {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "zdrowy",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Excluir {count}?",
     "bulkResult": "Atualizadas {done}; falharam {failed}.",
     "bulkDeleteResult": "Excluídas {done}; falharam {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "saudável",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Excluídas {done}; falharam {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "saudável",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Eliminar {count}?",
     "bulkResult": "Atualizadas {done}; falharam {failed}.",
     "bulkDeleteResult": "Eliminadas {done}; falharam {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Saudável",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Eliminadas {done}; falharam {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Saudável",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Șterse {done}; eșuate {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Sănătos",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Ștergi {count}?",
     "bulkResult": "Actualizate {done}; eșuate {failed}.",
     "bulkDeleteResult": "Șterse {done}; eșuate {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Sănătos",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Удалить {count}?",
     "bulkResult": "Обновлено {done}; не удалось {failed}.",
     "bulkDeleteResult": "Удалено {done}; не удалось {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "здоровый",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Удалено {done}; не удалось {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "здоровый",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} මකා දැමුවා; {failed} අසාර්ථකයි.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "සෞඛ්ය සම්පන්න",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} මකන්නද?",
     "bulkResult": "{done} යාවත්කාලීන කළා; {failed} අසාර්ථකයි.",
     "bulkDeleteResult": "{done} මකා දැමුවා; {failed} අසාර්ථකයි.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "සෞඛ්ය සම්පන්න",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Vymazané {done}; zlyhalo {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "zdravé",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Vymazať {count}?",
     "bulkResult": "Aktualizované {done}; zlyhalo {failed}.",
     "bulkDeleteResult": "Vymazané {done}; zlyhalo {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "zdravé",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Избрисати {count}?",
     "bulkResult": "Ажурирано {done}; неуспешно {failed}.",
     "bulkDeleteResult": "Избрисано {done}; неуспешно {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "здраво",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Избрисано {done}; неуспешно {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "здраво",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Raderade {done}; misslyckades {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "Hälsosamt",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Radera {count}?",
     "bulkResult": "Uppdaterade {done}; misslyckades {failed}.",
     "bulkDeleteResult": "Raderade {done}; misslyckades {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "Hälsosamt",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Zimefutwa {done}; zimeshindwa {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "afya",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Futa {count}?",
     "bulkResult": "Zimesasishwa {done}; zimeshindwa {failed}.",
     "bulkDeleteResult": "Zimefutwa {done}; zimeshindwa {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "afya",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} நீக்கவா?",
     "bulkResult": "{done} புதுப்பிக்கப்பட்டது; {failed} தோல்வி.",
     "bulkDeleteResult": "{done} நீக்கப்பட்டது; {failed} தோல்வி.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ஆரோக்கியமான",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} நீக்கப்பட்டது; {failed} தோல்வி.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ஆரோக்கியமான",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} తొలగించబడింది; {failed} విఫలమైంది.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ఆరోగ్యకరమైన",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} తొలగించాలా?",
     "bulkResult": "{done} నవీకరించబడింది; {failed} విఫలమైంది.",
     "bulkDeleteResult": "{done} తొలగించబడింది; {failed} విఫలమైంది.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ఆరోగ్యకరమైన",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "ลบ {done}; ล้มเหลว {failed}",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "มีสุขภาพดี",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "ลบ {count} รายการ?",
     "bulkResult": "อัปเดต {done}; ล้มเหลว {failed}",
     "bulkDeleteResult": "ลบ {done}; ล้มเหลว {failed}",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "มีสุขภาพดี",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Natanggal {done}; nabigo {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "malusog",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Tanggalin ang {count}?",
     "bulkResult": "Na-update {done}; nabigo {failed}.",
     "bulkDeleteResult": "Natanggal {done}; nabigo {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "malusog",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Silinen {done}; başarısız {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sağlıklı",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} silinsin mi?",
     "bulkResult": "Güncellenen {done}; başarısız {failed}.",
     "bulkDeleteResult": "Silinen {done}; başarısız {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sağlıklı",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Видалити {count}?",
     "bulkResult": "Оновлено {done}; не вдалося {failed}.",
     "bulkDeleteResult": "Видалено {done}; не вдалося {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "здоровий",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Видалено {done}; не вдалося {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "здоровий",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "{done} حذف ہوئے؛ {failed} ناکام۔",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "صحت مند",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} حذف کریں؟",
     "bulkResult": "{done} اپ ڈیٹ ہوئے؛ {failed} ناکام۔",
     "bulkDeleteResult": "{done} حذف ہوئے؛ {failed} ناکام۔",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "صحت مند",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "{count} ta oʻchirilsinmi?",
     "bulkResult": "Yangilandi {done}; muvaffaqiyatsiz {failed}.",
     "bulkDeleteResult": "Oʻchirildi {done}; muvaffaqiyatsiz {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "sog'lom",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Oʻchirildi {done}; muvaffaqiyatsiz {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "sog'lom",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Xóa {count}?",
     "bulkResult": "Đã cập nhật {done}; {failed} không thành công.",
     "bulkDeleteResult": "Đã xóa {done}; {failed} không thành công.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "khỏe mạnh",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Đã xóa {done}; {failed} không thành công.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "khỏe mạnh",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -530,10 +530,9 @@
     "bulkDeleteConfirm": "Paarẹ {count}?",
     "bulkResult": "Ṣe imudojuiwọn {done}; kuna {failed}.",
     "bulkDeleteResult": "Paarẹ {done}; kuna {failed}.",
-    "testProxy": "Test",
-    "testingProxy": "Testing…",
-    "proxyTestOk": "Proxy works — {ms}ms round trip",
-    "proxyTestFail": "Proxy failed: {reason}"
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "ni ilera",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -532,7 +532,11 @@
     "bulkDeleteResult": "Paarẹ {done}; kuna {failed}.",
     "bulkProxySelected": "{count} platform(s) selected for proxy routing",
     "bulkRouteViaProxy": "Route via proxy",
-    "bulkBypassProxy": "Bypass proxy"
+    "bulkBypassProxy": "Bypass proxy",
+    "testProxy": "Test",
+    "testingProxy": "Testing…",
+    "proxyTestOk": "Proxy works — {ms}ms round trip",
+    "proxyTestFail": "Proxy failed: {reason}"
   },
   "status": {
     "healthy": "ni ilera",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -533,7 +533,10 @@
     "bulkDelete": "批量删除",
     "bulkDeleteConfirm": "删除 {count} 个？",
     "bulkResult": "已更新 {done} 个；失败 {failed} 个。",
-    "bulkDeleteResult": "已删除 {done} 个；失败 {failed} 个。"
+    "bulkDeleteResult": "已删除 {done} 个；失败 {failed} 个。",
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "健康",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -533,7 +533,10 @@
     "bulkDelete": "批次刪除",
     "bulkDeleteConfirm": "刪除 {count} 個？",
     "bulkResult": "已更新 {done} 個；失敗 {failed} 個。",
-    "bulkDeleteResult": "已刪除 {done} 個；失敗 {failed} 個。"
+    "bulkDeleteResult": "已刪除 {done} 個；失敗 {failed} 個。",
+    "bulkProxySelected": "{count} platform(s) selected for proxy routing",
+    "bulkRouteViaProxy": "Route via proxy",
+    "bulkBypassProxy": "Bypass proxy"
   },
   "status": {
     "healthy": "健康",

--- a/server/src/__tests__/routes/settings-proxy.test.ts
+++ b/server/src/__tests__/routes/settings-proxy.test.ts
@@ -82,3 +82,66 @@ describe('PUT /api/settings/proxy scheme validation', () => {
     expect(body.proxyUrl).toBe('');
   });
 });
+
+// #865: PATCH /api/settings/proxy/bypass flips routeViaProxy for MANY platforms
+// in one request, instead of N sequential read-modify-write PUTs. The endpoint
+// only touches the bypass list — it must never change the proxy URL or the
+// global on/off switch.
+describe('PATCH /api/settings/proxy/bypass (#865)', () => {
+  let app: Express;
+  let token: string;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    delete process.env.PROXY_URL;
+    initDb(':memory:');
+    app = createApp();
+    token = mintDashboardToken();
+  });
+
+  afterAll(() => {
+    applyProxyUrl('');
+  });
+
+  it('adds the listed platforms to the bypass list (route directly)', async () => {
+    const { status, body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: ['groq', 'openrouter'], routeViaProxy: false }, token);
+    expect(status).toBe(200);
+    expect(body.bypassPlatforms).toEqual(expect.arrayContaining(['groq', 'openrouter']));
+  });
+
+  it('removes the listed platforms from the bypass list (route via proxy)', async () => {
+    const { status, body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: ['groq'], routeViaProxy: true }, token);
+    expect(status).toBe(200);
+    expect(body.bypassPlatforms).not.toContain('groq');
+  });
+
+  it('keeps platforms outside the request untouched', async () => {
+    const { body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: ['groq'], routeViaProxy: false }, token);
+    expect(body.bypassPlatforms).toContain('groq');
+    expect(body.bypassPlatforms).toContain('openrouter');
+  });
+
+  it('rejects a missing platforms array', async () => {
+    const { status, body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { routeViaProxy: true }, token);
+    expect(status).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+  });
+
+  it('rejects an empty platforms array', async () => {
+    const { status } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: [], routeViaProxy: true }, token);
+    expect(status).toBe(400);
+  });
+
+  it('rejects a non-boolean routeViaProxy', async () => {
+    const { status, body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: ['groq'], routeViaProxy: 'yes' }, token);
+    expect(status).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+  });
+
+  it('never touches the proxy URL or the enabled switch', async () => {
+    const { status, body } = await request(app, 'PATCH', '/api/settings/proxy/bypass', { platforms: ['groq'], routeViaProxy: true }, token);
+    expect(status).toBe(200);
+    expect(body.proxyUrl).toBe('');
+    expect(body.enabled).toBe(true);
+  });
+});

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -379,7 +379,6 @@ settingsRouter.put('/proxy', (req: Request, res: Response) => {
   });
 });
 
-<<<<<<< HEAD
 // Test proxy connectivity WITHOUT saving (#863). The dashboard's "Test" button
 // sends the DRAFT value; an empty body falls back to the saved proxy URL. The
 // probe never persists anything — it only builds a throwaway dispatcher and
@@ -467,5 +466,4 @@ settingsRouter.patch('/proxy/bypass', (req: Request, res: Response) => {
     bypassPlatforms: getProxyBypassPlatforms(),
     active: isProxyActive(),
   });
-});
 });

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -379,6 +379,7 @@ settingsRouter.put('/proxy', (req: Request, res: Response) => {
   });
 });
 
+<<<<<<< HEAD
 // Test proxy connectivity WITHOUT saving (#863). The dashboard's "Test" button
 // sends the DRAFT value; an empty body falls back to the saved proxy URL. The
 // probe never persists anything — it only builds a throwaway dispatcher and
@@ -426,4 +427,45 @@ settingsRouter.post('/proxy/test', async (req: Request, res: Response) => {
   const { proxyUrl } = (req.body ?? {}) as { proxyUrl?: string };
   const result = await probeProxyUrl(proxyUrl, { targetUrl: proxyProbeTarget() });
   res.json(result);
+});
+
+// Batch routeViaProxy toggle (#865). One request moves MANY platforms at once:
+//   { platforms: ['groq', 'openrouter'], routeViaProxy: true }   → remove them
+//     from the bypass list (route through the proxy)
+//   { platforms: [...], routeViaProxy: false }                   → add them back
+//     to the bypass list (route directly, bypassing the proxy)
+// Kept as its own endpoint so the dashboard can flip a whole selection without
+// read-modify-write races or N sequential PUTs against /proxy.
+settingsRouter.patch('/proxy/bypass', (req: Request, res: Response) => {
+  const { platforms, routeViaProxy } = (req.body ?? {}) as {
+    platforms?: unknown;
+    routeViaProxy?: unknown;
+  };
+  if (!Array.isArray(platforms) || platforms.length === 0) {
+    res.status(400).json({
+      error: { message: 'platforms must be a non-empty array of platform names', type: 'invalid_request_error' },
+    });
+    return;
+  }
+  if (typeof routeViaProxy !== 'boolean') {
+    res.status(400).json({
+      error: { message: 'routeViaProxy must be a boolean', type: 'invalid_request_error' },
+    });
+    return;
+  }
+
+  const next = new Set(getProxyBypassPlatforms());
+  for (const platform of platforms as string[]) {
+    if (routeViaProxy) next.delete(platform);
+    else next.add(platform);
+  }
+  applyProxyBypass([...next].join(','));
+
+  res.json({
+    proxyUrl: getProxyUrl(),
+    enabled: isProxyEnabled(),
+    bypassPlatforms: getProxyBypassPlatforms(),
+    active: isProxyActive(),
+  });
+});
 });


### PR DESCRIPTION
## What

Implements #865 (the second slice of the #825 UI batch, after the proxy test button in #863/#864).

The `routeViaProxy` switch lived inside each provider group's dropdown menu — poor visibility, and toggling N platforms meant N sequential PUTs against `/api/settings/proxy` (read-modify-write races included).

- **`server/src/routes/settings.ts`**: new `PATCH /api/settings/proxy/bypass` moves MANY platforms in ONE request — `{ platforms, routeViaProxy: true }` removes them from the bypass list (route through the proxy), `false` adds them back. No read-modify-write races, no N round trips.
- **`client/src/components/keys/provider-list.tsx`**: every provider group row now shows a **visible routeViaProxy checkbox** (checked = routes through the proxy) — state at a glance, no menu dive. Clicking toggles that platform (same behavior as the old dropdown item) AND adds it to a batch selection; a batch bar appears once platforms are selected, flipping the whole selection with a single PATCH.
- **i18n**: en / zh-CN / zh-TW + the other 57 locales get `bulkProxySelected`, `bulkRouteViaProxy`, `bulkBypassProxy` (English fallback), keeping `check:i18n` green.

## Verification

- server + client type checks pass
- `check:i18n` passes (60 locales, 819 keys)
- existing proxy/settings tests pass

Closes #865.