### PR TITLE
fix(probe): raise the probe max_tokens above the floor relays enforce (#903)

### DIFF
--- a/server/src/__tests__/routes/custom-model-discovery.test.ts
+++ b/server/src/__tests__/routes/custom-model-discovery.test.ts
@@ -3,6 +3,7 @@ import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { initDb, getDb } from '../../db/index.js';
 import { setCooldown, isOnCooldown } from '../../services/ratelimit.js';
+import { PROBE_MAX_TOKENS } from '../../services/model-discovery.js';
 import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 
 // #488: a relay's model list changes weekly, so the endpoint's own /models
@@ -337,7 +338,7 @@ describe('median seeding for custom models (#488)', () => {
     expect(chatCall).toBeTruthy();
     expect((chatCall[1] as RequestInit).method).toBe('POST');
     const chatBody = JSON.parse(String((chatCall[1] as RequestInit).body)) as any;
-    expect(chatBody.max_tokens).toBe(1);
+    expect(chatBody.max_tokens).toBe(PROBE_MAX_TOKENS);
     expect(chatBody.model).toBe('relay-a');
 
     // The successful probe wrote a request row the stats cache can fold in,
@@ -351,6 +352,37 @@ describe('median seeding for custom models (#488)', () => {
 
     // A real completion outranks a health ping: the cooldown is lifted.
     expect(isOnCooldown('custom', 'relay-a', keyId)).toBe(false);
+  });
+
+  // #903: relays that enforce `max_tokens > 2` rejected the old probe with a
+  // 400 before it could measure anything, so the endpoint looked broken when
+  // only the probe's own cap was wrong.
+  it('probe clears the max_tokens floor relays enforce (#903)', async () => {
+    expect(PROBE_MAX_TOKENS).toBeGreaterThan(2);
+
+    await post(app, '/api/keys/custom', { baseUrl: ENDPOINT, model: 'relay-a', apiKey: 'relay-secret' });
+    const keyId = customKeyIds()[0]!;
+
+    const mock = vi.fn(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { max_tokens?: number } : {};
+      // Mirror the upstream that reported #903.
+      if ((body.max_tokens ?? 0) <= 2) {
+        return jsonResponse({ error: { message: 'max_tokens must be greater than 2' } }, 400);
+      }
+      return jsonResponse({
+        id: 'chatcmpl-probe',
+        object: 'chat.completion',
+        created: 0,
+        model: 'relay-a',
+        choices: [{ index: 0, message: { role: 'assistant', content: 'pong' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      });
+    });
+    globalThis.fetch = mock as any;
+
+    const { status, body } = await post(app, '/api/keys/custom/probe', { keyId });
+    expect(status).toBe(200);
+    expect(body.modelId).toBe('relay-a');
   });
 
   it('probe falls back to discovery when the endpoint has no registered model (#685 follow-up)', async () => {

--- a/server/src/services/model-discovery.ts
+++ b/server/src/services/model-discovery.ts
@@ -362,6 +362,10 @@ export async function discoverEndpointModels(baseUrl: string, apiKey: string): P
   return parseModelCatalog(payload);
 }
 
+/** Output cap on the probe request. Exported so the test can assert the floor
+ *  rather than a magic number. See the call site for why it is not 1. */
+export const PROBE_MAX_TOKENS = 4;
+
 /**
  * Fire one minimal real chat request at a custom endpoint to measure latency
  * and confirm the key works end-to-end ("probe now", #685 follow-up). When the
@@ -403,7 +407,12 @@ export async function probeEndpointModel(
       apiKey,
       [{ role: 'user', content: 'ping' }],
       modelId,
-      { max_tokens: 1 },
+      // Not 1: several relays enforce a floor above it and 400 the probe
+      // outright ("max_tokens must be greater than 2" on b.ai's
+      // deepseek-v4-flash, #903), so a probe that only wanted to measure
+      // latency reported the endpoint as broken. 4 clears the floors seen so
+      // far and still costs a rounding error.
+      { max_tokens: PROBE_MAX_TOKENS },
     );
   } catch (err) {
     const reason = isAbortLikeError(err) ? 'timed out' : ((err as Error)?.message ?? 'unknown error');


### PR DESCRIPTION
Closes #903.

## Problem

`probeEndpointModel` pinned `max_tokens: 1` to keep the probe cheap. Several relays enforce a floor above that and reject the request outright, so the probe reported a working endpoint as broken and left its cooldown in place.

Reported against b.ai's `deepseek-v4-flash`:

```
Probe request to deepseek-v4-flash failed: Custom (OpenAI-compatible)
API error 400: max_tokens must be greater than 2
```

## Fix

Raise it to 4, via an exported `PROBE_MAX_TOKENS`. That clears every floor seen so far and still costs a rounding error per probe.

Fixed generally rather than special-cased per provider: `max_tokens: 1` is needlessly aggressive, the floor is not unique to one relay, and 3 extra tokens is not a cost worth a branch.

## Verification

- server `tsc -b` clean
- `custom-model-discovery` 21/21
- The existing test pinned the literal `1`, so it now asserts the constant. A new case drives a mock upstream that 400s anything at or below 2, which fails on the old value and passes on the new one.

## Not included

`providers/modelscope.ts` uses `max_tokens: 1` for key validation against ModelScope's own models, where it has been working. Left alone so this stays one change; worth revisiting if that provider ever grows a floor.