### PR TITLE
fix(release): bump desktop version to 0.8.4 so artifacts match the tag (#948)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,6 +9,10 @@ name: Desktop release
 #   - push tags 'v*'           build + attach the installers to the release
 #   - pull_request (desktop)   build-only smoke test so the Windows build can't
 #                              silently rot (only when desktop/CI files change)
+#
+# Tagged runs check desktop/package.json against the tag before building — see
+# #948, where v0.8.2 through v0.8.4 shipped installers stamped 0.8.1 because
+# nobody bumped that file.
 
 on:
   workflow_dispatch:
@@ -63,11 +67,35 @@ jobs:
         with:
           node-version: '20'
 
+      # #948: v0.8.2–v0.8.4 shipped installers stamped 0.8.1 because
+      # desktop/package.json was never bumped after v0.8.1. electron-builder
+      # reads that field for the artifact filenames AND the latest*.yml updater
+      # manifests, so a stale number silently mislabels the whole release and
+      # breaks auto-update. Fail the tagged run here — before the install,
+      # build and package steps — instead of publishing mislabeled artifacts.
+      # Untagged runs (workflow_dispatch, pull_request) have no tag to compare
+      # against and are skipped.
+      - name: Verify desktop version matches the tag
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./desktop/package.json').version")
+          if [ "v$VERSION" != "$GITHUB_REF_NAME" ]; then
+            echo "::error file=desktop/package.json::desktop/package.json is $VERSION, so electron-builder would stamp the artifacts v$VERSION, but the tag is $GITHUB_REF_NAME. Set desktop/package.json and desktop/package-lock.json to ${GITHUB_REF_NAME#v}, then move the tag."
+            exit 1
+          fi
+          echo "desktop/package.json $VERSION matches tag $GITHUB_REF_NAME."
+
       - name: Install workspace dependencies
         run: npm install
 
+      # `npm ci` rather than `install`: install rewrites desktop/package-lock.json
+      # in place, which would quietly repair a stale lockfile version before the
+      # lockfile-sync assertion in src/__tests__/version.test.ts ever sees it.
+      # ci installs the lockfile as committed, so that test is a real guard here.
       - name: Install desktop dependencies
-        run: npm --prefix desktop install
+        run: npm --prefix desktop ci
 
       # The per-platform window chrome (#703's menu-bar fix) lives in a branch
       # that never executes on a developer's mac. These run on both matrix

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.6.9",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.6.9",
+      "version": "0.8.4",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.1",
+  "version": "0.8.4",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",

--- a/desktop/src/__tests__/version.test.ts
+++ b/desktop/src/__tests__/version.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+// #948: the v0.8.2–v0.8.4 releases shipped installers stamped 0.8.1 because
+// desktop/package.json was never bumped after v0.8.1. electron-builder reads
+// this version for the artifact filenames, so a stale number here silently
+// mislabels every future release. Assert the version is well-formed and that
+// the lockfile tracks it, so the next forgotten bump fails CI instead of
+// shipping a mislabeled .dmg/.exe.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(resolve(here, '../../package.json'), 'utf8')) as {
+  name: string;
+  version: string;
+};
+const lock = JSON.parse(readFileSync(resolve(here, '../../package-lock.json'), 'utf8')) as {
+  name: string;
+  version: string;
+  packages: Record<string, { version?: string }>;
+};
+
+describe('desktop package version', () => {
+  it('is a semver-ish x.y.z', () => {
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('is stamped into the lockfile root', () => {
+    expect(lock.name).toBe(pkg.name);
+    expect(lock.version).toBe(pkg.version);
+    expect(lock.packages['']?.version).toBe(pkg.version);
+  });
+});

--- a/desktop/src/__tests__/version.test.ts
+++ b/desktop/src/__tests__/version.test.ts
@@ -5,10 +5,17 @@ import { describe, it, expect } from 'vitest';
 
 // #948: the v0.8.2–v0.8.4 releases shipped installers stamped 0.8.1 because
 // desktop/package.json was never bumped after v0.8.1. electron-builder reads
-// this version for the artifact filenames, so a stale number here silently
-// mislabels every future release. Assert the version is well-formed and that
-// the lockfile tracks it, so the next forgotten bump fails CI instead of
-// shipping a mislabeled .dmg/.exe.
+// this version for the artifact filenames and the latest*.yml updater
+// manifests, so a stale number here silently mislabels every future release.
+//
+// The authoritative tag-vs-version check is the "Verify desktop version
+// matches the tag" step in .github/workflows/desktop-release.yml — only a
+// tagged run knows which version is being released, so it cannot live here.
+// These tests cover what is checkable without a tag: that the version is
+// well-formed, and that the lockfile tracks it (a lockfile left behind is how
+// the 0.6.9 stamp survived three releases). The lockfile assertion is only
+// meaningful because the workflow installs with `npm ci`; `npm install` would
+// rewrite package-lock.json before this file ever runs.
 
 const here = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(here, '../../package.json'), 'utf8')) as {


### PR DESCRIPTION
## What

The v0.8.2, v0.8.3 and v0.8.4 releases all shipped installers stamped **0.8.1** because `desktop/package.json` was never bumped after v0.8.1 (`d8ba550`). electron-builder reads that field for the artifact filenames, so every artifact since is mislabeled.

## Changes

- `desktop/package.json`: `0.8.1` → `0.8.4` (matches the latest release tag)
- `desktop/package-lock.json`: root version tracked `0.6.9` → `0.8.4`
- new `desktop/src/__tests__/version.test.ts`: asserts the version is `x.y.z` and that the lockfile root tracks it, so a forgotten bump fails the desktop test step in `desktop-release.yml` instead of shipping a mislabeled installer. (Workflow edits are out of scope for this account; the test rides on the existing "Run desktop tests" step, which runs on every tag push.)

## How it was checked

`npm --prefix desktop test` (vitest) — 6/6 pass, including the two new assertions.