### PR TITLE
fix(models): 模型详情页显示 unified model id 徽章 / show the unified model id on the model detail page (#725)

### DIFF
--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -340,7 +340,8 @@ function ProviderSettingsRow({
     <div className="rounded-xl border bg-background/60 p-3">
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <span className="text-xs font-medium" title={endpointTitle}>{endpointLabel}</span>
-        <code className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">{model.modelId}</code>
+        <code className="rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">{model.modelId}</code>
+        <CopyButton text={model.modelId} label={t('models.copyModelId')} className="size-6" />
         <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{sourceLabel}</span>
         {model.hasOverrides && (
           <span className="rounded-full bg-emerald-600/15 px-1.5 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-400">

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -206,8 +206,15 @@ export default function ModelDetailPage() {
           </div>
         ) : (
           <>
-            {/* Summary badges */}
+            {/* Summary badges. The canonical (unified) model id leads: it is the
+                id callers actually put in a request body, and it was previously
+                only reachable via the hover copy button in the Models table
+                (#725, #708). */}
             <div className="flex items-center gap-2 flex-wrap">
+              <span className="inline-flex min-w-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] text-foreground">
+                <code className="min-w-0 truncate font-mono">{canonicalId}</code>
+                <CopyButton text={canonicalId} label={t('models.copyModelId')} className="size-4 shrink-0 border-0 bg-transparent" />
+              </span>
               <span className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground">{t('models.providerCount', { count: members.length })}</span>
               {quota && <span title={quota.title} className="text-[11px] rounded-full px-2 py-0.5 bg-muted text-muted-foreground tabular-nums">{quota.text}</span>}
               {vision && <span title={t('models.visionTitle')} className="text-[11px] rounded-full px-2 py-0.5 bg-cyan-600/15 text-cyan-700 dark:bg-cyan-400/15 dark:text-cyan-400">{t('models.vision')}</span>}
@@ -340,8 +347,8 @@ function ProviderSettingsRow({
     <div className="rounded-xl border bg-background/60 p-3">
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <span className="text-xs font-medium" title={endpointTitle}>{endpointLabel}</span>
-        <code className="rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">{model.modelId}</code>
-        <CopyButton text={model.modelId} label={t('models.copyModelId')} className="size-6" />
+        <code className="min-w-0 truncate rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">{model.modelId}</code>
+        <CopyButton text={model.modelId} label={t('models.copyModelId')} className="size-6 shrink-0" />
         <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{sourceLabel}</span>
         {model.hasOverrides && (
           <span className="rounded-full bg-emerald-600/15 px-1.5 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-400">


### PR DESCRIPTION
## 中文

实现 issue #725：

- `ModelDetailPage.tsx` 的 summary chips 区把 model id 从「仅 hover 可复制的隐藏文本」改为**始终可见的徽章 + 复制按钮**（复用现有 `models.copyModelId` 文案），无需 hover 即可发现与复制（issue #708）。
- 不新增 i18n 键，60 个 locale 保持 parity。

**验证**：client `tsc -b` 通过；`check-i18n.mjs` 60 locales / 837 keys 全绿。

## English

Implements #725:

- In `ModelDetailPage.tsx` the summary chips now render the model id as an **always-visible badge + copy button** (reusing the existing `models.copyModelId` label) instead of a hover-only hidden text — discoverable and copyable without hovering (#708).
- No new i18n keys; all 60 locales stay in parity.

**Verification**: client `tsc -b` passes; `check-i18n.mjs` 60 locales / 837 keys green.

---
Closes #725