### PR TITLE
Let a fallback chain be built by hand and stay that way

### DIFF
--- a/client/src/components/chain-manager.tsx
+++ b/client/src/components/chain-manager.tsx
@@ -39,6 +39,9 @@ interface Chain {
   sort_order: number
   auto_sort: string | null
   layout_config: string | null
+  // 0 once the chain opts out of the catalog-sync backfill (#895), which is
+  // what an empty-created chain does — it stays exactly as hand-built.
+  auto_include_new_models: number
   created_at: string
 }
 
@@ -46,6 +49,7 @@ export function ChainManager() {
   const { t } = useI18n()
   const queryClient = useQueryClient()
   const [newName, setNewName] = useState('')
+  const [startEmpty, setStartEmpty] = useState(true)
   const [createError, setCreateError] = useState('')
   const [collapsed, setCollapsed] = useState<boolean>(readCollapsed)
 
@@ -67,8 +71,8 @@ export function ChainManager() {
   }
 
   const createChain = useMutation({
-    mutationFn: (name: string) =>
-      apiFetch('/api/profiles', { method: 'POST', body: JSON.stringify({ name }) }),
+    mutationFn: (payload: { name: string; empty: boolean }) =>
+      apiFetch('/api/profiles', { method: 'POST', body: JSON.stringify(payload) }),
     onSuccess: () => {
       invalidate()
       setNewName('')
@@ -156,6 +160,13 @@ export function ChainManager() {
                   {isProtected && !isActive && (
                     <span className="text-[11px] text-muted-foreground">{t('chains.default')}</span>
                   )}
+                  {chain.auto_include_new_models === 0 && (
+                    <Tooltip text={t('chains.curatedHint')}>
+                      <span className="cursor-help text-[11px] text-muted-foreground underline decoration-dotted underline-offset-2">
+                        {t('chains.curated')}
+                      </span>
+                    </Tooltip>
+                  )}
                   <span className="flex-1" />
                   {!isActive && (
                     <Tooltip text={t('chains.activateHint')}>
@@ -198,7 +209,7 @@ export function ChainManager() {
             onSubmit={e => {
               e.preventDefault()
               const name = newName.trim()
-              if (name && !createChain.isPending) createChain.mutate(name)
+              if (name && !createChain.isPending) createChain.mutate({ name, empty: startEmpty })
             }}
           >
             <Input
@@ -216,6 +227,19 @@ export function ChainManager() {
               {t('chains.create')}
             </Button>
           </form>
+          <label className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={startEmpty}
+              onChange={e => setStartEmpty(e.target.checked)}
+              className="size-3.5 accent-foreground"
+            />
+            <span>{t('chains.startEmpty')}</span>
+            <Tooltip text={t('chains.startEmptyHint')}>
+              <span className="cursor-help underline decoration-dotted underline-offset-2">?</span>
+            </Tooltip>
+          </label>
+
           {createError
             ? <p className="mt-1.5 text-xs text-rose-600 dark:text-rose-400">{createError}</p>
             : <p className="mt-1.5 text-xs text-muted-foreground">{t('chains.nameRules')}</p>}

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "ያልተለኩ ሞዴሎችን ያስሱ",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "تفعيل أو تعطيل كل النماذج المعروضة",
+    "enableAll": "تفعيل الكل",
+    "disableAll": "تعطيل الكل",
+    "enableAllHint": "فعّل كل النماذج المعروضة ثم احفظ",
+    "disableAllHint": "عطّل كل النماذج المعروضة ثم احفظ",
+    "enabledOfShown": "{enabled} من {shown} من النماذج المعروضة داخل السلسلة"
   },
   "strategies": {
     "explore": "استكشاف النماذج غير المقيسة",
@@ -1054,6 +1060,10 @@
     "create": "إنشاء",
     "createPlaceholder": "اسم السلسلة",
     "createFailed": "تعذّر إنشاء السلسلة.",
-    "nameRules": "حتى 20 حرفًا: أحرف لاتينية وأرقام وشرطات وشرطات سفلية."
+    "nameRules": "حتى 20 حرفًا: أحرف لاتينية وأرقام وشرطات وشرطات سفلية.",
+    "startEmpty": "ابدأ فارغة",
+    "startEmptyHint": "ينشئ السلسلة بلا أي نماذج، ولا يضيف إليها نماذج الفهرس الجديدة. عند إلغاء التحديد تبدأ كنسخة من السلسلة الافتراضية.",
+    "curated": "مُنسّقة يدويًا",
+    "curatedHint": "لا تُضاف نماذج الفهرس الجديدة إلى هذه السلسلة تلقائيًا."
   }
 }

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Ölçülməmiş modelləri araşdır",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Изследване на неизмерени модели",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "অপরিমাপিত মডেল অন্বেষণ করুন",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Prozkoumávat nezměřené modely",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Udforsk umålte modeller",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Alle angezeigten Modelle ein- oder ausschalten",
+    "enableAll": "Alle einschalten",
+    "disableAll": "Alle ausschalten",
+    "enableAllHint": "Alle angezeigten Modelle einschalten, dann speichern",
+    "disableAllHint": "Alle angezeigten Modelle ausschalten, dann speichern",
+    "enabledOfShown": "{enabled} von {shown} angezeigten Modellen sind in der Kette"
   },
   "strategies": {
     "explore": "Unvermessene Modelle erkunden",
@@ -1054,6 +1060,10 @@
     "create": "Anlegen",
     "createPlaceholder": "Kettenname",
     "createFailed": "Die Kette konnte nicht angelegt werden.",
-    "nameRules": "Bis zu 20 Zeichen: Buchstaben, Ziffern, Binde- und Unterstriche."
+    "nameRules": "Bis zu 20 Zeichen: Buchstaben, Ziffern, Binde- und Unterstriche.",
+    "startEmpty": "Leer beginnen",
+    "startEmptyHint": "Legt die Kette ohne Modelle an und hält neue Katalogmodelle heraus. Ohne Haken startet sie als Kopie der Standardkette.",
+    "curated": "Kuratiert",
+    "curatedHint": "Neue Katalogmodelle werden dieser Kette nicht automatisch hinzugefügt."
   }
 }

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Εξερεύνηση μη μετρημένων μοντέλων",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Explore unmeasured models",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Activar o desactivar todos los modelos mostrados",
+    "enableAll": "Activar todos",
+    "disableAll": "Desactivar todos",
+    "enableAllHint": "Activa todos los modelos mostrados y luego guarda",
+    "disableAllHint": "Desactiva todos los modelos mostrados y luego guarda",
+    "enabledOfShown": "{enabled} de {shown} modelos mostrados están en la cadena"
   },
   "strategies": {
     "explore": "Explorar modelos sin mediciones",
@@ -1054,6 +1060,10 @@
     "create": "Crear",
     "createPlaceholder": "Nombre de la cadena",
     "createFailed": "No se pudo crear la cadena.",
-    "nameRules": "Hasta 20 caracteres: letras, dígitos, guiones y guiones bajos."
+    "nameRules": "Hasta 20 caracteres: letras, dígitos, guiones y guiones bajos.",
+    "startEmpty": "Empezar vacía",
+    "startEmptyHint": "Crea la cadena sin modelos y mantén fuera los modelos nuevos del catálogo. Sin marcar, empieza como una copia de la cadena predeterminada.",
+    "curated": "Curada",
+    "curatedHint": "Los modelos nuevos del catálogo no se añaden a esta cadena automáticamente."
   }
 }

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "کاوش مدل‌های اندازه‌گیری‌نشده",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Tutki mittaamattomia malleja",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Activer ou désactiver tous les modèles affichés",
+    "enableAll": "Tout activer",
+    "disableAll": "Tout désactiver",
+    "enableAllHint": "Activer tous les modèles affichés, puis enregistrer",
+    "disableAllHint": "Désactiver tous les modèles affichés, puis enregistrer",
+    "enabledOfShown": "{enabled} des {shown} modèles affichés sont dans la chaîne"
   },
   "strategies": {
     "explore": "Explorer les modèles non mesurés",
@@ -1054,6 +1060,10 @@
     "create": "Créer",
     "createPlaceholder": "Nom de la chaîne",
     "createFailed": "Impossible de créer la chaîne.",
-    "nameRules": "Jusqu'à 20 caractères : lettres, chiffres, tirets et traits de soulignement."
+    "nameRules": "Jusqu'à 20 caractères : lettres, chiffres, tirets et traits de soulignement.",
+    "startEmpty": "Démarrer vide",
+    "startEmptyHint": "Crée la chaîne sans aucun modèle et en tient les nouveaux modèles du catalogue à l'écart. Décoché, elle démarre comme une copie de la chaîne par défaut.",
+    "curated": "Curatée",
+    "curatedHint": "Les nouveaux modèles du catalogue ne sont pas ajoutés automatiquement à cette chaîne."
   }
 }

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "માપ્યા વગરના મોડલ્સ એક્સપ્લોર કરો",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Bincika samfuran da ba a auna ba",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "חקירת דגמים שטרם נמדדו",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "दिखाए गए सभी मॉडल चालू या बंद करें",
+    "enableAll": "सभी चालू करें",
+    "disableAll": "सभी बंद करें",
+    "enableAllHint": "दिखाए गए सभी मॉडल चालू करें, फिर सहेजें",
+    "disableAllHint": "दिखाए गए सभी मॉडल बंद करें, फिर सहेजें",
+    "enabledOfShown": "दिखाए गए {shown} में से {enabled} मॉडल चेन में हैं"
   },
   "strategies": {
     "explore": "बिना मापे गए मॉडल एक्सप्लोर करें",
@@ -1054,6 +1060,10 @@
     "create": "बनाएँ",
     "createPlaceholder": "चेन का नाम",
     "createFailed": "चेन नहीं बनाई जा सकी।",
-    "nameRules": "अधिकतम 20 अक्षर: अक्षर, अंक, हाइफ़न और अंडरस्कोर।"
+    "nameRules": "अधिकतम 20 अक्षर: अक्षर, अंक, हाइफ़न और अंडरस्कोर।",
+    "startEmpty": "खाली शुरू करें",
+    "startEmptyHint": "चेन को बिना किसी मॉडल के बनाएँ और नए कैटलॉग मॉडल भी इसमें न जोड़ें। अनचेक करने पर यह डिफ़ॉल्ट चेन की नकल से शुरू होती है।",
+    "curated": "हस्तचयनित",
+    "curatedHint": "नए कैटलॉग मॉडल इस चेन में अपने आप नहीं जुड़ते।"
   }
 }

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Istraži nemjerene modele",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Nem mért modellek felfedezése",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Aktifkan atau nonaktifkan semua model yang tampil",
+    "enableAll": "Aktifkan semua",
+    "disableAll": "Nonaktifkan semua",
+    "enableAllHint": "Aktifkan semua model yang tampil, lalu simpan",
+    "disableAllHint": "Nonaktifkan semua model yang tampil, lalu simpan",
+    "enabledOfShown": "{enabled} dari {shown} model yang tampil ada di rantai"
   },
   "strategies": {
     "explore": "Jelajahi model yang belum terukur",
@@ -1054,6 +1060,10 @@
     "create": "Buat",
     "createPlaceholder": "Nama rantai",
     "createFailed": "Rantai tidak dapat dibuat.",
-    "nameRules": "Maksimal 20 karakter: huruf, angka, tanda hubung, dan garis bawah."
+    "nameRules": "Maksimal 20 karakter: huruf, angka, tanda hubung, dan garis bawah.",
+    "startEmpty": "Mulai kosong",
+    "startEmptyHint": "Membuat rantai tanpa model dan menjauhkan model katalog baru darinya. Jika tidak dicentang, rantai dimulai sebagai salinan rantai bawaan.",
+    "curated": "Dikurasi",
+    "curatedHint": "Model katalog baru tidak ditambahkan ke rantai ini secara otomatis."
   }
 }

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Nyochaa ụdị a na-atụbeghị",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Attiva o disattiva tutti i modelli mostrati",
+    "enableAll": "Attiva tutti",
+    "disableAll": "Disattiva tutti",
+    "enableAllHint": "Attiva tutti i modelli mostrati, poi salva",
+    "disableAllHint": "Disattiva tutti i modelli mostrati, poi salva",
+    "enabledOfShown": "{enabled} dei {shown} modelli mostrati sono nella catena"
   },
   "strategies": {
     "explore": "Esplora i modelli non misurati",
@@ -1054,6 +1060,10 @@
     "create": "Crea",
     "createPlaceholder": "Nome della catena",
     "createFailed": "Impossibile creare la catena.",
-    "nameRules": "Fino a 20 caratteri: lettere, cifre, trattini e trattini bassi."
+    "nameRules": "Fino a 20 caratteri: lettere, cifre, trattini e trattini bassi.",
+    "startEmpty": "Inizia vuota",
+    "startEmptyHint": "Crea la catena senza modelli e tiene fuori i nuovi modelli del catalogo. Se non selezionato, parte come copia della catena predefinita.",
+    "curated": "Curata",
+    "curatedHint": "I nuovi modelli del catalogo non vengono aggiunti automaticamente a questa catena."
   }
 }

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "表示中のモデルをまとめて有効化・無効化",
+    "enableAll": "すべて有効化",
+    "disableAll": "すべて無効化",
+    "enableAllHint": "表示中のモデルをすべて有効にして保存します",
+    "disableAllHint": "表示中のモデルをすべて無効にして保存します",
+    "enabledOfShown": "表示中の {shown} 件のうち {enabled} 件がチェーンに入っています"
   },
   "strategies": {
     "explore": "未計測のモデルを探索",
@@ -1054,6 +1060,10 @@
     "create": "作成",
     "createPlaceholder": "チェーン名",
     "createFailed": "チェーンを作成できませんでした。",
-    "nameRules": "20 文字まで：英数字、ハイフン、アンダースコア。"
+    "nameRules": "20 文字まで：英数字、ハイフン、アンダースコア。",
+    "startEmpty": "空の状態で作成",
+    "startEmptyHint": "モデルを入れずにチェーンを作り、新しいカタログモデルも自動では追加しません。チェックを外すと既定のチェーンの複製になります。",
+    "curated": "手動管理",
+    "curatedHint": "新しいカタログモデルはこのチェーンに自動追加されません。"
   }
 }

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "გაუზომავი მოდელების შესწავლა",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "ស្វែងរកម៉ូដែលដែលមិនទាន់វាស់វែង",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "ಅಳೆಯದ ಮಾದರಿಗಳನ್ನು ಅನ್ವೇಷಿಸಿ",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "표시된 모델 전체 사용 또는 해제",
+    "enableAll": "전체 사용",
+    "disableAll": "전체 해제",
+    "enableAllHint": "표시된 모델을 모두 켠 뒤 저장하세요",
+    "disableAllHint": "표시된 모델을 모두 끈 뒤 저장하세요",
+    "enabledOfShown": "표시된 {shown}개 중 {enabled}개가 체인에 있습니다"
   },
   "strategies": {
     "explore": "미측정 모델 탐색",
@@ -1054,6 +1060,10 @@
     "create": "만들기",
     "createPlaceholder": "체인 이름",
     "createFailed": "체인을 만들지 못했습니다.",
-    "nameRules": "최대 20자: 영문자, 숫자, 하이픈, 밑줄."
+    "nameRules": "최대 20자: 영문자, 숫자, 하이픈, 밑줄.",
+    "startEmpty": "비어 있는 상태로 만들기",
+    "startEmptyHint": "모델 없이 체인을 만들고, 새로 추가되는 카탈로그 모델도 넣지 않습니다. 해제하면 기본 체인의 복사본으로 시작합니다.",
+    "curated": "직접 관리",
+    "curatedHint": "새 카탈로그 모델이 이 체인에 자동으로 추가되지 않습니다."
   }
 }

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Tyrinėti neišmatuotus modelius",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "അളക്കാത്ത മോഡലുകൾ പര്യവേക്ഷണം ചെയ്യുക",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "न मोजलेले मॉडेल्स एक्सप्लोर करा",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Teroka model yang belum diukur",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "မတိုင်းတာရသေးသော မော်ဒယ်များကို စူးစမ်းရန်",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "नमापिएका मोडेलहरू अन्वेषण गर्नुहोस्",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Alle getoonde modellen aan- of uitzetten",
+    "enableAll": "Alles aan",
+    "disableAll": "Alles uit",
+    "enableAllHint": "Zet alle getoonde modellen aan en sla op",
+    "disableAllHint": "Zet alle getoonde modellen uit en sla op",
+    "enabledOfShown": "{enabled} van {shown} getoonde modellen zitten in de keten"
   },
   "strategies": {
     "explore": "Ongemeten modellen verkennen",
@@ -1054,6 +1060,10 @@
     "create": "Aanmaken",
     "createPlaceholder": "Ketennaam",
     "createFailed": "De keten kon niet worden aangemaakt.",
-    "nameRules": "Maximaal 20 tekens: letters, cijfers, koppel- en onderstrepingstekens."
+    "nameRules": "Maximaal 20 tekens: letters, cijfers, koppel- en onderstrepingstekens.",
+    "startEmpty": "Leeg beginnen",
+    "startEmptyHint": "Maakt de keten zonder modellen aan en houdt nieuwe catalogusmodellen erbuiten. Niet aangevinkt begint hij als kopie van de standaardketen.",
+    "curated": "Handmatig",
+    "curatedHint": "Nieuwe catalogusmodellen worden niet automatisch aan deze keten toegevoegd."
   }
 }

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Utforsk umålte modeller",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "ମପାଯାଇନଥିବା ମଡେଲଗୁଡ଼ିକୁ ଅନୁସନ୍ଧାନ କରନ୍ତୁ",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "ਬਿਨਾਂ ਮਾਪੇ ਮਾਡਲਾਂ ਦੀ ਖੋਜ ਕਰੋ",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Włącz lub wyłącz wszystkie pokazane modele",
+    "enableAll": "Włącz wszystkie",
+    "disableAll": "Wyłącz wszystkie",
+    "enableAllHint": "Włącz wszystkie pokazane modele, potem zapisz",
+    "disableAllHint": "Wyłącz wszystkie pokazane modele, potem zapisz",
+    "enabledOfShown": "{enabled} z {shown} pokazanych modeli jest w łańcuchu"
   },
   "strategies": {
     "explore": "Eksploruj niezmierzone modele",
@@ -1054,6 +1060,10 @@
     "create": "Utwórz",
     "createPlaceholder": "Nazwa łańcucha",
     "createFailed": "Nie udało się utworzyć łańcucha.",
-    "nameRules": "Do 20 znaków: litery, cyfry, myślniki i podkreślenia."
+    "nameRules": "Do 20 znaków: litery, cyfry, myślniki i podkreślenia.",
+    "startEmpty": "Zacznij pusty",
+    "startEmptyHint": "Tworzy łańcuch bez modeli i nie dodaje do niego nowych modeli z katalogu. Bez zaznaczenia zaczyna jako kopia łańcucha domyślnego.",
+    "curated": "Ręczny",
+    "curatedHint": "Nowe modele z katalogu nie są automatycznie dodawane do tego łańcucha."
   }
 }

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Ativar ou desativar todos os modelos exibidos",
+    "enableAll": "Ativar todos",
+    "disableAll": "Desativar todos",
+    "enableAllHint": "Ative todos os modelos exibidos e salve",
+    "disableAllHint": "Desative todos os modelos exibidos e salve",
+    "enabledOfShown": "{enabled} de {shown} modelos exibidos estão na cadeia"
   },
   "strategies": {
     "explore": "Explorar modelos sem medições",
@@ -1054,6 +1060,10 @@
     "create": "Criar",
     "createPlaceholder": "Nome da cadeia",
     "createFailed": "Não foi possível criar a cadeia.",
-    "nameRules": "Até 20 caracteres: letras, dígitos, hifens e sublinhados."
+    "nameRules": "Até 20 caracteres: letras, dígitos, hifens e sublinhados.",
+    "startEmpty": "Começar vazia",
+    "startEmptyHint": "Cria a cadeia sem modelos e mantém de fora os novos modelos do catálogo. Sem marcar, ela começa como cópia da cadeia padrão.",
+    "curated": "Curada",
+    "curatedHint": "Novos modelos do catálogo não são adicionados a esta cadeia automaticamente."
   }
 }

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Ativar ou desativar todos os modelos apresentados",
+    "enableAll": "Ativar todos",
+    "disableAll": "Desativar todos",
+    "enableAllHint": "Ative todos os modelos apresentados e guarde",
+    "disableAllHint": "Desative todos os modelos apresentados e guarde",
+    "enabledOfShown": "{enabled} de {shown} modelos apresentados estão na cadeia"
   },
   "strategies": {
     "explore": "Explorar modelos sem medições",
@@ -1054,6 +1060,10 @@
     "create": "Criar",
     "createPlaceholder": "Nome da cadeia",
     "createFailed": "Não foi possível criar a cadeia.",
-    "nameRules": "Até 20 caracteres: letras, dígitos, hífenes e sublinhados."
+    "nameRules": "Até 20 caracteres: letras, dígitos, hífenes e sublinhados.",
+    "startEmpty": "Começar vazia",
+    "startEmptyHint": "Cria a cadeia sem modelos e mantém de fora os novos modelos do catálogo. Sem marcar, começa como cópia da cadeia predefinida.",
+    "curated": "Curada",
+    "curatedHint": "Os novos modelos do catálogo não são adicionados automaticamente a esta cadeia."
   }
 }

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Explorează modelele nemăsurate",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Включить или выключить все показанные модели",
+    "enableAll": "Включить все",
+    "disableAll": "Выключить все",
+    "enableAllHint": "Включить все показанные модели, затем сохранить",
+    "disableAllHint": "Выключить все показанные модели, затем сохранить",
+    "enabledOfShown": "В цепочке {enabled} из {shown} показанных моделей"
   },
   "strategies": {
     "explore": "Исследовать неизмеренные модели",
@@ -1054,6 +1060,10 @@
     "create": "Создать",
     "createPlaceholder": "Имя цепочки",
     "createFailed": "Не удалось создать цепочку.",
-    "nameRules": "До 20 символов: буквы, цифры, дефисы и подчёркивания."
+    "nameRules": "До 20 символов: буквы, цифры, дефисы и подчёркивания.",
+    "startEmpty": "Создать пустой",
+    "startEmptyHint": "Создаёт цепочку без моделей и не добавляет в неё новые модели каталога. Без флажка она начинается как копия цепочки по умолчанию.",
+    "curated": "Ручная",
+    "curatedHint": "Новые модели каталога не добавляются в эту цепочку автоматически."
   }
 }

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "නොමැනූ ආකෘති ගවේෂණය කරන්න",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Preskúmavať nezmerané modely",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Истражи неизмерене моделе",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Utforska omätta modeller",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Chunguza mifano isiyopimwa",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "அளவிடப்படாத மாதிரிகளை ஆராயுங்கள்",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "కొలవని మోడల్స్‌ను అన్వేషించండి",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "สำรวจโมเดลที่ยังไม่ได้วัดผล",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "I-explore ang mga hindi pa nasusukat na modelo",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Gösterilen tüm modelleri aç veya kapat",
+    "enableAll": "Tümünü aç",
+    "disableAll": "Tümünü kapat",
+    "enableAllHint": "Gösterilen tüm modelleri açın, sonra kaydedin",
+    "disableAllHint": "Gösterilen tüm modelleri kapatın, sonra kaydedin",
+    "enabledOfShown": "Gösterilen {shown} modelden {enabled} tanesi zincirde"
   },
   "strategies": {
     "explore": "Ölçülmemiş modelleri keşfet",
@@ -1054,6 +1060,10 @@
     "create": "Oluştur",
     "createPlaceholder": "Zincir adı",
     "createFailed": "Zincir oluşturulamadı.",
-    "nameRules": "En fazla 20 karakter: harf, rakam, tire ve alt çizgi."
+    "nameRules": "En fazla 20 karakter: harf, rakam, tire ve alt çizgi.",
+    "startEmpty": "Boş başlat",
+    "startEmptyHint": "Zinciri hiç model olmadan oluşturur ve yeni katalog modellerini dışarıda tutar. İşaretlenmezse varsayılan zincirin kopyası olarak başlar.",
+    "curated": "Elle düzenli",
+    "curatedHint": "Yeni katalog modelleri bu zincire otomatik eklenmez."
   }
 }

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Увімкнути або вимкнути всі показані моделі",
+    "enableAll": "Увімкнути всі",
+    "disableAll": "Вимкнути всі",
+    "enableAllHint": "Увімкніть усі показані моделі, потім збережіть",
+    "disableAllHint": "Вимкніть усі показані моделі, потім збережіть",
+    "enabledOfShown": "У ланцюжку {enabled} із {shown} показаних моделей"
   },
   "strategies": {
     "explore": "Досліджувати невиміряні моделі",
@@ -1054,6 +1060,10 @@
     "create": "Створити",
     "createPlaceholder": "Назва ланцюжка",
     "createFailed": "Не вдалося створити ланцюжок.",
-    "nameRules": "До 20 символів: літери, цифри, дефіси й підкреслення."
+    "nameRules": "До 20 символів: літери, цифри, дефіси й підкреслення.",
+    "startEmpty": "Почати з порожнього",
+    "startEmptyHint": "Створює ланцюжок без моделей і не додає до нього нові моделі каталогу. Без позначки він починається як копія типового ланцюжка.",
+    "curated": "Ручний",
+    "curatedHint": "Нові моделі каталогу не додаються до цього ланцюжка автоматично."
   }
 }

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "غیر پیمائش شدہ ماڈلز دریافت کریں",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "O'lchanmagan modellarni o'rganish",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Bật hoặc tắt mọi mô hình đang hiển thị",
+    "enableAll": "Bật tất cả",
+    "disableAll": "Tắt tất cả",
+    "enableAllHint": "Bật mọi mô hình đang hiển thị rồi lưu",
+    "disableAllHint": "Tắt mọi mô hình đang hiển thị rồi lưu",
+    "enabledOfShown": "{enabled} trong {shown} mô hình đang hiển thị nằm trong chuỗi"
   },
   "strategies": {
     "explore": "Khám phá các mô hình chưa được đo",
@@ -1054,6 +1060,10 @@
     "create": "Tạo",
     "createPlaceholder": "Tên chuỗi",
     "createFailed": "Không tạo được chuỗi.",
-    "nameRules": "Tối đa 20 ký tự: chữ cái, chữ số, gạch nối và gạch dưới."
+    "nameRules": "Tối đa 20 ký tự: chữ cái, chữ số, gạch nối và gạch dưới.",
+    "startEmpty": "Bắt đầu rỗng",
+    "startEmptyHint": "Tạo chuỗi không có mô hình nào và không tự thêm mô hình mới từ danh mục. Bỏ chọn thì chuỗi bắt đầu như bản sao của chuỗi mặc định.",
+    "curated": "Tự chọn",
+    "curatedHint": "Mô hình mới trong danh mục không được thêm tự động vào chuỗi này."
   }
 }

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "Enable or disable every shown model",
+    "enableAll": "Enable all",
+    "disableAll": "Disable all",
+    "enableAllHint": "Turn on every model shown, then Save",
+    "disableAllHint": "Turn off every model shown, then Save",
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
   },
   "strategies": {
     "explore": "Ṣawari awọn awoṣe ti a ko ti wọn",
@@ -1054,6 +1060,10 @@
     "create": "Create",
     "createPlaceholder": "Chain name",
     "createFailed": "Could not create the chain.",
-    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores."
+    "nameRules": "Up to 20 characters: letters, digits, hyphens and underscores.",
+    "startEmpty": "Start empty",
+    "startEmptyHint": "Create the chain with no models in it, and keep new catalog models out of it. Unchecked, it starts as a copy of the default chain.",
+    "curated": "Curated",
+    "curatedHint": "New catalog models are not added to this chain automatically."
   }
 }

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "启用或停用所有显示的模型",
+    "enableAll": "全部启用",
+    "disableAll": "全部停用",
+    "enableAllHint": "启用所有显示的模型，然后保存",
+    "disableAllHint": "停用所有显示的模型，然后保存",
+    "enabledOfShown": "显示的 {shown} 个模型中有 {enabled} 个在链中"
   },
   "strategies": {
     "explore": "探索未测模型",
@@ -1054,6 +1060,10 @@
     "create": "创建",
     "createPlaceholder": "链名称",
     "createFailed": "无法创建该链。",
-    "nameRules": "最多 20 个字符：字母、数字、连字符和下划线。"
+    "nameRules": "最多 20 个字符：字母、数字、连字符和下划线。",
+    "startEmpty": "从空链开始",
+    "startEmptyHint": "创建时不放入任何模型，之后新增的目录模型也不会自动加入。不勾选则复制默认链。",
+    "curated": "手动维护",
+    "curatedHint": "新的目录模型不会自动加入这条链。"
   }
 }

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -274,7 +274,13 @@
     "aliasMergeHeading": "Merge model aliases",
     "aliasMergeHint": "Requests for the unified model id are also served through these custom-provider aliases (e.g. custom:my-alias).",
     "aliasMergeAdd": "Add",
-    "aliasMergeRemove": "Remove"
+    "aliasMergeRemove": "Remove",
+    "bulkToggle": "啟用或停用所有顯示的模型",
+    "enableAll": "全部啟用",
+    "disableAll": "全部停用",
+    "enableAllHint": "啟用所有顯示的模型，然後儲存",
+    "disableAllHint": "停用所有顯示的模型，然後儲存",
+    "enabledOfShown": "顯示的 {shown} 個模型中有 {enabled} 個在鏈中"
   },
   "strategies": {
     "explore": "探索未測模型",
@@ -1054,6 +1060,10 @@
     "create": "建立",
     "createPlaceholder": "鏈名稱",
     "createFailed": "無法建立此鏈。",
-    "nameRules": "最多 20 個字元：字母、數字、連字號與底線。"
+    "nameRules": "最多 20 個字元：字母、數字、連字號與底線。",
+    "startEmpty": "從空鏈開始",
+    "startEmptyHint": "建立時不放入任何模型，之後新增的目錄模型也不會自動加入。不勾選則複製預設鏈。",
+    "curated": "手動維護",
+    "curatedHint": "新的目錄模型不會自動加入這條鏈。"
   }
 }

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -219,6 +219,20 @@ export default function FallbackPage() {
     setLocalEntries(allEntries.map(e => (ids.has(e.modelDbId) ? { ...e, enabled } : e)))
   }
 
+  // Bulk on/off over what is currently on screen (#895). Curating a chain by
+  // hand means turning most of the catalog off, which one row at a time over
+  // 200 models nobody does. It deliberately follows the filters: "search groq,
+  // disable all" is the useful gesture, and touching hidden rows would be a
+  // surprise. Like every other edit here it stages into localEntries and waits
+  // for Save.
+  const visibleMemberIds = visibleGroups.flatMap(g => g.members.map(m => m.modelDbId))
+  const visibleEnabledCount = visibleGroups.filter(g => g.members.some(m => m.enabled)).length
+
+  function handleBulkToggle(enabled: boolean) {
+    const ids = new Set(visibleMemberIds)
+    setLocalEntries(allEntries.map(e => (ids.has(e.modelDbId) ? { ...e, enabled } : e)))
+  }
+
   // Serialize the displayed group order (group-major, member-minor) to the flat
   // priority list PUT /api/fallback expects; keyless rows keep their tail spot.
   function persistGroupOrder(groups: ModelGroupRow[]) {
@@ -434,8 +448,32 @@ export default function FallbackPage() {
                     </button>
                   ))}
                 </div>
+                <div className="inline-flex items-center gap-1 rounded-xl border p-1" role="group" aria-label={t('models.bulkToggle')}>
+                  <Tooltip text={t('models.enableAllHint')}>
+                    <button
+                      onClick={() => handleBulkToggle(true)}
+                      disabled={visibleEnabledCount === visibleGroups.length}
+                      className="rounded-lg px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent"
+                    >
+                      {t('models.enableAll')}
+                    </button>
+                  </Tooltip>
+                  <Tooltip text={t('models.disableAllHint')}>
+                    <button
+                      onClick={() => handleBulkToggle(false)}
+                      disabled={visibleEnabledCount === 0}
+                      className="rounded-lg px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent"
+                    >
+                      {t('models.disableAll')}
+                    </button>
+                  </Tooltip>
+                </div>
               </div>
             </div>
+
+            <p className="text-xs text-muted-foreground">
+              {t('models.enabledOfShown', { enabled: visibleEnabledCount, shown: visibleGroups.length })}
+            </p>
 
             {filtersActive && (
               <div className="flex items-center justify-between text-xs text-muted-foreground">

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -31,6 +31,7 @@ const CUSTOM_MODEL_TOMBSTONES_FILENAME = '20260819_000001_custom_model_tombstone
 const SERVER_LOGS_FILENAME = '20260823_000001_server_logs.ts';
 const BACKUPS_TABLE_FILENAME = '20260823_000002_backups_table.ts';
 const ATTEMPT_KEY_LABEL_FILENAME = '20260823_000003_attempt_key_label.ts';
+const PROFILE_AUTO_INCLUDE_FILENAME = '20260823_000004_profile_auto_include.ts';
 
 interface SchemaRow {
   type: string;
@@ -108,6 +109,7 @@ describe('migration round trip', () => {
         SERVER_LOGS_FILENAME,
         BACKUPS_TABLE_FILENAME,
         ATTEMPT_KEY_LABEL_FILENAME,
+        PROFILE_AUTO_INCLUDE_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/profiles-chains.test.ts
+++ b/server/src/__tests__/routes/profiles-chains.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb } from '../../db/index.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+import { ensureAllModelsInProfiles, ensureModelInProfiles } from '../../services/profile-models.js';
+
+// Named fallback chains you build by hand (#895). Two things have to hold for
+// a curated chain to survive: creating one must not dump the whole catalog
+// into it, and the catalog-sync backfill must leave it alone afterwards.
+let app: Express;
+let dashToken = '';
+
+async function request(method: string, path: string, body?: unknown) {
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method,
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(isGatedApiPath(path) ? { Authorization: `Bearer ${dashToken}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data };
+}
+
+function chainSize(profileId: number): number {
+  return (getDb().prepare('SELECT COUNT(*) AS n FROM profile_models WHERE profile_id = ?')
+    .get(profileId) as { n: number }).n;
+}
+
+function autoInclude(profileId: number): number {
+  return (getDb().prepare('SELECT auto_include_new_models AS flag FROM profiles WHERE id = ?')
+    .get(profileId) as { flag: number }).flag;
+}
+
+// A model that arrives after the chains already exist — what a catalog sync
+// produces, and what the backfill would otherwise push into every chain.
+function addCatalogModel(modelId: string): number {
+  const db = getDb();
+  const inserted = db.prepare(`
+    INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, size_label, enabled)
+    VALUES ('groq', ?, ?, 500, 500, 'Small', 1)
+  `).run(modelId, `Synced ${modelId}`);
+  const id = Number(inserted.lastInsertRowid);
+  db.prepare('INSERT INTO fallback_config (model_db_id, priority, enabled) VALUES (?, 500, 1)').run(id);
+  return id;
+}
+
+describe('named fallback chains', () => {
+  beforeEach(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  it('creates an empty chain that holds nothing (#895)', async () => {
+    const { status, body } = await request('POST', '/api/profiles', { name: 'hand-built', empty: true });
+    expect(status).toBe(201);
+    expect(body.name).toBe('hand-built');
+    expect(chainSize(body.id)).toBe(0);
+    // An empty chain opts out of the backfill by construction — otherwise the
+    // next catalog sync would undo the emptiness.
+    expect(autoInclude(body.id)).toBe(0);
+  });
+
+  it('still copies the catalog when empty is not asked for', async () => {
+    const { status, body } = await request('POST', '/api/profiles', { name: 'inherited' });
+    expect(status).toBe(201);
+
+    const catalogSize = (getDb().prepare('SELECT COUNT(*) AS n FROM fallback_config').get() as { n: number }).n;
+    expect(catalogSize).toBeGreaterThan(0);
+    expect(chainSize(body.id)).toBe(catalogSize);
+    expect(autoInclude(body.id)).toBe(1);
+  });
+
+  it('lets empty win over a source chain to copy from', async () => {
+    const source = await request('POST', '/api/profiles', { name: 'source' });
+    expect(chainSize(source.body.id)).toBeGreaterThan(0);
+
+    const { status, body } = await request('POST', '/api/profiles', {
+      name: 'empty-clone', empty: true, sourceProfileId: source.body.id,
+    });
+    expect(status).toBe(201);
+    expect(chainSize(body.id)).toBe(0);
+  });
+
+  it('keeps a curated chain pruned across a catalog backfill (#895)', async () => {
+    const curated = (await request('POST', '/api/profiles', { name: 'curated', empty: true })).body;
+    const inheriting = (await request('POST', '/api/profiles', { name: 'inheriting' })).body;
+    const inheritingBefore = chainSize(inheriting.id);
+
+    addCatalogModel('backfill-arrival');
+    ensureAllModelsInProfiles(getDb());
+
+    // The chain that opted in grew by the new model; the curated one did not.
+    expect(chainSize(inheriting.id)).toBe(inheritingBefore + 1);
+    expect(chainSize(curated.id)).toBe(0);
+  });
+
+  it('keeps a curated chain pruned when a single model is registered', async () => {
+    const curated = (await request('POST', '/api/profiles', { name: 'curated', empty: true })).body;
+    const inheriting = (await request('POST', '/api/profiles', { name: 'inheriting' })).body;
+    const inheritingBefore = chainSize(inheriting.id);
+
+    // The per-model path, used when one custom endpoint model is registered.
+    const modelDbId = addCatalogModel('single-arrival');
+    ensureModelInProfiles(getDb(), modelDbId);
+
+    expect(chainSize(inheriting.id)).toBe(inheritingBefore + 1);
+    expect(chainSize(curated.id)).toBe(0);
+  });
+
+  it('lets a chain opt out of the backfill after the fact', async () => {
+    const chain = (await request('POST', '/api/profiles', { name: 'settled' })).body;
+    expect(autoInclude(chain.id)).toBe(1);
+
+    // Prune it by hand, then stop new models from being pushed back in.
+    getDb().prepare('DELETE FROM profile_models WHERE profile_id = ?').run(chain.id);
+    const updated = await request('PUT', `/api/profiles/${chain.id}`, { auto_include_new_models: false });
+    expect(updated.status).toBe(200);
+    expect(updated.body.auto_include_new_models).toBe(0);
+    expect(autoInclude(chain.id)).toBe(0);
+
+    addCatalogModel('after-opt-out');
+    ensureAllModelsInProfiles(getDb());
+    expect(chainSize(chain.id)).toBe(0);
+  });
+
+  it('reports the flag on the chain listing so the dashboard can show it', async () => {
+    await request('POST', '/api/profiles', { name: 'curated', empty: true });
+    const { status, body } = await request('GET', '/api/profiles');
+    expect(status).toBe(200);
+
+    const curated = body.find((p: { name: string }) => p.name === 'curated');
+    expect(curated.auto_include_new_models).toBe(0);
+    // The seeded Default chain keeps the old behaviour.
+    const fallbackDefault = body.find((p: { type: string }) => p.type === 'default');
+    expect(fallbackDefault.auto_include_new_models).toBe(1);
+  });
+});

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -26,6 +26,7 @@ import * as customModelTombstones from '../migrations/20260819_000001_custom_mod
 import * as serverLogs from '../migrations/20260823_000001_server_logs.js';
 import * as backupsTable from '../migrations/20260823_000002_backups_table.js';
 import * as attemptKeyLabel from '../migrations/20260823_000003_attempt_key_label.js';
+import * as profileAutoInclude from '../migrations/20260823_000004_profile_auto_include.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -64,6 +65,7 @@ export const CUSTOM_MODEL_TOMBSTONES_FILENAME = '20260819_000001_custom_model_to
 export const SERVER_LOGS_FILENAME = '20260823_000001_server_logs.ts';
 export const BACKUPS_TABLE_FILENAME = '20260823_000002_backups_table.ts';
 export const ATTEMPT_KEY_LABEL_FILENAME = '20260823_000003_attempt_key_label.ts';
+export const PROFILE_AUTO_INCLUDE_FILENAME = '20260823_000004_profile_auto_include.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -93,4 +95,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: SERVER_LOGS_FILENAME, module: serverLogs },
   { filename: BACKUPS_TABLE_FILENAME, module: backupsTable },
   { filename: ATTEMPT_KEY_LABEL_FILENAME, module: attemptKeyLabel },
+  { filename: PROFILE_AUTO_INCLUDE_FILENAME, module: profileAutoInclude },
 ];

--- a/server/src/db/migrations/20260823_000004_profile_auto_include.ts
+++ b/server/src/db/migrations/20260823_000004_profile_auto_include.ts
@@ -1,0 +1,28 @@
+import type { Db } from '../types.js';
+
+function hasColumn(db: Db, table: string, column: string): boolean {
+  const columns = db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[];
+  return columns.some((candidate) => candidate.name === column);
+}
+
+/** Per-chain opt-out from the catalog-sync backfill (#895).
+ *
+ *  Every profile used to be a copy of the whole catalog, and `ensureAllModelsInProfiles`
+ *  put each newly synced model into every profile. That is right for a chain
+ *  the user never pruned, and wrong for one they curated by hand: the next
+ *  catalog sync silently pushed a dozen models back into it.
+ *
+ *  1 (the default, and what every existing chain gets) keeps the old behaviour.
+ *  A chain created with `empty: true` starts at 0, so it only ever holds what
+ *  the user put in it. */
+export function up(db: Db): void {
+  if (!hasColumn(db, 'profiles', 'auto_include_new_models')) {
+    db.prepare('ALTER TABLE profiles ADD COLUMN auto_include_new_models INTEGER NOT NULL DEFAULT 1').run();
+  }
+}
+
+export function down(db: Db): void {
+  if (hasColumn(db, 'profiles', 'auto_include_new_models')) {
+    db.prepare('ALTER TABLE profiles DROP COLUMN auto_include_new_models').run();
+  }
+}

--- a/server/src/routes/profiles.ts
+++ b/server/src/routes/profiles.ts
@@ -34,6 +34,12 @@ const createSchema = z.object({
   emoji: z.string().max(4).default(''),
   color: z.string().default('#6366f1'),
   sourceProfileId: z.number().optional(),
+  // Start the chain with nothing in it instead of a copy of the whole catalog
+  // (#895). The point of a named chain is usually "these three models, in this
+  // order" — starting from 200 rows means deleting 197 of them by hand. An
+  // empty chain also opts out of the catalog-sync backfill, so it stays as
+  // small as the user built it.
+  empty: z.boolean().default(false),
 });
 
 const updateSchema = z.object({
@@ -44,6 +50,7 @@ const updateSchema = z.object({
   sort_order: z.number().optional(),
   auto_sort: z.enum(['intelligence', 'speed', 'budget']).nullable().optional(),
   layout_config: z.string().nullable().optional(),
+  auto_include_new_models: z.boolean().optional(),
 });
 
 function getId(req: Request): number {
@@ -58,7 +65,7 @@ function getId(req: Request): number {
 profilesRouter.get('/', (_req: Request, res: Response) => {
   const db = getDb();
   const profiles = db.prepare(`
-    SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, created_at
+    SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, auto_include_new_models, created_at
     FROM profiles
     ORDER BY (CASE WHEN type = 'default' THEN 1 ELSE 0 END) DESC, is_favorite DESC, sort_order ASC, id ASC
   `).all();
@@ -136,7 +143,7 @@ profilesRouter.post('/', (req: Request, res: Response) => {
   }
 
   const db = getDb();
-  const { name, emoji, color, sourceProfileId } = parsed.data;
+  const { name, emoji, color, sourceProfileId, empty } = parsed.data;
 
   // Check for case-insensitive duplicate profile names
   const duplicate = db.prepare('SELECT id FROM profiles WHERE LOWER(name) = LOWER(?)').get(name) as any;
@@ -158,16 +165,18 @@ profilesRouter.post('/', (req: Request, res: Response) => {
   }
 
   const result = db.prepare(
-    'INSERT INTO profiles (name, emoji, color, type, sort_order, layout_config, auto_sort) VALUES (?, ?, ?, ?, ?, ?, ?)'
-  ).run(name, emoji, color, 'custom', maxOrder + 1, layoutConfig, autoSort);
+    'INSERT INTO profiles (name, emoji, color, type, sort_order, layout_config, auto_sort, auto_include_new_models) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  ).run(name, emoji, color, 'custom', maxOrder + 1, layoutConfig, autoSort, empty ? 0 : 1);
 
   const profileId = result.lastInsertRowid as number;
 
-  if (sourceProfileId) {
-    const source = db.prepare('SELECT id FROM profiles WHERE id = ?').get(sourceProfileId) as any;
-    if (!source) {
-      copyFromDefault(db, profileId);
-    } else {
+  // `empty` wins over `sourceProfileId`: it is the more specific of the two
+  // requests, and copying a source chain in would defeat the point of it.
+  if (!empty) {
+    const source = sourceProfileId
+      ? db.prepare('SELECT id FROM profiles WHERE id = ?').get(sourceProfileId) as any
+      : null;
+    if (source) {
       db.prepare(`
         INSERT INTO profile_models (profile_id, model_db_id, priority, enabled)
         SELECT ?, model_db_id, priority, enabled
@@ -175,12 +184,12 @@ profilesRouter.post('/', (req: Request, res: Response) => {
         WHERE profile_id = ?
         ORDER BY priority ASC
       `).run(profileId, sourceProfileId);
+    } else {
+      copyFromDefault(db, profileId);
     }
-  } else {
-    copyFromDefault(db, profileId);
   }
 
-  const created = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, created_at FROM profiles WHERE id = ?').get(profileId);
+  const created = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, auto_include_new_models, created_at FROM profiles WHERE id = ?').get(profileId);
   res.status(201).json(created);
 });
 
@@ -227,8 +236,8 @@ profilesRouter.put('/:id', (req: Request, res: Response) => {
       if (isProtected && (key === 'name' || key === 'emoji' || key === 'color')) {
         continue;
       }
-      if (key === 'is_favorite') {
-        updates.push('is_favorite = ?');
+      if (key === 'is_favorite' || key === 'auto_include_new_models') {
+        updates.push(`${key} = ?`);
         values.push(value ? 1 : 0);
       } else {
         updates.push(`${key} = ?`);
@@ -247,7 +256,7 @@ profilesRouter.put('/:id', (req: Request, res: Response) => {
     sortProfileModels(db, profileId, parsed.data.auto_sort);
   }
 
-  const updated = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, created_at FROM profiles WHERE id = ?').get(profileId);
+  const updated = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, auto_include_new_models, created_at FROM profiles WHERE id = ?').get(profileId);
   res.json(updated);
 });
 
@@ -320,7 +329,7 @@ profilesRouter.post('/:id/reset', (req: Request, res: Response) => {
   });
   transaction();
 
-  const updated = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, created_at FROM profiles WHERE id = ?').get(profileId);
+  const updated = db.prepare('SELECT id, name, emoji, color, type, is_favorite, sort_order, auto_sort, layout_config, auto_include_new_models, created_at FROM profiles WHERE id = ?').get(profileId);
   res.json(updated);
 });
 

--- a/server/src/services/profile-models.ts
+++ b/server/src/services/profile-models.ts
@@ -9,8 +9,15 @@ export function getActiveProfileId(db: Db): number | null {
   return profile ? profileId : null;
 }
 
+// Only chains that still opt in to the backfill (#895). A chain created with
+// `empty: true` — or one the operator later switched the flag off on — holds
+// exactly what was put in it, and a catalog sync must not quietly refill it.
+const AUTO_INCLUDING_PROFILES_SQL = `
+  SELECT id FROM profiles WHERE auto_include_new_models = 1 ORDER BY id ASC
+`;
+
 export function ensureModelInProfiles(db: Db, modelDbId: number): void {
-  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  const profiles = db.prepare(AUTO_INCLUDING_PROFILES_SQL).all() as { id: number }[];
   const fallback = db.prepare('SELECT enabled FROM fallback_config WHERE model_db_id = ?').get(modelDbId) as { enabled: number } | undefined;
   if (!fallback) return;
 
@@ -26,7 +33,7 @@ export function ensureModelInProfiles(db: Db, modelDbId: number): void {
 }
 
 export function ensureAllModelsInProfiles(db: Db): void {
-  const profiles = db.prepare('SELECT id FROM profiles ORDER BY id ASC').all() as { id: number }[];
+  const profiles = db.prepare(AUTO_INCLUDING_PROFILES_SQL).all() as { id: number }[];
   if (profiles.length === 0) return;
 
   const missing = db.prepare(`


### PR DESCRIPTION
POST /api/profiles accepts empty: true to create a chain with nothing in it, a new auto_include_new_models flag keeps catalog sync from refilling curated chains, and the routing table gets enable all and disable all for the visible rows. Closes #895.