### PR TITLE
fix(google): diff cumulative streamGenerateContent chunks to true incremental deltas

### DIFF
--- a/server/src/__tests__/providers/google.test.ts
+++ b/server/src/__tests__/providers/google.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GoogleProvider } from '../../providers/google.js';
+import { GoogleProvider, diffCumulativeText } from '../../providers/google.js';
 
 describe('GoogleProvider', () => {
   let provider: GoogleProvider;
@@ -682,6 +682,53 @@ describe('GoogleProvider', () => {
     expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('stop');
   });
 
+  it('diffs cumulative streamGenerateContent chunks into true incremental deltas', async () => {
+    // Regression: Gemini (notably with thinking/structured output) can resend
+    // the full accumulated text per chunk instead of only new fragments.
+    // Downstream delta-append consumers rendered duplicated output when the
+    // cumulative chunk was forwarded as-is. Each emitted delta.content must be
+    // a strictly incremental suffix.
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(sseResponse([
+      'data: {"candidates":[{"content":{"parts":[{"text":"Qual"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"Qual deles"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"Qual deles você quer atacar?"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}\n\n',
+    ]));
+
+    const chunks = await collect(provider.streamChatCompletion(
+      'test-key',
+      [{ role: 'user', content: 'Hi' }],
+      'gemini-2.5-pro',
+    ));
+
+    const deltas = chunks.map(c => c.choices[0].delta.content).filter((d): d is string => Boolean(d));
+    // strictly incremental — no delta repeats text already emitted
+    expect(deltas).toEqual(['Qual', ' deles', ' você quer atacar?']);
+    expect(deltas.join('')).toBe('Qual deles você quer atacar?');
+    expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('stop');
+  });
+
+  it('cumulative diffing does not corrupt reasoning_content or tool calls', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(sseResponse([
+      'data: {"candidates":[{"content":{"parts":[{"text":"thinking hard","thought":true}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"city":"Uberaba"}}}]},"finishReason":"STOP"}]}\n\n',
+    ]));
+
+    const chunks = await collect(provider.streamChatCompletion(
+      'test-key',
+      [{ role: 'user', content: 'Hi' }],
+      'gemini-2.5-pro',
+    ));
+
+    const reasoning = chunks.map(c => c.choices[0].delta.reasoning_content ?? '').join('');
+    const text = chunks.map(c => c.choices[0].delta.content ?? '').join('');
+    expect(reasoning).toBe('thinking hard'); // thought parts bypass the text diff
+    expect(text).toBe('Answer');
+    const tools = chunks.flatMap(c => c.choices[0].delta.tool_calls ?? []);
+    expect(tools.length).toBe(1);
+  });
+
   it('skips a malformed SSE frame instead of aborting the whole stream', async () => {
     // Regression: previously an unguarded JSON.parse would propagate, killing
     // the stream after a single bad chunk. Other providers (openai-compat,
@@ -702,6 +749,50 @@ describe('GoogleProvider', () => {
     const text = chunks.map(c => c.choices[0].delta.content ?? '').join('');
     expect(text).toBe('Hello');
     expect(chunks[chunks.length - 1].choices[0].finish_reason).toBe('stop');
+  });
+
+  // Regression: Gemini's streamGenerateContent doesn't guarantee incremental
+  // chunks — some responses resend the full candidate text accumulated so
+  // far in each chunk. Forwarding that as-is duplicated/overlapped text for
+  // every downstream consumer of this OpenAI-compatible stream (#observed as
+  // duplicated paragraphs in ATLAS's chat surfaces routed through Gemini).
+  it('diffs cumulative chunks down to the true incremental delta', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(sseResponse([
+      'data: {"candidates":[{"content":{"parts":[{"text":"Qual deles"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[{"text":"Qual deles você quer atacar?"}]}}]}\n\n',
+      'data: {"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}]}\n\n',
+    ]));
+
+    const chunks = await collect(provider.streamChatCompletion(
+      'test-key',
+      [{ role: 'user', content: 'Hi' }],
+      'gemini-2.5-pro',
+    ));
+
+    const text = chunks.map(c => c.choices[0].delta.content ?? '').join('');
+    expect(text).toBe('Qual deles você quer atacar?');
+  });
+
+  describe('diffCumulativeText', () => {
+    it('forwards the first chunk unchanged', () => {
+      expect(diffCumulativeText('', 'Qual deles')).toBe('Qual deles');
+    });
+
+    it('diffs a cumulative chunk down to the new suffix', () => {
+      expect(diffCumulativeText('Qual deles você quer', 'Qual deles você quer atacar?')).toBe(' atacar?');
+    });
+
+    it('forwards a genuinely incremental chunk as-is', () => {
+      expect(diffCumulativeText('Qual deles', ' você quer')).toBe(' você quer');
+    });
+
+    it('drops an exact repeat of already-sent text', () => {
+      expect(diffCumulativeText('Qual deles', 'Qual deles')).toBeNull();
+    });
+
+    it('drops a chunk that is a strict prefix of already-sent text', () => {
+      expect(diffCumulativeText('Qual deles você quer', 'Qual deles')).toBeNull();
+    });
   });
 
   it('streams functionCall parts as tool_calls with finish_reason=tool_calls', async () => {

--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -522,6 +522,24 @@ function extractReasoningContent(parts: GeminiPart[] | undefined): string | null
   return text.length > 0 ? text : null;
 }
 
+/**
+ * Normalizes a Gemini stream chunk's text against what's already been sent
+ * on this stream, returning just the new incremental piece.
+ *
+ * Handles both chunking modes Gemini uses in the wild: genuinely incremental
+ * chunks (`chunkText` doesn't overlap `previousText`, forwarded as-is) and
+ * cumulative chunks (`chunkText` restates everything sent so far plus more,
+ * sliced down to the new suffix). A chunk that is a strict prefix of, or
+ * identical to, what's already been sent carries no new content.
+ */
+export function diffCumulativeText(previousText: string, chunkText: string): string | null {
+  if (!previousText) return chunkText;
+  if (chunkText === previousText) return null;
+  if (chunkText.startsWith(previousText)) return chunkText.slice(previousText.length);
+  if (previousText.startsWith(chunkText)) return null;
+  return chunkText;
+}
+
 function toGeminiStopSequences(stop: CompletionOptions['stop']): string[] | undefined {
   if (!stop) return undefined;
   return Array.isArray(stop) ? stop : [stop];
@@ -686,6 +704,16 @@ export class GoogleProvider extends BaseProvider {
     let sawToolCalls = false;
 
     const seenToolCallKeys = new Set<string>();
+    // Gemini's streamGenerateContent does not guarantee incremental chunks —
+    // some responses (notably when thinking/structured output is involved)
+    // resend the full candidate text accumulated so far in each chunk rather
+    // than just the new fragment. Every downstream consumer of this
+    // OpenAI-compatible stream (including ATLAS's delta buffer and chat
+    // renderers) trusts `delta.content` to be a true incremental delta;
+    // forwarding a cumulative chunk as-is duplicates/overlaps the rendered
+    // text. Track what's already been emitted and diff cumulative chunks
+    // down to just the new suffix before yielding.
+    let previousText = '';
 
     // Same mid-stream inactivity watchdog as readSseStream (#553): this adapter
     // parses Gemini's own frame format, so it reads the body itself and used to
@@ -742,7 +770,12 @@ export class GoogleProvider extends BaseProvider {
           const candidate = chunk.candidates?.[0];
           const parts = candidate?.content?.parts ?? [];
 
-          const text = extractText(parts);
+          const rawText = extractText(parts);
+          // Gemini may resend cumulative text; diff to a true incremental delta.
+          // (L2 fix: duplicated output in downstream delta-append consumers.)
+          const deltaText = rawText ? diffCumulativeText(previousText, rawText) : null;
+          if (deltaText) previousText += deltaText;
+          const text = deltaText ?? null;
           const reasoningContent = extractReasoningContent(parts);
           const toolCalls = extractToolCalls(parts).filter(call => {
             const key = `${call.id}:${call.function.name}:${call.function.arguments}`;


### PR DESCRIPTION
## Problem

Gemini's `streamGenerateContent` does not guarantee incremental chunks. In several modes — notably **thinking models** and some structured-output responses — each SSE frame carries the **full accumulated candidate text** rather than only the new fragment.

The OpenAI-compatible chunk contract that this proxy exposes expects `delta.content` to be a strictly incremental suffix. Forwarding Gemini's cumulative chunks as-is caused downstream consumers (chat renderers, delta-buffering clients) to display duplicated/overlapping output.

## Fix

Track the text already emitted and diff each chunk's visible text down to the new suffix (`diffCumulativeText`) before yielding:

- thought/reasoning parts bypass the text diff and keep flowing as `reasoning_content`
- tool calls unchanged (existing `seenToolCallKeys` dedupe still applies)
- malformed SSE frames still skipped defensively

## Tests

- Unit tests for the `diffCumulativeText` helper (prefix-extension, exact-repeat, subset, disjoint cases)
- Streaming regression test: cumulative chunks render as strictly incremental deltas, joined text equals full content
- Streaming regression test: reasoning_content and tool calls pass through unaffected while visible text is diffed

All 34 tests in `google.test.ts` pass.