### PR TITLE
fix(ui): prevent monthly token budget figures from wrapping off-screen (#887)

### DIFF
--- a/client/src/components/token-usage-bar.tsx
+++ b/client/src/components/token-usage-bar.tsx
@@ -44,7 +44,7 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
 
   return (
     <section className="rounded-3xl border bg-card p-5">
-      <div className="flex items-baseline justify-between mb-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 mb-3">
         <h2 className="text-sm font-medium">{t('models.monthlyTokenBudget')}</h2>
         <span className="text-xs text-muted-foreground tabular-nums">
           <span className="text-foreground font-medium">{formatTokens(remaining)}</span> {t('models.remaining')}


### PR DESCRIPTION
## 中文

修复 #887 monthly token budget 数字被遮挡的问题。

### 问题

token-usage-bar.tsx 顶部统计行（remaining · % of total · used）使用 flex 不加 wrap，在窄屏时 used-amount 数字被推到屏幕外。

### 修复

添加 flex-wrap + gap-x-3 gap-y-1，让统计行在空间不足时自动换行到第二行，不再被截断。

### 验证

- client tsc -b ✅

## English

Fixes #887 monthly token budget figures obscured.

### Problem

The summary line (remaining · % of total · used) in token-usage-bar.tsx used flex without wrap, pushing the used-amount figure off-screen on narrow viewports.

### Fix

Add flex-wrap + gap-x-3 gap-y-1 so the stats wrap to a second line when space is tight.

### Verification

- client tsc -b ✅