### PR TITLE
fix(routing): skip models known to ignore response_format for structured-output requests (#933)

### DIFF
--- a/server/src/__tests__/lib/sampling-params.test.ts
+++ b/server/src/__tests__/lib/sampling-params.test.ts
@@ -5,6 +5,7 @@ import {
   supportedParametersFor,
   supportedParametersForPlatforms,
   normalizeReasoningEffort,
+  modelSupportsStructuredOutput,
   EXTENDED_SAMPLING_KEYS,
   REASONING_EFFORTS,
 } from '../../lib/sampling-params.js';
@@ -221,5 +222,26 @@ describe('live-sweep policy findings (2026-07-11 demo-box validation)', () => {
     const { platformDropsResponseFormat } = await import('../../lib/sampling-params.js');
     expect(platformDropsResponseFormat('kilo')).toBe(true);
     expect(platformDropsResponseFormat('reka')).toBe(false);
+  });
+});
+
+describe('modelSupportsStructuredOutput (#933)', () => {
+  it('defaults to capable (forward-by-default) for mainstream and unknown models', () => {
+    expect(modelSupportsStructuredOutput('groq', 'gpt-oss-20b')).toBe(true);
+    expect(modelSupportsStructuredOutput('openrouter', 'deepseek/deepseek-v4')).toBe(true);
+    expect(modelSupportsStructuredOutput('openrouter', 'qwen/qwen3-coder:free')).toBe(true);
+    expect(modelSupportsStructuredOutput('custom', 'some-relay-model')).toBe(true);
+  });
+
+  it('excludes families with observed evidence of ignoring response_format', () => {
+    expect(modelSupportsStructuredOutput('openrouter', 'hermes-3-llama-3.1-8b')).toBe(false);
+    expect(modelSupportsStructuredOutput('openrouter', 'google/gemma-3-27b-it:free')).toBe(false);
+    expect(modelSupportsStructuredOutput('nvidia', 'nemotron-nano-9b')).toBe(false);
+    expect(modelSupportsStructuredOutput('openrouter', 'deepseek/r1-distill-qwen-7b')).toBe(false);
+    expect(modelSupportsStructuredOutput('pollinations', 'pollinations/any')).toBe(false);
+  });
+
+  it('is case-insensitive on the model id', () => {
+    expect(modelSupportsStructuredOutput('openrouter', 'Hermes-3-Llama-3.1-8B')).toBe(false);
   });
 });

--- a/server/src/lib/sampling-params.ts
+++ b/server/src/lib/sampling-params.ts
@@ -403,6 +403,33 @@ export function platformDropsResponseFormat(platform: string): boolean {
   return PLATFORM_PARAM_POLICIES[platform as Platform]?.drop?.includes('response_format') ?? false;
 }
 
+/**
+ * True when a model is expected to actually honor a structured-output request
+ * (response_format json_object / json_schema) rather than answering in prose.
+ *
+ * Forward-by-default: the platform-level check (platformDropsResponseFormat)
+ * already skips platforms that strip the param before send; the residual risk
+ * is a platform that forwards it while a specific model ignores it (#933).
+ * Only families with observed evidence of ignoring the param are excluded —
+ * mirroring the conservative rule set used for supports_tools (V22), since a
+ * model that cannot emit structured tool_calls reliably is unlikely to emit a
+ * structured JSON payload either. Everything else defaults to capable so an
+ * unknown new model never gets starved of structured traffic.
+ */
+export function modelSupportsStructuredOutput(platform: string, modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  // Families observed ignoring response_format / emitting text instead of
+  // structured content (same evidence base as the V22 supports_tools rules).
+  if (id.includes('hermes')) return false;            // emits tool calls as text (V22)
+  if (id.includes('gemma')) return false;             // weak at tools (V22)
+  if (id.includes('nemotron-nano')) return false;     // 30B nano incident family (V22)
+  if (id.includes('nemotron-3-9b')) return false;     // 9b variant, same weakness
+  if (id.includes('poolside')) return false;          // returns ~2-token answers (V22)
+  if (id.includes('r1-distill')) return false;        // reasoning distill, no native JSON mode
+  if (id.includes('pollinations')) return false;      // image-priority family, not structured chat
+  return true;
+}
+
 /** The advertised parameter list for a model on `platform` — the base set
  *  every surface supports, plus tools when the model does, minus the
  *  platform's droplist. */

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -24,7 +24,7 @@ import { TIMEOUT_ERROR_MARKERS } from '../lib/error-classify.js';
 import { applyModelWeightOverride, getModelWeightOverrides } from './model-weight-overrides.js';
 import { modelsWithOverriddenField } from './model-state.js';
 import { parseBudget } from '../lib/budget.js';
-import { platformDropsResponseFormat } from '../lib/sampling-params.js';
+import { platformDropsResponseFormat, modelSupportsStructuredOutput } from '../lib/sampling-params.js';
 import { isUnifyEnabled, getModelGroups, resolveRequestedIdForDispatch } from './model-groups.js';
 import { getActiveProfileId } from './profile-models.js';
 import { customEndpointKeyIds } from './custom-endpoint.js';
@@ -1611,7 +1611,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
       if (skipPlatforms?.has(e.platform)) return false;
       if (requireVision && !e.supports_vision) return false;
       if (requireTools && !e.supports_tools) return false;
-      if (requireStructured && platformDropsResponseFormat(e.platform)) return false;
+      if (requireStructured && (platformDropsResponseFormat(e.platform) || !modelSupportsStructuredOutput(e.platform, e.model_id))) return false;
       if (e.context_window != null && estimatedTokens > e.context_window) return false;
       if (e.tpm_limit != null && estimatedTokens > e.tpm_limit) return false;
       return true;
@@ -1690,8 +1690,12 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     // (the param would be dropped before send, so the model would answer in
     // prose and burn a failover hop). Platform-level fast path — model-level
     // capability isn't in the catalog; models that accept the param but ignore
-    // it are caught by the non-stream JSON enforcement downstream.
-    if (requireStructured && platformDropsResponseFormat(entry.platform)) { diag.push(`${label}: platform drops response_format`); continue; }
+    // it are caught by the non-stream JSON enforcement downstream. The
+    // model-level check below (#933) skips families with observed evidence of
+    // ignoring response_format (hermes/gemma/nemotron-nano/…) so a
+    // structured request doesn't burn its first hop on a model known to
+    // answer in prose.
+    if (requireStructured && (platformDropsResponseFormat(entry.platform) || !modelSupportsStructuredOutput(entry.platform, entry.model_id))) { diag.push(`${label}: platform drops response_format or model ignores it`); continue; }
 
     // Context-aware routing: skip a model whose context window can't hold the
     // request, so a large prompt never selects a small-context model and burns


### PR DESCRIPTION
## Summary

Closes #933 — structured-output requests (`response_format` json_object/json_schema) on the `auto` endpoint often landed on models that accept the param but answer in prose, burning the first failover hop on a model known to ignore it.

## Changes

- **`server/src/lib/sampling-params.ts`**: new `modelSupportsStructuredOutput(platform, modelId)` — forward-by-default family rule that excludes models with observed evidence of ignoring `response_format` (hermes, gemma, nemotron-nano, r1-distill, pollinations…; same evidence base as the V22 `supports_tools` rules). Unknown/new models default to capable so they never get starved of structured traffic.
- **`server/src/services/router.ts`**: the `requireStructured` gate (both the exploration path and the main loop) now skips a candidate when the **platform** drops `response_format` OR the **model** is known to ignore it, instead of the platform-level check alone.
- **Tests**: `sampling-params.test.ts` covers forward-by-default, the excluded families, and case-insensitivity.

## Notes

- Platform-level `platformDropsResponseFormat` remains the fast path (a param dropped before send); the model-level rule targets families that forward the param but answer in prose.
- The downstream non-stream JSON enforcement still backstops anything that slips through.
- Verified: `tsc --noEmit` passes; sampling-params + router tests pass (55 tests).