### PR TITLE
fix(i18n): complete zh-CN translations for switchToEnglish and planGeneric (#315)

### DIFF
--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -12,7 +12,7 @@
     "switchLight": "切换到浅色主题",
     "switchDark": "切换到深色主题",
     "switchToChinese": "切换到中文",
-    "switchToEnglish": "Switch to English",
+    "switchToEnglish": "切换到英文",
     "modelsMenu": "浏览模型类型",
     "agents": "智能体"
   },
@@ -672,7 +672,7 @@
     "upsellDescription": "新免费模型上线即用，无需等待 30 天。一个密钥，所有设备。随时取消，路由器永久免费。",
     "goPremium": "升级到高级版",
     "bundled": "内置",
-    "planGeneric": "Premium"
+    "planGeneric": "高级版"
   },
   "languages": {
     "en": "English",


### PR DESCRIPTION
## 中文

认领 #315 简体中文审阅。

经逐键比对 en.json（749 键），发现初始中文译本中有 2 处漏翻（值与英文完全相同）：

- nav.switchToEnglish: 'Switch to English' -> '切换到英文'
- premium.planGeneric: 'Premium' -> '高级版'

其余 747 键均已正确翻译，或属有意保留原文的类别：语言名（languages.*，60 项）、品牌/模型名（Anthropic、Gemini Pro/Flash、Opus/Sonnet/Haiku，7 项）、缩写术语（RPM/RPD/TPM/TPD、Base URL、Messages，8 项）、占位符/代码（fla_XXX、new-password、you@example.com 等，4 项）。

验证：JSON 语法正确，check-i18n 60 locales / 749 keys 全绿。

## English

Claiming #315 zh-CN review.

Compared all 749 keys against en.json - found 2 untranslated strings (identical to English):

- nav.switchToEnglish: 'Switch to English' -> '切换到英文'
- premium.planGeneric: 'Premium' -> '高级版'

The other 747 keys are either correctly translated or intentionally kept in English: language names (languages.*, 60), brand/model names (Anthropic, Gemini Pro/Flash, Opus/Sonnet/Haiku, 7), acronyms (RPM/RPD/TPM/TPD, Base URL, Messages, 8), placeholders/code (fla_XXX, new-password, you@example.com, etc., 4).

Verified: JSON valid, check-i18n 60 locales / 749 keys all green.