### PR TITLE
feat(providers): add Volcengine Ark, LongCat and iFlytek Spark (supersedes #922/#923/#924)

### DIFF
--- a/client/src/components/keys/shared.tsx
+++ b/client/src/components/keys/shared.tsx
@@ -63,6 +63,14 @@ export const PLATFORMS: { value: Platform; label: string; url: string; keyless?:
   { value: 'anyapi', label: 'AnyAPI (free key)', url: 'https://anyapi.ai' },
   { value: 'modelscope', label: 'ModelScope (free key, needs Aliyun cn binding)', url: 'https://modelscope.cn/my/myaccesstoken' },
   { value: 'aihorde', label: 'AI Horde (no key needed, slow)', url: 'https://aihorde.net/register', keyless: true },
+  // Chinese domestic providers. All four gate API access behind real-name
+  // verification on the cloud account, so the label says so up front rather
+  // than letting a user mint a key that 401s on every call (the ModelScope
+  // lesson, #581). LongCat is the one that takes an overseas email signup.
+  { value: 'qianfan', label: 'Baidu Qianfan (free ERNIE, needs cn real-name)', url: 'https://console.bce.baidu.com/qianfan/overview' },
+  { value: 'volcengine', label: 'Volcengine Ark (free daily, needs cn real-name)', url: 'https://console.volcengine.com/ark' },
+  { value: 'longcat', label: 'LongCat (free daily, email signup ok)', url: 'https://longcat.chat/platform' },
+  { value: 'xfyun', label: 'iFlytek Spark (free Lite, needs cn real-name)', url: 'https://console.xfyun.cn' },
 ]
 
 // 'custom' is configured through its own form (base URL + model), not the

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -309,6 +309,10 @@ export const platformColors: Record<string, string> = {
   anyapi:      '#0891b2',
   modelscope:  '#624aff',
   aihorde:     '#dc2626',
+  qianfan:     '#2932e1',
+  volcengine:  '#00b8d9',
+  longcat:     '#ffd100',
+  xfyun:       '#1f6fd0',
 }
 
 // ── Grouped (unified) rendering ──────────────────────────────────────────────

--- a/server/src/__tests__/providers/cn-providers.test.ts
+++ b/server/src/__tests__/providers/cn-providers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getProvider } from '../../providers/index.js';
+import { AUTH_JSON_PROVIDER_MAP, detectPlatform } from '../../lib/key-parser.js';
+import type { Platform } from '@freellmapi/shared/types.js';
+
+// Chinese domestic providers (#922/#923/#924). The failure this file guards
+// against is a HALF-registered platform: the original PRs registered the
+// provider and the Platform type but skipped the key-parser and the Keys page,
+// so the provider existed on the server and was unreachable for a user — no way
+// to add a key through the dashboard, and no way to import one from a .env.
+// Registration is only useful when every entry point agrees, so assert them
+// together.
+
+const CN_PLATFORMS: { platform: Platform; baseUrl: string; envPrefixes: string[]; jsonAliases: string[] }[] = [
+  {
+    platform: 'qianfan',
+    baseUrl: 'https://qianfan.baidubce.com/v2',
+    envPrefixes: ['QIANFAN_', 'BAIDU_', 'ERNIE_'],
+    jsonAliases: ['qianfan', 'baidu', 'ernie'],
+  },
+  {
+    platform: 'volcengine',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    envPrefixes: ['VOLCENGINE_', 'VOLC_', 'ARK_', 'DOUBAO_'],
+    jsonAliases: ['volcengine', 'volc', 'ark', 'doubao'],
+  },
+  {
+    platform: 'longcat',
+    baseUrl: 'https://api.longcat.chat/openai/v1',
+    envPrefixes: ['LONGCAT_'],
+    jsonAliases: ['longcat'],
+  },
+  {
+    platform: 'xfyun',
+    baseUrl: 'https://spark-api-open.xf-yun.com/v1',
+    envPrefixes: ['XFYUN_', 'SPARK_', 'IFLYTEK_'],
+    jsonAliases: ['xfyun', 'spark', 'iflytek'],
+  },
+];
+
+describe('Chinese domestic providers: registration', () => {
+  it.each(CN_PLATFORMS)('$platform is registered as an OpenAI-compatible provider', ({ platform }) => {
+    const provider = getProvider(platform);
+    expect(provider).toBeDefined();
+    expect(provider!.platform).toBe(platform);
+  });
+
+  // The base URL is the one thing a typo makes silently useless: every request
+  // 404s at a plausible-looking host. These four are transcribed from each
+  // vendor's own OpenAI-compatibility doc.
+  it.each(CN_PLATFORMS)('$platform points at the documented OpenAI-compatible base URL', ({ platform, baseUrl }) => {
+    const provider = getProvider(platform) as unknown as { baseUrl: string };
+    expect(provider.baseUrl).toBe(baseUrl);
+  });
+});
+
+describe('Chinese domestic providers: key import', () => {
+  it.each(CN_PLATFORMS)('$platform resolves from its .env prefixes', ({ platform, envPrefixes }) => {
+    for (const prefix of envPrefixes) {
+      expect(detectPlatform(prefix)).toBe(platform);
+    }
+  });
+
+  it.each(CN_PLATFORMS)('$platform resolves from its auth.json aliases', ({ platform, jsonAliases }) => {
+    for (const alias of jsonAliases) {
+      expect(AUTH_JSON_PROVIDER_MAP[alias]).toBe(platform);
+    }
+  });
+});

--- a/server/src/lib/key-parser.ts
+++ b/server/src/lib/key-parser.ts
@@ -82,6 +82,17 @@ export const PREFIX_MAP: Record<string, string> = {
   ANYAPI_: 'anyapi',
   ANY_API_: 'anyapi',
   AIHORDE_: 'aihorde',
+  QIANFAN_: 'qianfan',
+  BAIDU_: 'qianfan',
+  ERNIE_: 'qianfan',
+  VOLCENGINE_: 'volcengine',
+  VOLC_: 'volcengine',
+  ARK_: 'volcengine',
+  DOUBAO_: 'volcengine',
+  LONGCAT_: 'longcat',
+  XFYUN_: 'xfyun',
+  SPARK_: 'xfyun',
+  IFLYTEK_: 'xfyun',
 };
 
 export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
@@ -115,6 +126,17 @@ export const AUTH_JSON_PROVIDER_MAP: Record<string, string> = {
   'model-scope': 'modelscope',
   anyapi: 'anyapi',
   'any-api': 'anyapi',
+  qianfan: 'qianfan',
+  baidu: 'qianfan',
+  ernie: 'qianfan',
+  volcengine: 'volcengine',
+  volc: 'volcengine',
+  ark: 'volcengine',
+  doubao: 'volcengine',
+  longcat: 'longcat',
+  xfyun: 'xfyun',
+  spark: 'xfyun',
+  iflytek: 'xfyun',
 };
 
 export function detectPlatform(prefix: string): string | null {

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -395,6 +395,46 @@ register(new OpenAICompatProvider({
 // provider-quota.ts keys on response headers, never on that message text.
 register(new ModelScopeProvider());
 
+// ── Chinese domestic providers (#922/#923/#924) ─────────────────────────────
+// Plain OpenAI-compatible Bearer endpoints, so no dedicated provider class is
+// needed. Every one of these requires Chinese real-name verification on the
+// cloud account before a key serves traffic (LongCat aside — it takes an email
+// signup from outside mainland China). Catalog rows live in the hosted catalog,
+// never in a migration, so a free user cannot pick them up from a binary
+// upgrade ahead of the premium window.
+
+// Baidu Qianfan (百度千帆). ERNIE-Speed / ERNIE-Lite / ERNIE-Tiny are free via
+// pay-as-you-go billing, bounded by rate limits rather than a token balance.
+register(new OpenAICompatProvider({
+  platform: 'qianfan',
+  name: 'Baidu Qianfan',
+  baseUrl: 'https://qianfan.baidubce.com/v2',
+}));
+
+// Volcengine Ark (火山方舟, ByteDance). Doubao models on a recurring daily
+// per-model free reward quota (2M tokens/day/model for individual developers).
+register(new OpenAICompatProvider({
+  platform: 'volcengine',
+  name: 'Volcengine Ark',
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+}));
+
+// LongCat (Meituan / 美团). Daily free quota; the platform also speaks the
+// Anthropic wire format at /anthropic, which we do not use here.
+register(new OpenAICompatProvider({
+  platform: 'longcat',
+  name: 'LongCat',
+  baseUrl: 'https://api.longcat.chat/openai/v1',
+}));
+
+// iFlytek Spark (讯飞星火). Auth is the console APIPassword as a Bearer token;
+// the Lite model is the free one.
+register(new OpenAICompatProvider({
+  platform: 'xfyun',
+  name: 'iFlytek Spark',
+  baseUrl: 'https://spark-api-open.xf-yun.com/v1',
+}));
+
 // AI Horde — free, community-powered inference (volunteer workers) via an
 // OpenAI-compatible proxy. Dedicated AIHordeProvider (not OpenAICompatProvider)
 // because the proxy is queue-based and diverges from the OpenAI contract:

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -31,7 +31,8 @@ const PLATFORMS = [
   'google', 'groq', 'cerebras', 'bai', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
-  'routeway', 'bazaarlink', 'ainative', 'aion', 'anyapi', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'modelscope', 'aihorde', 'custom',
+  'routeway', 'bazaarlink', 'ainative', 'aion', 'anyapi', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'modelscope',
+  'qianfan', 'volcengine', 'longcat', 'xfyun', 'aihorde', 'custom',
 ] as const;
 
 const ALLOWED_IMPORT_EXTENSIONS = new Set(['.env', '.json', '.jsonc', '.md', '.txt', '.csv']);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -139,6 +139,38 @@ export type Platform =
   // verification — tokens mint without binding, then every call 401s. Catalog
   // rows land after community testing confirms per-model behavior (#581).
   | 'modelscope'
+  // ── Chinese domestic providers (#922/#923/#924) ────────────────────────────
+  // All four need Chinese real-name verification (实名认证) on the cloud account
+  // before a key will serve traffic, the same wall ModelScope hits above.
+  // LongCat is the exception worth knowing: its platform accepts an email
+  // signup from outside mainland China.
+  //
+  // Baidu Qianfan (百度千帆) — OpenAI-compatible (https://qianfan.baidubce.com/v2).
+  // The ERNIE-Speed / ERNIE-Lite / ERNIE-Tiny series are free indefinitely via
+  // pay-as-you-go billing rather than a token pool, so the ceiling is rate
+  // limits, not a balance. Baidu calls the arrangement "long-term". Real-name
+  // auth (individual or enterprise) required.
+  | 'qianfan'
+  // Volcengine Ark (火山方舟, ByteDance) — OpenAI-compatible
+  // (https://ark.cn-beijing.volces.com/api/v3). Individual developers get a
+  // RECURRING daily per-model free reward quota (raised from 500K to 2M
+  // tokens/day/model), on top of a one-time 500K new-user grant. The strongest
+  // recurring free tier of the four.
+  | 'volcengine'
+  // LongCat (Meituan / 美团) — OpenAI-compatible
+  // (https://api.longcat.chat/openai/v1); also exposes an Anthropic-compatible
+  // surface at /anthropic. Free tier is daily; the figure quoted at platform
+  // launch was 100K tokens/day. Meituan has ANNOUNCED a 50M tokens/day
+  // Flash-Lite free tier but it was described as a future plan, so it is not
+  // treated as live here.
+  | 'longcat'
+  // iFlytek Spark (讯飞星火) — OpenAI-compatible
+  // (https://spark-api-open.xf-yun.com/v1), Bearer auth using the console's
+  // APIPassword (not the APIKey/APISecret pair the older WebSocket API used).
+  // The Lite model (model id `lite`) is documented as free to call; iFlytek
+  // does not publish a token ceiling or a QPS figure for it, so neither is
+  // claimed here.
+  | 'xfyun'
   // AI Horde — free, community-powered inference (volunteer workers) via an
   // OpenAI-compatible proxy (https://oai.aihorde.net/v1). Queue-based, so calls
   // can take tens of seconds; no tool support; usage is reported as kudos, not


### PR DESCRIPTION
Supersedes #922, #923 and #924. Those three are stacked strict supersets of one
another (922 ⊂ 923 ⊂ 924), so merging more than one conflicts on both
`keys.ts` and `shared/types.ts`.

## Wired at every entry point

The original PRs registered the provider and the `Platform` type but stopped
there, which left every new platform **unreachable**: no Keys-page entry, so no
way to add a key in the dashboard, and no `key-parser` prefixes, so no way to
import one from a `.env` or `auth.json`. This wires all of it:

| File | Added |
|---|---|
| `shared/types.ts` | `qianfan`, `volcengine`, `longcat`, `xfyun` |
| `server/src/providers/index.ts` | 4 `OpenAICompatProvider` registrations |
| `server/src/routes/keys.ts` | zod platform allowlist |
| `server/src/lib/key-parser.ts` | 12 env prefixes + 12 auth.json aliases |
| `client/.../keys/shared.tsx` | Keys page dropdown |
| `client/src/lib/routing.ts` | platform colors |

New `cn-providers.test.ts` asserts all four registration points together, so a
half-wired platform fails CI instead of shipping.

## Endpoints verified

Each base URL was hit live and returns a well-formed OpenAI-shaped auth error
at the exact path the registration uses:

```
longcat     401 invalid_api_key
xfyun       401 Unauthorized
qianfan     429 OverRateLimit
volcengine  401 AuthenticationError
```

## Provider facts corrected against vendor docs

- **LongCat is Meituan (美团)**, not 面壁智能 as #923/#924 claimed.
- LongCat's launch free tier is **100K tokens/day**; the 50M/day Flash-Lite
  figure was announced as a *future plan* and is not asserted.
- iFlytek publishes **no** token cap and no QPS for Spark Lite, so #924's
  "QPS=2" is dropped.
- Volcengine's recurring **2M tokens/day/model** daily quota is real and is the
  strongest free tier of the group.

## Tencent Hunyuan deliberately excluded

`hunyuan-lite` was made free in May 2024 — the source of #922's text — but
Tencent's current pricing doc no longer lists that model, and the free
allowance is now a one-time 1M-token grant valid one year with no
replenishment. That does not meet the recurring-free bar.

## Baidu Qianfan registered but carries no catalog rows

Same trap: the "permanently free ERNIE-Speed/Lite" claim traces to a May 2024
announcement. Baidu's own retirement doc retired ERNIE-Speed-8K/128K,
ERNIE-Lite-8K and ERNIE-Tiny-8K on **2026-01-27**, and the named replacements
are paid. The platform is registered so a row is a one-line addition if that
changes.

Catalog rows ship through the signed hosted catalog, never a migration
(`catalog/ops/README.md`).

## Tests

`npm run build` clean; `npm test` green — 2384 server + 95 + 90 client tests,
i18n validates across 60 locales.