### PR TITLE
Group the model budget legend by provider pool

### DIFF
--- a/client/src/components/token-usage-bar.tsx
+++ b/client/src/components/token-usage-bar.tsx
@@ -1,12 +1,26 @@
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronDown } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 import { formatPercent, formatTokens, platformColors, type TokenUsageData } from '@/lib/routing'
+import {
+  buildLegendGroups,
+  poolScopeWords,
+  type FreeTierPool,
+  type FreeTierResponse,
+  type LegendGroup,
+} from '@/lib/pool-legend'
 
 // Legend rows visible while collapsed (~6 rows: 6 × 16px line + 5 × 6px gap).
 const LEGEND_COLLAPSED_PX = 126
+
+const METRIC_KEYS: Record<string, string> = {
+  tokens: 'freeTier.metricTokens',
+  requests: 'freeTier.metricRequests',
+  credits: 'freeTier.metricCredits',
+  neurons: 'freeTier.metricNeurons',
+}
 
 // Stacked monthly token-budget bar with a collapsible per-model legend,
 // extracted from FallbackPage.
@@ -28,11 +42,19 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
   })
   const usedPct = totalBudget > 0 ? Math.min(100, (totalUsed / totalBudget) * 100) : 0
 
+  // Provider pools (#905): many models on one platform share a single free
+  // allowance, so the legend groups its rows under the pool they draw from
+  // rather than repeating the same numbers in a second table of its own.
+  const { data: freeTier } = useQuery({
+    queryKey: ['free-tier'],
+    queryFn: () => apiFetch<FreeTierResponse>('/api/free-tier'),
+  })
+
   // A model with no published monthly quota has nothing to say in a
   // remaining/budget legend, and one provider can contribute a hundred of them
   // (#887) — drowning the models that do have a budget. Count them instead.
-  const budgeted = modelsWithWidth.filter(m => m.budget > 0)
-  const unpublishedCount = modelsWithWidth.length - budgeted.length
+  const { groups, unpublishedCount, rowCount } = buildLegendGroups(modelsWithWidth, freeTier?.pools)
+  const hasPoolHeaders = groups.some(g => g.pool !== null)
 
   // Collapse the per-model legend to a few rows; the chevron reveals the rest.
   // The toggle only appears when the legend actually overflows the collapsed
@@ -48,7 +70,7 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
     const ro = new ResizeObserver(check)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [budgeted.length, unpublishedCount])
+  }, [rowCount, groups.length, unpublishedCount])
 
   return (
     <section className="rounded-3xl border bg-card p-5">
@@ -97,23 +119,41 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
         style={collapsible ? { maxHeight: expanded ? legendRef.current?.scrollHeight : LEGEND_COLLAPSED_PX } : undefined}
       >
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-5 gap-y-1.5 text-xs tabular-nums">
-          {budgeted.map((m, i) => (
-            <div key={i} className="flex items-center gap-2 min-w-0">
-              <span
-                className="size-2 rounded-sm flex-shrink-0"
-                style={{ backgroundColor: platformColors[m.platform] ?? '#94a3b8' }}
-              />
-              <span className="truncate">{m.displayName}</span>
-              <span className="flex-1" />
-              {/* remaining / budget: a bare remaining figure gives no sense of
-                  how much of the allowance is gone (#887). */}
-              <span
-                className="font-mono text-muted-foreground"
-                title={t('models.legendRemainingTitle', { name: m.displayName, platform: m.platform })}
-              >
-                {formatTokens(m.remainingTokens)}<span className="mx-0.5">/</span>{formatTokens(m.budget)}
-              </span>
-            </div>
+          {groups.map(group => (
+            <Fragment key={group.pool?.poolKey ?? 'independent'}>
+              {group.pool ? (
+                <PoolHeader pool={group.pool} />
+              ) : (
+                // Only worth naming once something else in the list IS a pool;
+                // on its own it is just the flat legend.
+                hasPoolHeaders && (
+                  <div className="col-span-full text-muted-foreground pt-1.5 first:pt-0">
+                    {t('freeTier.independentBudgets')}
+                  </div>
+                )
+              )}
+              {group.models.map((m, i) => (
+                <div
+                  key={`${m.platform}:${m.modelId ?? i}`}
+                  className={`flex items-center gap-2 min-w-0 ${group.pool || hasPoolHeaders ? 'pl-4' : ''}`}
+                >
+                  <span
+                    className="size-2 rounded-sm flex-shrink-0"
+                    style={{ backgroundColor: platformColors[m.platform] ?? '#94a3b8' }}
+                  />
+                  <span className="truncate">{m.displayName}</span>
+                  <span className="flex-1" />
+                  {/* remaining / budget: a bare remaining figure gives no sense of
+                      how much of the allowance is gone (#887). */}
+                  <span
+                    className="font-mono text-muted-foreground"
+                    title={t('models.legendRemainingTitle', { name: m.displayName, platform: m.platform })}
+                  >
+                    {formatTokens(m.remainingTokens)}<span className="mx-0.5">/</span>{formatTokens(m.budget)}
+                  </span>
+                </div>
+              ))}
+            </Fragment>
           ))}
         </div>
       </div>
@@ -131,155 +171,68 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
           onClick={() => setExpanded(e => !e)}
           className="mt-2 flex w-full items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
-          {expanded ? t('models.showLess') : t('models.showAllModels', { count: budgeted.length })}
+          {expanded ? t('models.showLess') : t('models.showAllModels', { count: rowCount })}
           <ChevronDown className={`size-3.5 transition-transform duration-300 ${expanded ? 'rotate-180' : ''}`} />
         </button>
       )}
-
-      <FreeTierPools />
     </section>
   )
 }
 
-interface FreeTierPool {
-  poolKey: string
-  platform: string
-  modelCount: number
-  disabledModelCount: number
-  keyCount: number
-  documentedBudget: number
-  bestLabel: string
-  kind: 'documented' | 'credits' | 'unpublished'
-  quota: {
-    limit: number | null
-    remaining: number | null
-    resetAt: string | null
-    metric: string
-    keyCount: number
-  } | null
-}
-
-interface FreeTierResponse {
-  generatedAt: string
-  summary: {
-    poolCount: number
-    documentedMonthlyTokens: number
-    creditsBasedPools: number
-    unpublishedPools: number
-  }
-  pools: FreeTierPool[]
-}
-
-const METRIC_KEYS: Record<string, string> = {
-  tokens: 'freeTier.metricTokens',
-  requests: 'freeTier.metricRequests',
-  credits: 'freeTier.metricCredits',
-  neurons: 'freeTier.metricNeurons',
-}
-
-// Pool-deduped free-tier budgets (#905). The stacked bar above sums per model,
-// which double-counts every model sharing one provider allowance; this is the
-// same capacity counted once per pool. It is a detail view, so it lives as a
-// collapsed row under the bar rather than as its own page — and it only fetches
-// once someone opens it.
-function FreeTierPools() {
+// One pool of models, headed by everything the separate pools table used to
+// show: what the pool is, how many models sit in it, the documented allowance
+// scaled by usable keys, and the live reading with its metric named.
+function PoolHeader({ pool }: { pool: NonNullable<LegendGroup['pool']> }) {
   const { t } = useI18n()
-  const [open, setOpen] = useState(false)
-  const { data } = useQuery({
-    queryKey: ['free-tier'],
-    queryFn: () => apiFetch<FreeTierResponse>('/api/free-tier'),
-    enabled: open,
-  })
+  const scope = poolScopeWords(pool.poolKey)
+  const label = scope
+    ? t('freeTier.poolLabel', { platform: pool.platform, scope })
+    : t('freeTier.poolLabelBare', { platform: pool.platform })
 
   return (
-    <div className="mt-3 border-t pt-2">
-      <button
-        onClick={() => setOpen(o => !o)}
-        className="flex w-full items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        aria-expanded={open}
-      >
-        {data ? t('freeTier.poolsToggle', { count: data.summary.poolCount }) : t('freeTier.poolsToggleBare')}
-        <ChevronDown className={`size-3.5 transition-transform duration-300 ${open ? 'rotate-180' : ''}`} />
-      </button>
-
-      {open && data && (
-        <div className="mt-3">
-          <p className="text-xs text-muted-foreground mb-2">
-            {t('freeTier.summary', {
-              pools: data.summary.poolCount,
-              budget: formatTokens(data.summary.documentedMonthlyTokens),
-              credits: data.summary.creditsBasedPools,
-              unpublished: data.summary.unpublishedPools,
-            })}
-          </p>
-          {data.pools.length === 0 ? (
-            <p className="text-xs text-muted-foreground py-2">{t('freeTier.empty')}</p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-xs tabular-nums">
-                <thead className="text-muted-foreground">
-                  <tr className="border-b">
-                    <th className="text-left font-normal py-1.5 pr-3">{t('freeTier.pool')}</th>
-                    <th className="text-right font-normal py-1.5 px-3">{t('freeTier.models')}</th>
-                    <th className="text-right font-normal py-1.5 px-3">{t('freeTier.budget')}</th>
-                    <th className="text-left font-normal py-1.5 px-3">{t('freeTier.kind')}</th>
-                    <th className="text-right font-normal py-1.5 px-3">{t('freeTier.remaining')}</th>
-                    <th className="text-left font-normal py-1.5 pl-3">{t('freeTier.resetAt')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.pools.map(p => (
-                    <tr key={p.poolKey} className="border-b last:border-0">
-                      <td className="py-1.5 pr-3">
-                        <span className="inline-flex items-center gap-2 min-w-0">
-                          <span
-                            className="size-2 rounded-sm flex-shrink-0"
-                            style={{ backgroundColor: platformColors[p.platform] ?? '#94a3b8' }}
-                          />
-                          <span className="truncate font-mono">{p.poolKey}</span>
-                        </span>
-                      </td>
-                      <td className="text-right py-1.5 px-3">
-                        {p.modelCount}
-                        {p.disabledModelCount > 0 && (
-                          <span className="text-muted-foreground">
-                            {' '}
-                            {t('freeTier.disabledModels', { count: p.disabledModelCount })}
-                          </span>
-                        )}
-                      </td>
-                      <td className="text-right py-1.5 px-3">
-                        {p.documentedBudget > 0 ? formatTokens(p.documentedBudget) : '—'}
-                      </td>
-                      <td className="py-1.5 px-3 text-muted-foreground">
-                        {t(`freeTier.kind${p.kind === 'documented' ? 'Documented' : p.kind === 'credits' ? 'Credits' : 'Unpublished'}`)}
-                      </td>
-                      <td className="text-right py-1.5 px-3">
-                        {p.quota?.remaining != null ? (
-                          <>
-                            {formatTokens(p.quota.remaining)}{' '}
-                            {/* Always say WHICH budget the number counts: a
-                                request counter next to a token budget reads as
-                                tokens otherwise. */}
-                            <span className="text-muted-foreground">
-                              {t(METRIC_KEYS[p.quota.metric] ?? 'freeTier.metricOther')}
-                            </span>
-                          </>
-                        ) : (
-                          '—'
-                        )}
-                      </td>
-                      <td className="py-1.5 pl-3 text-muted-foreground whitespace-nowrap">
-                        {p.quota?.resetAt ? new Date(p.quota.resetAt).toLocaleString() : '—'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+    <div className="col-span-full flex flex-wrap items-center gap-x-2 gap-y-0.5 pt-1.5 first:pt-0">
+      <span
+        className="size-2 rounded-sm flex-shrink-0"
+        style={{ backgroundColor: platformColors[pool.platform] ?? '#94a3b8' }}
+      />
+      <span className="font-medium truncate" title={pool.poolKey}>{label}</span>
+      <span className="text-muted-foreground">
+        {t('freeTier.poolModels', { count: pool.modelCount })}
+        {pool.disabledModelCount > 0 && ` ${t('freeTier.disabledModels', { count: pool.disabledModelCount })}`}
+      </span>
+      <span className="flex-1" />
+      <PoolQuota pool={pool} />
+      {pool.documentedBudget > 0 ? (
+        <span
+          className="font-mono text-muted-foreground"
+          title={t('freeTier.poolBudgetTitle', { count: Math.max(1, pool.keyCount) })}
+        >
+          {t('freeTier.poolBudget', { budget: formatTokens(pool.documentedBudget) })}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">
+          {pool.kind === 'credits' ? t('freeTier.kindCredits') : t('freeTier.poolNoQuota')}
+        </span>
       )}
     </div>
+  )
+}
+
+// The live reading, with the metric spelled out: a request counter next to a
+// token budget reads as tokens otherwise.
+function PoolQuota({ pool }: { pool: FreeTierPool }) {
+  const { t } = useI18n()
+  if (!pool.quota || pool.quota.remaining == null) return null
+  const metric = t(METRIC_KEYS[pool.quota.metric] ?? 'freeTier.metricOther')
+  return (
+    <span className="text-muted-foreground whitespace-nowrap">
+      <span className="font-mono">{formatTokens(pool.quota.remaining)}</span> {metric} {t('models.remaining')}
+      {pool.quota.resetAt && (
+        <>
+          <span className="mx-1.5">·</span>
+          {t('freeTier.poolResets', { time: new Date(pool.quota.resetAt).toLocaleString() })}
+        </>
+      )}
+    </span>
   )
 }

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "رصيد",
     "metricNeurons": "خلية عصبية",
     "metricOther": "وحدة",
-    "empty": "لا توجد نماذج مفعّلة تحتوي على بيانات ميزانية الطبقة المجانية."
+    "empty": "لا توجد نماذج مفعّلة تحتوي على بيانات ميزانية الطبقة المجانية.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "سلاسل التجاوز",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "Guthaben",
     "metricNeurons": "Neuronen",
     "metricOther": "Einheiten",
-    "empty": "Keine aktivierten Modelle mit Free-Tier-Budgetdaten."
+    "empty": "Keine aktivierten Modelle mit Free-Tier-Budgetdaten.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback-Ketten",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "créditos",
     "metricNeurons": "neuronas",
     "metricOther": "unidades",
-    "empty": "No hay modelos habilitados con datos de presupuesto del nivel gratuito."
+    "empty": "No hay modelos habilitados con datos de presupuesto del nivel gratuito.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Cadenas de reserva",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "crédits",
     "metricNeurons": "neurones",
     "metricOther": "unités",
-    "empty": "Aucun modèle activé avec des données de budget d'offre gratuite."
+    "empty": "Aucun modèle activé avec des données de budget d'offre gratuite.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Chaînes de repli",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "क्रेडिट",
     "metricNeurons": "न्यूरॉन",
     "metricOther": "इकाई",
-    "empty": "फ्री टियर बजट डेटा वाला कोई सक्षम मॉडल नहीं।"
+    "empty": "फ्री टियर बजट डेटा वाला कोई सक्षम मॉडल नहीं।",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "फ़ॉलबैक चेन",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "kredit",
     "metricNeurons": "neuron",
     "metricOther": "unit",
-    "empty": "Tidak ada model aktif dengan data anggaran tingkat gratis."
+    "empty": "Tidak ada model aktif dengan data anggaran tingkat gratis.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Rantai fallback",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "crediti",
     "metricNeurons": "neuroni",
     "metricOther": "unità",
-    "empty": "Nessun modello abilitato con dati di budget del piano gratuito."
+    "empty": "Nessun modello abilitato con dati di budget del piano gratuito.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Catene di fallback",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "クレジット",
     "metricNeurons": "ニューロン",
     "metricOther": "単位",
-    "empty": "無料枠の予算データを持つ有効なモデルがありません。"
+    "empty": "無料枠の予算データを持つ有効なモデルがありません。",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "フォールバックチェーン",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "크레딧",
     "metricNeurons": "뉴런",
     "metricOther": "단위",
-    "empty": "무료 등급 예산 데이터가 있는 활성화된 모델이 없습니다."
+    "empty": "무료 등급 예산 데이터가 있는 활성화된 모델이 없습니다.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "폴백 체인",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "tegoeden",
     "metricNeurons": "neuronen",
     "metricOther": "eenheden",
-    "empty": "Geen ingeschakelde modellen met gegevens over het gratis budget."
+    "empty": "Geen ingeschakelde modellen met gegevens over het gratis budget.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback-ketens",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "kredytów",
     "metricNeurons": "neuronów",
     "metricOther": "jednostek",
-    "empty": "Brak włączonych modeli z danymi o budżecie darmowego poziomu."
+    "empty": "Brak włączonych modeli z danymi o budżecie darmowego poziomu.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Łańcuchy awaryjne",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "créditos",
     "metricNeurons": "neurônios",
     "metricOther": "unidades",
-    "empty": "Nenhum modelo ativado com dados de orçamento do nível gratuito."
+    "empty": "Nenhum modelo ativado com dados de orçamento do nível gratuito.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Cadeias de fallback",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Cadeias de fallback",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "кредитов",
     "metricNeurons": "нейронов",
     "metricOther": "единиц",
-    "empty": "Нет включённых моделей с данными о бесплатном лимите."
+    "empty": "Нет включённых моделей с данными о бесплатном лимите.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Цепочки резервирования",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "kredi",
     "metricNeurons": "nöron",
     "metricOther": "birim",
-    "empty": "Ücretsiz katman bütçe verisi olan etkin model yok."
+    "empty": "Ücretsiz katman bütçe verisi olan etkin model yok.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Yedek zincirleri",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Ланцюжки резервування",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "tín dụng",
     "metricNeurons": "nơ-ron",
     "metricOther": "đơn vị",
-    "empty": "Không có mô hình đang bật nào có dữ liệu hạn mức miễn phí."
+    "empty": "Không có mô hình đang bật nào có dữ liệu hạn mức miễn phí.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Chuỗi dự phòng",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "Fallback chains",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "积分",
     "metricNeurons": "神经元",
     "metricOther": "单位",
-    "empty": "没有启用且带免费额度数据的模型。"
+    "empty": "没有启用且带免费额度数据的模型。",
+    "poolLabel": "{platform} · {scope} 共享池",
+    "poolLabelBare": "{platform} · 共享池",
+    "poolModels": "{count} 个模型",
+    "poolBudget": "{budget}/月",
+    "poolBudgetTitle": "整个额度池共用一份月度额度，已按该平台 {count} 个可用密钥换算。池中列出的每个模型都从同一份额度里扣。",
+    "poolNoQuota": "未公布额度",
+    "poolResets": "{time} 重置",
+    "independentBudgets": "独立额度"
   },
   "chains": {
     "title": "回退链",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -1050,7 +1050,15 @@
     "metricCredits": "credits",
     "metricNeurons": "neurons",
     "metricOther": "units",
-    "empty": "No enabled models with free-tier budget data."
+    "empty": "No enabled models with free-tier budget data.",
+    "poolLabel": "{platform} · shared {scope} pool",
+    "poolLabelBare": "{platform} · shared pool",
+    "poolModels": "{count} models",
+    "poolBudget": "{budget}/mo",
+    "poolBudgetTitle": "One monthly allowance for the whole pool, scaled by the {count} usable keys on this platform. Every model listed under it draws from the same budget.",
+    "poolNoQuota": "no published quota",
+    "poolResets": "resets {time}",
+    "independentBudgets": "independent budgets"
   },
   "chains": {
     "title": "回退鏈",

--- a/client/src/lib/pool-legend.test.ts
+++ b/client/src/lib/pool-legend.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { buildLegendGroups, isPerModelPool, poolScopeWords, type FreeTierPool, type LegendRow } from './pool-legend'
+
+function row(platform: string, modelId: string, budget: number, used = 0): LegendRow {
+  return {
+    displayName: `${platform}/${modelId}`,
+    platform,
+    modelId,
+    budget,
+    used,
+    usedTokens: used,
+    remainingTokens: Math.max(0, budget - used),
+    widthPct: 0,
+  }
+}
+
+function pool(over: Partial<FreeTierPool> & Pick<FreeTierPool, 'poolKey' | 'platform' | 'memberModelIds'>): FreeTierPool {
+  return {
+    modelCount: over.memberModelIds.length,
+    disabledModelCount: 0,
+    keyCount: 1,
+    documentedBudget: 0,
+    bestLabel: '',
+    kind: 'documented',
+    quota: null,
+    ...over,
+  }
+}
+
+describe('pool scope wording', () => {
+  it('reads the scope out of a pool key', () => {
+    expect(poolScopeWords('groq::account')).toBe('account')
+    expect(poolScopeWords('openrouter::free')).toBe('free')
+  })
+
+  it('drops a scope that would only repeat the word "pool"', () => {
+    // "nvidia · shared credit pool pool" helps nobody.
+    expect(poolScopeWords('nvidia::credit-pool')).toBe('credit')
+    expect(poolScopeWords('mistral::experiment-pool')).toBe('experiment')
+    expect(poolScopeWords('cerebras::shared')).toBe('')
+  })
+})
+
+describe('per-model pools', () => {
+  it('recognises a pool that is really just one model', () => {
+    expect(isPerModelPool(pool({ poolKey: 'custom::llama-3', platform: 'custom', memberModelIds: ['llama-3'] }))).toBe(true)
+    expect(isPerModelPool(pool({ poolKey: 'groq::account', platform: 'groq', memberModelIds: ['llama-3'] }))).toBe(false)
+  })
+})
+
+describe('legend grouping', () => {
+  const groq = pool({
+    poolKey: 'groq::account',
+    platform: 'groq',
+    memberModelIds: ['a', 'b'],
+    documentedBudget: 15_000_000,
+    disabledModelCount: 1,
+  })
+  const solo = pool({ poolKey: 'custom::c', platform: 'custom', memberModelIds: ['c'], documentedBudget: 1_000 })
+
+  it('nests each model under the pool that names it', () => {
+    const { groups, rowCount } = buildLegendGroups(
+      [row('groq', 'a', 10), row('groq', 'b', 20), row('custom', 'c', 30)],
+      [groq, solo],
+    )
+    expect(groups.map(g => g.pool?.poolKey ?? null)).toEqual(['groq::account', null])
+    expect(groups[0].models.map(m => m.modelId)).toEqual(['a', 'b'])
+    // A one-model pool is not worth a header of its own; it lands in the
+    // trailing independent group.
+    expect(groups[1].models.map(m => m.modelId)).toEqual(['c'])
+    expect(rowCount).toBe(3)
+  })
+
+  it('folds models with no published budget into the count, as the flat legend did', () => {
+    const { groups, unpublishedCount, rowCount } = buildLegendGroups(
+      [row('groq', 'a', 10), row('groq', 'b', 0)],
+      [groq],
+    )
+    expect(unpublishedCount).toBe(1)
+    expect(rowCount).toBe(1)
+    expect(groups[0].models.map(m => m.modelId)).toEqual(['a'])
+  })
+
+  it('keeps a header for a pool whose only numbers are live ones', () => {
+    const live = pool({
+      poolKey: 'kilo::anonymous',
+      platform: 'kilo',
+      memberModelIds: ['k'],
+      documentedBudget: 0,
+      kind: 'unpublished',
+      quota: { limit: null, remaining: 40, resetAt: null, metric: 'requests', keyCount: 1 },
+    })
+    const { groups, unpublishedCount } = buildLegendGroups([row('kilo', 'k', 0)], [live])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].models).toHaveLength(0)
+    expect(unpublishedCount).toBe(1)
+  })
+
+  it('drops a pool that publishes nothing and reports nothing', () => {
+    const silent = pool({
+      poolKey: 'llm7::anonymous',
+      platform: 'llm7',
+      memberModelIds: ['x'],
+      documentedBudget: 0,
+      kind: 'unpublished',
+    })
+    const { groups, unpublishedCount } = buildLegendGroups([row('llm7', 'x', 0)], [silent])
+    expect(groups).toHaveLength(0)
+    expect(unpublishedCount).toBe(1)
+  })
+
+  it('falls back to one flat group before the pools have loaded', () => {
+    const { groups, unpublishedCount, rowCount } = buildLegendGroups(
+      [row('groq', 'a', 10), row('groq', 'b', 0)],
+      undefined,
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0].pool).toBeNull()
+    expect(rowCount).toBe(1)
+    expect(unpublishedCount).toBe(1)
+  })
+
+  it('orders pools the way the server sent them and puts loose models last', () => {
+    const small = pool({ poolKey: 'kilo::anonymous', platform: 'kilo', memberModelIds: ['k'], documentedBudget: 5 })
+    const { groups } = buildLegendGroups(
+      [row('custom', 'c', 30), row('kilo', 'k', 5), row('groq', 'a', 10)],
+      [groq, small, solo],
+    )
+    expect(groups.map(g => g.pool?.poolKey ?? 'independent')).toEqual([
+      'groq::account',
+      'kilo::anonymous',
+      'independent',
+    ])
+  })
+})

--- a/client/src/lib/pool-legend.ts
+++ b/client/src/lib/pool-legend.ts
@@ -1,0 +1,151 @@
+// Grouping for the token-bar legend: which quota pool each model row belongs
+// to (#907 + #1005 merged into one list).
+//
+// The stacked bar's legend lists models; GET /api/free-tier lists the provider
+// pools those models draw from. They used to be two separate accordions saying
+// related things about the same numbers, so the legend now nests its model rows
+// under their pool. The join is platform + provider model id, which is what
+// both payloads carry per model — the pool key itself is provider knowledge
+// (see inferQuotaPoolKey on the server) and is deliberately NOT re-derived here.
+
+import type { TokenUsageData } from './routing'
+
+export type PoolKind = 'documented' | 'credits' | 'unpublished'
+
+export interface FreeTierPool {
+  poolKey: string
+  platform: string
+  memberModelIds: string[]
+  modelCount: number
+  disabledModelCount: number
+  keyCount: number
+  documentedBudget: number
+  bestLabel: string
+  kind: PoolKind
+  quota: {
+    limit: number | null
+    remaining: number | null
+    resetAt: string | null
+    metric: string
+    keyCount: number
+  } | null
+}
+
+export interface FreeTierResponse {
+  generatedAt: string
+  summary: {
+    poolCount: number
+    documentedMonthlyTokens: number
+    creditsBasedPools: number
+    unpublishedPools: number
+  }
+  pools: FreeTierPool[]
+}
+
+export type LegendModel = TokenUsageData['models'][number]
+
+export interface LegendRow extends LegendModel {
+  usedTokens: number
+  remainingTokens: number
+  widthPct: number
+}
+
+export interface LegendGroup {
+  /** The pool these rows share, or null for the trailing independent-budget
+   *  group (models whose "pool" is just themselves). */
+  pool: FreeTierPool | null
+  models: LegendRow[]
+}
+
+export interface LegendGrouping {
+  groups: LegendGroup[]
+  /** Rows with no budget to show, folded into the "+N with no published quota"
+   *  summary line the same way the flat legend folded them. */
+  unpublishedCount: number
+  /** How many model rows the groups actually render (drives "show all N"). */
+  rowCount: number
+}
+
+/** A pool of one model is not a pool: the model IS the budget. Those rows read
+ *  better ungrouped, so they collect in one trailing group instead of getting a
+ *  header each. */
+export function isPerModelPool(pool: FreeTierPool): boolean {
+  return pool.memberModelIds.some(id => pool.poolKey === `${pool.platform}::${id}`)
+}
+
+const scopeSeparator = '::'
+
+/**
+ * "groq::account" -> "account", "nvidia::credit-pool" -> "credit",
+ * "cerebras::shared" -> "" (nothing left worth saying).
+ * The caller turns what comes back into a sentence, so a scope that adds no
+ * information comes back empty rather than as a word to repeat.
+ */
+export function poolScopeWords(poolKey: string): string {
+  const index = poolKey.indexOf(scopeSeparator)
+  const scope = index === -1 ? '' : poolKey.slice(index + scopeSeparator.length)
+  const words = scope.replace(/[-_]+/g, ' ').replace(/\s+pool$/, '').trim()
+  return words === 'shared' ? '' : words
+}
+
+/**
+ * Nest the legend's model rows under their pools.
+ *
+ * Pool order is the server's (largest documented budget first) so the biggest
+ * allowance heads the list; model order inside a group is the chain order the
+ * bar itself uses. A pool that publishes nothing AND has no live reading and no
+ * budgeted member says nothing a reader can act on, so it folds into the
+ * unpublished count instead of taking up a header row.
+ */
+export function buildLegendGroups(models: LegendRow[], pools: FreeTierPool[] | undefined): LegendGrouping {
+  const budgeted = models.filter(m => m.budget > 0)
+
+  if (!pools || pools.length === 0) {
+    // No pool data (still loading, or an install with no keys): the flat legend.
+    return {
+      groups: budgeted.length ? [{ pool: null, models: budgeted }] : [],
+      unpublishedCount: models.length - budgeted.length,
+      rowCount: budgeted.length,
+    }
+  }
+
+  const poolByModel = new Map<string, FreeTierPool>()
+  for (const pool of pools) {
+    for (const id of pool.memberModelIds) poolByModel.set(`${pool.platform}::${id}`, pool)
+  }
+
+  const shared = new Map<string, LegendRow[]>()
+  const independent: LegendRow[] = []
+  let unpublishedCount = 0
+  for (const model of models) {
+    const pool = model.modelId ? poolByModel.get(`${model.platform}::${model.modelId}`) : undefined
+    if (model.budget <= 0) {
+      unpublishedCount += 1
+      continue
+    }
+    if (!pool || isPerModelPool(pool)) {
+      independent.push(model)
+      continue
+    }
+    const list = shared.get(pool.poolKey)
+    if (list) list.push(model)
+    else shared.set(pool.poolKey, [model])
+  }
+
+  const groups: LegendGroup[] = []
+  for (const pool of pools) {
+    if (isPerModelPool(pool)) continue
+    const rows = shared.get(pool.poolKey) ?? []
+    // A live remaining figure or a documented budget is worth a header even
+    // when every member model is itself unpublished.
+    const worthShowing = rows.length > 0 || pool.documentedBudget > 0 || pool.quota?.remaining != null
+    if (worthShowing) groups.push({ pool, models: rows })
+  }
+  if (independent.length) groups.push({ pool: null, models: independent })
+
+  return {
+    groups,
+    unpublishedCount,
+    rowCount: groups.reduce((sum, g) => sum + g.models.length, 0),
+  }
+}

--- a/server/src/__tests__/routes/free-tier.test.ts
+++ b/server/src/__tests__/routes/free-tier.test.ts
@@ -44,9 +44,10 @@ function observe(row: {
 }
 
 // GET /api/free-tier reports one budget per provider pool (#905). The pools it
-// reports are read by the collapsed table under the stacked token bar, so it
-// has to agree with /api/fallback/token-usage about key scaling, and it must
-// never present a request counter as if it were a token budget.
+// reports group the per-model legend under the stacked token bar, so it
+// has to agree with /api/fallback/token-usage about key scaling and about which
+// models are in play, and it must never present a request counter as if it were
+// a token budget.
 describe('free-tier pool overview (#905)', () => {
   let app: Express;
   let groqKey = 0;
@@ -152,6 +153,34 @@ describe('free-tier pool overview (#905)', () => {
     expect(groq.disabledModelCount).toBe(1);
     // The disabled row does not reduce the pool's documented budget.
     expect(groq.documentedBudget).toBe(15_000_000);
+  });
+
+  it('names the models in each pool so the legend can group its rows', async () => {
+    const { body } = await get(app, '/api/free-tier');
+    const groq = body.pools.find((p: any) => p.poolKey === 'groq::account');
+    // The legend joins its own per-model rows on platform + model id, so the
+    // pool has to name its members; the count has to agree with modelCount, and
+    // the chain-disabled row is a member like any other.
+    expect(groq.memberModelIds).toHaveLength(groq.modelCount);
+    expect(new Set(groq.memberModelIds).size).toBe(groq.modelCount);
+
+    const usage = await get(app, '/api/fallback/token-usage');
+    const chainIds = (usage.body.models as any[])
+      .filter(m => m.platform === 'groq')
+      .map(m => m.modelId)
+      .sort();
+    expect([...groq.memberModelIds].sort()).toEqual(chainIds);
+
+    // Every model of every pool maps back to exactly one pool: the join the
+    // legend does cannot put one row under two headers.
+    const seen = new Set<string>();
+    for (const pool of body.pools) {
+      for (const id of pool.memberModelIds) {
+        const qualified = `${pool.platform}::${id}`;
+        expect(seen.has(qualified)).toBe(false);
+        seen.add(qualified);
+      }
+    }
   });
 
   it('classifies a credits-only pool and skips platforms with no key', async () => {

--- a/server/src/routes/free-tier.ts
+++ b/server/src/routes/free-tier.ts
@@ -18,8 +18,8 @@ import type { Platform, QuotaMetric } from '@freellmapi/shared/types.js';
  * reports them.
  *
  * The model set, the key-count scaling and the enabled semantics deliberately
- * match GET /api/fallback/token-usage (the stacked bar this table sits under),
- * so the two never disagree about the same pool:
+ * match GET /api/fallback/token-usage (the stacked bar whose legend these pools
+ * group), so the two never disagree about the same pool:
  *   - only platforms that actually have an enabled key are counted;
  *   - a documented budget is per account, so it is scaled by the usable
  *     (enabled + healthy/unknown) key count for the platform;
@@ -32,6 +32,12 @@ export const freeTierRouter = Router();
 interface PoolAgg {
   poolKey: string;
   platform: string;
+  // Which chain models this pool holds, as their provider model ids. The
+  // dashboard legend lists models, not pools, so it needs this to put each
+  // model row under its own pool header; without it the client would have to
+  // re-implement inferQuotaPoolKey (which is provider knowledge that lives
+  // here). Ordered as the chain returns them.
+  memberModelIds: string[];
   modelCount: number;
   disabledModelCount: number;
   keyCount: number;
@@ -142,6 +148,7 @@ freeTierRouter.get('/', (_req: Request, res: Response) => {
       p = {
         poolKey,
         platform: row.platform,
+        memberModelIds: [],
         modelCount: 0,
         disabledModelCount: 0,
         keyCount: keyCountMap.get(row.platform) ?? 0,
@@ -151,6 +158,7 @@ freeTierRouter.get('/', (_req: Request, res: Response) => {
       };
       pools.set(poolKey, p);
     }
+    p.memberModelIds.push(row.model_id);
     p.modelCount += 1;
     if (row.chain_enabled === 0) p.disabledModelCount += 1;
     // One budget per pool: keep the largest documented value.


### PR DESCRIPTION
The separate free tier pools accordion is gone. The show all models legend now groups models under their quota pool, with the pool budget, live remaining with the metric named, and reset time on the header row. Pools payload gains memberModelIds for an exact join.