### PR TITLE
feat(ui): manually reset cooldowns from the router-pressure panel (#878)

### DIFF
--- a/client/src/components/penalty-inspector.tsx
+++ b/client/src/components/penalty-inspector.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { AlertTriangle, ChevronDown, Clock3, Gauge } from 'lucide-react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle, ChevronDown, Clock3, Gauge, RefreshCcw } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 
@@ -88,6 +88,19 @@ export function PenaltyInspector() {
     queryFn: () => apiFetch('/api/fallback/penalty-inspector'),
     refetchInterval: 5_000,
   })
+  const queryClient = useQueryClient()
+
+  // #878: an escalated cooldown can bench a key for up to 24h off one bad
+  // window; once the operator has fixed the cause (proxy, region, quota) the
+  // only way back was waiting — offer a manual lift on the spot.
+  const resetCooldown = useMutation({
+    mutationFn: (keyId: number) =>
+      apiFetch(`/api/keys/${keyId}/cooldowns`, { method: 'DELETE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['fallback', 'penalty-inspector'] })
+      queryClient.invalidateQueries({ queryKey: ['keys'] })
+    },
+  })
 
   const rows = data?.rows ?? []
   if (rows.length === 0) return null
@@ -167,11 +180,21 @@ export function PenaltyInspector() {
                 {row.cooldowns.length === 0 ? (
                   <span className="text-muted-foreground">{t('penaltyInspector.noCooldown')}</span>
                 ) : row.cooldowns.map(cooldown => (
-                  <span key={`${cooldown.keyId}:${cooldown.expiresAtMs}`} className="rounded-full bg-sky-600/15 px-2 py-0.5 text-sky-700 dark:text-sky-400">
+                  <span key={`${cooldown.keyId}:${cooldown.expiresAtMs}`} className="inline-flex items-center gap-1 rounded-full bg-sky-600/15 px-2 py-0.5 text-sky-700 dark:text-sky-400">
                     {t('penaltyInspector.cooldownChip', {
                       key: cooldown.keyLabel || `#${cooldown.keyId}`,
                       time: formatDuration(cooldown.expiresInMs),
                     })}
+                    <button
+                      type="button"
+                      onClick={() => resetCooldown.mutate(cooldown.keyId)}
+                      disabled={resetCooldown.isPending}
+                      aria-label={t('penaltyInspector.resetCooldown')}
+                      title={t('penaltyInspector.resetCooldown')}
+                      className="rounded-full p-0.5 transition-colors hover:bg-sky-700/20 disabled:opacity-50"
+                    >
+                      <RefreshCcw className="size-3" />
+                    </button>
                   </span>
                 ))}
               </div>

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -304,6 +304,7 @@
     "factor": "ውጤት x{factor}",
     "noCooldown": "ማቀዝቀዝ የለም",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} የቅርብ ጊዜ ስህተቶች",
     "noRecentErrors": "ምንም የቅርብ ጊዜ ስህተቶች የሉም",
     "noKey": "ቁልፍ የለም",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -304,6 +304,7 @@
     "factor": "النتيجة x{factor}",
     "noCooldown": "لا يوجد تهدئة",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "الأخطاء الأخيرة {count}",
     "noRecentErrors": "لا توجد أخطاء الأخيرة",
     "noKey": "لا يوجد مفتاح",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -304,6 +304,7 @@
     "factor": "xal x{factor}",
     "noCooldown": "Soyuma vaxtı yoxdur",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} son səhvlər",
     "noRecentErrors": "Son vaxtlar heç bir səhv yoxdur",
     "noKey": "Açar yoxdur",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Няма време за презареждане",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} скорошни грешки",
     "noRecentErrors": "Няма скорошни грешки",
     "noKey": "Без ключ",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -304,6 +304,7 @@
     "factor": "স্কোর x{factor}",
     "noCooldown": "কুলডাউন নেই",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} সাম্প্রতিক ত্রুটি৷",
     "noRecentErrors": "কোন সাম্প্রতিক ত্রুটি",
     "noKey": "কোন চাবি নেই",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -304,6 +304,7 @@
     "factor": "skóre x{factor}",
     "noCooldown": "Žádný cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} nedávné chyby",
     "noRecentErrors": "Žádné nedávné chyby",
     "noKey": "Bez klíče",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Ingen cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} nylige fejl",
     "noRecentErrors": "Ingen nylige fejl",
     "noKey": "Ingen nøgle",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -304,6 +304,7 @@
     "factor": "Ergebnis x{factor}",
     "noCooldown": "Keine Abklingzeit",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} aktuelle Fehler",
     "noRecentErrors": "Keine aktuellen Fehler",
     "noKey": "kein Schlüssel",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -304,6 +304,7 @@
     "factor": "βαθμολογία x{factor}",
     "noCooldown": "Χωρίς ψύξη",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} πρόσφατα σφάλματα",
     "noRecentErrors": "Δεν υπάρχουν πρόσφατα σφάλματα",
     "noKey": "χωρίς κλειδί",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "No cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} recent errors",
     "noRecentErrors": "No recent errors",
     "noKey": "no key",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -304,6 +304,7 @@
     "factor": "puntuación x{factor}",
     "noCooldown": "Sin cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} errores recientes",
     "noRecentErrors": "Sin errores recientes",
     "noKey": "sin clave",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -304,6 +304,7 @@
     "factor": "امتیاز x{factor}",
     "noCooldown": "بدون خنک شدن",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "خطاهای اخیر {count}",
     "noRecentErrors": "هیچ خطای اخیر",
     "noKey": "بدون کلید",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -304,6 +304,7 @@
     "factor": "pisteet x{factor}",
     "noCooldown": "Ei jäähdytysaikaa",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} viimeaikaiset virheet",
     "noRecentErrors": "Ei viimeaikaisia virheitä",
     "noKey": "ei avainta",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Aucun cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} erreurs récentes",
     "noRecentErrors": "Aucune erreur récente",
     "noKey": "aucune clé",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -304,6 +304,7 @@
     "factor": "સ્કોર x{factor}",
     "noCooldown": "કૂલડાઉન નથી",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} તાજેતરની ભૂલો",
     "noRecentErrors": "તાજેતરની કોઈ ભૂલો નથી",
     "noKey": "કોઈ ચાવી નથી",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -304,6 +304,7 @@
     "factor": "maki x{factor}",
     "noCooldown": "Babu sanyi",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} kurakurai na baya-bayan nan",
     "noRecentErrors": "Babu kurakurai na baya-bayan nan",
     "noKey": "babu makulli",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -304,6 +304,7 @@
     "factor": "ציון x{factor}",
     "noCooldown": "אין קירור",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} שגיאות אחרונות",
     "noRecentErrors": "אין שגיאות אחרונות",
     "noKey": "אין מפתח",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -304,6 +304,7 @@
     "factor": "स्कोर x{factor}",
     "noCooldown": "कोई ठंडक नहीं",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} हाल की त्रुटियाँ",
     "noRecentErrors": "कोई हालिया त्रुटि नहीं",
     "noKey": "कोई कुंजी नहीं",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Nema cooldowna",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} nedavne pogreške",
     "noRecentErrors": "Nema nedavnih pogrešaka",
     "noKey": "Nema ključa",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -304,6 +304,7 @@
     "factor": "pontszám x{factor}",
     "noCooldown": "Nincs újratöltési idő",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} legutóbbi hibák",
     "noRecentErrors": "Nincs friss hiba",
     "noKey": "Nincs kulcs",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -304,6 +304,7 @@
     "factor": "skor x{factor}",
     "noCooldown": "Tidak ada cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} kesalahan terbaru",
     "noRecentErrors": "Tidak ada kesalahan terbaru",
     "noKey": "tidak ada kunci",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -304,6 +304,7 @@
     "factor": "akara x{factor}",
     "noCooldown": "Enweghị mmachi",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} mperi nso nso a",
     "noRecentErrors": "Enweghị mperi nso nso a",
     "noKey": "enweghị igodo",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -304,6 +304,7 @@
     "factor": "punteggio x{factor}",
     "noCooldown": "Nessun cooldown",
     "cooldownChip": "{key}: {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} errori recenti",
     "noRecentErrors": "Nessun errore recente",
     "noKey": "nessuna chiave",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -304,6 +304,7 @@
     "factor": "スコア x{factor}",
     "noCooldown": "クールダウンなし",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} 最近のエラー",
     "noRecentErrors": "最近のエラーはありません",
     "noKey": "鍵がありません",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -304,6 +304,7 @@
     "factor": "ქულა x{factor}",
     "noCooldown": "არ არის გაგრილება",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ბოლოდროინდელი შეცდომები",
     "noRecentErrors": "ბოლო შეცდომები არ არის",
     "noKey": "გასაღების გარეშე",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -304,6 +304,7 @@
     "factor": "ពិន្ទុ x{factor}",
     "noCooldown": "គ្មានពេលត្រឡប់មកវិញ",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count}",
     "noRecentErrors": "គ្មានកំហុសថ្មីៗ",
     "noKey": "គ្មានសោ",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -304,6 +304,7 @@
     "factor": "ಸ್ಕೋರ್ x{factor}",
     "noCooldown": "ಕೂಲ್‌ಡೌನ್ ಇಲ್ಲ",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ಇತ್ತೀಚಿನ ದೋಷಗಳು",
     "noRecentErrors": "ಇತ್ತೀಚಿನ ದೋಷಗಳಿಲ್ಲ",
     "noKey": "ಕೀ ಇಲ್ಲ",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -304,6 +304,7 @@
     "factor": "점수 x{factor}",
     "noCooldown": "쿨다운 없음",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} 최근 오류",
     "noRecentErrors": "최근 오류 없음",
     "noKey": "열쇠 없음",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Nėra atvėsimo laiko",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} pastarųjų klaidų",
     "noRecentErrors": "Jokių naujausių klaidų",
     "noKey": "Be rakto",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -304,6 +304,7 @@
     "factor": "സ്കോർ x{factor}",
     "noCooldown": "കൂൾഡൗൺ ഇല്ല",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} സമീപകാല പിശകുകൾ",
     "noRecentErrors": "സമീപകാല പിശകുകളൊന്നുമില്ല",
     "noKey": "താക്കോൽ ഇല്ല",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -304,6 +304,7 @@
     "factor": "गुण x{factor}",
     "noCooldown": "कूलडाउन नाही",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} अलीकडील त्रुटी",
     "noRecentErrors": "अलीकडील त्रुटी नाहीत",
     "noKey": "चावी नाही",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -304,6 +304,7 @@
     "factor": "skor x{factor}",
     "noCooldown": "Tiada masa sejuk",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ralat terkini",
     "noRecentErrors": "Tiada ralat terkini",
     "noKey": "tiada kunci",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -304,6 +304,7 @@
     "factor": "အမှတ် x{factor}",
     "noCooldown": "Cooldown မရှိပါ",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} အမှားများ",
     "noRecentErrors": "မကြာသေးမီက အမှားမရှိပါ",
     "noKey": "သော့မရှိ",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -304,6 +304,7 @@
     "factor": "स्कोर x{factor}",
     "noCooldown": "कूलडाउन छैन",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} त्रुटिहरू",
     "noRecentErrors": "हालैका त्रुटि छैन",
     "noKey": "कुञ्जी छैन",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Geen cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} recente fouten",
     "noRecentErrors": "Geen recente fouten",
     "noKey": "Geen sleutel",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Ingen nedkjøling",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} nylige feil",
     "noRecentErrors": "Ingen nylige feil",
     "noKey": "Ingen nøkkel",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -304,6 +304,7 @@
     "factor": "ସ୍କୋର x{factor}",
     "noCooldown": "କୌଣସି କୁଲଡାଉନ୍ ନାହିଁ",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ସାମ୍ପ୍ରତିକ ତ୍ରୁଟି",
     "noRecentErrors": "କୌଣସି ସାମ୍ପ୍ରତିକ ତ୍ରୁଟି ନାହିଁ",
     "noKey": "କୌଣସି ଚାବି ନାହିଁ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -304,6 +304,7 @@
     "factor": "ਸਕੋਰ x{factor}",
     "noCooldown": "ਕੋਈ ਠੰਡਾ ਨਹੀਂ",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ਹਾਲੀਆ ਤਰੁੱਟੀਆਂ",
     "noRecentErrors": "ਕੋਈ ਹਾਲੀਆ ਤਰੁੱਟੀਆਂ ਨਹੀਂ",
     "noKey": "ਕੋਈ ਕੁੰਜੀ ਨਹੀਂ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -304,6 +304,7 @@
     "factor": "wynik x{factor}",
     "noCooldown": "Brak możliwości odnowienia",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "Ostatnie błędy {count}",
     "noRecentErrors": "Brak ostatnich błędów",
     "noKey": "brak klucza",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -304,6 +304,7 @@
     "factor": "pontuação x{factor}",
     "noCooldown": "Sem cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} erros recentes",
     "noRecentErrors": "Nenhum erro recente",
     "noKey": "sem chave",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -304,6 +304,7 @@
     "factor": "pontuação x{factor}",
     "noCooldown": "Sem tempo de recarga",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} erros recentes",
     "noRecentErrors": "Sem erros recentes",
     "noKey": "sem chave",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -304,6 +304,7 @@
     "factor": "Scor x{factor}",
     "noCooldown": "Fără timp de reîncărcare",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} erori recente",
     "noRecentErrors": "Fără erori recente",
     "noKey": "fără cheie",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -304,6 +304,7 @@
     "factor": "оценка x{factor}",
     "noCooldown": "Нет времени восстановления",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} недавние ошибки",
     "noRecentErrors": "Нет недавних ошибок",
     "noKey": "нет ключа",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -304,6 +304,7 @@
     "factor": "ලකුණු x{factor}",
     "noCooldown": "සිසිල් කිරීමක් නැත",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} මෑත කාලීන දෝෂ",
     "noRecentErrors": "මෑත කාලීන දෝෂ නොමැත",
     "noKey": "යතුරක් නැත",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -304,6 +304,7 @@
     "factor": "skóre x{factor}",
     "noCooldown": "Žiadny cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} nedávne chyby",
     "noRecentErrors": "Žiadne nedávne chyby",
     "noKey": "Bez kľúča",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -304,6 +304,7 @@
     "factor": "резултат к{factor}",
     "noCooldown": "Нема хлађења",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} недавне грешке",
     "noRecentErrors": "Нема недавних грешака",
     "noKey": "без кључа",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Ingen cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} senaste felen",
     "noRecentErrors": "Inga nyligen inträffade fel",
     "noKey": "Ingen nyckel",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -304,6 +304,7 @@
     "factor": "alama x{factor}",
     "noCooldown": "Hakuna baridi",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} makosa ya hivi majuzi",
     "noRecentErrors": "Hakuna makosa ya hivi majuzi",
     "noKey": "hakuna ufunguo",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -304,6 +304,7 @@
     "factor": "மதிப்பெண் x{factor}",
     "noCooldown": "கூல்டவுன் இல்லை",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} சமீபத்திய பிழைகள்",
     "noRecentErrors": "சமீபத்திய பிழைகள் இல்லை",
     "noKey": "சாவி இல்லை",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -304,6 +304,7 @@
     "factor": "స్కోర్ x{factor}",
     "noCooldown": "కూల్‌డౌన్ లేదు",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} ఇటీవలి లోపాలు",
     "noRecentErrors": "ఇటీవలి లోపాలు లేవు",
     "noKey": "కీ లేదు",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -304,6 +304,7 @@
     "factor": "คะแนน x{factor}",
     "noCooldown": "ไม่มีคูลดาวน์",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "ข้อผิดพลาดล่าสุด {count}",
     "noRecentErrors": "ไม่มีข้อผิดพลาดล่าสุด",
     "noKey": "ไม่มีกุญแจ",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -304,6 +304,7 @@
     "factor": "score x{factor}",
     "noCooldown": "Walang cooldown",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} mga kamakailang error",
     "noRecentErrors": "Walang kamakailang error",
     "noKey": "walang susi",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -304,6 +304,7 @@
     "factor": "puan x{factor}",
     "noCooldown": "Bekleme süresi yok",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} son hatalar",
     "noRecentErrors": "Yakın zamanda hata yok",
     "noKey": "anahtar yok",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -304,6 +304,7 @@
     "factor": "оцінка x{factor}",
     "noCooldown": "Немає перезарядки",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} останні помилки",
     "noRecentErrors": "Немає останніх помилок",
     "noKey": "немає ключа",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -304,6 +304,7 @@
     "factor": "سکور x{factor}",
     "noCooldown": "کوئی کولڈاؤن نہیں۔",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} حالیہ غلطیاں",
     "noRecentErrors": "کوئی حالیہ غلطیاں نہیں ہیں۔",
     "noKey": "کوئی چابی نہیں",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -304,6 +304,7 @@
     "factor": "ball x{factor}",
     "noCooldown": "Sovutish yo'q",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} oxirgi xatolar",
     "noRecentErrors": "Oxirgi xatolar yo'q",
     "noKey": "kalit yo'q",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -304,6 +304,7 @@
     "factor": "điểm x{factor}",
     "noCooldown": "Không có thời gian hồi chiêu",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} lỗi gần đây",
     "noRecentErrors": "Không có lỗi gần đây",
     "noKey": "không có chìa khóa",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -304,6 +304,7 @@
     "factor": "Dimegilio x{factor}",
     "noCooldown": "Ko si itura",
     "cooldownChip": "{key} - {time}",
+    "resetCooldown": "Reset cooldown",
     "errorsHeading": "{count} to šẹšẹ aṣiṣe",
     "noRecentErrors": "Ko si awọn aṣiṣe aipẹ",
     "noKey": "ko si bọtini",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -304,6 +304,7 @@
     "factor": "得分 x{factor}",
     "noCooldown": "无冷却",
     "cooldownChip": "{key}，{time}",
+    "resetCooldown": "重置冷却",
     "errorsHeading": "{count} 个近期错误",
     "noRecentErrors": "暂无近期错误",
     "noKey": "无密钥",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -304,6 +304,7 @@
     "factor": "分數 x{factor}",
     "noCooldown": "無冷卻",
     "cooldownChip": "{key}，{time}",
+    "resetCooldown": "重設冷卻",
     "errorsHeading": "{count} 個近期錯誤",
     "noRecentErrors": "尚無近期錯誤",
     "noKey": "無金鑰",


### PR DESCRIPTION
Closes #878

## What
Adds a manual cooldown reset to the **Router pressure** panel: every cooldown chip now carries a small refresh button that calls the existing `DELETE /api/keys/:id/cooldowns` endpoint and instantly lifts that key's cooldown (up to 24h for an escalated bench), instead of forcing the operator to wait it out or restart.

After a successful reset the panel and the keys list are invalidated so the lifted state shows immediately.

## Why
Scenario from #878: a proxy rotated onto a bad server got every Gemini key cooldowned by region-based 403s. Once the proxy is fixed there is no way to recover the keys without waiting for the full cooldown — a manual lift is the missing escape hatch.

## Notes
- Server endpoint `DELETE /api/keys/:id/cooldowns` already exists and is covered by `server/src/__tests__/routes/keys-cooldowns.test.ts` — this PR only adds the client UI + i18n.
- i18n added to all 60 locales (`resetCooldown`), with proper zh-CN / zh-TW translations; `check:i18n` passes.
- `tsc -b` and client `vitest run` (69 tests) pass.
