### PR TITLE
Bump desktop to 0.8.6 so the release artifacts match the v0.8.6 tag

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
The v0.8.6 tag was pushed with desktop/package.json still at 0.8.5, so the Desktop release workflow's version guard (#961) stopped all three platform builds before packaging and release v0.8.6 has no installers. This bumps desktop/package.json and the lockfile; the tag gets moved onto the merge commit and the workflow re-run.