### PR TITLE
fix(tests): bind test servers to the loopback address they are called on

### DIFF
--- a/server/src/__tests__/integration/full-flow.test.ts
+++ b/server/src/__tests__/integration/full-flow.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function req(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/lib/app-version.test.ts
+++ b/server/src/__tests__/lib/app-version.test.ts
@@ -74,7 +74,8 @@ describe('GET /api/settings/version', () => {
   });
 
   async function get(headers: Record<string, string>) {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/settings/version`, { headers });
     const body = await res.json().catch(() => null);
@@ -99,7 +100,8 @@ describe('GET /api/settings/version', () => {
     // its value. Mounting there would have shadowed it and produced a dead route
     // besides. This asserts /api/version is still ANSWERED BY OLLAMA: with the
     // emulation off (the default) that is its own 404, never a version payload.
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/version`);
     const body = await res.json();

--- a/server/src/__tests__/routes/admin-rate-limit.test.ts
+++ b/server/src/__tests__/routes/admin-rate-limit.test.ts
@@ -6,7 +6,8 @@ import { initDb } from '../../db/index.js';
 import { mintDashboardToken } from '../helpers/auth.js';
 
 async function request(app: Express, path: string, token?: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: token ? { Authorization: `Bearer ${token}` } : {},

--- a/server/src/__tests__/routes/analytics-client.test.ts
+++ b/server/src/__tests__/routes/analytics-client.test.ts
@@ -5,7 +5,8 @@ import { getDb, initDb } from '../../db/index.js';
 import { mintDashboardToken } from '../helpers/auth.js';
 
 async function get(app: Express, path: string, token: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const address = server.address() as { port: number };
   const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
     headers: { Authorization: `Bearer ${token}` },

--- a/server/src/__tests__/routes/analytics-request-attempts.test.ts
+++ b/server/src/__tests__/routes/analytics-request-attempts.test.ts
@@ -11,7 +11,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/analytics-requests.test.ts
+++ b/server/src/__tests__/routes/analytics-requests.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/analytics.test.ts
+++ b/server/src/__tests__/routes/analytics.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/anthropic-documents.test.ts
+++ b/server/src/__tests__/routes/anthropic-documents.test.ts
@@ -14,7 +14,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string, body: any, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/anthropic-fallback-convergence.test.ts
+++ b/server/src/__tests__/routes/anthropic-fallback-convergence.test.ts
@@ -37,7 +37,8 @@ function streamProvider(gen: () => AsyncGenerator<any>) {
 }
 
 async function post(app: Express, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}/v1/messages`, {
     method: 'POST',

--- a/server/src/__tests__/routes/anthropic.test.ts
+++ b/server/src/__tests__/routes/anthropic.test.ts
@@ -13,7 +13,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string, body: any, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -28,7 +29,8 @@ async function request(app: Express, path: string, body: any, extraHeaders: Reco
 }
 
 async function send(app: Express, method: string, path: string, body?: any, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/audio-transcriptions.test.ts
+++ b/server/src/__tests__/routes/audio-transcriptions.test.ts
@@ -49,7 +49,8 @@ interface MultipartOpts {
  *  using the saved real fetch so a mocked globalThis.fetch only intercepts
  *  upstream provider calls. */
 async function postTranscription(app: Express, opts: MultipartOpts) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const form = new FormData();
   if (opts.file) {

--- a/server/src/__tests__/routes/auth-reset-password.test.ts
+++ b/server/src/__tests__/routes/auth-reset-password.test.ts
@@ -35,7 +35,8 @@ function makeApp(): Express {
 }
 
 async function post(app: Express, path: string, body?: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/auth-setup-code.test.ts
+++ b/server/src/__tests__/routes/auth-setup-code.test.ts
@@ -22,7 +22,8 @@ function appWithRemote(remoteAddr: string): Express {
 }
 
 async function postSetup(app: Express, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/auth/setup`, {
     method: 'POST',

--- a/server/src/__tests__/routes/auth.test.ts
+++ b/server/src/__tests__/routes/auth.test.ts
@@ -4,7 +4,8 @@ import { createApp } from '../../app.js';
 import { initDb } from '../../db/index.js';
 
 async function call(app: Express, method: string, path: string, body?: any, token?: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/body-limit.test.ts
+++ b/server/src/__tests__/routes/body-limit.test.ts
@@ -5,7 +5,8 @@ import { loadConfig } from '../../lib/config.js';
 import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 
 async function post(app: Express, path: string, body: unknown, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/client-profiles.test.ts
+++ b/server/src/__tests__/routes/client-profiles.test.ts
@@ -21,7 +21,8 @@ async function request(
   path: string,
   opts: { body?: unknown; token?: string } = {},
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/csp-inline-bootstrap.test.ts
+++ b/server/src/__tests__/routes/csp-inline-bootstrap.test.ts
@@ -58,7 +58,8 @@ describe('CSP allows the inline theme bootstrap (#682)', () => {
   });
 
   it('serves that hash in the script-src directive', async () => {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/ping`);
     server.close();
@@ -67,7 +68,8 @@ describe('CSP allows the inline theme bootstrap (#682)', () => {
   });
 
   it('still refuses inline scripts generally — no unsafe-inline for scripts', async () => {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/ping`);
     server.close();

--- a/server/src/__tests__/routes/csp-security.test.ts
+++ b/server/src/__tests__/routes/csp-security.test.ts
@@ -11,7 +11,8 @@ async function getHeaders(
   forwardedProto?: string,
   host?: string,
 ): Promise<Headers> {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const headers: Record<string, string> = {};
   if (forwardedProto) headers['x-forwarded-proto'] = forwardedProto;

--- a/server/src/__tests__/routes/custom-endpoint-identity.test.ts
+++ b/server/src/__tests__/routes/custom-endpoint-identity.test.ts
@@ -24,7 +24,8 @@ const SHARED_MODEL = 'deepseek-v3.1';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/custom-modalities.test.ts
+++ b/server/src/__tests__/routes/custom-modalities.test.ts
@@ -10,7 +10,8 @@ const realFetch = globalThis.fetch;
 let dashToken = '';
 
 async function post(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -26,7 +27,8 @@ async function post(app: Express, path: string, body: unknown) {
 }
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},
@@ -37,7 +39,8 @@ async function get(app: Express, path: string) {
 }
 
 async function del(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'DELETE',

--- a/server/src/__tests__/routes/custom-model-discovery.test.ts
+++ b/server/src/__tests__/routes/custom-model-discovery.test.ts
@@ -17,7 +17,8 @@ const realFetch = globalThis.fetch;
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: unknown, auth = true) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/custom-provider-multikey.test.ts
+++ b/server/src/__tests__/routes/custom-provider-multikey.test.ts
@@ -15,7 +15,8 @@ const ENDPOINT = 'http://127.0.0.1:18080/v1';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/custom-provider.test.ts
+++ b/server/src/__tests__/routes/custom-provider.test.ts
@@ -11,7 +11,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function post(app: Express, path: string, body: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -27,7 +28,8 @@ async function post(app: Express, path: string, body: any) {
 }
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},
@@ -38,7 +40,8 @@ async function get(app: Express, path: string) {
 }
 
 async function del(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'DELETE',
@@ -212,7 +215,7 @@ describe('Custom Provider Endpoints', () => {
         '\n',
       );
     });
-    await new Promise<void>(resolve => upstream.listen(0, resolve));
+    await new Promise<void>(resolve => upstream.listen(0, '127.0.0.1', resolve));
     const upstreamPort = (upstream.address() as any).port;
 
     // Point the custom provider at the NDJSON upstream and pin its model.
@@ -222,7 +225,8 @@ describe('Custom Provider Endpoints', () => {
     });
     expect(reg.status).toBe(201);
 
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as any;
     const res = await fetch(`http://127.0.0.1:${addr.port}/v1/chat/completions`, {
       method: 'POST',

--- a/server/src/__tests__/routes/disabled-model-routing.test.ts
+++ b/server/src/__tests__/routes/disabled-model-routing.test.ts
@@ -10,7 +10,8 @@ let app: Express;
 let dashToken = '';
 
 async function request(method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/docs.test.ts
+++ b/server/src/__tests__/routes/docs.test.ts
@@ -5,7 +5,8 @@ import { initDb } from '../../db/index.js';
 import { openapiSpec } from '../../docs/openapi.js';
 
 async function request(app: Express, method: string, path: string, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const res = await fetch(url, { method, headers });

--- a/server/src/__tests__/routes/embeddings-usage.test.ts
+++ b/server/src/__tests__/routes/embeddings-usage.test.ts
@@ -13,7 +13,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},

--- a/server/src/__tests__/routes/error-handler-security.test.ts
+++ b/server/src/__tests__/routes/error-handler-security.test.ts
@@ -12,7 +12,8 @@ async function triggerError(message: string, status: number) {
   });
   app.use(errorHandler);
 
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}/boom`);
   const json = await res.json();

--- a/server/src/__tests__/routes/fallback-detail-header.test.ts
+++ b/server/src/__tests__/routes/fallback-detail-header.test.ts
@@ -41,7 +41,8 @@ function clearDetailSetting(): void {
 }
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/fallback-hardening.test.ts
+++ b/server/src/__tests__/routes/fallback-hardening.test.ts
@@ -32,7 +32,8 @@ const { setRoutingStrategy, getAllPenalties } = await import('../../services/rou
 const { msUntilNextUtcMidnight, resetEmptyCompletionStreaks, EMPTY_COMPLETION_STREAK_LIMIT } = await import('../../lib/fallback-loop.js');
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/fallback-keycount-parity.test.ts
+++ b/server/src/__tests__/routes/fallback-keycount-parity.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: { Authorization: `Bearer ${dashToken}` },

--- a/server/src/__tests__/routes/fallback.test.ts
+++ b/server/src/__tests__/routes/fallback.test.ts
@@ -10,7 +10,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/fusion.test.ts
+++ b/server/src/__tests__/routes/fusion.test.ts
@@ -10,7 +10,8 @@ import { setCooldown } from '../../services/ratelimit.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const res = await fetch(url, {

--- a/server/src/__tests__/routes/gemini.test.ts
+++ b/server/src/__tests__/routes/gemini.test.ts
@@ -11,7 +11,8 @@ async function request(
   body?: unknown,
   headers: Record<string, string> = {},
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const address = server.address() as { port: number };
   const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/keys-cooldowns.test.ts
+++ b/server/src/__tests__/routes/keys-cooldowns.test.ts
@@ -8,7 +8,8 @@ import { setCooldown, isOnCooldown } from '../../services/ratelimit.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 
@@ -104,7 +105,8 @@ describe('Key cooldown visibility and clearing', () => {
 
   it('requires dashboard auth', async () => {
     const id = await createKey(app, 'groq', 'gsk_testkeyvalue123456');
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as any;
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys/${id}/cooldowns`, {
       method: 'DELETE',

--- a/server/src/__tests__/routes/keys-desktop-reauth.test.ts
+++ b/server/src/__tests__/routes/keys-desktop-reauth.test.ts
@@ -27,7 +27,8 @@ function appWithRemote(remoteAddr: string): Express {
 }
 
 async function call(app: Express, path: string, method: 'GET' | 'POST') {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,
@@ -40,7 +41,8 @@ async function call(app: Express, path: string, method: 'GET' | 'POST') {
 
 async function addKey(): Promise<number> {
   const app = appWithRemote('127.0.0.1');
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys`, {
     method: 'POST',
@@ -132,7 +134,8 @@ describe('Desktop re-auth bypass is loopback-only (#786)', () => {
     process.env.FREEAPI_DESKTOP = '1';
     const id = await addKey();
     const app = appWithRemote('192.168.1.42');
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys/${id}/reveal`, {
       method: 'POST',

--- a/server/src/__tests__/routes/keys-export-csv.test.ts
+++ b/server/src/__tests__/routes/keys-export-csv.test.ts
@@ -11,7 +11,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function post(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -24,7 +25,8 @@ async function post(app: Express, path: string, body: unknown) {
 }
 
 async function exportCsvText(app: Express): Promise<{ status: number; text: string }> {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys/export?format=csv`, {
     headers: { Authorization: `Bearer ${dashToken}`, 'x-reauth-password': 'password123' },

--- a/server/src/__tests__/routes/keys-export-custom-roundtrip.test.ts
+++ b/server/src/__tests__/routes/keys-export-custom-roundtrip.test.ts
@@ -13,7 +13,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function exportText(app: Express, format: string): Promise<string> {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys/export?format=${format}`, {
     headers: { Authorization: `Bearer ${dashToken}`, 'x-reauth-password': 'password123' },
@@ -24,7 +25,8 @@ async function exportText(app: Express, format: string): Promise<string> {
 }
 
 async function importFile(app: Express, filename: string, content: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const form = new FormData();
   form.append('file', new Blob([content], { type: 'text/plain' }), filename);
@@ -39,7 +41,8 @@ async function importFile(app: Express, filename: string, content: string) {
 }
 
 async function listKeys(app: Express) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys`, {
     headers: { Authorization: `Bearer ${dashToken}` },

--- a/server/src/__tests__/routes/keys-export-password.test.ts
+++ b/server/src/__tests__/routes/keys-export-password.test.ts
@@ -8,7 +8,8 @@ let app: Express;
 let token: string;
 
 async function exportJson(app: Express, password?: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
   if (password) headers['x-reauth-password'] = password;
@@ -19,7 +20,8 @@ async function exportJson(app: Express, password?: string) {
 }
 
 async function addKey(app: Express) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   await fetch(`http://127.0.0.1:${addr.port}/api/keys`, {
     method: 'POST',

--- a/server/src/__tests__/routes/keys-import-models.test.ts
+++ b/server/src/__tests__/routes/keys-import-models.test.ts
@@ -14,7 +14,8 @@ const realFetch = globalThis.fetch;
 let dashToken = '';
 
 async function post(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await realFetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -27,7 +28,8 @@ async function post(app: Express, path: string, body: unknown) {
 }
 
 async function previewFile(app: Express, filename: string, content: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const form = new FormData();
   form.append('files', new Blob([content], { type: 'text/plain' }), filename);

--- a/server/src/__tests__/routes/keys-import-selected-custom.test.ts
+++ b/server/src/__tests__/routes/keys-import-selected-custom.test.ts
@@ -14,7 +14,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function post(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -27,7 +28,8 @@ async function post(app: Express, path: string, body: unknown) {
 }
 
 async function previewFile(app: Express, filename: string, content: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const form = new FormData();
   form.append('files', new Blob([content], { type: 'text/plain' }), filename);

--- a/server/src/__tests__/routes/keys-model-scope.test.ts
+++ b/server/src/__tests__/routes/keys-model-scope.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/keys-providers-checklist.test.ts
+++ b/server/src/__tests__/routes/keys-providers-checklist.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, path: string, withAuth = true) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: withAuth ? { Authorization: `Bearer ${dashToken}` } : {},

--- a/server/src/__tests__/routes/keys-proxy.test.ts
+++ b/server/src/__tests__/routes/keys-proxy.test.ts
@@ -9,7 +9,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/keys-reveal.test.ts
+++ b/server/src/__tests__/routes/keys-reveal.test.ts
@@ -12,7 +12,8 @@ let app: Express;
 let token: string;
 
 async function request(path: string, password?: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
   if (password !== undefined) headers['x-reauth-password'] = password;
@@ -23,7 +24,8 @@ async function request(path: string, password?: string) {
 }
 
 async function addKey(key = 'gsk_testkey123') {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/api/keys`, {
     method: 'POST',

--- a/server/src/__tests__/routes/keys-ssrf-guard.test.ts
+++ b/server/src/__tests__/routes/keys-ssrf-guard.test.ts
@@ -12,7 +12,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function post(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/keys.test.ts
+++ b/server/src/__tests__/routes/keys.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 
@@ -31,7 +32,8 @@ async function multipartRequest(
   field: 'file' | 'files',
   files: Array<{ filename: string; content: string; type?: string }>,
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const form = new FormData();

--- a/server/src/__tests__/routes/mcp.test.ts
+++ b/server/src/__tests__/routes/mcp.test.ts
@@ -6,7 +6,8 @@ import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 let app: Express;
 
 async function rpc(message: unknown, opts: { auth?: boolean } = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}/mcp`, {
     method: 'POST',
@@ -191,7 +192,8 @@ describe('MCP server (/mcp, stateless Streamable HTTP)', () => {
   });
 
   it('GET /mcp is 405 (stateless: no server-initiated stream)', async () => {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}/mcp`);
     server.close();

--- a/server/src/__tests__/routes/media-transcription-dashboard.test.ts
+++ b/server/src/__tests__/routes/media-transcription-dashboard.test.ts
@@ -13,7 +13,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},
@@ -24,7 +25,8 @@ async function get(app: Express, path: string) {
 }
 
 async function put(app: Express, path: string, body: unknown) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'PUT',

--- a/server/src/__tests__/routes/media-usage.test.ts
+++ b/server/src/__tests__/routes/media-usage.test.ts
@@ -13,7 +13,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function get(app: Express, path: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     headers: isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {},

--- a/server/src/__tests__/routes/models-management.test.ts
+++ b/server/src/__tests__/routes/models-management.test.ts
@@ -32,7 +32,8 @@ const TARGET_MODEL_PRIORITY = 9001;
 const RETAINED_MODEL_PRIORITY = 9002;
 
 async function request(app: Express, method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/ollama.test.ts
+++ b/server/src/__tests__/routes/ollama.test.ts
@@ -13,7 +13,8 @@ async function request(
   body?: unknown,
   headers: Record<string, string> = {},
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const address = server.address() as { port: number };
   const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/proxy-array-content.test.ts
+++ b/server/src/__tests__/routes/proxy-array-content.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-auth-cors.test.ts
+++ b/server/src/__tests__/routes/proxy-auth-cors.test.ts
@@ -4,7 +4,8 @@ import { createApp } from '../../app.js';
 import { initDb, getUnifiedApiKey } from '../../db/index.js';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-auth-rotation.test.ts
+++ b/server/src/__tests__/routes/proxy-auth-rotation.test.ts
@@ -40,7 +40,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy, getAllPenalties } = await import('../../services/router.js');
 
 async function post(app: Express, path: string, body: any, key: string, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-auto-model.test.ts
+++ b/server/src/__tests__/routes/proxy-auto-model.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-cache.test.ts
+++ b/server/src/__tests__/routes/proxy-cache.test.ts
@@ -8,7 +8,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const res = await fetch(url, {

--- a/server/src/__tests__/routes/proxy-completions.test.ts
+++ b/server/src/__tests__/routes/proxy-completions.test.ts
@@ -6,7 +6,8 @@ import { encrypt } from '../../lib/crypto.js';
 import { setRoutingStrategy } from '../../services/router.js';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-empty-completion.test.ts
+++ b/server/src/__tests__/routes/proxy-empty-completion.test.ts
@@ -23,7 +23,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy } = await import('../../services/router.js');
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-error-redaction.test.ts
+++ b/server/src/__tests__/routes/proxy-error-redaction.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-max-tokens-routing.test.ts
+++ b/server/src/__tests__/routes/proxy-max-tokens-routing.test.ts
@@ -21,7 +21,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy, routingReserveTokens, OUTPUT_RESERVE_CAP } = await import('../../services/router.js');
 
 async function post(app: Express, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}/v1/chat/completions`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-model-groups.test.ts
+++ b/server/src/__tests__/routes/proxy-model-groups.test.ts
@@ -10,7 +10,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const res = await fetch(url, {

--- a/server/src/__tests__/routes/proxy-multikey-penalty.test.ts
+++ b/server/src/__tests__/routes/proxy-multikey-penalty.test.ts
@@ -22,7 +22,8 @@ const { setRoutingStrategy, hasOtherUsableKey, getAllPenalties } = await import(
 const { setCooldown } = await import('../../services/ratelimit.js');
 
 async function post(app: Express, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}/v1/chat/completions`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-pinned-model.test.ts
+++ b/server/src/__tests__/routes/proxy-pinned-model.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-provider-level-skip.test.ts
+++ b/server/src/__tests__/routes/proxy-provider-level-skip.test.ts
@@ -39,7 +39,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy } = await import('../../services/router.js');
 
 async function post(app: Express, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}/v1/chat/completions`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-rate-limit.test.ts
+++ b/server/src/__tests__/routes/proxy-rate-limit.test.ts
@@ -4,7 +4,8 @@ import { createApp } from '../../app.js';
 import { initDb } from '../../db/index.js';
 
 async function request(app: Express, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}/v1/chat/completions`;
 

--- a/server/src/__tests__/routes/proxy-served-model.test.ts
+++ b/server/src/__tests__/routes/proxy-served-model.test.ts
@@ -16,7 +16,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/proxy-stream-integrity.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-integrity.test.ts
@@ -11,7 +11,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 // either failed over (before headers) or surfaced honestly (after).
 
 async function request(app: Express, path: string, body: any, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-tools-routing.test.ts
+++ b/server/src/__tests__/routes/proxy-tools-routing.test.ts
@@ -6,7 +6,8 @@ import { routeRequest, setRoutingStrategy } from '../../services/router.js';
 import { encrypt } from '../../lib/crypto.js';
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/proxy-tools.test.ts
+++ b/server/src/__tests__/routes/proxy-tools.test.ts
@@ -7,7 +7,8 @@ import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const url = `http://127.0.0.1:${addr.port}${path}`;
 

--- a/server/src/__tests__/routes/proxy-vision.test.ts
+++ b/server/src/__tests__/routes/proxy-vision.test.ts
@@ -4,7 +4,8 @@ import { createApp } from '../../app.js';
 import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/reasoning-control.test.ts
+++ b/server/src/__tests__/routes/reasoning-control.test.ts
@@ -12,7 +12,8 @@ import { effortFromAnthropicThinking } from '../../routes/anthropic.js';
 let dashToken = '';
 
 async function request(app: Express, path: string, body: any, extraHeaders: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/rescue-wants-tools.test.ts
+++ b/server/src/__tests__/routes/rescue-wants-tools.test.ts
@@ -36,7 +36,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy } = await import('../../services/router.js');
 
 async function post(app: Express, path: string, body: any, headers: Record<string, string>) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/responses-fallback-convergence.test.ts
+++ b/server/src/__tests__/routes/responses-fallback-convergence.test.ts
@@ -39,7 +39,8 @@ function throwingProvider(err: any) {
 }
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/responses-tool-args-repair.test.ts
+++ b/server/src/__tests__/routes/responses-tool-args-repair.test.ts
@@ -21,7 +21,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy } = await import('../../services/router.js');
 
 async function post(app: Express, path: string, body: any, key: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/responses.test.ts
+++ b/server/src/__tests__/routes/responses.test.ts
@@ -18,7 +18,8 @@ function fakeRoute(provider: any) {
 }
 
 async function post(app: Express, path: string, body: any, key?: string, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',
@@ -140,7 +141,8 @@ describe('POST /v1/responses (#96)', () => {
   // #103: the x-api-key header (Anthropic wire format) must authenticate here
   // too, not just on /v1/chat/completions.
   it('accepts the unified key via the x-api-key header', async () => {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as any;
     const res = await fetch(`http://127.0.0.1:${addr.port}/v1/responses`, {
       method: 'POST',

--- a/server/src/__tests__/routes/routed-via-header.test.ts
+++ b/server/src/__tests__/routes/routed-via-header.test.ts
@@ -16,7 +16,8 @@ const EXPECTED = `custom/${HOSTILE_MODEL}`;
 let dashToken = '';
 
 async function request(app: Express, method: string, path: string, body?: unknown, headers: Record<string, string> = {}) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/routing-semantics.test.ts
+++ b/server/src/__tests__/routes/routing-semantics.test.ts
@@ -15,7 +15,8 @@ let app: Express;
 let dashToken = '';
 
 async function request(method: string, path: string, body?: any) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/settings-output-limit.test.ts
+++ b/server/src/__tests__/routes/settings-output-limit.test.ts
@@ -6,7 +6,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 import { UNIFIED_MAX_TOKENS_SETTING, UNIFIED_MAX_TOKENS_AUTO } from '../../lib/sampling-params.js';
 
 async function request(app: Express, method: string, path: string, body: any, token: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/settings-proxy.test.ts
+++ b/server/src/__tests__/routes/settings-proxy.test.ts
@@ -6,7 +6,8 @@ import { mintDashboardToken } from '../helpers/auth.js';
 import { applyProxyUrl } from '../../lib/proxy.js';
 
 async function request(app: Express, method: string, path: string, body: any, token: string) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method,

--- a/server/src/__tests__/routes/static-assets-caching.test.ts
+++ b/server/src/__tests__/routes/static-assets-caching.test.ts
@@ -45,7 +45,7 @@ describe('static SPA: gzip compression + asset cache headers', () => {
   let server: Server;
   let port: number;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     process.env.ENCRYPTION_KEY = '0'.repeat(64);
     initDb(':memory:');
 
@@ -61,7 +61,8 @@ describe('static SPA: gzip compression + asset cache headers', () => {
     fs.writeFileSync(path.join(tmpDir, 'assets', 'vendor-Q1w2E3r4.js'), BIG_JS);
 
     process.env.CLIENT_DIST = tmpDir;
-    server = createApp().listen(0);
+    server = createApp().listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     port = (server.address() as { port: number }).port;
   });
 

--- a/server/src/__tests__/routes/static-client.test.ts
+++ b/server/src/__tests__/routes/static-client.test.ts
@@ -26,7 +26,8 @@ describe('CLIENT_DIST override', () => {
   it('serves the SPA from the overridden directory', async () => {
     process.env.CLIENT_DIST = tmpDir;
     const app = createApp();
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const port = (server.address() as any).port;
 
     const res = await fetch(`http://127.0.0.1:${port}/`);

--- a/server/src/__tests__/routes/status.test.ts
+++ b/server/src/__tests__/routes/status.test.ts
@@ -10,7 +10,8 @@ async function request(
   path: string,
   headers: Record<string, string> = {},
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as { port: number };
   const url = `http://127.0.0.1:${addr.port}${path}`;
   const res = await fetch(url, { method, headers });

--- a/server/src/__tests__/routes/tool-validate-surfaces.test.ts
+++ b/server/src/__tests__/routes/tool-validate-surfaces.test.ts
@@ -28,7 +28,8 @@ const { encrypt } = await import('../../lib/crypto.js');
 const { setRoutingStrategy } = await import('../../services/router.js');
 
 async function post(app: Express, path: string, body: any, headers: Record<string, string>) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const addr = server.address() as any;
   const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
     method: 'POST',

--- a/server/src/__tests__/routes/update-release.test.ts
+++ b/server/src/__tests__/routes/update-release.test.ts
@@ -13,7 +13,7 @@ const RELEASES_PAGE = 'https://github.com/tashfeenahmed/freellmapi/releases';
 
 function httpGet(app: Express, path: string): Promise<{ status: number; body: any }> {
   return new Promise((resolve, reject) => {
-    const server = app.listen(0, () => {
+    const server = app.listen(0, '127.0.0.1', () => {
       const address = server.address();
       if (!address || typeof address === 'string') return reject(new Error('No test server address'));
       const req = http.request(
@@ -194,7 +194,8 @@ describe('/api/settings/update-check', () => {
   });
 
   async function request(method: string, body?: unknown) {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const address = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${address.port}/api/settings/update-check`, {
       method,

--- a/server/src/__tests__/routes/update.test.ts
+++ b/server/src/__tests__/routes/update.test.ts
@@ -11,7 +11,7 @@ const VERSION = '0.6.8';
 
 function httpGet(app: Express, path: string): Promise<{ status: number; body: any }> {
   return new Promise((resolve, reject) => {
-    const server = app.listen(0, () => {
+    const server = app.listen(0, '127.0.0.1', () => {
       const address = server.address();
       if (!address || typeof address === 'string') return reject(new Error('No test server address'));
       const req = http.request(

--- a/server/src/__tests__/routes/url-tokens.test.ts
+++ b/server/src/__tests__/routes/url-tokens.test.ts
@@ -12,7 +12,8 @@ async function request(
   body?: unknown,
   headers: Record<string, string> = {},
 ) {
-  const server = app.listen(0);
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
   const address = server.address() as { port: number };
   const response = await fetch(`http://127.0.0.1:${address.port}${path}`, {
     method,

--- a/server/src/__tests__/services/catalog-sync-source.test.ts
+++ b/server/src/__tests__/services/catalog-sync-source.test.ts
@@ -95,7 +95,8 @@ describe('models.source provenance', () => {
   });
 
   async function request(method: string, path: string, body?: unknown) {
-    const server = app.listen(0);
+    const server = app.listen(0, '127.0.0.1');
+    if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
     const addr = server.address() as { port: number };
     const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
       method,


### PR DESCRIPTION
Root cause of the long-standing suite flake, found and verified.

## What was happening

Every route test starts its server with `app.listen(0)`, which binds the **IPv6 wildcard** `::`, then requests `http://127.0.0.1:PORT` over **IPv4**. Those are different addresses, so an unrelated local process holding an IPv4 listener on the same port number binds happily — no `EADDRINUSE` — and wins the connection. The test's request gets answered by that other process.

`lsof` caught it in the act:

```
node    18666  TCP *:53398 (LISTEN)            <- the test server, IPv6 wildcard
workerd 55367  TCP 127.0.0.1:53398 (LISTEN)    <- wrangler dev, IPv4 loopback
```

On my machine four `workerd` processes (wrangler dev) squat ephemeral `127.0.0.1` ports and answered test requests with bare `404`s and `501 Unsupported Operation`. That is the source of every symptom we have been chasing:

- assertion failures on nonsense statuses (`expected 404 to be 201`, `expected 501 to be 200`, `expected 500 to be 401`)
- empty / non-JSON bodies breaking `JSON.parse` — the `"Unsupporte…"` body was literally `Unsupported Operation`
- 5s test timeouts, when an unguarded `JSON.parse` threw inside an `end` handler so the promise never settled
- a **different file** failing each run, because which port collides is random

It never reproduced in isolation because nothing else was competing for the port.

## The fix

Bind to the address the tests actually connect to. `listen(port, host)` resolves the host asynchronously (unlike `listen(port)`, which binds synchronously), so `address()` is null right after the call — each site now waits for `listening` first.

114 call sites across 87 files; 3 already bound `127.0.0.1` and were left alone.

## Verification

With wrangler still running and the same competing listeners present:

| | before | after |
|---|---|---|
| full-suite runs clean | ~1 failure every 2–4 runs | **10 / 10 clean** |

Counts match the previous baseline exactly: 2317 passed / 5 skipped. (An intermediate version of this change made `static-assets-caching.test.ts` throw in `beforeAll`, which *silently skipped* its 5 tests — caught by the skip count moving from 5 to 10, and fixed.)

Full suite green: 212 files / 2317 server, 44 CLI, 69 client, i18n across 60 locales.