### PR TITLE
feat(providers): add UnoRouter aggregator platform (#875)

### DIFF
--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -376,6 +376,16 @@ register(new OpenAICompatProvider({
   baseUrl: 'https://api.orcarouter.ai/v1',
 }));
 
+// UnoRouter — OpenAI-compatible aggregator (api.unorouter.com/v1). One key
+// for hundreds of models; follows OpenAI Chat Completions / Anthropic Messages
+// / OpenAI Responses formats. Free tier per the awesome-free-llm-apis listing
+// (#875); catalog rows live in the hosted catalog and arrive via catalog-sync.
+register(new OpenAICompatProvider({
+  platform: 'unorouter',
+  name: 'UnoRouter',
+  baseUrl: 'https://api.unorouter.com/v1',
+}));
+
 // ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
 // (api-inference.modelscope.cn/v1, Bearer auth). Free tier: 2000 requests/day
 // account-wide. Token from modelscope.cn/my/myaccesstoken, BUT calls only work

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -31,7 +31,7 @@ const PLATFORMS = [
   'google', 'groq', 'cerebras', 'bai', 'nvidia', 'mistral',
   'openrouter', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama',
   'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'ovh', 'agnes', 'reka', 'siliconflow',
-  'routeway', 'bazaarlink', 'ainative', 'aion', 'anyapi', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'modelscope',
+  'routeway', 'bazaarlink', 'ainative', 'aion', 'anyapi', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'unorouter', 'modelscope',
   'qianfan', 'volcengine', 'longcat', 'xfyun', 'aihorde', 'custom',
 ] as const;
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -132,6 +132,10 @@ export type Platform =
   // (never fall back to paid). Catalog rows live in the Oracle catalog
   // (premium now, free after the 30-day model-age gate).
   | 'orcarouter'
+  // UnoRouter — OpenAI-compatible aggregator (api.unorouter.com/v1). One key
+  // for hundreds of models; OpenAI Chat Completions / Anthropic Messages /
+  // OpenAI Responses formats. Catalog rows live in the hosted catalog.
+  | 'unorouter'
   // ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
   // (api-inference.modelscope.cn/v1). Free tier is 2000 requests/day
   // account-wide, but calls only work after the ModelScope account is bound to


### PR DESCRIPTION
## Summary

Closes #875 — adds **UnoRouter** (unorouter.com) as an OpenAI-compatible aggregator platform. One key for hundreds of models, following OpenAI Chat Completions / Anthropic Messages / OpenAI Responses formats. Per the awesome-free-llm-apis listing, it offers a free tier.

## Changes

- **`server/src/providers/index.ts`**: register `OpenAICompatProvider` for `unorouter` with `baseUrl: https://api.unorouter.com/v1` (verified against official docs)
- **`shared/types.ts`**: add `'unorouter'` to the `Platform` union
- **`server/src/routes/keys.ts`**: add `unorouter` to the `PLATFORMS` allowlist

## Notes

- Catalog rows live in the hosted catalog and arrive via catalog-sync, same as other aggregator platforms (xKiro/OrcaRouter).
- Verified: `tsc --noEmit` passes; providers + keys route tests pass (269 tests).