### PR TITLE
Analytics: show every provider label on the category charts (#890)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "jsdom": "^30.0.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^30.0.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",

--- a/client/src/lib/chart-axis.render.test.tsx
+++ b/client/src/lib/chart-axis.render.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+//
+// The prop-shape tests next door prove `categoryAxisProps()` returns the right
+// numbers. They cannot prove those numbers change what recharts draws — the
+// original #890 fix would have passed them even if the props had been spread
+// onto the wrong element. So this file mounts a real recharts <BarChart> and
+// counts the <text> ticks that come out, both with and without our props.
+//
+// Two things make that work under jsdom:
+//
+//  1. recharts needs a laid-out size, and jsdom lays nothing out. We pass
+//     explicit width/height to the chart instead of using ResponsiveContainer.
+//  2. recharts decides which ticks to drop by *measuring* each label: it puts
+//     the text in a hidden span and reads getBoundingClientRect(). jsdom
+//     returns zeroes there, so every label would look infinitely thin and
+//     nothing would ever be dropped — the "before" case would silently pass.
+//     We stub the rect with a simple monospace-ish metric so the drop logic
+//     has real widths to work with.
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { act } from 'react'
+import type { ReactElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { Bar, BarChart, XAxis, YAxis } from 'recharts'
+import { categoryAxisProps, verticalCategoryAxisProps } from './chart-axis'
+
+/** Stand-in glyph width, in px, for the measurement stub below. */
+const MEASURED_CHAR_WIDTH = 6
+
+const realGetBoundingClientRect = Element.prototype.getBoundingClientRect
+
+beforeAll(() => {
+  ;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+  Element.prototype.getBoundingClientRect = function measured(this: Element): DOMRect {
+    const text = this.textContent ?? ''
+    const fontSize = Number.parseFloat((this as HTMLElement).style?.fontSize ?? '') || 11
+    const width = text.length * MEASURED_CHAR_WIDTH
+    const height = fontSize * 1.2
+    return {
+      width,
+      height,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+})
+
+afterAll(() => {
+  Element.prototype.getBoundingClientRect = realGetBoundingClientRect
+})
+
+const CHART_WIDTH = 400
+const CHART_HEIGHT = 240
+const tickStyle = { fontSize: 11 } as const
+
+// 16 providers, each name long enough that recharts has to make a choice, and
+// each still distinguishable after the steep tier truncates it to 12 chars.
+const CATEGORY_COUNT = 16
+const platforms = Array.from({ length: CATEGORY_COUNT }, (_, i) => ({
+  platform: `p${String(i).padStart(2, '0')}-provider-name`,
+  requests: i + 1,
+}))
+const errorCategories = Array.from({ length: CATEGORY_COUNT }, (_, i) => ({
+  category: `e${String(i).padStart(2, '0')}-error-kind`,
+  count: i + 1,
+}))
+
+function renderTicks(node: ReactElement, axisSelector: string): string[] {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root = createRoot(host)
+  act(() => {
+    root.render(node)
+  })
+  const ticks = [...host.querySelectorAll(`${axisSelector} .recharts-cartesian-axis-tick-value`)]
+    .map((el) => el.textContent ?? '')
+  act(() => {
+    root.unmount()
+  })
+  host.remove()
+  return ticks
+}
+
+describe('category XAxis rendering (#890)', () => {
+  it('drops most provider labels with recharts defaults', () => {
+    const ticks = renderTicks(
+      <BarChart width={CHART_WIDTH} height={CHART_HEIGHT} data={platforms}>
+        <XAxis dataKey="platform" tick={tickStyle} />
+        <Bar dataKey="requests" />
+      </BarChart>,
+      '.recharts-xAxis-tick-labels',
+    )
+    // This is the bug: 'preserveEnd' thins the axis right out. (The guard on
+    // the low end keeps this from passing vacuously if the chart ever stops
+    // rendering at all under jsdom.)
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(ticks.length).toBeLessThan(CATEGORY_COUNT)
+    expect(ticks).not.toContain(platforms[0].platform)
+  })
+
+  it('renders every provider label with categoryAxisProps()', () => {
+    const props = categoryAxisProps(CATEGORY_COUNT)
+    const ticks = renderTicks(
+      <BarChart width={CHART_WIDTH} height={CHART_HEIGHT} data={platforms}>
+        <XAxis dataKey="platform" tick={tickStyle} {...props} />
+        <Bar dataKey="requests" />
+      </BarChart>,
+      '.recharts-xAxis-tick-labels',
+    )
+    expect(ticks).toHaveLength(CATEGORY_COUNT)
+    // Every category is present, and each is still telling them apart.
+    expect(ticks).toEqual(platforms.map((p) => props.tickFormatter(p.platform)))
+    expect(new Set(ticks).size).toBe(CATEGORY_COUNT)
+  })
+
+  it('still renders every label when the categories are few', () => {
+    const few = platforms.slice(0, 6)
+    const props = categoryAxisProps(few.length)
+    const ticks = renderTicks(
+      <BarChart width={CHART_WIDTH} height={CHART_HEIGHT} data={few}>
+        <XAxis dataKey="platform" tick={tickStyle} {...props} />
+        <Bar dataKey="requests" />
+      </BarChart>,
+      '.recharts-xAxis-tick-labels',
+    )
+    expect(ticks).toHaveLength(few.length)
+  })
+})
+
+describe('category YAxis rendering, layout="vertical" (#890)', () => {
+  it('drops error-category labels with recharts defaults', () => {
+    const ticks = renderTicks(
+      <BarChart width={CHART_WIDTH} height={CHART_HEIGHT} data={errorCategories} layout="vertical">
+        <XAxis type="number" tick={tickStyle} />
+        <YAxis type="category" dataKey="category" tick={tickStyle} width={128} />
+        <Bar dataKey="count" />
+      </BarChart>,
+      '.recharts-yAxis-tick-labels',
+    )
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(ticks.length).toBeLessThan(CATEGORY_COUNT)
+    expect(ticks).not.toContain(errorCategories[0].category)
+  })
+
+  it('renders every error-category label with verticalCategoryAxisProps()', () => {
+    const props = verticalCategoryAxisProps()
+    const ticks = renderTicks(
+      <BarChart width={CHART_WIDTH} height={CHART_HEIGHT} data={errorCategories} layout="vertical">
+        <XAxis type="number" tick={tickStyle} />
+        <YAxis type="category" dataKey="category" tick={tickStyle} {...props} />
+        <Bar dataKey="count" />
+      </BarChart>,
+      '.recharts-yAxis-tick-labels',
+    )
+    expect(ticks).toHaveLength(CATEGORY_COUNT)
+    expect(ticks).toEqual(errorCategories.map((e) => props.tickFormatter(e.category)))
+  })
+})

--- a/client/src/lib/chart-axis.test.ts
+++ b/client/src/lib/chart-axis.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { categoryAxisProps, truncateAxisLabel, MAX_AXIS_LABEL } from './chart-axis'
+
+describe('categoryAxisProps (#890)', () => {
+  it('forces every tick so recharts never skips a provider label', () => {
+    // The default 'preserveStartEnd' interval is exactly what hid the middle
+    // provider names; 0 means "render a tick for every category".
+    expect(categoryAxisProps().interval).toBe(0)
+  })
+
+  it('rotates labels and reserves vertical room for them', () => {
+    const p = categoryAxisProps()
+    expect(p.angle).not.toBe(0)
+    expect(p.textAnchor).toBe('end')
+    expect(p.height).toBeGreaterThan(30)
+  })
+
+  it('truncates over-long labels but leaves short ones alone', () => {
+    expect(truncateAxisLabel('groq')).toBe('groq')
+    expect(truncateAxisLabel('x'.repeat(MAX_AXIS_LABEL))).toBe('x'.repeat(MAX_AXIS_LABEL))
+    const long = truncateAxisLabel('anthropic-compatible-very-long-relay-host')
+    expect(long.length).toBe(MAX_AXIS_LABEL)
+    expect(long.endsWith('…')).toBe(true)
+  })
+
+  it('truncation is stable (idempotent) so a second pass changes nothing', () => {
+    const once = truncateAxisLabel('anthropic-compatible-very-long-relay-host')
+    expect(truncateAxisLabel(once)).toBe(once)
+  })
+})

--- a/client/src/lib/chart-axis.test.ts
+++ b/client/src/lib/chart-axis.test.ts
@@ -1,20 +1,96 @@
 import { describe, expect, it } from 'vitest'
-import { categoryAxisProps, truncateAxisLabel, MAX_AXIS_LABEL } from './chart-axis'
+import type { CategoryAxisProps } from './chart-axis'
+import {
+  categoryAxisProps,
+  truncateAxisLabel,
+  verticalCategoryAxisProps,
+  MAX_AXIS_LABEL,
+  MAX_AXIS_LABEL_STEEP,
+  VERTICAL_AXIS_WIDTH,
+} from './chart-axis'
+
+// Same estimate the module sizes itself with: ~0.5em per glyph at 11px.
+const CHAR_WIDTH = 5.5
+const LINE_HEIGHT = 13
+const NARROW_PLOT_WIDTH = 280
+
+const sin = (deg: number) => Math.sin((Math.abs(deg) * Math.PI) / 180)
 
 describe('categoryAxisProps (#890)', () => {
   it('forces every tick so recharts never skips a provider label', () => {
-    // The default 'preserveStartEnd' interval is exactly what hid the middle
-    // provider names; 0 means "render a tick for every category".
-    expect(categoryAxisProps().interval).toBe(0)
+    // recharts' default interval is 'preserveEnd', which is exactly what hid
+    // the middle provider names; 0 means "render a tick for every category".
+    for (const count of [0, 1, 5, 10, 11, 15, 16, 40]) {
+      expect(categoryAxisProps(count).interval).toBe(0)
+    }
   })
 
   it('rotates labels and reserves vertical room for them', () => {
-    const p = categoryAxisProps()
+    const p = categoryAxisProps(5)
     expect(p.angle).not.toBe(0)
     expect(p.textAnchor).toBe('end')
     expect(p.height).toBeGreaterThan(30)
   })
 
+  it('tilts harder as the chart gets more crowded', () => {
+    // A handful of providers reads best on a gentle tilt...
+    expect(categoryAxisProps(4).angle).toBe(-30)
+    expect(categoryAxisProps(10).angle).toBe(-30)
+    // ...but past what -30° can seat on a phone the labels have to steepen.
+    expect(categoryAxisProps(11).angle).toBe(-45)
+    expect(categoryAxisProps(15).angle).toBe(-45)
+    expect(categoryAxisProps(16).angle).toBe(-90)
+    // Beyond even the vertical tier's capacity we stay vertical — there is
+    // nothing steeper, and interval 0 still beats dropping labels.
+    expect(categoryAxisProps(500).angle).toBe(-90)
+  })
+
+  it('never lets a tilt pack labels closer together than they are thick', () => {
+    // The point of the tiers: at the chosen angle, each label's horizontal
+    // footprint must still fit the slice of a narrow (mobile) plot it gets.
+    for (const count of [1, 5, 10, 11, 15, 16, 21]) {
+      const { angle } = categoryAxisProps(count)
+      const bandNeeded = LINE_HEIGHT / sin(angle)
+      const bandAvailable = NARROW_PLOT_WIDTH / Math.max(count, 1)
+      expect(bandAvailable).toBeGreaterThanOrEqual(bandNeeded)
+    }
+  })
+
+  it('reserves enough height for the longest label it will actually draw', () => {
+    // The original fix under-provisioned this: an 18-char label at -30° needs
+    // ~50px and only ~48 were left after the tick gap.
+    const longest = 'x'.repeat(64)
+    for (const count of [1, 8, 10, 11, 15, 16, 40]) {
+      const p = categoryAxisProps(count)
+      const drawn = p.tickFormatter(longest)
+      const needed = drawn.length * CHAR_WIDTH * sin(p.angle)
+      expect(p.height).toBeGreaterThanOrEqual(needed)
+    }
+  })
+
+  it('keeps the reserved strip a sane share of a 240px chart', () => {
+    for (const count of [1, 12, 16, 40]) {
+      expect(categoryAxisProps(count).height).toBeLessThanOrEqual(80)
+    }
+  })
+
+  it('truncates to the cap that matches the tier it picked', () => {
+    const long = 'anthropic-compatible-very-long-relay-host'
+    expect(categoryAxisProps(4).tickFormatter(long).length).toBe(MAX_AXIS_LABEL)
+    expect(categoryAxisProps(40).tickFormatter(long).length).toBe(MAX_AXIS_LABEL_STEEP)
+  })
+
+  it('assumes the roomiest tier when the caller does not pass a count', () => {
+    // Compare the plain fields: the two tickFormatters are equivalent
+    // closures, but not the same object, so toEqual would trip over them.
+    const bare = ({ interval, angle, textAnchor, height }: CategoryAxisProps) =>
+      ({ interval, angle, textAnchor, height })
+    expect(bare(categoryAxisProps())).toEqual(bare(categoryAxisProps(1)))
+    expect(categoryAxisProps().tickFormatter('x'.repeat(64)).length).toBe(MAX_AXIS_LABEL)
+  })
+})
+
+describe('truncateAxisLabel', () => {
   it('truncates over-long labels but leaves short ones alone', () => {
     expect(truncateAxisLabel('groq')).toBe('groq')
     expect(truncateAxisLabel('x'.repeat(MAX_AXIS_LABEL))).toBe('x'.repeat(MAX_AXIS_LABEL))
@@ -23,8 +99,33 @@ describe('categoryAxisProps (#890)', () => {
     expect(long.endsWith('…')).toBe(true)
   })
 
+  it('honours an explicit cap', () => {
+    expect(truncateAxisLabel('anthropic-relay', 8)).toBe('anthrop…')
+  })
+
   it('truncation is stable (idempotent) so a second pass changes nothing', () => {
     const once = truncateAxisLabel('anthropic-compatible-very-long-relay-host')
     expect(truncateAxisLabel(once)).toBe(once)
+  })
+})
+
+describe('verticalCategoryAxisProps (#890, errors-by-category)', () => {
+  it('forces every tick on the category (Y) axis of a vertical bar chart', () => {
+    // implicitYAxis defaults to 'preserveEnd' just like the X one, so the
+    // horizontal "errors by category" chart dropped labels the same way.
+    expect(verticalCategoryAxisProps().interval).toBe(0)
+  })
+
+  it('keeps the gutter it reserves and truncates labels to fit it', () => {
+    const p = verticalCategoryAxisProps()
+    expect(p.width).toBe(VERTICAL_AXIS_WIDTH)
+    const drawn = p.tickFormatter('upstream-authentication-failed')
+    expect(drawn.length * CHAR_WIDTH).toBeLessThanOrEqual(VERTICAL_AXIS_WIDTH)
+    expect(drawn.endsWith('…')).toBe(true)
+    expect(p.tickFormatter('rate_limit')).toBe('rate_limit')
+  })
+
+  it('does not rotate — a side-on axis has its own gutter, not a tick pitch', () => {
+    expect(verticalCategoryAxisProps()).not.toHaveProperty('angle')
   })
 })

--- a/client/src/lib/chart-axis.ts
+++ b/client/src/lib/chart-axis.ts
@@ -1,0 +1,47 @@
+// recharts XAxis props for the category (provider / agent / error) bar charts
+// on the analytics page.
+//
+// recharts' default `interval` is 'preserveStartEnd': when there are more
+// categories than fit in the width, it silently DROPS the middle ticks so the
+// labels don't overlap. The visible result is the #890 complaint — only a few
+// provider names render, the rest are only visible on hover, and the bars no
+// longer line up with the labels the user can actually see (a bar with no label
+// looks like a different provider than it is).
+//
+// The fix is to force EVERY tick (`interval={0}`) and rotate + truncate the
+// labels so they fit without overlapping. These are exactly the props the
+// category charts need on top of the shared `tick` style; the timeline
+// (timestamp) charts are time series and don't need them.
+
+export interface CategoryAxisProps {
+  /** Show every category tick instead of letting recharts skip the middle ones. */
+  interval: 0
+  /** Tilt the labels so long provider names don't collide horizontally. */
+  angle: number
+  /** Anchor rotated labels to their tick. */
+  textAnchor: 'end'
+  /** Vertical room reserved for the (rotated) labels under the plot. */
+  height: number
+  /** Truncate over-long labels so the rotated ticks stay legible. */
+  tickFormatter: (value: string) => string
+}
+
+// Longest label shown in full; anything longer is elided with an ellipsis.
+// 18 chars at 11px rotated ~30° fits comfortably in the reserved axis height.
+export const MAX_AXIS_LABEL = 18
+
+export function truncateAxisLabel(value: string): string {
+  if (value.length <= MAX_AXIS_LABEL) return value
+  return value.slice(0, MAX_AXIS_LABEL - 1) + '…'
+}
+
+/** The XAxis props that make a category chart show all of its labels. */
+export function categoryAxisProps(): CategoryAxisProps {
+  return {
+    interval: 0,
+    angle: -30,
+    textAnchor: 'end',
+    height: 56,
+    tickFormatter: truncateAxisLabel,
+  }
+}

--- a/client/src/lib/chart-axis.ts
+++ b/client/src/lib/chart-axis.ts
@@ -1,17 +1,83 @@
-// recharts XAxis props for the category (provider / agent / error) bar charts
-// on the analytics page.
+// recharts axis props for the category (provider / agent / error) bar charts on
+// the analytics page.
 //
-// recharts' default `interval` is 'preserveStartEnd': when there are more
-// categories than fit in the width, it silently DROPS the middle ticks so the
-// labels don't overlap. The visible result is the #890 complaint — only a few
-// provider names render, the rest are only visible on hover, and the bars no
-// longer line up with the labels the user can actually see (a bar with no label
-// looks like a different provider than it is).
+// recharts' default `interval` is 'preserveEnd' (see `implicitXAxis` /
+// `implicitYAxis` in recharts' axisSelectors): when the labels are wider than
+// the space available it silently DROPS ticks, keeping the tail and thinning
+// out everything before it. The visible result is the #890 complaint — only a
+// few provider names render, the rest are only visible on hover, and the bars
+// no longer line up with the labels the user can actually see (a bar with no
+// label looks like a different provider than it is).
 //
-// The fix is to force EVERY tick (`interval={0}`) and rotate + truncate the
-// labels so they fit without overlapping. These are exactly the props the
-// category charts need on top of the shared `tick` style; the timeline
-// (timestamp) charts are time series and don't need them.
+// The fix is to force EVERY tick (`interval={0}`) and then make the labels fit
+// by rotating and truncating them. Forcing the ticks on its own just trades a
+// dropped label for an unreadable pile of overlapping ones, so the rotation
+// has to be chosen from how many categories there are — hence the tiers below.
+// The timeline (timestamp) charts are time series and want none of this.
+
+/** `fontSize` the analytics axes render their ticks at. */
+export const AXIS_FONT_SIZE = 11
+
+/**
+ * Average advance width of one glyph at {@link AXIS_FONT_SIZE} in the UI font.
+ * Deliberately an estimate: this module has to size the axis before layout, so
+ * it cannot measure. ~0.5em is a good average for lowercase Latin in a
+ * humanist sans, and provider/agent names are lowercase-heavy.
+ */
+const CHAR_WIDTH = 5.5
+
+/** Line box of a single-line tick label — its thickness across the rotation. */
+const LINE_HEIGHT = 13
+
+/** Gap between the plot edge and the start of the label (tick line + margin). */
+const TICK_GAP = 8
+
+/**
+ * Plot width of the narrowest panel we lay out for: the analytics grid is
+ * `grid-cols-1` under `lg`, so on a phone a chart gets roughly this many
+ * pixels. Every tier below is sized so its labels still clear each other here,
+ * which means they clear each other on every wider screen too.
+ */
+const NARROW_PLOT_WIDTH = 280
+
+/** Longest label shown in full on a shallow tier; longer ones are elided. */
+export const MAX_AXIS_LABEL = 18
+
+/**
+ * Longest label on the steep (-90°) tier. A vertical label spends its whole
+ * length on the axis height, so an 18-char cap there would eat ~110px of a
+ * 240px chart. 12 keeps the reserved strip in line with the other tiers.
+ */
+export const MAX_AXIS_LABEL_STEEP = 12
+
+const toRadians = (degrees: number) => (Math.abs(degrees) * Math.PI) / 180
+
+/** Horizontal room one rotated label occupies, i.e. the minimum tick spacing. */
+function bandWidth(angle: number): number {
+  return LINE_HEIGHT / Math.sin(toRadians(angle))
+}
+
+/** Vertical room a `maxChars`-long label needs once rotated to `angle`. */
+function axisHeight(angle: number, maxChars: number): number {
+  return Math.ceil(maxChars * CHAR_WIDTH * Math.sin(toRadians(angle))) + TICK_GAP
+}
+
+/** How many categories fit at `angle` before the labels start to collide. */
+function categoryCapacity(angle: number): number {
+  return Math.floor(NARROW_PLOT_WIDTH / bandWidth(angle))
+}
+
+/**
+ * Shallowest rotation first. A shallower angle is easier to read and costs
+ * less vertical room; a steeper one packs more categories in. We take the
+ * first tier that can seat the data, so charts with a handful of providers
+ * keep the gentle -30° tilt and only crowded ones pay for -45°/-90°.
+ */
+const TIERS: ReadonlyArray<{ angle: number; maxChars: number }> = [
+  { angle: -30, maxChars: MAX_AXIS_LABEL },
+  { angle: -45, maxChars: MAX_AXIS_LABEL },
+  { angle: -90, maxChars: MAX_AXIS_LABEL_STEEP },
+]
 
 export interface CategoryAxisProps {
   /** Show every category tick instead of letting recharts skip the middle ones. */
@@ -26,22 +92,59 @@ export interface CategoryAxisProps {
   tickFormatter: (value: string) => string
 }
 
-// Longest label shown in full; anything longer is elided with an ellipsis.
-// 18 chars at 11px rotated ~30° fits comfortably in the reserved axis height.
-export const MAX_AXIS_LABEL = 18
-
-export function truncateAxisLabel(value: string): string {
-  if (value.length <= MAX_AXIS_LABEL) return value
-  return value.slice(0, MAX_AXIS_LABEL - 1) + '…'
+/** Truncate `value` to `max` characters, spending the last one on an ellipsis. */
+export function truncateAxisLabel(value: string, max: number = MAX_AXIS_LABEL): string {
+  if (value.length <= max) return value
+  return value.slice(0, max - 1) + '…'
 }
 
-/** The XAxis props that make a category chart show all of its labels. */
-export function categoryAxisProps(): CategoryAxisProps {
+/**
+ * The XAxis props that make a horizontal category chart show all of its labels.
+ *
+ * @param categoryCount how many bars the chart is about to draw. Callers know
+ *   their own `data.length`; passing it lets the axis pick a rotation that
+ *   still fits. Omitting it assumes the roomiest (shallowest) tier.
+ */
+export function categoryAxisProps(categoryCount = 0): CategoryAxisProps {
+  const tier = TIERS.find((t) => categoryCount <= categoryCapacity(t.angle)) ?? TIERS[TIERS.length - 1]
   return {
     interval: 0,
-    angle: -30,
+    angle: tier.angle,
     textAnchor: 'end',
-    height: 56,
-    tickFormatter: truncateAxisLabel,
+    height: axisHeight(tier.angle, tier.maxChars),
+    tickFormatter: (value: string) => truncateAxisLabel(value, tier.maxChars),
+  }
+}
+
+/** Width reserved for the category axis of a `layout="vertical"` bar chart. */
+export const VERTICAL_AXIS_WIDTH = 128
+
+/** Longest label that fits inside {@link VERTICAL_AXIS_WIDTH}. */
+const VERTICAL_MAX_LABEL = Math.min(
+  MAX_AXIS_LABEL,
+  Math.floor((VERTICAL_AXIS_WIDTH - TICK_GAP) / CHAR_WIDTH),
+)
+
+export interface VerticalCategoryAxisProps {
+  /** Show every category tick — 'preserveEnd' drops them here too. */
+  interval: 0
+  /** Horizontal room reserved for the labels beside the plot. */
+  width: number
+  /** Truncate over-long labels so they stay inside {@link VERTICAL_AXIS_WIDTH}. */
+  tickFormatter: (value: string) => string
+}
+
+/**
+ * The YAxis props for a `layout="vertical"` category chart (bars run left to
+ * right, so the *category* axis is the Y one). Rotation doesn't help here:
+ * labels sit side-on in their own gutter and are limited by that gutter's
+ * width, not by the tick spacing. So this is just "show every tick, and keep
+ * each label short enough to fit the gutter".
+ */
+export function verticalCategoryAxisProps(): VerticalCategoryAxisProps {
+  return {
+    interval: 0,
+    width: VERTICAL_AXIS_WIDTH,
+    tickFormatter: (value: string) => truncateAxisLabel(value, VERTICAL_MAX_LABEL),
   }
 }

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -38,6 +38,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip as HoverTooltip } from '@/components/tooltip'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 import { platformColors } from '@/lib/routing'
+import { categoryAxisProps } from '@/lib/chart-axis'
 import { useI18n } from '@/i18n'
 
 type TimeRange = '24h' | '7d' | '30d' | '90d'
@@ -655,7 +656,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="requests" name={t('analytics.requests')} fill={primaryFill} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -671,7 +672,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byClient} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="clientAgent" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                  <XAxis dataKey="clientAgent" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="requests" name={t('analytics.requests')} fill={seriesB} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -688,7 +689,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
                   <YAxis unit="ms" tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Legend wrapperStyle={{ fontSize: 12 }} iconType="rect" />
@@ -709,7 +710,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
                   <YAxis unit="ms" tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="avgTtfbMs" name={t('analytics.avgTtft')} fill={seriesA} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -742,7 +743,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={errorDist.byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="count" name={t('analytics.errors')} fill="var(--destructive)" radius={[3, 3, 0, 0]} maxBarSize={24} />

--- a/client/src/pages/AnalyticsPage.tsx
+++ b/client/src/pages/AnalyticsPage.tsx
@@ -38,7 +38,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip as HoverTooltip } from '@/components/tooltip'
 import { formatSqliteUtcToLocalTime } from '@/lib/utils'
 import { platformColors } from '@/lib/routing'
-import { categoryAxisProps } from '@/lib/chart-axis'
+import { categoryAxisProps, verticalCategoryAxisProps } from '@/lib/chart-axis'
 import { useI18n } from '@/i18n'
 
 type TimeRange = '24h' | '7d' | '30d' | '90d'
@@ -656,7 +656,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps(byPlatform.length)} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="requests" name={t('analytics.requests')} fill={primaryFill} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -672,7 +672,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byClient} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="clientAgent" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
+                  <XAxis dataKey="clientAgent" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps(byClient.length)} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="requests" name={t('analytics.requests')} fill={seriesB} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -689,7 +689,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps(byPlatform.length)} />
                   <YAxis unit="ms" tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Legend wrapperStyle={{ fontSize: 12 }} iconType="rect" />
@@ -710,7 +710,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps(byPlatform.length)} />
                   <YAxis unit="ms" tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="avgTtfbMs" name={t('analytics.avgTtft')} fill={seriesA} radius={[3, 3, 0, 0]} maxBarSize={24} />
@@ -728,7 +728,7 @@ export default function AnalyticsPage() {
                 <BarChart data={errorDist.byCategory} layout="vertical" margin={{ top: 6, right: 12, left: 8, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} horizontal={false} />
                   <XAxis type="number" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} allowDecimals={false} />
-                  <YAxis type="category" dataKey="category" tick={axisStyle} tickLine={false} axisLine={false} width={128} />
+                  <YAxis type="category" dataKey="category" tick={axisStyle} tickLine={false} axisLine={false} {...verticalCategoryAxisProps()} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="count" name={t('analytics.errors')} fill="var(--destructive)" radius={[0, 3, 3, 0]} maxBarSize={24} />
                 </BarChart>
@@ -743,7 +743,7 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={errorDist.byPlatform} margin={{ top: 6, right: 6, left: -12, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="2 4" stroke={gridStyle} />
-                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps()} />
+                  <XAxis dataKey="platform" tick={axisStyle} tickLine={false} axisLine={{ stroke: gridStyle }} {...categoryAxisProps(errorDist.byPlatform.length)} />
                   <YAxis tick={axisStyle} tickLine={false} axisLine={false} />
                   <Tooltip contentStyle={tooltipStyle} />
                   <Bar dataKey="count" name={t('analytics.errors')} fill="var(--destructive)" radius={[3, 3, 0, 0]} maxBarSize={24} />

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,10 +1,19 @@
 // Standalone vitest config so tests don't load vite.config.ts (whose React +
-// Tailwind plugins are pointless for unit tests). Store/timer tests are plain
-// TypeScript, so the default node environment is enough — no jsdom.
+// Tailwind plugins are pointless for unit tests). Most tests are plain
+// TypeScript and run in the default node environment — no jsdom.
+//
+// The exception is the chart-axis render test, which mounts a real recharts
+// chart to prove the axis props actually reach recharts. That single file
+// opts into jsdom with an `@vitest-environment jsdom` docblock, so we only pay
+// for a DOM where one is genuinely needed.
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  // esbuild only reads the *nearest* tsconfig.json, and ours is a solution
+  // file (`files: []` + project references), so `jsx: react-jsx` from
+  // tsconfig.app.json never reaches it. Say it here instead.
+  esbuild: { jsx: 'automatic' },
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 })

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -6,6 +6,22 @@
 // chart to prove the axis props actually reach recharts. That single file
 // opts into jsdom with an `@vitest-environment jsdom` docblock, so we only pay
 // for a DOM where one is genuinely needed.
+//
+// Two things about that jsdom dependency are deliberate and easy to undo by
+// accident:
+//
+//   * It is declared in the *root* package.json, not this one. vitest itself
+//     hoists to the root node_modules, and vitest resolves an environment
+//     package relative to its own location — it never looks inside
+//     client/node_modules. A client-level jsdom that npm chooses to nest
+//     (which it does, depending on how the rest of the tree deduplicates)
+//     makes the run die with "Cannot find package 'jsdom'".
+//   * It is pinned to ^27. jsdom 28+ depends on undici, and undici 8 both
+//     declares `engines: >=22.19.0` and calls worker_threads.markAsUncloneable
+//     unguarded — a function Node 20 does not have. Since the repo supports
+//     Node >=20.18 and CI runs the suite on Node 20, that combination fails
+//     at import time with "webidl.util.markAsUncloneable is not a function".
+//     jsdom 27 has no undici dependency at all.
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^30.0.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
@@ -82,6 +83,59 @@
       "engines": {
         "node": ">=20.18.0 <25.0.0",
         "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -556,6 +610,159 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -1383,6 +1590,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4402,6 +4627,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5070,6 +5305,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5218,6 +5467,35 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5234,6 +5512,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -5513,6 +5798,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6626,6 +6924,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6982,6 +7293,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7079,6 +7397,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7851,6 +8220,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -9149,6 +9525,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10007,6 +10396,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -10641,6 +11043,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -10818,15 +11227,28 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -11044,6 +11466,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -12619,6 +13051,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -12626,6 +13071,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -12708,6 +13188,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "cli"
       ],
       "devDependencies": {
-        "concurrently": "^9.1.2"
+        "concurrently": "^9.1.2",
+        "jsdom": "^27.4.0"
       },
       "engines": {
         "node": ">=20.18.0 <25.0.0",
@@ -74,7 +75,6 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "jsdom": "^30.0.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
@@ -85,21 +85,25 @@
         "npm": ">=10.0.0"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
-      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.3.0",
-        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.5.2"
-      },
-      "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "lru-cache": "^11.2.5"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
@@ -113,19 +117,17 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
-      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
+        "css-tree": "^3.1.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2"
-      },
-      "engines": {
-        "node": "^22.13.0 || >=24.0.0"
+        "lru-cache": "^11.2.6"
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
@@ -137,6 +139,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -610,19 +619,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -5331,6 +5327,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -5468,32 +5490,27 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-url": "^15.1.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=20"
       }
     },
-    "node_modules/data-urls/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -6967,6 +6984,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7400,54 +7431,43 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
-      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.3.0",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
-        "@exodus/bytes": "^1.15.1",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.5.2",
-        "parse5": "^8.0.1",
+        "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.2",
-        "undici": "^8.9.0",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^17.1.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.2.3"
+        "canvas": "^3.0.0"
       },
       "peerDependenciesMeta": {
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -11468,16 +11488,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -13084,28 +13094,27 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
-      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.15.1",
         "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": "^22.14.0 || >=24.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -13172,6 +13181,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "db:migration:create": "npm run db:migration:create -w server"
   },
   "devDependencies": {
-    "concurrently": "^9.1.2"
+    "concurrently": "^9.1.2",
+    "jsdom": "^27.4.0"
   },
   "engines": {
     "node": ">=20.18.0 <25.0.0",


### PR DESCRIPTION
## What changed

recharts' default `interval` is `preserveEnd` (see `implicitXAxis` /
`implicitYAxis` in recharts' `axisSelectors`): when the labels are wider than
the space available it silently **drops ticks**, keeping the tail and thinning
out everything before it. The visible result is exactly the #890 complaint —
only a few provider names render, the rest are only visible on hover, and a bar
no longer lines up with the label the user can actually see (a bar with no
label reads as a different provider than it is).

The fix forces **every** tick (`interval={0}`) and then makes the labels fit by
rotating and truncating them, via a small pure helper applied to the six
category charts:

- requests by provider
- requests by agent
- latency by provider
- TTFT by provider
- errors by provider
- errors by category — this one is `layout="vertical"`, so its *category* axis
  is the `YAxis`; it gets its own helper (rotation doesn't apply there — the
  labels sit side-on in a fixed-width gutter)

The timeline charts are time series and are untouched.

Forcing the ticks on its own just trades a dropped label for a pile of
overlapping ones, so `categoryAxisProps(count)` takes the number of categories
and picks the **shallowest tilt that still seats them** on a 280px plot (the
width a chart gets in the single-column mobile layout):

| categories | angle | label cap | reserved height |
| --- | --- | --- | --- |
| ≤ 10 | -30° | 18 chars | 58px |
| ≤ 15 | -45° | 18 chars | 79px |
| > 15 | -90° | 12 chars | 74px |

Both the capacity and the height are derived from the font metrics rather than
hard-coded, so the reserved strip is always big enough for the longest label
the tier will actually draw.

## Files

- `client/src/lib/chart-axis.ts` — `categoryAxisProps(categoryCount)`,
  `verticalCategoryAxisProps()`, `truncateAxisLabel(value, max)`
- `client/src/pages/AnalyticsPage.tsx` — spreads the props on the 5 category
  X-axes and the errors-by-category Y-axis, passing each chart's `data.length`
- `client/src/lib/chart-axis.test.ts` — helper regression tests (tier choice,
  no-collision invariant, height-fits-label invariant, truncation)
- `client/src/lib/chart-axis.render.test.tsx` — mounts a real recharts
  `<BarChart>` under jsdom with 16 categories and counts the rendered tick
  `<text>` elements: the defaults drop most of them, the helpers render all 16.
  This proves the props reach recharts rather than merely having the right
  shape. It stubs `getBoundingClientRect`, which recharts uses to measure
  labels and which jsdom answers with zeroes.
- `client/vitest.config.ts` — picks up `*.test.tsx`; the render test opts into
  jsdom with a per-file docblock so everything else stays on node
- `package.json` (root) — `jsdom@^27` added as a devDependency. Two details
  worth keeping: it lives at the **root** because vitest hoists there and
  resolves environment packages relative to itself (a nested
  `client/node_modules/jsdom` gives "Cannot find package 'jsdom'"), and it is
  **pinned to 27** because jsdom 28+ pulls in undici, and undici 8 requires
  Node >= 22.19 and calls `worker_threads.markAsUncloneable` unguarded — which
  Node 20 does not have. jsdom 27 has no undici dependency at all.

## How it was checked

- `npm run build -w client` (`tsc -b && vite build`) — passes
- `npm test` (whole repo) — server 2499 passed / 5 skipped, cli 95, client
  182/182 across 16 files (client was 167/15)
- `npx eslint` on the changed files — clean
