### PR TITLE
fix(ui): surface full provider name when truncated in the model/provider picker (#945)

### DIFF
--- a/client/src/components/model-combobox.tsx
+++ b/client/src/components/model-combobox.tsx
@@ -101,7 +101,7 @@ export function ModelCombobox({
           'flex h-8 w-[260px] items-center justify-between gap-2 whitespace-nowrap rounded-lg border border-input bg-transparent px-3 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30'
         }
       >
-        <span className={`truncate ${triggerLabel ? '' : 'text-muted-foreground'}`}>{triggerLabel || triggerPlaceholder}</span>
+        <span className={`truncate ${triggerLabel ? '' : 'text-muted-foreground'}`} title={triggerLabel || undefined}>{triggerLabel || triggerPlaceholder}</span>
         <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
       </PopoverTrigger>
       <PopoverContent align={align} className="w-[300px] p-0" onKeyDown={onKeyDown}>
@@ -135,7 +135,7 @@ export function ModelCombobox({
                 }`}
               >
                 <Check className={`size-4 shrink-0 ${o.value === value ? 'opacity-100' : 'opacity-0'}`} />
-                <span className={`min-w-0 flex-1 truncate ${o.note ? 'opacity-50' : ''}`}>{o.label}</span>
+                <span className={`min-w-0 flex-1 truncate ${o.note ? 'opacity-50' : ''}`} title={o.label}>{o.label}</span>
                 {o.note && (
                   <span className="rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide bg-amber-500/15 text-amber-600 dark:text-amber-400">
                     {o.note}


### PR DESCRIPTION
## Summary
Closes #945.

The add-key dialog's provider picker (ModelCombobox) renders each option label with `truncate` and no `title` fallback, so long labels like **"OVH AI Endpoints (no key needed)"** clip to **"OVH AI Endpoints (no key ne…"** and the full text is unreachable. The trigger label (the selected provider shown on the collapsed control) has the same problem.

## Fix
Add a `title` attribute to both the trigger and the list option so the full name is reachable on hover — matching the codebase's existing convention for truncated text (e.g. `baseUrl` in `provider-list.tsx` carries `title={k.baseUrl}`).

No layout change: the truncation stays (it's correct for a fixed-width picker); the text just becomes inspectable.

## Checks
- client: tsc clean (only pre-existing TS5101 baseUrl deprecation), vitest 177 passed (1 pre-existing jsdom missing-package error)
- no i18n keys touched