### PR TITLE
fix(media): support model-specific FLUX image payloads

### DIFF
--- a/server/src/__tests__/services/media.test.ts
+++ b/server/src/__tests__/services/media.test.ts
@@ -68,6 +68,46 @@ describe('media service', () => {
       expect(r.images[0].b64_json).toBe('AAAA');
     });
 
+    it('NVIDIA FLUX.1 Dev: sends the validated 28-step 1024x1024 payload', async () => {
+      addMedia('nvidia', 'black-forest-labs/flux.1-dev', 'image');
+      addKey('nvidia');
+      const fetchMock = vi.fn(async () => jsonResponse({ artifacts: [{ base64: 'DEV' }] }));
+      globalThis.fetch = fetchMock as any;
+
+      await runImageGeneration('black-forest-labs/flux.1-dev', {
+        prompt: 'a lighthouse',
+        size: '512x512',
+      });
+
+      const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+      expect(body).toEqual({
+        prompt: 'a lighthouse',
+        mode: 'base',
+        steps: 28,
+        width: 1024,
+        height: 1024,
+        cfg_scale: 3.5,
+      });
+    });
+
+    it('NVIDIA FLUX.2 Klein 4B: omits unsupported mode and guidance fields', async () => {
+      addMedia('nvidia', 'black-forest-labs/flux.2-klein-4b', 'image');
+      addKey('nvidia');
+      const fetchMock = vi.fn(async () => jsonResponse({ artifacts: [{ base64: 'KLEIN' }] }));
+      globalThis.fetch = fetchMock as any;
+
+      await runImageGeneration('black-forest-labs/flux.2-klein-4b', {
+        prompt: 'a red kite',
+        size: '512x512',
+      });
+
+      const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+      expect(body).toEqual({ prompt: 'a red kite', steps: 4, width: 1024, height: 1024 });
+      expect(body).not.toHaveProperty('mode');
+      expect(body).not.toHaveProperty('guidance');
+      expect(body).not.toHaveProperty('cfg_scale');
+    });
+
     it('Pollinations: keyless GET, raw bytes → b64_json (no api key needed)', async () => {
       addMedia('pollinations', 'flux', 'image');
       globalThis.fetch = vi.fn(async () =>
@@ -77,17 +117,16 @@ describe('media service', () => {
       expect(r.images[0].b64_json).toBe(Buffer.from('PNGDATA').toString('base64'));
     });
 
-    it('Cloudflare: JSON {result.image} → b64_json', async () => {
+    it('Cloudflare FLUX.1 Schnell: sends only the prompt and maps result.image', async () => {
       addMedia('cloudflare', '@cf/black-forest-labs/flux-1-schnell', 'image');
       addKey('cloudflare', 'acct123:token456');
       const fetchMock = vi.fn(async () => jsonResponse({ result: { image: 'CFB64' }, success: true }));
       globalThis.fetch = fetchMock as any;
       const r = await runImageGeneration('@cf/black-forest-labs/flux-1-schnell', { prompt: 'x' });
       expect(r.images[0].b64_json).toBe('CFB64');
-      // A row without meta keeps the JSON body every other CF image model takes.
       const init = fetchMock.mock.calls[0][1] as RequestInit;
       expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
-      expect(JSON.parse(String(init.body))).toMatchObject({ prompt: 'x' });
+      expect(JSON.parse(String(init.body))).toEqual({ prompt: 'x' });
     });
 
     it('Cloudflare: requestStyle multipart sends form-data (FLUX.2 rejects JSON)', async () => {

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -328,11 +328,32 @@ async function callImageProvider(
     }
     case 'nvidia': {
       // NVIDIA NIM image models live at ai.api.nvidia.com/v1/genai/{model};
-      // response is { artifacts: [{ base64 }] }.
+      // response is { artifacts: [{ base64 }] }. The hosted FLUX deployments
+      // do not share one request schema: FLUX.1 Dev rejects the four-step
+      // defaults used by Schnell, while FLUX.2 Klein rejects `mode` and
+      // guidance fields entirely.
+      let body: Record<string, unknown>;
+      switch (row.model_id) {
+        case 'black-forest-labs/flux.1-dev':
+          body = {
+            prompt: p.prompt,
+            mode: 'base',
+            steps: 28,
+            width: 1024,
+            height: 1024,
+            cfg_scale: 3.5,
+          };
+          break;
+        case 'black-forest-labs/flux.2-klein-4b':
+          body = { prompt: p.prompt, steps: 4, width: 1024, height: 1024 };
+          break;
+        default:
+          body = { prompt: p.prompt, mode: 'base', steps: 4, width: w, height: h };
+      }
       const r = await mediaFetch(`https://ai.api.nvidia.com/v1/genai/${row.model_id}`, 'nvidia', 'image', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Accept: 'application/json', Authorization: `Bearer ${key}` },
-        body: JSON.stringify({ prompt: p.prompt, mode: 'base', steps: 4, width: w, height: h }),
+        body: JSON.stringify(body),
       });
       const j = (await r.json()) as { artifacts?: { base64?: string }[] };
       return (j.artifacts ?? []).map(a => ({ b64_json: a.base64 }));
@@ -359,10 +380,15 @@ async function callImageProvider(
         form.append('height', String(h));
         init = { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: form };
       } else {
+        // Cloudflare's FLUX.1 Schnell schema is prompt-only; dimensions that
+        // the other JSON image models accept are rejected as extra fields.
+        const body = row.model_id === '@cf/black-forest-labs/flux-1-schnell'
+          ? { prompt: p.prompt }
+          : { prompt: p.prompt, width: w, height: h };
         init = {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-          body: JSON.stringify({ prompt: p.prompt, width: w, height: h }),
+          body: JSON.stringify(body),
         };
       }
       const r = await mediaFetch(url, 'cloudflare', 'image', init);


### PR DESCRIPTION
## Summary
- send Cloudflare FLUX.1 Schnell a prompt-only JSON body
- use the validated 28-step 1024x1024 payload for NVIDIA FLUX.1 Dev
- omit unsupported mode and guidance fields for NVIDIA FLUX.2 Klein 4B
- add regression coverage for all three provider-specific schemas

## Validation
- npm run test -w server -- src/__tests__/services/media.test.ts (21 passed)
- npm run build -w server