### PR TITLE
feat(router): same-model cross-provider fallback

### DIFF
--- a/server/src/__tests__/services/router-sibling-fallback.test.ts
+++ b/server/src/__tests__/services/router-sibling-fallback.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initDb, getDb } from '../../db/index.js';
+import { routeRequest, setRoutingStrategy, type ChainRow } from '../../services/router.js';
+import { encrypt } from '../../lib/crypto.js';
+
+// Same-model cross-provider fallback: when a client pins an explicit model
+// and that model_id is also served by other enabled platforms, those sibling
+// rows should be tried immediately after the pinned one once it's ruled out
+// — ahead of an unrelated model that would otherwise win on priority/score.
+
+function addKey(platform: string): void {
+  const { encrypted, iv, authTag } = encrypt(`${platform}-secret`);
+  getDb().prepare(`
+    INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
+    VALUES (?, ?, ?, ?, ?, 'healthy', 1)
+  `).run(platform, platform, encrypted, iv, authTag);
+}
+
+function row(overrides: Partial<ChainRow>): ChainRow {
+  return {
+    model_db_id: 0,
+    priority: 0,
+    enabled: 1,
+    platform: '',
+    model_id: '',
+    display_name: '',
+    intelligence_rank: 50,
+    size_label: 'medium',
+    monthly_token_budget: '',
+    rpm_limit: null,
+    rpd_limit: null,
+    tpm_limit: null,
+    tpd_limit: null,
+    supports_vision: 0,
+    supports_tools: 0,
+    context_window: null,
+    key_id: null,
+    endpoint_scope: '',
+    ...overrides,
+  };
+}
+
+describe('same-model cross-provider fallback', () => {
+  const PINNED_ID = 9001;
+  const UNRELATED_ID = 9002;
+  const SIBLING_ID = 9003;
+
+  // Base priority order (no pin involved): pinned, then the unrelated model
+  // (better priority than the sibling), then the sibling last. This is the
+  // order a failed pin would fall through to WITHOUT the patch.
+  const chain: ChainRow[] = [
+    row({ model_db_id: PINNED_ID, priority: 1, platform: 'groq', model_id: 'shared-model' }),
+    row({ model_db_id: UNRELATED_ID, priority: 2, platform: 'google', model_id: 'different-model' }),
+    row({ model_db_id: SIBLING_ID, priority: 3, platform: 'cerebras', model_id: 'shared-model' }),
+  ];
+
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    getDb().prepare("DELETE FROM settings WHERE key = 'active_profile_id'").run();
+    getDb().prepare('DELETE FROM api_keys').run();
+    setRoutingStrategy('priority');
+    addKey('groq');
+    addKey('google');
+    addKey('cerebras');
+  });
+
+  it('routes to the pinned model first', () => {
+    const route = routeRequest(1000, undefined, PINNED_ID, false, false, undefined, chain);
+    expect(route.platform).toBe('groq');
+    route.release?.();
+  });
+
+  it('falls through to the same-model sibling on another platform, ahead of a better-priority unrelated model', () => {
+    const route = routeRequest(1000, undefined, PINNED_ID, false, false, new Set([PINNED_ID]), chain);
+    expect(route.platform).toBe('cerebras');
+    expect(route.modelId).toBe('shared-model');
+    route.release?.();
+  });
+
+  it('falls through to the unrelated model once both the pin and its sibling are ruled out', () => {
+    const route = routeRequest(1000, undefined, PINNED_ID, false, false, new Set([PINNED_ID, SIBLING_ID]), chain);
+    expect(route.platform).toBe('google');
+    route.release?.();
+  });
+
+  it('is a no-op when the pinned model has no siblings', () => {
+    const noSiblingChain: ChainRow[] = [
+      row({ model_db_id: PINNED_ID, priority: 1, platform: 'groq', model_id: 'solo-model' }),
+      row({ model_db_id: UNRELATED_ID, priority: 2, platform: 'google', model_id: 'different-model' }),
+    ];
+    const route = routeRequest(1000, undefined, PINNED_ID, false, false, new Set([PINNED_ID]), noSiblingChain);
+    expect(route.platform).toBe('google');
+    route.release?.();
+  });
+});

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -1596,7 +1596,10 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   // Sticky session / Explicit pinning: move preferred model to front of chain
   if (preferredModelDbId) {
     const idx = sortedChain.findIndex(e => e.model_db_id === preferredModelDbId);
+    let preferredModelIdForSiblings: string | null = null;
+
     if (idx >= 0) {
+      preferredModelIdForSiblings = sortedChain[idx].model_id;
       if (idx > 0) {
         const [preferred] = sortedChain.splice(idx, 1);
         sortedChain.unshift(preferred);
@@ -1614,9 +1617,34 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
         FROM models m
         WHERE m.id = ? AND m.enabled = 1
       `).get(preferredModelDbId) as ChainRow | undefined;
-      
+
       if (pinnedRow) {
+        preferredModelIdForSiblings = pinnedRow.model_id;
         sortedChain.unshift(pinnedRow);
+      }
+    }
+
+    // Same-model cross-provider fallback (request-scoped, does not touch the
+    // global routing strategy or active profile): when the client pinned an
+    // explicit model_id that is ALSO served by other enabled providers (a
+    // literal model_id collision across platforms — e.g. two catalog rows
+    // both named "gpt-oss-120b"), cluster those sibling rows immediately
+    // behind the pinned one, ahead of the rest of the chain. sortedChain is
+    // already ordered by the active strategy, so pulling siblings out in
+    // place preserves their existing best-first relative order among
+    // themselves. If the pinned model has no siblings (the common case — most
+    // providers mint their own model ids), this is a no-op and behavior is
+    // unchanged from before. Only kicks in for requests that explicitly named
+    // a model; "auto"/sticky routing is untouched.
+    if (preferredModelIdForSiblings) {
+      const siblingIdxs: number[] = [];
+      for (let i = 1; i < sortedChain.length; i++) {
+        if (sortedChain[i].model_id === preferredModelIdForSiblings) siblingIdxs.push(i);
+      }
+      if (siblingIdxs.length > 0) {
+        const siblings = siblingIdxs.map(i => sortedChain[i]);
+        for (let k = siblingIdxs.length - 1; k >= 0; k--) sortedChain.splice(siblingIdxs[k], 1);
+        sortedChain.splice(1, 0, ...siblings);
       }
     }
   }


### PR DESCRIPTION
## What it does

When a client pins an explicit model and that same `model_id` is served by multiple enabled platforms, failed attempts now try sibling rows for the same model immediately after the pinned row, before falling through to unrelated models.

Previously, a failed explicit pin could fall through to whichever unrelated model scored next in the chain.

## Scope

- Request-scoped: only applies when `preferredModelDbId` is set.
- Auto and sticky routing behavior is unchanged.
- No-op when the pinned model has no same-model siblings.

## Tests

Adds four regression tests covering:

- pinned model remains first;
- same-model sibling is selected before an unrelated model;
- unrelated model is selected after all same-model rows are exhausted;
- no-sibling behavior remains unchanged.

Full server test suite: 214 files, 2,352 tests passed, 5 skipped.
Server build passes.
