### PR TITLE
feat(ui): 融合显式面板支持搜索与提供商筛选 / search + provider filter for the explicit Fusion panel (#872)

### DIFF
--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -694,7 +694,11 @@
     "howToUse": "እንዴት መጠቀም እንደሚቻል",
     "howToUseHelp": "መደበኛ የውይይት ጥያቄ ከሞዴል \"ውህደት\" ጋር ይላኩ. እነዚህ ቅንብሮች ነባሪ ናቸው; ማንኛውም ጥያቄ በ\"ውህደት\" መስክ ሊሽራቸው ይችላል።",
     "unsavedChanges": "ያልተቀመጡ ለውጦች",
-    "save": "አስቀምጥ"
+    "save": "አስቀምጥ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ከፍተኛ",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -694,7 +694,11 @@
     "howToUse": "كيفية الاستخدام",
     "howToUseHelp": "إرسال طلب محادثة عادي مع النموذج \"الانصهار\". هذه الإعدادات هي الإعدادات الافتراضية؛ يمكن لأي طلب تجاوزها بحقل \"الاندماج\".",
     "unsavedChanges": "التغييرات غير المحفوظة",
-    "save": "حفظ"
+    "save": "حفظ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "قسط",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -694,7 +694,11 @@
     "howToUse": "İstifadə",
     "howToUseHelp": "Model \"fusion\" ilə normal çat sorğusu göndərin. Bu parametrlər standartdır; istənilən istənilən sorğu onları \"birləşmə\" sahəsi ilə üstələyə bilər.",
     "unsavedChanges": "Yadda saxlanmamış dəyişikliklər",
-    "save": "Xilas et"
+    "save": "Xilas et",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -694,7 +694,11 @@
     "howToUse": "Как да използвате",
     "howToUseHelp": "Изпратете обикновена заявка за чат с модел \"fusion\". Тези настройки са по подразбиране; Всяка заявка може да ги замени с поле \"сливане\".",
     "unsavedChanges": "Незапазени промени",
-    "save": "Запази"
+    "save": "Запази",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Премиум",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -694,7 +694,11 @@
     "howToUse": "কিভাবে ব্যবহার করবেন",
     "howToUseHelp": "মডেল \"ফিউশন\" সহ একটি সাধারণ চ্যাট অনুরোধ পাঠান। এই সেটিংস ডিফল্ট; যেকোনো অনুরোধ একটি \"ফিউশন\" ফিল্ড দিয়ে তাদের ওভাররাইড করতে পারে।",
     "unsavedChanges": "অসংরক্ষিত পরিবর্তন",
-    "save": "সংরক্ষণ করুন"
+    "save": "সংরক্ষণ করুন",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "প্রিমিয়াম",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -694,7 +694,11 @@
     "howToUse": "Jak používat",
     "howToUseHelp": "Pošlete běžný chat s modelem \"fusion\". Tato nastavení jsou výchozí; Jakýkoli požadavek je může přepsat polem \"fúze\".",
     "unsavedChanges": "Neuložené změny",
-    "save": "Uložit"
+    "save": "Uložit",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Prémiové",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -694,7 +694,11 @@
     "howToUse": "Sådan bruger du",
     "howToUseHelp": "Send en normal chatanmodning med modellen \"fusion\". Disse indstillinger er standard; enhver anmodning kan tilsidesætte dem med et \"fusion\"-felt.",
     "unsavedChanges": "Ændringer uden gemte",
-    "save": "Gem"
+    "save": "Gem",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -694,7 +694,11 @@
     "howToUse": "Wie zu verwenden",
     "howToUseHelp": "Senden Sie eine normale Chat-Anfrage mit dem Model „Fusion“. Diese Einstellungen sind die Standardeinstellungen; Jede Anfrage kann sie mit einem „Fusion“-Feld überschreiben.",
     "unsavedChanges": "Nicht gespeicherte Änderungen",
-    "save": "Speichern"
+    "save": "Speichern",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -694,7 +694,11 @@
     "howToUse": "Τρόπος χρήσης",
     "howToUseHelp": "Στείλτε ένα κανονικό αίτημα συνομιλίας με το μοντέλο \"fusion\". Αυτές οι ρυθμίσεις είναι οι προεπιλεγμένες. Οποιοδήποτε αίτημα μπορεί να τα παρακάμψει με ένα πεδίο \"fusion\".",
     "unsavedChanges": "Μη αποθηκευμένες αλλαγές",
-    "save": "Αποθήκευση"
+    "save": "Αποθήκευση",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Ασφάλιστρο",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -710,7 +710,11 @@
     "howToUse": "How to use",
     "howToUseHelp": "Send a normal chat request with model \"fusion\". These settings are the default; any request can override them with a \"fusion\" field.",
     "unsavedChanges": "Unsaved changes",
-    "save": "Save"
+    "save": "Save",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -694,7 +694,11 @@
     "howToUse": "Cómo usarlo",
     "howToUseHelp": "Envía una solicitud de chat normal con el modelo «fusion». Estos ajustes son los predeterminados; cualquier solicitud puede anularlos con un campo «fusion».",
     "unsavedChanges": "Cambios sin guardar",
-    "save": "Guardar"
+    "save": "Guardar",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -694,7 +694,11 @@
     "howToUse": "نحوه استفاده",
     "howToUseHelp": "یک درخواست چت معمولی با مدل \"fusion\" ارسال کنید. این تنظیمات پیش فرض هستند. هر درخواستی می تواند آنها را با یک فیلد \"fusion\" لغو کند.",
     "unsavedChanges": "تغییرات ذخیره نشده",
-    "save": "ذخیره کنید"
+    "save": "ذخیره کنید",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "حق بیمه",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -694,7 +694,11 @@
     "howToUse": "Käyttöohje",
     "howToUseHelp": "Lähetä tavallinen chat-pyyntö mallin \"fusion\" kanssa. Nämä asetukset ovat oletusasetukset; Mikä tahansa pyyntö voi ohittaa ne \"fuusio\"-kentällä.",
     "unsavedChanges": "Tallentamattomat muutokset",
-    "save": "Tallenna"
+    "save": "Tallenna",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -694,7 +694,11 @@
     "howToUse": "Comment l’utiliser",
     "howToUseHelp": "Envoyez une requête de chat normale avec le modèle « fusion ». Ces réglages sont les valeurs par défaut ; toute requête peut les remplacer via un champ « fusion ».",
     "unsavedChanges": "Modifications non enregistrées",
-    "save": "Enregistrer"
+    "save": "Enregistrer",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -694,7 +694,11 @@
     "howToUse": "કેવી રીતે ઉપયોગ કરવો",
     "howToUseHelp": "મોડેલ \"ફ્યુઝન\" સાથે સામાન્ય ચેટ વિનંતી મોકલો. આ સેટિંગ્સ મૂળભૂત છે; કોઈપણ વિનંતી તેમને \"ફ્યુઝન\" ફીલ્ડ વડે ઓવરરાઈડ કરી શકે છે.",
     "unsavedChanges": "વણસાચવેલા ફેરફારો",
-    "save": "સાચવો"
+    "save": "સાચવો",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "પ્રીમિયમ",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -694,7 +694,11 @@
     "howToUse": "Yadda ake amfani da shi",
     "howToUseHelp": "Aika buƙatun taɗi na yau da kullun tare da ƙirar \"fusion\". Waɗannan saitunan tsoho ne; kowace bukata na iya shafe su da filin \"fusion\".",
     "unsavedChanges": "Canje-canjen da ba a ajiye su ba",
-    "save": "Ajiye"
+    "save": "Ajiye",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -694,7 +694,11 @@
     "howToUse": "איך להשתמש",
     "howToUseHelp": "שלח בקשת צ'אט רגילה עם מודל \"fusion\". הגדרות אלו הן ברירת המחדל; כל בקשה יכולה לעקוף אותן באמצעות שדה \"מיזוג\".",
     "unsavedChanges": "שינויים שלא נשמרו",
-    "save": "שמור"
+    "save": "שמור",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "פרימיום",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -694,7 +694,11 @@
     "howToUse": "कैसे उपयोग करें",
     "howToUseHelp": "मॉडल \"फ़्यूज़न\" के साथ एक सामान्य चैट अनुरोध भेजें। ये सेटिंग्स डिफ़ॉल्ट हैं; कोई भी अनुरोध उन्हें \"फ़्यूज़न\" फ़ील्ड से ओवरराइड कर सकता है।",
     "unsavedChanges": "सहेजे न गए परिवर्तन",
-    "save": "सहेजें"
+    "save": "सहेजें",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "प्रीमियम",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -694,7 +694,11 @@
     "howToUse": "Kako koristiti",
     "howToUseHelp": "Pošalji običan chat zahtjev s modelom \"fusion\". Ove postavke su zadane; bilo koji zahtjev može ih nadjačati poljem \"fuzija\".",
     "unsavedChanges": "Nespremljene promjene",
-    "save": "Spasi"
+    "save": "Spasi",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premija",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -694,7 +694,11 @@
     "howToUse": "Hogyan kell használni",
     "howToUseHelp": "Küldj egy normál chatkérést a modell \"fusion\"-val. Ezek az alapbeállítások; bármilyen kérés felülírhatja őket egy \"fúziós\" mezővel.",
     "unsavedChanges": "Mentetlen változtatások",
-    "save": "Mentés"
+    "save": "Mentés",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Prémium",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -694,7 +694,11 @@
     "howToUse": "Cara menggunakan",
     "howToUseHelp": "Kirim request chat biasa dengan model \"fusion\". Pengaturan ini adalah default; permintaan apa pun dapat menimpanya dengan bidang \"fusi\".",
     "unsavedChanges": "Perubahan yang belum disimpan",
-    "save": "Simpan"
+    "save": "Simpan",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premi",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -694,7 +694,11 @@
     "howToUse": "Otu esi eji",
     "howToUseHelp": "zipu arịrịọ nkata nkịtị nwere ihe nlereanya \"fusion\". Ntọala ndị a bụ ndabara; Arịrịọ ọ bụla nwere ike iji mpaghara “fusion” wezuga ha.",
     "unsavedChanges": "Mgbanwe anaghị echekwa",
-    "save": "Chekwa"
+    "save": "Chekwa",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "adịchaghị",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -694,7 +694,11 @@
     "howToUse": "Come usare",
     "howToUseHelp": "Invia una normale richiesta chat con modello \"fusion\". Queste impostazioni sono il default; qualsiasi richiesta può sovrascriverle con un campo \"fusion\".",
     "unsavedChanges": "Modifiche non salvate",
-    "save": "Salva"
+    "save": "Salva",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -694,7 +694,11 @@
     "howToUse": "使用方法",
     "howToUseHelp": "モデル「fusion」を使用して通常のチャット リクエストを送信します。これらの設定はデフォルトです。どのリクエストでも「fusion」フィールドでそれらをオーバーライドできます。",
     "unsavedChanges": "未保存の変更",
-    "save": "保存"
+    "save": "保存",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "プレミアム",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -694,7 +694,11 @@
     "howToUse": "როგორ გამოვიყენოთ",
     "howToUseHelp": "გააგზავნეთ ჩვეულებრივი ჩატის მოთხოვნა მოდელის \"fusion\"-ით. ეს პარამეტრები ნაგულისხმევია; ნებისმიერ მოთხოვნას შეუძლია გადალახოს ისინი \"fusion\" ველით.",
     "unsavedChanges": "შენახული ცვლილებები",
-    "save": "შენახვა"
+    "save": "შენახვა",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "პრემიუმი",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -694,7 +694,11 @@
     "howToUse": "របៀបប្រើ",
     "howToUseHelp": "ផ្ញើសំណើជជែកធម្មតាជាមួយម៉ូដែល \"fusion\"។ ការកំណត់ទាំងនេះគឺជាការកំណត់លំនាំដើម; សំណើណាមួយអាចបដិសេធវាដោយវាល \"fusion\"។",
     "unsavedChanges": "ការផ្លាស់ប្តូរដែលមិនបានរក្សាទុក",
-    "save": "រក្សាទុក"
+    "save": "រក្សាទុក",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ព្រីមៀម",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -694,7 +694,11 @@
     "howToUse": "ಹೇಗೆ ಬಳಸುವುದು",
     "howToUseHelp": "ಮಾದರಿ \"ಸಮ್ಮಿಳನ\" ದೊಂದಿಗೆ ಸಾಮಾನ್ಯ ಚಾಟ್ ವಿನಂತಿಯನ್ನು ಕಳುಹಿಸಿ. ಈ ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಡೀಫಾಲ್ಟ್ ಆಗಿರುತ್ತವೆ; ಯಾವುದೇ ವಿನಂತಿಯು ಅವುಗಳನ್ನು \"ಸಮ್ಮಿಳನ\" ಕ್ಷೇತ್ರದೊಂದಿಗೆ ಅತಿಕ್ರಮಿಸಬಹುದು.",
     "unsavedChanges": "ಉಳಿಸದ ಬದಲಾವಣೆಗಳು",
-    "save": "ಉಳಿಸಿ"
+    "save": "ಉಳಿಸಿ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ಪ್ರೀಮಿಯಂ",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -694,7 +694,11 @@
     "howToUse": "사용방법",
     "howToUseHelp": "모델 \"fusion\"을 사용하여 일반 채팅 요청을 보냅니다. 이러한 설정은 기본값입니다. 모든 요청은 \"fusion\" 필드로 이를 재정의할 수 있습니다.",
     "unsavedChanges": "저장되지 않은 변경사항",
-    "save": "저장"
+    "save": "저장",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "프리미엄",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -694,7 +694,11 @@
     "howToUse": "Kaip naudoti",
     "howToUseHelp": "Siųskite įprastą pokalbio užklausą su modelio \"fuzija\". Šie nustatymai yra numatytieji; Bet koks prašymas gali juos perrašyti \"fuzijos\" lauku.",
     "unsavedChanges": "Neišsaugoti pakeitimai",
-    "save": "Išsaugoti"
+    "save": "Išsaugoti",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -694,7 +694,11 @@
     "howToUse": "എങ്ങനെ ഉപയോഗിക്കാം",
     "howToUseHelp": "മോഡൽ \"ഫ്യൂഷൻ\" ഉപയോഗിച്ച് ഒരു സാധാരണ ചാറ്റ് അഭ്യർത്ഥന അയയ്ക്കുക. ഈ ക്രമീകരണങ്ങൾ സ്ഥിരസ്ഥിതിയാണ്; ഏതൊരു അഭ്യർത്ഥനയ്ക്കും ഒരു \"ഫ്യൂഷൻ\" ഫീൽഡ് ഉപയോഗിച്ച് അവയെ മറികടക്കാൻ കഴിയും.",
     "unsavedChanges": "സംരക്ഷിക്കാത്ത മാറ്റങ്ങൾ",
-    "save": "സംരക്ഷിക്കുക"
+    "save": "സംരക്ഷിക്കുക",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "പ്രീമിയം",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -694,7 +694,11 @@
     "howToUse": "कसे वापरावे",
     "howToUseHelp": "मॉडेल \"फ्यूजन\" सह सामान्य चॅट विनंती पाठवा. या सेटिंग्ज डीफॉल्ट आहेत; कोणतीही विनंती त्यांना \"फ्यूजन\" फील्डसह अधिलिखित करू शकते.",
     "unsavedChanges": "जतन न केलेले बदल",
-    "save": "जतन करा"
+    "save": "जतन करा",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "प्रीमियम",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -694,7 +694,11 @@
     "howToUse": "Cara menggunakan",
     "howToUseHelp": "Hantar permintaan sembang biasa dengan model \"fusion\". Tetapan ini adalah lalai; Mana-mana permintaan boleh menggantikannya dengan medan \"fusion\".",
     "unsavedChanges": "Perubahan yang belum disimpan",
-    "save": "Simpan"
+    "save": "Simpan",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -694,7 +694,11 @@
     "howToUse": "အသုံးပြုနည်း",
     "howToUseHelp": "\"fusion\" မော်ဒယ်ဖြင့် ပုံမှန် စကားပြောတောင်းဆိုမှု ပို့ပါ။ ဤဆက်တင်များသည် ပုံမှန်ဖြစ်သည်။ မည်သည့် တောင်းဆိုမှုမဆို \"fusion\" ကွက်လပ်ဖြင့် အစားထိုးနိုင်သည်။",
     "unsavedChanges": "မသိမ်းဆည်းထားသော ပြင်ဆင်မှုများ",
-    "save": "သိမ်းဆည်းပါ"
+    "save": "သိမ်းဆည်းပါ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ပရီးမီယံ",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -694,7 +694,11 @@
     "howToUse": "कसरी प्रयोग गर्ने?",
     "howToUseHelp": "मोडेल \"फ्यूजन\" संग एक सामान्य च्याट अनुरोध पठाउनुहोस्। यी सेटिङहरू पूर्वनिर्धारित हुन्; कुनै पनि अनुरोधले तिनीहरूलाई \"फ्यूजन\" फिल्डको साथ ओभरराइड गर्न सक्छ।",
     "unsavedChanges": "बचत नगरिएका परिवर्तनहरू",
-    "save": "बचत गर्नुहोस्"
+    "save": "बचत गर्नुहोस्",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "प्रिमियम",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -694,7 +694,11 @@
     "howToUse": "Hoe te gebruiken",
     "howToUseHelp": "Stuur een normaal chatverzoek met model \"fusion\". Deze instellingen zijn standaard; elk verzoek kan ze overschrijven met een \"fusie\"-veld.",
     "unsavedChanges": "Wijzigingen die niet opgeslagen zijn",
-    "save": "Sla op"
+    "save": "Sla op",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premie",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -694,7 +694,11 @@
     "howToUse": "Hvordan bruke",
     "howToUseHelp": "Send en vanlig chatforespørsel med modellen \"fusion\". Disse innstillingene er standard; Enhver forespørsel kan overstyre dem med et \"fusjonsfelt\".",
     "unsavedChanges": "Ulagrede endringer",
-    "save": "Lagre"
+    "save": "Lagre",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -694,7 +694,11 @@
     "howToUse": "କିପରି ବ୍ୟବହାର କରିବେ",
     "howToUseHelp": "ମଡେଲ୍ \"ଫ୍ୟୁଜନ୍\" ସହ ଏକ ସାମାନ୍ୟ ଚାଟ୍ ଅନୁରୋଧ ପ୍ରେରଣ କରନ୍ତୁ। ଏହି ସେଟିଂସ୍ ହେଉଛି ଡିଫଲ୍ଟ; ଯେକୌଣସି ଅନୁରୋଧ ସେମାନଙ୍କୁ ଏକ \"ଫ୍ୟୁଜନ୍\" ଫିଲ୍ଡ ସହିତ ଓଭରରାଇଡ୍ କରିପାରେ ।",
     "unsavedChanges": "ଅସଞ୍ଚିତ ପରିବର୍ତ୍ତନଗୁଡିକ",
-    "save": "ସଞ୍ଚୟ କରନ୍ତୁ"
+    "save": "ସଞ୍ଚୟ କରନ୍ତୁ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ପ୍ରିମିୟମ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -694,7 +694,11 @@
     "howToUse": "ਕਿਵੇਂ ਵਰਤਣਾ ਹੈ",
     "howToUseHelp": "ਮਾਡਲ \"ਫਿਊਜ਼ਨ\" ਦੇ ਨਾਲ ਇੱਕ ਆਮ ਚੈਟ ਬੇਨਤੀ ਭੇਜੋ। ਇਹ ਸੈਟਿੰਗਾਂ ਡਿਫੌਲਟ ਹਨ; ਕੋਈ ਵੀ ਬੇਨਤੀ ਉਹਨਾਂ ਨੂੰ \"ਫਿਊਜ਼ਨ\" ਖੇਤਰ ਨਾਲ ਓਵਰਰਾਈਡ ਕਰ ਸਕਦੀ ਹੈ।",
     "unsavedChanges": "ਅਣਰੱਖਿਅਤ ਤਬਦੀਲੀਆਂ",
-    "save": "ਸੇਵ ਕਰੋ"
+    "save": "ਸੇਵ ਕਰੋ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ਪ੍ਰੀਮੀਅਮ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -694,7 +694,11 @@
     "howToUse": "Jak używać",
     "howToUseHelp": "Wyślij normalną prośbę o czat z modelem „fusion”. Te ustawienia są domyślne; każde żądanie może je zastąpić polem „fusion”.",
     "unsavedChanges": "Niezapisane zmiany",
-    "save": "Zapisz"
+    "save": "Zapisz",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -694,7 +694,11 @@
     "howToUse": "Como usar",
     "howToUseHelp": "Envie uma requisição de chat normal com o modelo \"fusion\". Estas configurações são o padrão; qualquer requisição pode sobrescrevê-las com um campo \"fusion\".",
     "unsavedChanges": "Alterações não salvas",
-    "save": "Salvar"
+    "save": "Salvar",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -694,7 +694,11 @@
     "howToUse": "Como usar",
     "howToUseHelp": "Envia um pedido de chat normal com o modelo \"fusion\". Estas definições são as predefinidas; Qualquer pedido pode sobrepê-los com um campo de \"fusão\".",
     "unsavedChanges": "Alterações não guardadas",
-    "save": "Guardar"
+    "save": "Guardar",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -694,7 +694,11 @@
     "howToUse": "Cum să folosești",
     "howToUseHelp": "Trimite o cerere normală de chat cu modelul \"fusion\". Aceste setări sunt cele implicite; Orice cerere le poate suprascrie cu un câmp \"fuziune\".",
     "unsavedChanges": "Modificări nesalvate",
-    "save": "Salvează"
+    "save": "Salvează",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -694,7 +694,11 @@
     "howToUse": "Как использовать",
     "howToUseHelp": "Отправьте обычный запрос в чат с моделью «fusion». Эти настройки установлены по умолчанию; любой запрос может переопределить их с помощью поля «fusion».",
     "unsavedChanges": "Несохраненные изменения",
-    "save": "Сохранить"
+    "save": "Сохранить",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Премиум",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -694,7 +694,11 @@
     "howToUse": "භාවිතා කරන ආකාරය",
     "howToUseHelp": "මාදිලිය \"විලයන\" සමඟ සාමාන්‍ය කතාබස් ඉල්ලීමක් යවන්න. මෙම සැකසුම් පෙරනිමි වේ; ඕනෑම ඉල්ලීමක් \"විලයන\" ක්ෂේත්‍රයකින් ඒවා අභිබවා යා හැක.",
     "unsavedChanges": "නොසුරකින ලද වෙනස්කම්",
-    "save": "සුරකින්න"
+    "save": "සුරකින්න",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "වාරික",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -694,7 +694,11 @@
     "howToUse": "Ako používať",
     "howToUseHelp": "Pošli bežnú chatovú požiadavku s modelom \"fusion\". Tieto nastavenia sú predvolené; Akákoľvek požiadavka ich môže prepísať pomocou poľa \"fúzia\".",
     "unsavedChanges": "Neuložené zmeny",
-    "save": "Uložiť"
+    "save": "Uložiť",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Prémiové",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -694,7 +694,11 @@
     "howToUse": "Како користити",
     "howToUseHelp": "Пошаљите нормалан захтев за ћаскање са моделом \"фусион\". Ова подешавања су подразумевана; сваки захтев их може заменити пољем „фузије“.",
     "unsavedChanges": "Несачуване промене",
-    "save": "Сачувај"
+    "save": "Сачувај",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Премиум",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -694,7 +694,11 @@
     "howToUse": "Hur man använder",
     "howToUseHelp": "Skicka en vanlig chattförfrågan med modellen \"fusion\". Dessa inställningar är standard; Vilken begäran som helst kan åsidosätta dem med ett \"fusion\"-fält.",
     "unsavedChanges": "Osparade ändringar",
-    "save": "Spara"
+    "save": "Spara",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -694,7 +694,11 @@
     "howToUse": "Jinsi ya kutumia",
     "howToUseHelp": "Tuma ombi la kawaida la gumzo na muundo wa \"fusion\". Mipangilio hii ndiyo chaguo-msingi; ombi lolote linaweza kuzibatilisha kwa uga wa \"fusion\".",
     "unsavedChanges": "Mabadiliko ambayo hayajahifadhiwa",
-    "save": "Hifadhi"
+    "save": "Hifadhi",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -694,7 +694,11 @@
     "howToUse": "எப்படி பயன்படுத்துவது",
     "howToUseHelp": "மாதிரி \"ஃப்யூஷன்\" உடன் சாதாரண அரட்டை கோரிக்கையை அனுப்பவும். இந்த அமைப்புகள் இயல்புநிலை; எந்தவொரு கோரிக்கையும் அவற்றை \"இணைவு\" புலத்துடன் மேலெழுதலாம்.",
     "unsavedChanges": "சேமிக்கப்படாத மாற்றங்கள்",
-    "save": "சேமிக்கவும்"
+    "save": "சேமிக்கவும்",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "பிரீமியம்",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -694,7 +694,11 @@
     "howToUse": "ఎలా ఉపయోగించాలి",
     "howToUseHelp": "మోడల్ \"ఫ్యూజన్\"తో సాధారణ చాట్ అభ్యర్థనను పంపండి. ఈ సెట్టింగ్‌లు డిఫాల్ట్; ఏదైనా అభ్యర్థన వాటిని \"ఫ్యూజన్\" ఫీల్డ్‌తో భర్తీ చేయగలదు.",
     "unsavedChanges": "సేవ్ చేయని మార్పులు",
-    "save": "సేవ్ చేయండి"
+    "save": "సేవ్ చేయండి",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "ప్రీమియం",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -694,7 +694,11 @@
     "howToUse": "วิธีใช้",
     "howToUseHelp": "ส่งคำขอแชทปกติด้วยโมเดล \"ฟิวชั่น\" การตั้งค่าเหล่านี้เป็นค่าเริ่มต้น คำขอใดๆ ก็ตามสามารถแทนที่คำขอเหล่านั้นด้วยฟิลด์ \"ฟิวชั่น\"",
     "unsavedChanges": "การเปลี่ยนแปลงที่ไม่ได้บันทึก",
-    "save": "บันทึก"
+    "save": "บันทึก",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "พรีเมี่ยม",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -694,7 +694,11 @@
     "howToUse": "Paano gamitin",
     "howToUseHelp": "Magpadala ng normal na chat request gamit ang modelong \"fusion\". Ang mga setting na ito ang default; Anumang request ay maaaring mag-override gamit ang \"fusion\" field.",
     "unsavedChanges": "Mga hindi na-save na pagbabago",
-    "save": "I-save"
+    "save": "I-save",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -694,7 +694,11 @@
     "howToUse": "Nasıl kullanılır",
     "howToUseHelp": "\"Fusion\" modeliyle normal bir sohbet isteği gönderin. Bu ayarlar varsayılandır; herhangi bir istek bunları bir \"füzyon\" alanıyla geçersiz kılabilir.",
     "unsavedChanges": "Kaydedilmemiş değişiklikler",
-    "save": "Kaydet"
+    "save": "Kaydet",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "prim",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -694,7 +694,11 @@
     "howToUse": "Як використовувати",
     "howToUseHelp": "Надішліть звичайний запит у чат із моделлю \"fusion\". Ці налаштування є типовими; будь-який запит може замінити їх за допомогою поля \"fusion\".",
     "unsavedChanges": "Незбережені зміни",
-    "save": "зберегти"
+    "save": "зберегти",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Преміум",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -694,7 +694,11 @@
     "howToUse": "استعمال کرنے کا طریقہ",
     "howToUseHelp": "ماڈل \"فیوژن\" کے ساتھ ایک عام چیٹ کی درخواست بھیجیں۔ یہ ترتیبات پہلے سے طے شدہ ہیں۔ کوئی بھی درخواست انہیں \"فیوژن\" فیلڈ کے ساتھ اوور رائیڈ کر سکتی ہے۔",
     "unsavedChanges": "غیر محفوظ شدہ تبدیلیاں",
-    "save": "محفوظ کریں۔"
+    "save": "محفوظ کریں۔",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "پریمیم",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -694,7 +694,11 @@
     "howToUse": "Qanday foydalanish kerak",
     "howToUseHelp": "\"Fusion\" modeli bilan oddiy suhbat so'rovini yuboring. Bu sozlamalar sukut bo'yicha; har qanday so'rov ularni \"fusion\" maydoni bilan bekor qilishi mumkin.",
     "unsavedChanges": "Saqlanmagan o'zgarishlar",
-    "save": "Saqlash"
+    "save": "Saqlash",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Premium",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -694,7 +694,11 @@
     "howToUse": "Cách sử dụng",
     "howToUseHelp": "Gửi yêu cầu trò chuyện bình thường với mô hình \"fusion\". Các cài đặt này là mặc định; mọi yêu cầu đều có thể ghi đè chúng bằng trường \"kết hợp\".",
     "unsavedChanges": "Những thay đổi chưa được lưu",
-    "save": "Lưu"
+    "save": "Lưu",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Cao cấp",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -694,7 +694,11 @@
     "howToUse": "Bawo ni lati lo",
     "howToUseHelp": "Firanṣẹ ibeere iwiregbe deede pẹlu awoṣe “Fusion”. Awọn eto wọnyi jẹ aiyipada; eyikeyi ìbéèrè le idojuk wọn pẹlu kan \"fusion\" aaye.",
     "unsavedChanges": "Awọn iyipada ti ko ni fipamọ",
-    "save": "Fipamọ"
+    "save": "Fipamọ",
+    "searchPlaceholder": "Search models…",
+    "providerFilterLabel": "Filter by provider",
+    "providerAll": "All providers",
+    "noMatch": "No models match your search."
   },
   "premium": {
     "title": "Ere",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -694,7 +694,11 @@
     "howToUse": "如何使用",
     "howToUseHelp": "发送普通的对话请求，并将 model 设为 “fusion”。这些设置为默认值；任何请求都可以通过 “fusion” 字段覆盖它们。",
     "unsavedChanges": "有未保存的更改",
-    "save": "保存"
+    "save": "保存",
+    "searchPlaceholder": "搜索模型…",
+    "providerFilterLabel": "按提供商筛选",
+    "providerAll": "全部提供商",
+    "noMatch": "没有匹配搜索条件的模型。"
   },
   "premium": {
     "title": "高级版",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -694,7 +694,11 @@
     "howToUse": "如何使用",
     "howToUseHelp": "傳送一般的對話請求，並將 model 設為 “fusion”。這些設定為預設值；任何請求都可以透過 “fusion” 欄位覆蓋它們。",
     "unsavedChanges": "有未儲存的變更",
-    "save": "儲存"
+    "save": "儲存",
+    "searchPlaceholder": "搜尋模型…",
+    "providerFilterLabel": "依供應商篩選",
+    "providerAll": "全部供應商",
+    "noMatch": "沒有符合搜尋條件的模型。"
   },
   "premium": {
     "title": "高級版",

--- a/client/src/lib/fusion-filter.test.ts
+++ b/client/src/lib/fusion-filter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { filterFusionModels, fusionProviders } from './fusion-filter'
+import type { ModelOption } from './model-groups'
+
+const opt = (value: string, label: string, platform: string, platforms: string[] = [platform]): ModelOption => ({
+  value,
+  label,
+  platform,
+  platforms,
+  providerCount: platforms.length,
+  sizeTier: 3,
+  intelligenceRank: 50,
+})
+
+const options: ModelOption[] = [
+  opt('gpt-4.1', 'GPT-4.1', 'OpenAI', ['OpenAI']),
+  opt('claude-sonnet-4', 'Claude Sonnet 4', 'Anthropic', ['Anthropic']),
+  opt('deepseek-v3', 'DeepSeek V3', 'DeepSeek', ['DeepSeek', 'NVIDIA']),
+]
+
+describe('filterFusionModels (#872)', () => {
+  it('keeps everything when query and provider are empty', () => {
+    expect(filterFusionModels(options, '', null)).toHaveLength(3)
+  })
+
+  it('matches a case-insensitive substring on the display name', () => {
+    expect(filterFusionModels(options, 'claude', null).map(o => o.value)).toEqual(['claude-sonnet-4'])
+  })
+
+  it('matches on the canonical id', () => {
+    expect(filterFusionModels(options, 'deepseek-v3', null).map(o => o.value)).toEqual(['deepseek-v3'])
+  })
+
+  it('filters to a single provider', () => {
+    expect(filterFusionModels(options, '', 'OpenAI').map(o => o.value)).toEqual(['gpt-4.1'])
+  })
+
+  it('keeps multi-provider rows when any listed provider matches', () => {
+    expect(filterFusionModels(options, '', 'NVIDIA').map(o => o.value)).toEqual(['deepseek-v3'])
+  })
+
+  it('combines query and provider filters', () => {
+    expect(filterFusionModels(options, 'v3', 'DeepSeek').map(o => o.value)).toEqual(['deepseek-v3'])
+    expect(filterFusionModels(options, 'claude', 'OpenAI')).toHaveLength(0)
+  })
+
+  it('trims the query', () => {
+    expect(filterFusionModels(options, '  sonnet  ', null).map(o => o.value)).toEqual(['claude-sonnet-4'])
+  })
+})
+
+describe('fusionProviders (#872)', () => {
+  it('collects and sorts every distinct provider name', () => {
+    expect(fusionProviders(options)).toEqual(['Anthropic', 'DeepSeek', 'NVIDIA', 'OpenAI'])
+  })
+})

--- a/client/src/lib/fusion-filter.ts
+++ b/client/src/lib/fusion-filter.ts
@@ -1,0 +1,38 @@
+// Filtering helpers for the Fusion panel model picker (issue #872).
+// The explicit panel can list hundreds of models once several providers are
+// connected, so it needs a search box plus a provider filter instead of an
+// unscrollable wall of rows. Pure functions so the UI stays thin and the
+// matching rules are unit-testable.
+
+import type { ModelOption } from './model-groups'
+
+/**
+ * Match a model option against a free-text query (case-insensitive substring
+ * over name, canonical id, and every provider name) and an optional provider
+ * filter. A null/empty provider means "all providers".
+ */
+export function filterFusionModels(
+  options: ModelOption[],
+  query: string,
+  provider: string | null,
+): ModelOption[] {
+  const q = query.trim().toLowerCase()
+  return options.filter(o => {
+    if (provider && !(o.platform === provider || o.platforms.includes(provider))) {
+      return false
+    }
+    if (!q) return true
+    const haystack = `${o.label} ${o.value} ${o.platform} ${o.platforms.join(' ')}`.toLowerCase()
+    return haystack.includes(q)
+  })
+}
+
+/** Distinct provider names across the options, sorted for a stable Select list. */
+export function fusionProviders(options: ModelOption[]): string[] {
+  const seen = new Set<string>()
+  for (const o of options) {
+    seen.add(o.platform)
+    for (const p of o.platforms) seen.add(p)
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b))
+}

--- a/client/src/pages/FusionPage.tsx
+++ b/client/src/pages/FusionPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Check, Layers } from 'lucide-react'
+import { Check, Layers, Search } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { buildModelOptions } from '@/lib/model-groups'
+import { filterFusionModels, fusionProviders } from '@/lib/fusion-filter'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
@@ -40,6 +41,7 @@ interface FallbackEntry {
 }
 
 const JUDGE_AUTO = '__auto__'
+const PROVIDER_ALL = '__all__'
 
 export default function FusionPage() {
   const { t } = useI18n()
@@ -76,6 +78,16 @@ export default function FusionPage() {
   const [k, setK] = useState<number>(4)
   const [strategy, setStrategy] = useState<Strategy>('synthesize')
   const [exposePanel, setExposePanel] = useState<boolean>(false)
+  const [panelQuery, setPanelQuery] = useState('')
+  const [panelProvider, setPanelProvider] = useState<string>(PROVIDER_ALL)
+
+  // Issue #872: the explicit panel can list hundreds of models, so support a
+  // free-text search and a provider filter before showing the rows.
+  const panelProviders = useMemo(() => fusionProviders(modelOptions), [modelOptions])
+  const visibleModels = useMemo(
+    () => filterFusionModels(modelOptions, panelQuery, panelProvider === PROVIDER_ALL ? null : panelProvider),
+    [modelOptions, panelQuery, panelProvider],
+  )
 
   // Hydrate local state from the server once it loads.
   useEffect(() => {
@@ -165,34 +177,65 @@ export default function FusionPage() {
               {modelOptions.length === 0 ? (
                 <p className="text-xs text-muted-foreground">{t('fusion.noModels')}</p>
               ) : (
-                <div className="max-h-80 overflow-y-auto rounded-xl border divide-y">
-                  {modelOptions.map(o => {
-                    const selected = models.includes(o.value)
-                    const atCap = !selected && models.length >= maxK
-                    return (
-                      <button
-                        key={o.value}
-                        type="button"
-                        disabled={atCap}
-                        onClick={() => toggleModel(o.value)}
-                        className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors ${
-                          selected ? 'bg-muted/50' : atCap ? 'opacity-40' : 'hover:bg-muted/30'
-                        }`}
-                      >
-                        <span className={`flex size-4 items-center justify-center rounded border ${selected ? 'bg-foreground text-background' : ''}`}>
-                          {selected && <Check className="size-3" />}
-                        </span>
-                        <span className="min-w-0 flex-1">
-                          <span className="text-sm font-medium">{o.label}</span>
-                          <span className="ml-2 font-mono text-[11px] text-muted-foreground">{o.value}</span>
-                        </span>
-                        <Badge variant="secondary" className="text-[10px]">
-                          {o.providerCount > 1 ? t('models.providerCount', { count: o.providerCount }) : o.platform}
-                        </Badge>
-                      </button>
-                    )
-                  })}
-                </div>
+                <>
+                  {/* Issue #872: search + provider filter over a long model list. */}
+                  <div className="flex items-center gap-2">
+                    <div className="relative flex-1">
+                      <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        value={panelQuery}
+                        onChange={e => setPanelQuery(e.target.value)}
+                        placeholder={t('fusion.searchPlaceholder')}
+                        className="pl-8"
+                      />
+                    </div>
+                    <Select value={panelProvider} onValueChange={v => setPanelProvider(v ?? PROVIDER_ALL)}>
+                      <SelectTrigger className="w-44 shrink-0" aria-label={t('fusion.providerFilterLabel')}>
+                        <SelectValue>
+                          {(v: string) => v === PROVIDER_ALL
+                            ? t('fusion.providerAll')
+                            : (panelProviders.find(p => p === v) ?? v)}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={PROVIDER_ALL}>{t('fusion.providerAll')}</SelectItem>
+                        {panelProviders.map(p => (
+                          <SelectItem key={p} value={p}>{p}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="max-h-80 overflow-y-auto rounded-xl border divide-y">
+                    {visibleModels.length === 0 ? (
+                      <p className="px-3 py-6 text-center text-xs text-muted-foreground">{t('fusion.noMatch')}</p>
+                    ) : visibleModels.map(o => {
+                      const selected = models.includes(o.value)
+                      const atCap = !selected && models.length >= maxK
+                      return (
+                        <button
+                          key={o.value}
+                          type="button"
+                          disabled={atCap}
+                          onClick={() => toggleModel(o.value)}
+                          className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors ${
+                            selected ? 'bg-muted/50' : atCap ? 'opacity-40' : 'hover:bg-muted/30'
+                          }`}
+                        >
+                          <span className={`flex size-4 items-center justify-center rounded border ${selected ? 'bg-foreground text-background' : ''}`}>
+                            {selected && <Check className="size-3" />}
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="text-sm font-medium">{o.label}</span>
+                            <span className="ml-2 font-mono text-[11px] text-muted-foreground">{o.value}</span>
+                          </span>
+                          <Badge variant="secondary" className="text-[10px]">
+                            {o.providerCount > 1 ? t('models.providerCount', { count: o.providerCount }) : o.platform}
+                          </Badge>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </>
               )}
             </section>
           )}


### PR DESCRIPTION
## 中文

实现 #872：Fusion 页面「指定模型组（Explicit panel）」支持搜索与按提供商筛选，避免连接多家提供商后模型列表过长难以挑选。

**改动**
- 新增 `client/src/lib/fusion-filter.ts`：纯函数 `filterFusionModels`（按名称/规范 id/提供商做大小写不敏感子串匹配 + 可选提供商过滤）与 `fusionProviders`（去重排序的提供商列表）
- `FusionPage.tsx` 显式面板新增搜索框 + 提供商下拉（含「全部提供商」），渲染过滤后的列表，无匹配时显示提示
- i18n：en / zh-CN / zh-TW + 其余 57 个 locale 补齐 4 个新键（`fusion.searchPlaceholder` / `providerFilterLabel` / `providerAll` / `noMatch`）
- 新增 `fusion-filter.test.ts`：8 个用例覆盖查询/提供商/组合过滤与去重排序

**验证**
- client tsc 通过（基线 TS5101 baseUrl 弃用警告除外，与本次无关）
- `vitest run` 全绿（77/77，含新增 8 个用例）
- `check:i18n` 通过（60 locales / 820 keys）

---

## English

Implements #872: the Fusion "Explicit panel" model picker now supports search and provider filtering, so long model lists stay navigable after connecting many providers.

**Changes**
- New `client/src/lib/fusion-filter.ts`: pure helpers `filterFusionModels` (case-insensitive substring match over name / canonical id / providers, plus optional provider filter) and `fusionProviders` (deduped, sorted provider list)
- `FusionPage.tsx` explicit panel gains a search box + provider dropdown (with "All providers"); renders the filtered list and shows a hint when nothing matches
- i18n: en / zh-CN / zh-TW plus the other 57 locales get the 4 new keys (`fusion.searchPlaceholder` / `providerFilterLabel` / `providerAll` / `noMatch`)
- New `fusion-filter.test.ts`: 8 cases covering query / provider / combined filters and deduped sorting

**Verification**
- client tsc passes (baseline TS5101 baseUrl deprecation aside, unrelated to this change)
- `vitest run` all green (77/77, incl. the 8 new cases)
- `check:i18n` passes (60 locales / 820 keys)