### PR TITLE
feat(modules): 依赖-free 可插拔模块注册表，compression 为旗舰模块 / dependency-free pluggable-module registry (#763)

### DIFF
--- a/server/src/__tests__/services/modules.test.ts
+++ b/server/src/__tests__/services/modules.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import { initDb, getDb, setSetting } from '../../db/index.js';
+
+const {
+  registerModule,
+  enableModule,
+  disableModule,
+  isModuleEnabled,
+  listModules,
+  _resetModulesForTesting,
+  COMPRESSION_MODULE_ID,
+} = await import('../../services/modules.js');
+const { COMPRESSION_SETTING, getCompressionConfig } = await import('../../services/compression/config.js');
+
+// #763 pluggable-module registry: a dependency-free register/enable/disable/
+// isEnabled surface, with compression wired in as the flagship provider-backed
+// module (its enabled state follows the existing `compression` setting).
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = '0'.repeat(64);
+  initDb(':memory:');
+});
+
+beforeEach(() => {
+  _resetModulesForTesting();
+  getDb().prepare("DELETE FROM settings WHERE key = ?").run(COMPRESSION_SETTING);
+});
+
+describe('modules registry', () => {
+  it('register → list shows the module, disabled by default', () => {
+    registerModule({ id: 'paid-models', label: 'Paid Models' });
+    const view = listModules().find(m => m.id === 'paid-models');
+    expect(view).toEqual({ id: 'paid-models', label: 'Paid Models', enabled: false, providerBacked: false });
+    expect(isModuleEnabled('paid-models')).toBe(false);
+  });
+
+  it('enable/disable flip the flag', () => {
+    registerModule({ id: 'paid-models', label: 'Paid Models' });
+    expect(enableModule('paid-models')).toBe(true);
+    expect(isModuleEnabled('paid-models')).toBe(true);
+    expect(disableModule('paid-models')).toBe(true);
+    expect(isModuleEnabled('paid-models')).toBe(false);
+  });
+
+  it('unknown module ids are no-ops', () => {
+    expect(enableModule('nope')).toBe(false);
+    expect(disableModule('nope')).toBe(false);
+    expect(isModuleEnabled('nope')).toBe(false);
+  });
+
+  it('duplicate registration throws', () => {
+    registerModule({ id: 'paid-models', label: 'Paid Models' });
+    expect(() => registerModule({ id: 'paid-models', label: 'Duplicate' })).toThrow(/already registered/);
+  });
+
+  it('a provider-backed module follows its provider, ignoring enable/disable', () => {
+    let on = false;
+    registerModule({ id: 'demo', label: 'Demo', isEnabled: () => on });
+    expect(isModuleEnabled('demo')).toBe(false);
+    enableModule('demo'); // provider wins — still off
+    expect(isModuleEnabled('demo')).toBe(false);
+    on = true;
+    expect(isModuleEnabled('demo')).toBe(true);
+    disableModule('demo'); // provider wins — still on
+    expect(isModuleEnabled('demo')).toBe(true);
+    expect(listModules().find(m => m.id === 'demo')).toMatchObject({ providerBacked: true });
+  });
+});
+
+describe('modules: flagship compression module', () => {
+  it('compression is registered by default', () => {
+    expect(isModuleEnabled(COMPRESSION_MODULE_ID)).toBe(false); // mode defaults to 'off'
+  });
+
+  it('enabled when the compression mode is not off', () => {
+    setSetting(COMPRESSION_SETTING, JSON.stringify({ ...getCompressionConfig(), mode: 'standard' }));
+    expect(isModuleEnabled(COMPRESSION_MODULE_ID)).toBe(true);
+  });
+
+  it('disabled again when mode returns to off', () => {
+    setSetting(COMPRESSION_SETTING, JSON.stringify({ ...getCompressionConfig(), mode: 'standard' }));
+    expect(isModuleEnabled(COMPRESSION_MODULE_ID)).toBe(true);
+    setSetting(COMPRESSION_SETTING, JSON.stringify({ ...getCompressionConfig(), mode: 'off' }));
+    expect(isModuleEnabled(COMPRESSION_MODULE_ID)).toBe(false);
+  });
+});

--- a/server/src/services/modules.ts
+++ b/server/src/services/modules.ts
@@ -1,0 +1,115 @@
+import { getCompressionConfig } from './compression/config.js';
+
+/**
+ * Dependency-free pluggable-module registry (#763).
+ *
+ * As the project grows, features that ship as opt-in modules (compression
+ * today, a potential paid-model module tomorrow) need a single, tiny registry
+ * so operators and dashboards can ask "is module X on?" without reaching into
+ * each feature's internals. This module has no third-party dependencies; the
+ * flagship compression module is registered here, wired to its existing
+ * setting (mode ≠ 'off' counts as enabled).
+ *
+ * Enabled state can be either a plain boolean (set via enable/disable) or a
+ * lazily-evaluated provider function (e.g. reading a setting) — the provider
+ * wins when present, so a feature's own config remains the source of truth
+ * while the registry stays read-only with respect to it.
+ */
+
+export interface ModuleRegistration {
+  /** Stable module id, e.g. 'compression'. */
+  id: string;
+  /** Short human-readable label for dashboards. */
+  label: string;
+  /** Lazily-evaluated source of truth; when provided it wins over enable/disable. */
+  isEnabled?: () => boolean;
+}
+
+interface ModuleEntry {
+  id: string;
+  label: string;
+  enabled: boolean;
+  provider?: () => boolean;
+}
+
+export const COMPRESSION_MODULE_ID = 'compression';
+
+const modules = new Map<string, ModuleEntry>();
+
+/** Register a module. Throws on a duplicate id so wiring bugs surface at boot. */
+export function registerModule(reg: ModuleRegistration): void {
+  if (modules.has(reg.id)) throw new Error(`Module already registered: ${reg.id}`);
+  modules.set(reg.id, {
+    id: reg.id,
+    label: reg.label,
+    enabled: false,
+    provider: reg.isEnabled,
+  });
+}
+
+/** Force-enable a module (no-op when the module has a provider — its config rules). */
+export function enableModule(id: string): boolean {
+  const entry = modules.get(id);
+  if (!entry) return false;
+  if (entry.provider) return isModuleEnabled(id);
+  entry.enabled = true;
+  return true;
+}
+
+/** Force-disable a module (no-op when the module has a provider). */
+export function disableModule(id: string): boolean {
+  const entry = modules.get(id);
+  if (!entry) return false;
+  if (entry.provider) return isModuleEnabled(id);
+  entry.enabled = false;
+  return true;
+}
+
+/** Whether a module is on: its provider function when present, else the flag. */
+export function isModuleEnabled(id: string): boolean {
+  const entry = modules.get(id);
+  if (!entry) return false;
+  return entry.provider ? entry.provider() : entry.enabled;
+}
+
+export interface ModuleView {
+  id: string;
+  label: string;
+  enabled: boolean;
+  /** True when the module has a provider-backed (config-driven) enabled state. */
+  providerBacked: boolean;
+}
+
+/** All registered modules, sorted by id for stable dashboards. */
+export function listModules(): ModuleView[] {
+  return [...modules.values()]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map(e => ({
+      id: e.id,
+      label: e.label,
+      enabled: isModuleEnabled(e.id),
+      providerBacked: e.provider !== undefined,
+    }));
+}
+
+/** Test seam: wipe the registry and re-register the built-in modules so a
+ *  test that clears between cases still sees compression registered. */
+export function _resetModulesForTesting(): void {
+  modules.clear();
+  registerBuiltinModules();
+}
+
+// ── Flagship module: compression ────────────────────────────────────────────
+// Wired to the existing `compression` setting: any mode other than 'off'
+// counts as enabled. The provider function is evaluated lazily on every
+// isModuleEnabled() call, so config changes take effect immediately without a
+// re-registration dance.
+function registerBuiltinModules(): void {
+  registerModule({
+    id: COMPRESSION_MODULE_ID,
+    label: 'Compression',
+    isEnabled: () => getCompressionConfig().mode !== 'off',
+  });
+}
+
+registerBuiltinModules();


### PR DESCRIPTION
## 中文

实现 issue #763（#843 的模块化切片）：

- 新增 `services/modules.ts`：**依赖-free** 的可插拔模块注册表——`register` / `enable` / `disable` / `isEnabled` / `listModules`，无第三方依赖；
- 启用状态支持两种形态：普通布尔开关，或**惰性求值的 provider 函数**（provider 存在时优先，功能自身配置仍是唯一事实来源）；
- **compression 注册为旗舰模块**：启用状态与现有 `compression` 设置联动（mode ≠ off 即视为启用），配置变更即时生效，无需重新注册；
- 单测 8 例：注册/列表、开关翻转、provider-backed 状态（enable/disable 不覆盖 provider）、重复注册报错、compression 联动（off→standard→off）。

**验证**：server `tsc -b` 通过（仅 sharp 缺失的既有报错）；vitest modules 8/8 + compression 20/20。

## English

Implements #763 (the modularity slice of #843):

- New `services/modules.ts`: a **dependency-free** pluggable-module registry — `register` / `enable` / `disable` / `isEnabled` / `listModules`, no third-party deps;
- Enabled state can be a plain boolean flag or a **lazily-evaluated provider function** (provider wins when present, so each feature's own config stays the source of truth);
- **Compression registered as the flagship module**: enabled state wired to the existing `compression` setting (mode ≠ 'off' counts as enabled), taking effect immediately on config change;
- 8 unit tests: register/list, flag flipping, provider-backed state (enable/disable never override the provider), duplicate-registration throws, compression wiring (off→standard→off).

**Verification**: server `tsc -b` passes (only the pre-existing sharp-missing error); vitest modules 8/8 + compression 20/20.

---
Closes #763