### PR TITLE
fix(deploy): chown data dir on PaaS runtimes via root entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,22 @@ COPY --from=build --chown=node:node /app/client/dist ./client/dist
 
 RUN mkdir -p /app/server/data && chown -R node:node /app/server/data
 
+# PaaS runtimes (Railway, Render) mount the persistent volume root-owned while
+# the app runs as USER node, so better-sqlite3 cannot create the DB there.
+# The entrypoint chowns the data dir as root, then drops back to node.
+COPY --chown=root:root docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Deliberately last of the runtime layers: the SHA changes on every commit, and
 # an ARG/ENV above the COPYs invalidates the cache for all of them on each build.
 ARG FREELLMAPI_COMMIT_SHA
 ENV FREELLMAPI_COMMIT_SHA=${FREELLMAPI_COMMIT_SHA}
 
-USER node
+# Runs as root so docker-entrypoint.sh can chown a root-owned volume mount on
+# PaaS runtimes; the entrypoint drops back to the node user before exec'ing CMD.
+USER root
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 EXPOSE 3001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ RUN mkdir -p /app/server/data && chown -R node:node /app/server/data
 # PaaS runtimes (Railway, Render) mount the persistent volume root-owned while
 # the app runs as USER node, so better-sqlite3 cannot create the DB there.
 # The entrypoint chowns the data dir as root, then drops back to node.
-COPY --chown=root:root docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Deliberately last of the runtime layers: the SHA changes on every commit, and
 # an ARG/ENV above the COPYs invalidates the cache for all of them on each build.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# PaaS runtimes (Railway, Render, ...) bind-mount the persistent volume at
+# /app/server/data with root ownership, while the image runs as USER node.
+# Chown the data dir before starting so better-sqlite3 can create the DB
+# there, then drop back to the unprivileged user.
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p /app/server/data
+  chown -R node:node /app/server/data
+  if command -v runuser >/dev/null 2>&1; then
+    exec runuser -u node -- "$@"
+  fi
+  exec setpriv --reuid=node --regid=node --init-groups "$@"
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,13 +5,47 @@ set -e
 # /app/server/data with root ownership, while the image runs as USER node.
 # Chown the data dir before starting so better-sqlite3 can create the DB
 # there, then drop back to the unprivileged user.
-if [ "$(id -u)" = "0" ]; then
-  mkdir -p /app/server/data
-  chown -R node:node /app/server/data
-  if command -v runuser >/dev/null 2>&1; then
-    exec runuser -u node -- "$@"
+
+# Best effort by design: chown fails legitimately under --cap-drop=CHOWN and on
+# CIFS/NFS mounts that pin ownership. Startup must not abort over it — the app
+# may still be able to write, and if it cannot it says so itself.
+ensure_owned() {
+  dir="$1"
+  [ -n "$dir" ] || return 0
+
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    echo "docker-entrypoint: could not create $dir; continuing" >&2
   fi
-  exec setpriv --reuid=node --regid=node --init-groups "$@"
+  [ -d "$dir" ] || return 0
+
+  # Skip the recursive walk when the tree is already node-owned: on a large
+  # data dir that is the whole boot cost of this entrypoint.
+  if [ "$(stat -c %u "$dir" 2>/dev/null)" = "$NODE_UID" ]; then
+    return 0
+  fi
+
+  if ! chown -R "$NODE_UID:$NODE_GID" "$dir" 2>/dev/null; then
+    echo "docker-entrypoint: could not chown $dir; continuing" >&2
+  fi
+}
+
+if [ "$(id -u)" = "0" ]; then
+  NODE_UID="$(id -u node)"
+  NODE_GID="$(id -g node)"
+
+  ensure_owned /app/server/data
+  # docker/README.md tells single-mount PaaS operators to point these at their
+  # one persistent directory, which may sit outside /app/server/data.
+  if [ -n "$FREEAPI_DB_PATH" ]; then
+    ensure_owned "$(dirname "$FREEAPI_DB_PATH")"
+  fi
+  if [ -n "$FREEAPI_DB_BACKUP_PATH" ]; then
+    ensure_owned "$(dirname "$FREEAPI_DB_BACKUP_PATH")"
+  fi
+
+  # setpriv ships in util-linux on node:20-bookworm-slim, so it is always
+  # present; exec'ing it keeps node as PID 1 so signals reach the server.
+  exec setpriv --reuid=node --regid=node --init-groups -- "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Fixes SQLite DB creation failure on PaaS runtimes (Railway, Render) where the persistent volume is mounted root-owned while the image runs as `USER node`.

- Adds `docker-entrypoint.sh` that chowns `/app/server/data` then drops back to the `node` user.
- Runs the image as root so the entrypoint can chown, then execs the original command as the unprivileged user.

Tested against Railway.