### PR TITLE
fix(anthropic): list Claude-family ids so gateway pickers find models (#880)

### DIFF
--- a/server/src/__tests__/routes/anthropic.test.ts
+++ b/server/src/__tests__/routes/anthropic.test.ts
@@ -424,6 +424,29 @@ describe('Anthropic-compatible /v1/messages', () => {
     }
   });
 
+  // #880: Claude Desktop fetched the whole catalog over HTTP 200 and still
+  // reported "found 0 models", because it only accepts Claude-family ids. The
+  // listing now carries one id per family, and each one routes.
+  it('GET /v1/models lists a Claude-family id that /v1/messages then serves', async () => {
+    const { body } = await send(app, 'GET', '/v1/models', undefined, anthropicHeaders());
+    const sonnet = body.data.find((m: any) => m.id === 'claude-sonnet-4-5');
+    expect(sonnet).toBeTruthy();
+    expect(sonnet.type).toBe('model');
+    // The label must not read as hosted Claude.
+    expect(sonnet.display_name).toContain('Sonnet slot');
+    for (const id of ['claude-opus-4-5', 'claude-haiku-4-5']) {
+      expect(body.data.some((m: any) => m.id === id)).toBe(true);
+    }
+
+    // The whole point: a client that picks a discovered id gets a real answer.
+    const captured = mockJson(textCompletion('family slot routed'));
+    const response = await request(app, '/v1/messages', {
+      model: sonnet.id, max_tokens: 32, messages: [{ role: 'user', content: 'hello' }],
+    }, anthropicHeaders());
+    expect(response.status).toBe(200);
+    expect(captured.body).toBeTruthy();
+  });
+
   it('gates Claude Code discovery aliases and routes a selected alias', async () => {
     const hidden = await send(app, 'GET', '/v1/models', undefined, anthropicHeaders());
     expect(hidden.body.data.some((model: any) => model.id.startsWith('claude/'))).toBe(false);

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -23,7 +23,7 @@ import { extractApiToken, timingSafeStringEqual, getStickyModel, setStickyModel 
 import { runFallbackLoop, newFallbackState, recordUpstreamSuccess, type ExhaustionBody, setFallbackHeaders, setExhaustionHeaders, type AttemptRecord } from '../lib/fallback-loop.js';
 import { routedViaValue } from '../lib/header-value.js';
 import { applyTokenBudget, tokenBudgetMessage } from '../lib/guardrails.js';
-import { resolveAnthropicModel } from '../services/anthropic-map.js';
+import { resolveAnthropicModel, claudeFamilyDiscoveryEntries } from '../services/anthropic-map.js';
 import type { ReasoningEffort } from '../lib/sampling-params.js';
 import { buildModelListing } from '../services/model-listing.js';
 import { compressRequest, formatCompressionHeader } from '../services/compression/pipeline.js';
@@ -1018,8 +1018,13 @@ anthropicRouter.post('/messages/count_tokens', (req: Request, res: Response) => 
 // the caller speaks Anthropic (sends an `anthropic-version` header, as Claude
 // Code does) — otherwise it calls next() and the OpenAI-shaped handler in
 // proxyRouter serves the same path. Lists the SAME catalog as the OpenAI
-// endpoint (real free models that can serve a request right now, plus "auto") —
-// no fake Claude cloud models.
+// endpoint (real free models that can serve a request right now, plus "auto").
+// Nothing here is hosted Claude, and no entry claims to be.
+//
+// One entry per Claude family (claude-sonnet-4-5 and friends) rides along so
+// clients that only accept Claude-shaped ids can discover anything at all; see
+// CLAUDE_FAMILY_ALIASES for why, and note /messages already routed those ids
+// long before they were listed here.
 //
 // Optional `claude/<real-id>` aliases let Claude Code's gateway picker discover
 // the full catalog; /messages strips the synthetic prefix before routing.
@@ -1032,6 +1037,16 @@ anthropicRouter.get('/models', (req: Request, res: Response, next: NextFunction)
   const aliasesEnabled = getSetting('expose_cc_discovery_aliases') === '1';
   const data = [
     { type: 'model' as const, id: 'auto', display_name: 'Auto (router picks the best available model)', created_at: MODEL_CREATED_AT },
+    // Only when something can actually serve them: advertising a Sonnet slot
+    // backed by an empty pool would trade "0 models" for a model that 503s.
+    ...(available.length > 0
+      ? claudeFamilyDiscoveryEntries().map(a => ({
+        type: 'model' as const,
+        id: a.id,
+        display_name: a.displayName,
+        created_at: MODEL_CREATED_AT,
+      }))
+      : []),
     ...available.map(m => ({ type: 'model' as const, id: m.id, display_name: m.name, created_at: MODEL_CREATED_AT })),
     ...(aliasesEnabled
       ? available.map(m => ({

--- a/server/src/services/anthropic-map.ts
+++ b/server/src/services/anthropic-map.ts
@@ -104,3 +104,39 @@ export function resolveAnthropicModel(model?: string): ResolvedAnthropicModel {
   const id = lookupEnabled((model ?? '').trim());
   return id != null ? { preferredModelDbId: id, pinned: true } : { pinned: false };
 }
+
+// The canonical Claude id this gateway answers to for each family, and the
+// label discovery shows for it.
+//
+// These are NOT real Claude cloud models and are not presented as such: every
+// one of them is already accepted by `/v1/messages`, where classifyClaudeFamily
+// maps it onto the free pool through the operator's family map. They are listed
+// in `GET /v1/models` because some Anthropic clients only accept ids that look
+// like Claude models and reject a catalog of free-model ids outright. Claude
+// Desktop's third-party gateway picker is the reported case (#880): it fetched
+// the full catalog over HTTP 200 and still reported "found 0 models", because
+// nothing in it belonged to a Claude family.
+//
+// Listing them is honest in the sense that matters for discovery: these are ids
+// the gateway really will serve. The display name says where the request
+// actually goes so nobody reads the entry as hosted Claude.
+export const CLAUDE_FAMILY_ALIASES: { id: string; family: ClaudeFamily; label: string }[] = [
+  { id: 'claude-opus-4-5', family: 'opus', label: 'Opus' },
+  { id: 'claude-sonnet-4-5', family: 'sonnet', label: 'Sonnet' },
+  { id: 'claude-haiku-4-5', family: 'haiku', label: 'Haiku' },
+];
+
+// Discovery entries for the family aliases, named after where each one routes:
+// the pinned catalog model when the operator pinned one, otherwise the router.
+export function claudeFamilyDiscoveryEntries(): { id: string; displayName: string }[] {
+  const map = getClaudeModelMap();
+  return CLAUDE_FAMILY_ALIASES.map(({ id, family, label }) => {
+    const target = map[family];
+    return {
+      id,
+      displayName: !target || target === 'auto'
+        ? `${label} slot (auto-routed to a free model)`
+        : `${label} slot (routed to ${target})`,
+    };
+  });
+}


### PR DESCRIPTION
Fixes #880.

## What was happening

Claude Desktop's third-party gateway discovery hit `GET /v1/models`, got HTTP 200 and a catalog of 100+ models, and still reported **"Gateway returned no usable models"**. The reporter verified the endpoint by hand and it answered correctly in both the OpenAI and the Anthropic shape, which is what made this confusing.

The listing only ever contained real free-model ids (`qwen3.5-397b`, `gpt-oss-120b`, `deepseek-v4-flash`) plus `auto`. None of them belongs to a Claude family, so a client that validates discovered ids against the Claude families rejects every single one and lands on zero.

## Why the fix is small

The routing half already worked. `classifyClaudeFamily` in `server/src/services/anthropic-map.ts` has always accepted any `claude-*` alias at `/v1/messages` and resolved it through the operator's family map, to `auto` or to a pinned catalog model. Discovery just never mentioned those ids, so a picker had nothing to select even though the gateway would happily serve them.

So this lists one canonical id per family next to the real catalog:

- `claude-opus-4-5`
- `claude-sonnet-4-5`
- `claude-haiku-4-5`

## On not faking Claude

The handler comment said "no fake Claude cloud models" and that intent is kept. These entries are ids the gateway genuinely serves, not hosted Claude, and the display name says so outright:

- `Sonnet slot (auto-routed to a free model)` when the family maps to `auto`
- `Sonnet slot (routed to <model>)` when the operator pinned one

They also only appear when at least one model can actually serve them. Advertising a Sonnet slot backed by an empty pool would just trade "0 models" for a model that 503s on first use.

## Not gated behind a setting

I left this ungated rather than putting it behind a sibling of `expose_cc_discovery_aliases`. A default-off fix would leave the reported bug intact for anyone who does not find the toggle, and these ids were already routable, so listing them is closer to correcting the listing than to adding a feature. Happy to gate it if you would rather.

## Testing

`npm run test -w server` is green: 216 files, 2385 passed, 5 skipped. New test asserts the family id appears, that its label does not read as hosted Claude, and that posting the discovered id to `/v1/messages` actually gets served.

## One caveat worth flagging

I diagnosed this from our side of the wire. The evidence fits tightly (200 + full catalog + zero usable is exactly what id-family filtering looks like), but I could not run Claude Desktop against the gateway to confirm its validation rule, and it may also want dated ids like `claude-sonnet-4-5-20250929`. I deliberately did not invent dated ids. Worth asking @Arman-Espiar to confirm against a build before we treat this as fully closed.