### PR TITLE
fix: classify Zhipu "Prompt exceeds max length" 400 as context_too_large (#873)

### DIFF
--- a/server/src/__tests__/lib/exhaustion-statuses.test.ts
+++ b/server/src/__tests__/lib/exhaustion-statuses.test.ts
@@ -96,6 +96,21 @@ describe('isContextTooLargeError', () => {
     expect(isContextTooLargeError(new Error('request exceeds the maximum number of tokens'))).toBe(true);
   });
 
+  it('flags Zhipu AI prompt-length 400s (error 1261: "Prompt exceeds max length")', () => {
+    // #873: Zhipu returns HTTP 400 with "Prompt exceeds max length" for an
+    // over-long context. Its wording matches none of the OpenAI/Anthropic/Google
+    // markers, so it was mis-bucketed as provider_bad_request instead of
+    // context_too_large.
+    expect(isContextTooLargeError(Object.assign(
+      new Error('Zhipu API error 400: Prompt exceeds max length. Please shorten the prompt or set a longer context length.'),
+      { status: 400 },
+    ))).toBe(true);
+    expect(classifyAttemptError(Object.assign(
+      new Error('Zhipu API error 400: Prompt exceeds max length.'),
+      { status: 400 },
+    ))).toBe('context_too_large');
+  });
+
   it('flags literal HTTP 413s, including Groq TPM-ceiling 413s (Requested > Limit can never fit)', () => {
     expect(isContextTooLargeError(Object.assign(
       new Error('Groq API error 413: Request too large for model `llama-3.3-70b-versatile` in organization `org_x` on tokens per minute (TPM): Limit 30000, Requested 33476'),

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -374,6 +374,10 @@ export function isContextTooLargeError(err: any): boolean {
     || msg.includes('request entity too large')
     || msg.includes('request body too large')
     || msg.includes('content too large')
+    // Zhipu AI (bigmodel.cn) 400, error code 1261: "Prompt exceeds max length"
+    // (#873). Its wording matches none of the markers above, so without this it
+    // was mis-bucketed as provider_bad_request instead of context_too_large.
+    || msg.includes('exceeds max length')
     || msg.includes('api error 413');
 }
 


### PR DESCRIPTION
## Problem

Fix #873

Zhipu AI rejects an over-long context with `HTTP 400: "Prompt exceeds max length"` (bigmodel.cn error `1261`). That wording matches none of the markers in `isContextTooLargeError`, so the fallback loop bucketed it as `provider_bad_request` instead of `context_too_large`. Result: the failover ladder treated a size rejection as a generic bad request, and the exhaustion trail reported the wrong reason to the user.

## Change

- `server/src/lib/error-classify.ts`: add the Zhipu `exceeds max length` marker to `isContextTooLargeError`, alongside the existing OpenAI/Anthropic/Google/Groq shapes. `classifyAttemptError` already checks context-too-large ahead of `provider_bad_request`, so no ordering change is needed.

The marker is narrow (`exceeds max length`) and does not trip the existing "ordinary 400" negative case.

## Test verification (RED → GREEN)

New test in `exhaustion-statuses.test.ts` asserting the Zhipu 400 is both flagged by `isContextTooLargeError` and bucketed as `context_too_large` by `classifyAttemptError`.

RED — new test on unmodified `main` (before the fix):

```
 × isContextTooLargeError > flags Zhipu AI prompt-length 400s (error 1261: "Prompt exceeds max length")
AssertionError: expected false to be true // Object.is equality
 Tests  1 failed | 6 passed | 24 skipped (31)
```

GREEN — same test with the fix:

```
 Test Files  1 passed (1)
      Tests  7 passed | 24 skipped (31)
```

## Testing

- `npm run test:migrations` — pass
- `npm test` — full suite pass, no new failures vs. baseline (one pre-existing wall-clock perf assertion in `compression.test.ts`, "stays linear on protected-token-heavy adversarial payloads", flakes the same way on unmodified `main` on this machine; unrelated to this change)
- `npm run build` — pass
