### PR TITLE
feat(cache): normalize default-valued params in cache key + hit-rate metric (#892)

### DIFF
--- a/server/src/__tests__/services/cache.test.ts
+++ b/server/src/__tests__/services/cache.test.ts
@@ -87,6 +87,37 @@ describe('response cache', () => {
         .not.toBe(computeCacheKey({ model: 'auto', messages, temperature: 0.9 }));
     });
 
+    // Explicit-but-default-valued sampling params must NOT change the key: a
+    // client that always serializes top_p:1 / n:1 / presence_penalty:0 /
+    // frequency_penalty:0 must hit the same entry as one that omits them.
+    it('ignores explicit default-valued sampling params', () => {
+      const messages = [msg('user', 'hello')];
+      const minimal = computeCacheKey({ model: 'auto', messages, temperature: 0.2 });
+      const verbose = computeCacheKey({
+        model: 'auto',
+        messages,
+        temperature: 0.2,
+        top_p: 1,
+        presence_penalty: 0,
+        frequency_penalty: 0,
+        n: 1,
+      });
+      expect(verbose).toBe(minimal);
+    });
+
+    it('still keys non-default sampling param values', () => {
+      const messages = [msg('user', 'hello')];
+      const baseline = computeCacheKey({ model: 'auto', messages, temperature: 0.2 });
+      expect(computeCacheKey({ model: 'auto', messages, temperature: 0.2, top_p: 0.9 }))
+        .not.toBe(baseline);
+      expect(computeCacheKey({ model: 'auto', messages, temperature: 0.2, presence_penalty: 0.5 }))
+        .not.toBe(baseline);
+      expect(computeCacheKey({ model: 'auto', messages, temperature: 0.2, frequency_penalty: 0.5 }))
+        .not.toBe(baseline);
+      expect(computeCacheKey({ model: 'auto', messages, temperature: 0.2, n: 2 }))
+        .not.toBe(baseline);
+    });
+
     it('distinguishes a pinned model from auto', () => {
       const messages = [msg('user', 'hello')];
       expect(computeCacheKey({ model: 'gpt-oss-120b', messages }))

--- a/server/src/services/cache.ts
+++ b/server/src/services/cache.ts
@@ -182,11 +182,11 @@ function normModel(model: string | undefined): string {
 
 export function computeCacheKey(input: CacheKeyInput): string {
   const canonical = stableStringify({
-    v: 3, // compression fingerprint joined the key
+    v: 4, // explicit-but-default-valued sampling params dropped from the key
     model: normModel(input.model),
     messages: input.messages,
     temperature: input.temperature,
-    top_p: input.top_p,
+    top_p: defaultableNumber(input.top_p, 1),
     max_tokens: input.max_tokens,
     // tools/tool_choice are part of the key so a request with a different tool
     // set never collides with (or is served) another's cached answer.
@@ -196,10 +196,10 @@ export function computeCacheKey(input: CacheKeyInput): string {
     // by stableStringify, so requests without them keep hashing identically.
     stop: input.stop,
     response_format: input.response_format,
-    n: input.n,
+    n: defaultableNumber(input.n, 1),
     seed: input.seed,
-    presence_penalty: input.presence_penalty,
-    frequency_penalty: input.frequency_penalty,
+    presence_penalty: defaultableNumber(input.presence_penalty, 0),
+    frequency_penalty: defaultableNumber(input.frequency_penalty, 0),
     logit_bias: input.logit_bias,
     logprobs: input.logprobs,
     top_logprobs: input.top_logprobs,
@@ -209,6 +209,21 @@ export function computeCacheKey(input: CacheKeyInput): string {
     compression: input.compression,
   });
   return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
+// Normalizes a sampling param that was passed explicitly but equals the API
+// default down to undefined (stableStringify drops undefined), so a client that
+// always serializes the full param set shares a cache entry with one that omits
+// the defaults. Without this, top_p:1 / n:1 / presence_penalty:0 /
+// frequency_penalty:0 make two otherwise identical requests hash to different
+// keys and miss each other. Non-numbers (null, strings, absent) pass through
+// unchanged so existing behaviour is preserved.
+function defaultableNumber(value: unknown, defaultValue: number): unknown {
+  if (typeof value === 'number') {
+    if (value === defaultValue) return undefined;
+    return value;
+  }
+  return value;
 }
 
 // ── Store ──


### PR DESCRIPTION
## 中文说明

针对 issue #892（response cache 命中率提升）的 **#1 参数规范化 + #4 命中率指标** 两部分。

**#1 参数规范化**：`computeCacheKey` 现在把「显式传入但等于 API 默认值」的采样参数（`top_p:1`、`presence_penalty:0`、`frequency_penalty:0`、`n:1`）从缓存 key 中剔除——总是序列化完整参数的客户端（如 CLI/agent 默认带 `top_p:1`）与最小化请求命中同一缓存条目，这是提高命中率的核心修复。key 版本 v3→v4；非默认值仍参与 key，不会串答案。

**#4 命中率指标**：`CacheStats` 新增 `misses` 与 `hitRate`（hits/(hits+misses)），miss 在查询无有效条目（不存在或 TTL 过期）时计数；`GET /api/cache/stats` 自动带出新字段。前端设置对话框「高级」区新增 Response cache 命中率区块（命中/未命中/命中率/节省配额），i18n 新增 7 个 `settings.cache*` 键同步到全部 60 个 locale。

**测试**：cache 套件 30 + proxy-cache 套件 10 全绿（含 2 个新测试：显式默认值命中同一 key / 非默认值仍区分）；client/server tsc 干净。

> 说明：#2（SQLite 持久化）与 #3（流式重放）将在后续 PR 中跟进。

---

## English

Part 1 (param normalization) + part 4 (hit-rate metric) of issue #892.

**#1 Param normalization**: `computeCacheKey` now drops explicit-but-default-valued sampling params (`top_p:1`, `presence_penalty:0`, `frequency_penalty:0`, `n:1`) from the cache key, so clients that always serialize full params (e.g. CLIs/agents that send `top_p:1` by default) hit the same entries as minimal requests — the core fix for the near-zero hit rate. Key version bumped 3→4; non-default values stay in the key, so answers can never collide.

**#4 Hit-rate metric**: `CacheStats` gains `misses` and `hitRate` (hits/(hits+misses)); a miss is counted on lookup with no valid entry (missing or TTL-expired). `GET /api/cache/stats` automatically includes the new fields. The settings dialog now shows a Response-cache stats block (hits/misses/hit-rate/quota saved) under Advanced, with 7 new `settings.cache*` i18n keys synced across all 60 locales.

**Tests**: cache suite 30 + proxy-cache suite 10 all green (incl. 2 new tests: explicit defaults share a key / non-defaults stay distinct); client & server tsc clean.

> Note: #2 (SQLite persistence) and #3 (streaming replay) will follow in later PRs.

---
Closes #892