### PR TITLE
feat(migrations): curated OpenCode 多模态模型——Qwen VL + Gemini 视频分析 / curated OpenCode multimodal models (#814)

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -26,6 +26,7 @@ const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endpoint_ho
 const KEY_MODEL_SCOPE_FILENAME = '20260805_000001_key_model_scope.ts';
 const CLIENT_PROFILES_FILENAME = '20260805_000002_client_profiles.ts';
 const API_KEY_PROXY_FILENAME = '20260810_000001_api_key_proxy.ts';
+const OPENCODE_MULTIMODAL_CURATION_FILENAME = '20260811_000001_opencode_multimodal_curation.ts';
 
 interface SchemaRow {
   type: string;
@@ -98,6 +99,7 @@ describe('migration round trip', () => {
         KEY_MODEL_SCOPE_FILENAME,
         CLIENT_PROFILES_FILENAME,
         API_KEY_PROXY_FILENAME,
+        OPENCODE_MULTIMODAL_CURATION_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -21,6 +21,7 @@ import * as customEndpointHostLabels from '../migrations/20260802_000001_custom_
 import * as keyModelScope from '../migrations/20260805_000001_key_model_scope.js';
 import * as clientProfiles from '../migrations/20260805_000002_client_profiles.js';
 import * as apiKeyProxy from '../migrations/20260810_000001_api_key_proxy.js';
+import * as opencodeMultimodalCuration from '../migrations/20260811_000001_opencode_multimodal_curation.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -54,6 +55,7 @@ export const CUSTOM_ENDPOINT_HOST_LABELS_FILENAME = '20260802_000001_custom_endp
 export const KEY_MODEL_SCOPE_FILENAME = '20260805_000001_key_model_scope.ts';
 export const CLIENT_PROFILES_FILENAME = '20260805_000002_client_profiles.ts';
 export const API_KEY_PROXY_FILENAME = '20260810_000001_api_key_proxy.ts';
+export const OPENCODE_MULTIMODAL_CURATION_FILENAME = '20260811_000001_opencode_multimodal_curation.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -78,4 +80,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: KEY_MODEL_SCOPE_FILENAME, module: keyModelScope },
   { filename: CLIENT_PROFILES_FILENAME, module: clientProfiles },
   { filename: API_KEY_PROXY_FILENAME, module: apiKeyProxy },
+  { filename: OPENCODE_MULTIMODAL_CURATION_FILENAME, module: opencodeMultimodalCuration },
 ];

--- a/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
+++ b/server/src/db/migrations/20260811_000001_opencode_multimodal_curation.ts
@@ -1,0 +1,140 @@
+import type { Db } from '../types.js';
+
+/**
+ * Curated OpenCode multimodal models (#814, part of #811 / the #843
+ * multimodal slice).
+ *
+ * Expose the selected coding/visual/short-video models as individual OpenCode
+ * choices while the complete enabled catalog stays behind capability-first
+ * auto routing. The three curated entries:
+ *   - Qwen VL            — vision (image understanding, UI screenshots)
+ *   - Gemini 3.5 Flash   — short-video analysis
+ *   - Gemini 3 Flash Preview — short-video analysis
+ *
+ * Fixed model ids make the migration roundtrip-stable (up → down → up yields
+ * identical rows). Models carry supports_vision = 1 so capability-first auto
+ * routing can use them for image/video requests, and are also available as
+ * pinned OpenCode choices.
+ *
+ * DOWN is a soft disable (enabled = 0) rather than a delete: SQLite's
+ * AUTOINCREMENT never reuses ids, so deleting and re-inserting rows on an
+ * up → down → up round trip would drift every model_db_id in fallback_config
+ * and break the roundtrip test's full-state equality. Soft-disable keeps the
+ * ids stable, and up() re-enables idempotently.
+ */
+
+// Column order of the models INSERT below. models gains columns over time
+// (supports_vision, endpoint_scope, ...), so the statement is written against
+// the CURRENT schema — same pattern as the V18 OpenCode Zen seed.
+const COLUMNS = `
+  (platform, model_id, display_name, intelligence_rank, speed_rank, size_label,
+   rpm_limit, rpd_limit, tpm_limit, tpd_limit, monthly_token_budget, context_window,
+   supports_vision)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`.trim();
+
+type ModelRow = [
+  platform: string,
+  modelId: string,
+  displayName: string,
+  intelRank: number,
+  speedRank: number,
+  sizeLabel: string,
+  rpm: number | null,
+  rpd: number | null,
+  tpm: number | null,
+  tpd: number | null,
+  budget: string,
+  contextWindow: number | null,
+  supportsVision: number,
+];
+
+// Promotional free-tier limits mirror the existing OpenCode Zen rows (V18):
+// conservative shared 20 RPM / 200 RPD. Vision rows get the same limits; the
+// 128K context matches the other Zen catalog rows.
+const ADDITIONS: ModelRow[] = [
+  ['opencode', 'qwen-vl',                 'Qwen VL (OpenCode Zen)',                6, 4, 'Large',    20, 200, null, null, 'promo (trial)', 131072, 1],
+  ['opencode', 'gemini-3.5-flash',        'Gemini 3.5 Flash (OpenCode Zen)',       8, 4, 'Large',    20, 200, null, null, 'promo (trial)', 131072, 1],
+  ['opencode', 'gemini-3-flash-preview',  'Gemini 3 Flash Preview (OpenCode Zen)', 9, 4, 'Large',    20, 200, null, null, 'promo (trial)', 131072, 1],
+];
+
+const MODEL_IDS = ADDITIONS.map(r => r[1]);
+const PLACEHOLDERS = MODEL_IDS.map(() => '?').join(', ');
+
+// Backfill fallback_config ONLY for the curated rows, never the whole models
+// table: a full-table backfill is order-dependent and would add different
+// rows on a second up() after other migrations' down() steps, breaking the
+// roundtrip test's full-state equality.
+function backfillCuratedFallback(db: Db): void {
+  const missing = db.prepare(`
+    SELECT m.id FROM models m
+    LEFT JOIN fallback_config f ON m.id = f.model_db_id
+    WHERE m.platform = 'opencode' AND m.model_id IN (${PLACEHOLDERS}) AND f.id IS NULL
+    ORDER BY m.intelligence_rank ASC
+  `).all(...MODEL_IDS) as { id: number }[];
+  if (missing.length === 0) return;
+  const maxPriority = (db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM fallback_config').get() as { mx: number }).mx;
+  const addFb = db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, ?, 1)');
+  for (let i = 0; i < missing.length; i++) addFb.run(missing[i].id, maxPriority + i + 1);
+}
+
+// Mirror profile_chain_backfill (20260714) for the curated rows only. That
+// migration runs BEFORE this one, so on a first up() our models don't exist
+// yet and it can't add them to profile_models; on an up→down→up round trip
+// they DO exist (down() only soft-disables), so the backfill would add them
+// the second time but not the first — breaking the roundtrip test's
+// full-state equality. Backfilling here keeps both passes identical.
+function backfillCuratedProfiles(db: Db): void {
+  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  if (profiles.length === 0) return;
+
+  const missing = db.prepare(`
+    SELECT f.priority, m.id AS model_db_id
+      FROM fallback_config f
+      JOIN models m ON m.id = f.model_db_id
+      LEFT JOIN profile_models pm ON pm.profile_id = ? AND pm.model_db_id = m.id
+     WHERE m.platform = 'opencode' AND m.model_id IN (${PLACEHOLDERS}) AND pm.id IS NULL
+     ORDER BY f.priority, m.id
+  `);
+  const maxPriority = db.prepare('SELECT COALESCE(MAX(priority), 0) AS mx FROM profile_models WHERE profile_id = ?');
+  const insertPm = db.prepare('INSERT INTO profile_models (profile_id, model_db_id, priority, enabled) VALUES (?, ?, ?, 1)');
+
+  for (const profile of profiles) {
+    const rows = missing.all(profile.id, ...MODEL_IDS) as { priority: number; model_db_id: number }[];
+    if (rows.length === 0) continue;
+    const max = maxPriority.get(profile.id) as { mx: number };
+    rows.forEach((row, index) => {
+      insertPm.run(profile.id, row.model_db_id, max.mx + index + 1);
+    });
+  }
+}
+
+export function up(db: Db): void {
+  const existing = db.prepare(
+    `SELECT id FROM models WHERE platform = 'opencode' AND model_id = ?`,
+  );
+  const insert = db.prepare(`INSERT OR IGNORE INTO models ${COLUMNS}`);
+  const reenable = db.prepare(
+    `UPDATE models SET enabled = 1, supports_vision = 1 WHERE platform = 'opencode' AND model_id = ?`,
+  );
+  const apply = db.transaction(() => {
+    for (const row of ADDITIONS) {
+      // Idempotent re-enable after a soft-disable down(): the row keeps its
+      // id, so fallback_config references stay stable across the round trip.
+      if (existing.get(row[1])) {
+        reenable.run(row[1]);
+      } else {
+        insert.run(...row);
+      }
+    }
+    backfillCuratedFallback(db);
+    backfillCuratedProfiles(db);
+  });
+  apply();
+}
+
+export function down(db: Db): void {
+  // Soft disable — never delete: ids must survive for the roundtrip test's
+  // full-state equality (see header comment).
+  db.prepare(`UPDATE models SET enabled = 0 WHERE platform = 'opencode' AND model_id IN (${PLACEHOLDERS})`).run(...MODEL_IDS);
+}


### PR DESCRIPTION
## 中文

实现 issue #814（#843 多模态切片的 curated 模型部分）：

- 新增迁移 `20260811_000001_opencode_multimodal_curation`：为 opencode 平台 seed 3 个 curated 多模态模型——`qwen-vl`（视觉）、`gemini-3.5-flash`、`gemini-3-flash-preview`（短视频分析），`supports_vision = 1`，沿用现有 Zen 行的保守 promo 限额（20 RPM / 200 RPD / 128K）；
- 自动路由保持能力优先（capability-first），curated 模型既可被 auto 路由使用，也可作为独立 OpenCode 选择；
- **DOWN 为软禁用（enabled = 0）而非删除**：SQLite AUTOINCREMENT 不复用 id，down 删行会让 fallback_config 引用漂移、破坏 roundtrip；up() 幂等（存在则 re-enable，否则插入），且只对 curated 行回填 fallback_config + profile_models，保证第一次/第二次 up 完全一致；
- 迁移已注册进 defaults.ts；roundtrip 测试更新为新文件名。

**验证**：server `tsc -b` 通过（仅 sharp 缺失的既有报错）；vitest roundtrip 3/3 + registry-drift 2/2。

## English

Implements #814 (the curated-models part of the #843 multimodal slice):

- New migration `20260811_000001_opencode_multimodal_curation`: seeds 3 curated multimodal models for the opencode platform — `qwen-vl` (vision), `gemini-3.5-flash`, `gemini-3-flash-preview` (short-video analysis), `supports_vision = 1`, with the same conservative promo limits as existing Zen rows (20 RPM / 200 RPD / 128K);
- Auto routing stays capability-first; curated models are usable by auto routing and as individual OpenCode choices;
- **DOWN soft-disables (enabled = 0) instead of deleting**: SQLite AUTOINCREMENT never reuses ids, so deleting on downgrade would drift fallback_config references and break the roundtrip test; up() is idempotent (re-enable or insert) and backfills fallback_config + profile_models for the curated rows only, keeping first/second up() passes identical;
- Registered in defaults.ts; roundtrip test updated for the new filename.

**Verification**: server `tsc -b` passes (only the pre-existing sharp-missing error); vitest roundtrip 3/3 + registry-drift 2/2.

---
Closes #814