### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Set up coding agents to use a FreeLLMAPI gateway",
   "license": "MIT",
   "repository": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "cli": {
       "name": "freellmapi",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"


### PR DESCRIPTION
Version bump only. 9 commits since v0.8.0 (2026-08-16).

## App: 0.8.0 -> 0.8.1

**Features**
- feat(providers): add B.AI gateway (#918)
- feat(proxy): add a Test button for the outbound proxy settings (#864)
- feat(cli): `freellmapi doctor`, proves a client's requests reach this gateway (#862)
- feat(contributing): optional commit checklist hook for Claude Code (#860)

**Fixes**
- fix(probe): raise the probe max_tokens above the floor relays enforce (#903)
- fix(media): support model-specific FLUX image payloads (#916)
- fix(models): show the canonical model id on the model detail page (#725)
- fix(cli): resolve --model against the unfiltered catalog before launching (#861)

**Internal**
- chore(server): assert the pure lib modules never gain a value import (#858)

## CLI: 0.3.0 -> 0.4.0

`cli/package.json` has been stuck at 0.3.0 since #629 (2026-07-27), and `cli-release.yml` only publishes when that version changes. So #862 and #861 have been on main but absent from npm: `npx freellmapi` still serves 0.3.0 with no `doctor` command and the --model bug intact.

Minor rather than patch because `doctor` is a new user-facing command. Lockfile updated to match (`packages.cli.version`), so `npm ci` stays consistent.