### PR TITLE
fix(i18n): disambiguate routeViaProxy from an AI agent in zh-CN / zh-TW (#825)

### DIFF
--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -446,7 +446,7 @@
     "summaryIssueOne": "{count} 个问题",
     "summaryIssueOther": "{count} 个问题",
     "providerActions": "提供方操作",
-    "routeViaProxy": "经由代理转发",
+    "routeViaProxy": "经由代理服务器转发",
     "checkNow": "立即检查",
     "proxyEnvHintBefore": "也可通过 ",
     "proxyEnvHintAfter": " 环境变量配置（优先生效）。留空则禁用。示例：",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -446,7 +446,7 @@
     "summaryIssueOne": "{count} 個問題",
     "summaryIssueOther": "{count} 個問題",
     "providerActions": "提供者操作",
-    "routeViaProxy": "經由代理轉發",
+    "routeViaProxy": "經由代理伺服器轉發",
     "checkNow": "立即檢查",
     "proxyEnvHintBefore": "也可透過 ",
     "proxyEnvHintAfter": " 環境變數設定（優先生效）。留空則停用。範例：",


### PR DESCRIPTION
## What

Addresses the outstanding wording point of #825 (reopened by the maintainer for this alone): `routeViaProxy` in zh-CN / zh-TW reads 「代理」 as an AI agent. Revised to:

- zh-CN: 「经由代理转发」 → **「经由代理服务器转发」**
- zh-TW: 「經由代理轉發」 → **「經由代理伺服器轉發」**

「代理服务器」 (proxy server) rules out the agent reading; the tooltip keeps the English "Proxy" as a hint.

## Notes

- #841 landed the first revision (通过代理路由 → 经由代理转发), this PR is the second agreed revision per @yfdyh000's point.
- `check:i18n` passes (60 locales).
- The other two #825 points stay closed out: per-key proxy = #819 (merged); visibility/bulk/test button = #863 (PR #864) and #865 (PR #866).

Closes #825.