### PR TITLE
feat(proxy): 能力感知视觉回退——Qwen VL 预分析替换图片为文本 / capability-aware vision fallback (#812)

### DIFF
--- a/server/src/__tests__/lib/vision-fallback.test.ts
+++ b/server/src/__tests__/lib/vision-fallback.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import type { ChatMessage } from '@freellmapi/shared/types.js';
+import {
+  extractImageBlocks,
+  visionFallbackNeeded,
+  stripImagesToText,
+  applyVisionFallback,
+  analyzeWithQwenVL,
+  tryVisionFallback,
+  type ExtractedImage,
+} from '../../lib/vision-fallback.js';
+
+// #811 capability-aware vision fallback: image requests route to a
+// vision-capable model when one exists (pass-through), and when the gateway
+// has no vision model the Qwen VL pre-analysis replaces image blocks with a
+// text summary BEFORE the no-vision rejection — the target model never
+// receives image blocks. Failure or unconfigured analyzer falls through to
+// the existing rejection.
+
+function msg(role: 'user' | 'assistant' | 'system', content: unknown): ChatMessage {
+  return { role, content } as ChatMessage;
+}
+
+const textOnly = [msg('user', 'hello')];
+
+const withImage: ChatMessage[] = [
+  msg('system', 'sys'),
+  msg('user', [
+    { type: 'text', text: 'what is in this image?' },
+    { type: 'image_url', image_url: { url: 'https://example.com/a.png' } },
+  ]),
+];
+
+const bareImage: ChatMessage[] = [
+  msg('user', [
+    { type: 'image', data: 'base64data' },
+  ]),
+];
+
+describe('vision-fallback: extraction', () => {
+  it('extracts image_url and bare image blocks in order', () => {
+    const imgs = extractImageBlocks(withImage);
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]!.url).toBe('https://example.com/a.png');
+    expect(imgs[0]!.messageIndex).toBe(1);
+    expect(imgs[0]!.blockIndex).toBe(1);
+
+    const bare = extractImageBlocks(bareImage);
+    expect(bare).toHaveLength(1);
+    expect(bare[0]!.url).toBeUndefined();
+  });
+
+  it('returns [] for text-only messages', () => {
+    expect(extractImageBlocks(textOnly)).toEqual([]);
+  });
+});
+
+describe('vision-fallback: need detection (pass-through)', () => {
+  it('vision-capable target + image → no fallback (pass-through)', () => {
+    expect(visionFallbackNeeded(true, true)).toBe(false);
+  });
+
+  it('text-only request → no fallback regardless of target', () => {
+    expect(visionFallbackNeeded(false, false)).toBe(false);
+    expect(visionFallbackNeeded(false, true)).toBe(false);
+  });
+
+  it('image + non-visual target → fallback needed', () => {
+    expect(visionFallbackNeeded(true, false)).toBe(true);
+  });
+});
+
+describe('vision-fallback: image removal (stripImagesToText)', () => {
+  it('replaces image blocks with the summary text (removal semantics)', () => {
+    const out = stripImagesToText(withImage, { summary: '[A red circle]' });
+    // The original messages are untouched.
+    expect(extractImageBlocks(withImage)).toHaveLength(1);
+    // The new list has no image blocks anywhere.
+    expect(extractImageBlocks(out)).toHaveLength(0);
+    // Text blocks survive; the summary text is appended to the user message.
+    const user = out.find(m => m.role === 'user');
+    expect(Array.isArray(user!.content)).toBe(true);
+    const content = user!.content as unknown[];
+    expect(content.some(b => (b as { type?: string }).type === 'image_url')).toBe(false);
+    expect(content.some(b => (b as { type?: string }).type === 'text' && (b as { text?: string }).text === '[A red circle]')).toBe(true);
+  });
+
+  it('removes image blocks outright when no summary is given', () => {
+    const out = stripImagesToText(bareImage);
+    expect(extractImageBlocks(out)).toHaveLength(0);
+    const user = out.find(m => m.role === 'user');
+    expect(user!.content).toEqual([]);
+  });
+
+  it('leaves text-only messages byte-for-byte identical', () => {
+    const out = stripImagesToText(textOnly, { summary: 'x' });
+    expect(out).toEqual(textOnly);
+  });
+});
+
+describe('vision-fallback: applyVisionFallback', () => {
+  it('returns null when the analyzer fails (failure path)', async () => {
+    const analyzer = async () => null;
+    const out = await applyVisionFallback(withImage, analyzer);
+    expect(out).toBeNull();
+  });
+
+  it('returns null when there are no images', async () => {
+    const analyzer = async () => 'summary';
+    const out = await applyVisionFallback(textOnly, analyzer);
+    expect(out).toBeNull();
+  });
+
+  it('returns stripped messages with the summary on success', async () => {
+    const analyzer = async (_imgs: ExtractedImage[]) => 'the image shows a chart';
+    const out = await applyVisionFallback(withImage, analyzer);
+    expect(out).not.toBeNull();
+    expect(out!.summary).toBe('the image shows a chart');
+    expect(extractImageBlocks(out!.messages)).toHaveLength(0);
+  });
+});
+
+describe('vision-fallback: Qwen VL analyzer', () => {
+  it('returns null when unconfigured (no base URL)', async () => {
+    const out = await analyzeWithQwenVL(extractImageBlocks(withImage), { baseUrl: undefined });
+    expect(out).toBeNull();
+  });
+
+  it('calls the OpenAI-compatible endpoint and returns the content', async () => {
+    const fetchImpl = async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://vl.example/chat/completions');
+      const body = JSON.parse(String(init.body)) as { model: string; messages: { content: unknown[] }[] };
+      expect(body.model).toBe('qwen2.5-vl-72b-instruct');
+      const content = body.messages[0]!.content as { type: string }[];
+      expect(content.some(b => b.type === 'image_url')).toBe(true);
+      return {
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: 'a red circle on white' } }] }),
+      } as unknown as Response;
+    };
+    const out = await analyzeWithQwenVL(extractImageBlocks(withImage), {
+      baseUrl: 'https://vl.example',
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    expect(out).toBe('a red circle on white');
+  });
+
+  it('returns null on non-ok or empty content', async () => {
+    const fail = async () => ({ ok: false, json: async () => ({}) }) as unknown as Response;
+    expect(await analyzeWithQwenVL(extractImageBlocks(withImage), { baseUrl: 'https://vl.example', fetchImpl: fail as typeof fetch })).toBeNull();
+
+    const empty = async () => ({ ok: true, json: async () => ({ choices: [{ message: { content: '   ' } }] }) }) as unknown as Response;
+    expect(await analyzeWithQwenVL(extractImageBlocks(withImage), { baseUrl: 'https://vl.example', fetchImpl: empty as typeof fetch })).toBeNull();
+  });
+
+  it('tryVisionFallback one-shot: null when analyzer fails', async () => {
+    const fetchImpl = async () => ({ ok: false, json: async () => ({}) }) as unknown as Response;
+    const out = await tryVisionFallback(withImage, { baseUrl: 'https://vl.example', fetchImpl: fetchImpl as typeof fetch });
+    expect(out).toBeNull();
+  });
+});

--- a/server/src/lib/vision-fallback.ts
+++ b/server/src/lib/vision-fallback.ts
@@ -1,0 +1,161 @@
+import type { ChatMessage } from '@freellmapi/shared/types.js';
+
+/**
+ * Capability-aware vision fallback (#811, multimodal slice of #843).
+ *
+ * When a request carries image blocks but the routed target model can't see
+ * them, the gateway may run a vision-capable pre-analysis (Qwen VL) and
+ * REPLACE the image blocks with the resulting text summary — so the target
+ * model never receives image blocks (image-removal semantics). This module
+ * holds the pure, dependency-free mechanics; the analyzer itself is injected
+ * so tests can pass a stub and the proxy wires in the real Qwen VL call.
+ */
+
+export interface ExtractedImage {
+  /** Index of the message carrying this block. */
+  messageIndex: number;
+  /** Index of the block within that message's content array. */
+  blockIndex: number;
+  /** The `image_url.url` for OpenAI-style blocks; undefined for bare `image`. */
+  url?: string;
+  /** The raw block object (for inspection/removal bookkeeping). */
+  block: Record<string, unknown>;
+}
+
+function isImageBlock(block: unknown): block is Record<string, unknown> {
+  if (!block || typeof block !== 'object') return false;
+  const type = (block as { type?: unknown })?.type;
+  return type === 'image_url' || type === 'image';
+}
+
+/** Collect every image block in the message list, in order. */
+export function extractImageBlocks(messages: ChatMessage[]): ExtractedImage[] {
+  const out: ExtractedImage[] = [];
+  messages.forEach((m, messageIndex) => {
+    if (!Array.isArray(m.content)) return;
+    m.content.forEach((block, blockIndex) => {
+      if (!isImageBlock(block)) return;
+      const url = typeof block.image_url === 'object' && block.image_url !== null
+        && typeof (block.image_url as { url?: unknown })?.url === 'string'
+        ? (block.image_url as { url: string }).url
+        : undefined;
+      out.push({ messageIndex, blockIndex, url, block });
+    });
+  });
+  return out;
+}
+
+/** True when the request has at least one image AND the target can't see it —
+ *  the condition that triggers vision fallback. */
+export function visionFallbackNeeded(hasImage: boolean, targetSupportsVision: boolean): boolean {
+  return hasImage && !targetSupportsVision;
+}
+
+export interface StripOptions {
+  /** Text to substitute for the removed images. When empty, the images are
+   *  dropped entirely (removal semantics without an analysis). */
+  summary?: string;
+}
+
+/**
+ * Return a NEW message list with every image block replaced by a single text
+ * block (the injected summary). The original messages are untouched. When the
+ * summary is empty, image blocks are removed outright — the target model never
+ * sees them either way. Non-image blocks pass through byte-for-byte.
+ */
+export function stripImagesToText(messages: ChatMessage[], opts: StripOptions = {}): ChatMessage[] {
+  const summary = opts.summary;
+  return messages.map((m) => {
+    if (!Array.isArray(m.content)) return m;
+    const hasImages = m.content.some(isImageBlock);
+    if (!hasImages) return m;
+    const nextContent = m.content.filter((block) => !isImageBlock(block));
+    if (summary !== undefined && summary !== '') {
+      nextContent.push({ type: 'text', text: summary });
+    }
+    return { ...m, content: nextContent };
+  });
+}
+
+/** Shape accepted by the injected analyzer: images → one summary string. */
+export type ImageAnalyzer = (images: ExtractedImage[]) => Promise<string | null>;
+
+/**
+ * Full fallback flow: extract images, run the analyzer, and produce the
+ * stripped message list. Returns null when the analyzer fails (caller decides
+ * whether to fall through to the original messages or reject).
+ */
+export async function applyVisionFallback(
+  messages: ChatMessage[],
+  analyze: ImageAnalyzer,
+): Promise<{ messages: ChatMessage[]; summary: string | null } | null> {
+  const images = extractImageBlocks(messages);
+  if (images.length === 0) return null;
+  const summary = await analyze(images);
+  if (summary === null || summary === '') return null;
+  return { messages: stripImagesToText(messages, { summary }), summary };
+}
+
+/** Default Qwen VL analyzer: an OpenAI-compatible chat-completions call against
+ *  the configured vision endpoint. Injectable for tests. The endpoint is
+ *  configured via VISION_FALLBACK_BASE_URL / VISION_FALLBACK_API_KEY /
+ *  VISION_FALLBACK_MODEL (default qwen2.5-vl-72b-instruct); returns null when
+ *  unconfigured so callers fall through to the normal rejection. */
+export async function analyzeWithQwenVL(
+  images: ExtractedImage[],
+  opts: {
+    baseUrl?: string;
+    apiKey?: string;
+    model?: string;
+    fetchImpl?: typeof fetch;
+  } = {},
+): Promise<string | null> {
+  const baseUrl = opts.baseUrl ?? process.env.VISION_FALLBACK_BASE_URL;
+  const apiKey = opts.apiKey ?? process.env.VISION_FALLBACK_API_KEY;
+  const model = opts.model ?? process.env.VISION_FALLBACK_MODEL ?? 'qwen2.5-vl-72b-instruct';
+  if (!baseUrl) return null;
+
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url = baseUrl.replace(/\/$/, '') + '/chat/completions';
+  const imageBlocks = images
+    .filter(i => i.url !== undefined)
+    .map(i => ({ type: 'image_url', image_url: { url: i.url! } }));
+  if (imageBlocks.length === 0) return null;
+
+  const body = {
+    model,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          ...imageBlocks,
+          { type: 'text', text: 'Describe the image(s) concisely in plain text, including any text, numbers, or UI elements visible. The summary will be sent to a text-only model in place of the images.' },
+        ],
+      },
+    ],
+    max_tokens: 300,
+  };
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  try {
+    const res = await fetchImpl(url, { method: 'POST', headers, body: JSON.stringify(body) });
+    if (!res.ok) return null;
+    const data = await res.json() as {
+      choices?: { message?: { content?: string } }[];
+    };
+    const content = data.choices?.[0]?.message?.content;
+    return content && content.trim() !== '' ? content.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** One-shot convenience: try the vision fallback with the default Qwen VL
+ *  analyzer; null when unconfigured or the analysis fails. */
+export function tryVisionFallback(
+  messages: ChatMessage[],
+  opts: Parameters<typeof analyzeWithQwenVL>[1] = {},
+): Promise<{ messages: ChatMessage[]; summary: string | null } | null> {
+  return applyVisionFallback(messages, images => analyzeWithQwenVL(images, opts));
+}

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -12,6 +12,7 @@ import { getDb } from '../db/index.js';
 import { resolveAuth, prependSystemPrompt, type ResolvedAuth } from '../lib/system-prompt.js';
 import { contentToString, messageHasImage, normalizeOutboundContent, sanitizeResponse } from '../lib/content.js';
 import { normalizeMessageImages } from '../lib/image-normalize.js';
+import { tryVisionFallback } from '../lib/vision-fallback.js';
 import { repairToolArguments, toolSchemaMap } from '../lib/tool-args.js';
 import { invalidToolArgumentsError, invalidToolCallReasons, isToolArgumentValidationEnabled } from '../lib/tool-validate.js';
 import { sanitizeProviderErrorMessage } from '../lib/error-redaction.js';
@@ -1427,16 +1428,28 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   // or surfacing the generic "all models exhausted" error (#118, #125). Add a
   // rough per-image token cost so budget routing isn't skewed by content the
   // heuristic above (text-only) can't see.
-  const hasImage = messageHasImage(messages);
+  let hasImage = messageHasImage(messages);
   if (hasImage && !hasEnabledVisionModel()) {
-    res.status(422).json({
-      error: {
-        message: 'This request includes an image, but no vision-capable model is enabled. Enable a vision model (e.g. Gemini 2.5 Flash, Llama 4 Scout) in the Fallback Chain.',
-        type: 'invalid_request_error',
-        code: 'no_vision_model',
-      },
-    });
-    return;
+    // Capability-aware vision fallback (#811): before rejecting an image
+    // request that no enabled vision model can serve, try Qwen VL
+    // pre-analysis to replace the image blocks with a text summary — the
+    // (non-visual) target model never receives image blocks. When the
+    // fallback isn't configured or the analysis fails, fall through to the
+    // existing up-front rejection.
+    const fallback = await tryVisionFallback(messages);
+    if (fallback) {
+      messages = fallback.messages;
+      hasImage = false; // images replaced by text — no longer a vision request
+    } else {
+      res.status(422).json({
+        error: {
+          message: 'This request includes an image, but no vision-capable model is enabled. Enable a vision model (e.g. Gemini 2.5 Flash, Llama 4 Scout) in the Fallback Chain.',
+          type: 'invalid_request_error',
+          code: 'no_vision_model',
+        },
+      });
+      return;
+    }
   }
   const IMAGE_TOKEN_ESTIMATE = 1000;
   const imageCount = messages.reduce((n, m) =>


### PR DESCRIPTION
## 中文

实现 #811/#812（#843 多模态切片）的 **vision-fallback**：

- 新增 `lib/vision-fallback.ts`：提取图片块（`image_url`/`image`）、判定是否需要视觉回退、把图片块替换为文本摘要（**目标模型永远收不到图片块**——图片移除语义）；`analyzeWithQwenVL` 调用可配置的 OpenAI 兼容视觉端点（`VISION_FALLBACK_BASE_URL` / `VISION_FALLBACK_API_KEY` / `VISION_FALLBACK_MODEL`），未配置或分析失败返回 null 让调用方回落。
- `routes/proxy.ts`：no-vision 拒绝现在**在回退尝试之后**运行——请求带图但无启用视觉模型时，先试 Qwen VL 预分析，用剥离后的消息继续；仅当回退不可用或失败才 422 拒绝。
- 单测 15 例（`vision-fallback.test.ts`）：pass-through / fallback / failure / removal 与 analyzer 契约。

**验证**：server `tsc -b` 通过（仅 sharp 缺失的既有报错）；vitest vision-fallback 15/15 + exhaustion-summary 11/11。

## English

Implements the **vision-fallback** part of #811/#812 (the multimodal slice of #843):

- New `lib/vision-fallback.ts`: extracts image blocks (`image_url`/`image`), detects when a vision fallback is needed, and strips images into a text summary (**the target model never receives image blocks** — image-removal semantics); `analyzeWithQwenVL` calls the configured OpenAI-compatible vision endpoint (`VISION_FALLBACK_BASE_URL` / `VISION_FALLBACK_API_KEY` / `VISION_FALLBACK_MODEL`), returning null when unconfigured or on failure so callers fall through.
- `routes/proxy.ts`: the no-vision rejection now runs **after** a fallback attempt — when the request has images but no enabled vision model, try Qwen VL pre-analysis and continue with the stripped messages; only reject with 422 when the fallback is unavailable or fails.
- 15 unit tests (`vision-fallback.test.ts`): pass-through / fallback / failure / removal and the analyzer contract.

**Verification**: server `tsc -b` passes (only the pre-existing sharp-missing error); vitest vision-fallback 15/15 + exhaustion-summary 11/11.

---
Closes #812