### PR TITLE
Smooth the playground sidebars and quiet the composer

### DIFF
--- a/client/src/components/playground/conversation-sidebar.tsx
+++ b/client/src/components/playground/conversation-sidebar.tsx
@@ -9,9 +9,21 @@ import { useI18n } from '@/i18n'
 // toggle and "new chat" stay reachable) so a long transcript can have the whole
 // width when you want it; the open/closed choice is remembered by the page.
 //
+// Open and collapsed are the same box at two widths. The container animates its
+// width and clips; both layers inside keep a FIXED width and are laid over each
+// other, so nothing reflows or squishes while the rail moves. Whichever layer is
+// not in use fades out and ends `invisible`, which also takes it out of the tab
+// order and the accessibility tree. A reader who asked for less motion gets the
+// old instant snap.
+//
 // Deliberately dumb: every mutation is handed up to PlaygroundPage, which owns
 // the active conversation, the transcript, and the saving. All this does is
 // list, select, rename in place, and confirm a delete.
+
+// Both layers sit on top of each other inside the animated container; only the
+// width and the fade differ.
+const LAYER =
+  'absolute inset-y-0 start-0 flex flex-col transition-[opacity,visibility] duration-200 ease-out motion-reduce:transition-none'
 
 export function ConversationSidebar({
   conversations,
@@ -63,9 +75,17 @@ export function ConversationSidebar({
     if (title && title !== previous?.title) onRename(renamingId, title)
   }
 
-  if (!open) {
-    return (
-      <div className="flex w-11 shrink-0 flex-col items-center gap-1 border-e bg-card py-3">
+  return (
+    <div
+      className={`relative shrink-0 overflow-hidden border-e bg-card transition-[width] duration-200 ease-out motion-reduce:transition-none ${
+        open ? 'w-60' : 'w-11'
+      }`}
+    >
+      <div
+        className={`${LAYER} w-11 items-center gap-1 py-3 ${
+          open ? 'invisible opacity-0' : 'visible opacity-100'
+        }`}
+      >
         <Button
           variant="ghost"
           size="icon-sm"
@@ -85,111 +105,111 @@ export function ConversationSidebar({
           <MessageSquarePlus className="size-4" />
         </Button>
       </div>
-    )
-  }
 
-  return (
-    <div className="flex w-60 shrink-0 flex-col overflow-hidden border-e bg-card">
-      <div className="flex shrink-0 items-center gap-1 border-b px-2.5 py-2">
-        <span className="flex-1 truncate text-xs font-medium text-muted-foreground">
-          {t('playgroundSessions.heading')}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onNew}
-          aria-label={t('playgroundSessions.newConversation')}
-          title={t('playgroundSessions.newConversation')}
-        >
-          <MessageSquarePlus className="size-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onToggle}
-          aria-label={t('playgroundSessions.hideSidebar')}
-          title={t('playgroundSessions.hideSidebar')}
-        >
-          <PanelLeftClose className="size-4" />
-        </Button>
-      </div>
+      <div
+        className={`${LAYER} w-60 ${open ? 'visible opacity-100' : 'invisible opacity-0'}`}
+      >
+        <div className="flex shrink-0 items-center gap-1 border-b px-2.5 py-2">
+          <span className="flex-1 truncate text-xs font-medium text-muted-foreground">
+            {t('playgroundSessions.heading')}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onNew}
+            aria-label={t('playgroundSessions.newConversation')}
+            title={t('playgroundSessions.newConversation')}
+          >
+            <MessageSquarePlus className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggle}
+            aria-label={t('playgroundSessions.hideSidebar')}
+            title={t('playgroundSessions.hideSidebar')}
+          >
+            <PanelLeftClose className="size-4" />
+          </Button>
+        </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
-        {conversations.length === 0 ? (
-          <p className="px-2 py-3 text-xs text-muted-foreground">
-            {t('playgroundSessions.empty')}
-          </p>
-        ) : (
-          <ul className="space-y-0.5">
-            {conversations.map(conversation => {
-              const isActive = conversation.id === activeId
-              const when = relativeTime(conversation.updatedAt)
-              return (
-                <li key={conversation.id}>
-                  {renamingId === conversation.id ? (
-                    <input
-                      ref={renameRef}
-                      value={draft}
-                      onChange={e => setDraft(e.target.value)}
-                      onBlur={commitRename}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter') { e.preventDefault(); commitRename() }
-                        if (e.key === 'Escape') { e.preventDefault(); setRenamingId(null) }
-                      }}
-                      aria-label={t('playgroundSessions.renamePlaceholder')}
-                      placeholder={t('playgroundSessions.renamePlaceholder')}
-                      className="w-full rounded-lg border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
-                    />
-                  ) : (
-                    <div
-                      className={`group flex items-center gap-0.5 rounded-lg pr-0.5 transition-colors ${
-                        isActive ? 'bg-muted' : 'hover:bg-muted/60'
-                      }`}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => onSelect(conversation.id)}
-                        onDoubleClick={() => startRename(conversation)}
-                        className="min-w-0 flex-1 px-2 py-1.5 text-left"
+        <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+          {conversations.length === 0 ? (
+            <p className="px-2 py-3 text-xs text-muted-foreground">
+              {t('playgroundSessions.empty')}
+            </p>
+          ) : (
+            <ul className="space-y-0.5">
+              {conversations.map(conversation => {
+                const isActive = conversation.id === activeId
+                const when = relativeTime(conversation.updatedAt)
+                return (
+                  <li key={conversation.id}>
+                    {renamingId === conversation.id ? (
+                      <input
+                        ref={renameRef}
+                        value={draft}
+                        onChange={e => setDraft(e.target.value)}
+                        onBlur={commitRename}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') { e.preventDefault(); commitRename() }
+                          if (e.key === 'Escape') { e.preventDefault(); setRenamingId(null) }
+                        }}
+                        aria-label={t('playgroundSessions.renamePlaceholder')}
+                        placeholder={t('playgroundSessions.renamePlaceholder')}
+                        className="w-full rounded-lg border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
+                      />
+                    ) : (
+                      <div
+                        className={`group flex items-center gap-0.5 rounded-lg pr-0.5 transition-colors ${
+                          isActive ? 'bg-muted' : 'hover:bg-muted/60'
+                        }`}
                       >
-                        <span className="block truncate text-sm">
-                          {conversation.title || t('playgroundSessions.untitled')}
-                        </span>
-                        <span className="block truncate text-[11px] text-muted-foreground tabular-nums">
-                          {t(`playgroundSessions.${when.key}`, { count: when.count })}
-                          {' · '}
-                          {t('playgroundSessions.messageCount', { count: conversation.messageCount })}
-                        </span>
-                      </button>
-                      {/* Row actions stay out of the way until the row is
-                          hovered or focused, so the list reads as titles. */}
-                      <div className="flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          onClick={() => startRename(conversation)}
-                          aria-label={t('playgroundSessions.rename')}
-                          title={t('playgroundSessions.rename')}
+                        <button
+                          type="button"
+                          onClick={() => onSelect(conversation.id)}
+                          onDoubleClick={() => startRename(conversation)}
+                          className="min-w-0 flex-1 px-2 py-1.5 text-left"
                         >
-                          <Pencil className="size-3" />
-                        </Button>
-                        <ConfirmButton
-                          size="icon-xs"
-                          armedSize="xs"
-                          onConfirm={() => onDelete(conversation.id)}
-                          aria-label={t('common.delete')}
-                          title={t('common.delete')}
-                        >
-                          <Trash2 className="size-3" />
-                        </ConfirmButton>
+                          <span className="block truncate text-sm">
+                            {conversation.title || t('playgroundSessions.untitled')}
+                          </span>
+                          <span className="block truncate text-[11px] text-muted-foreground tabular-nums">
+                            {t(`playgroundSessions.${when.key}`, { count: when.count })}
+                            {' · '}
+                            {t('playgroundSessions.messageCount', { count: conversation.messageCount })}
+                          </span>
+                        </button>
+                        {/* Row actions stay out of the way until the row is
+                            hovered or focused, so the list reads as titles. */}
+                        <div className="flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => startRename(conversation)}
+                            aria-label={t('playgroundSessions.rename')}
+                            title={t('playgroundSessions.rename')}
+                          >
+                            <Pencil className="size-3" />
+                          </Button>
+                          <ConfirmButton
+                            size="icon-xs"
+                            armedSize="xs"
+                            onConfirm={() => onDelete(conversation.id)}
+                            aria-label={t('common.delete')}
+                            title={t('common.delete')}
+                          >
+                            <Trash2 className="size-3" />
+                          </ConfirmButton>
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </li>
-              )
-            })}
-          </ul>
-        )}
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/playground/settings-rail.tsx
+++ b/client/src/components/playground/settings-rail.tsx
@@ -19,9 +19,10 @@ import { useI18n } from '@/i18n'
 // prompt it answers under, and the sampling knobs.
 //
 // It mirrors the conversation sidebar on the other edge: same collapse-to-a-
-// strip move, same remembered open/closed choice (kept by the page). Collapsed
-// it still says whether anything is set, so a temperature you dialled in last
-// week cannot quietly steer today's answers from behind a closed rail.
+// strip move, same width animation, same remembered open/closed choice (kept by
+// the page). Collapsed it still says whether anything is set, so a temperature
+// you dialled in last week cannot quietly steer today's answers from behind a
+// closed rail.
 //
 // Deliberately dumb, like the sidebar: it owns no state, every change goes up
 // to PlaygroundPage, which persists it.
@@ -31,6 +32,12 @@ const FIELD_LABEL_KEYS: Record<SamplingField, string> = {
   topP: 'playground.topP',
   maxTokens: 'playground.maxTokens',
 }
+
+// The open panel and the collapsed strip are stacked inside one container whose
+// WIDTH animates; each keeps its own fixed width so the contents never reflow
+// mid-move, and the idle one fades to `invisible` (out of the tab order too).
+const LAYER =
+  'absolute inset-y-0 end-0 flex flex-col transition-[opacity,visibility] duration-200 ease-out motion-reduce:transition-none'
 
 export interface SettingsRailProps {
   open: boolean
@@ -136,9 +143,17 @@ export function SettingsRail({
   // every request, or a knob overriding the provider's default.
   const tweaked = samplingActiveCount(sampling) > 0 || systemPrompt.trim().length > 0
 
-  if (!open) {
-    return (
-      <div className="flex w-11 shrink-0 flex-col items-center gap-1 border-s bg-card py-3">
+  return (
+    <div
+      className={`relative shrink-0 overflow-hidden border-s bg-card transition-[width] duration-200 ease-out motion-reduce:transition-none ${
+        open ? 'w-72' : 'w-11'
+      }`}
+    >
+      <div
+        className={`${LAYER} w-11 items-center gap-1 py-3 ${
+          open ? 'invisible opacity-0' : 'visible opacity-100'
+        }`}
+      >
         <Button
           variant="ghost"
           size="icon-sm"
@@ -150,81 +165,81 @@ export function SettingsRail({
         </Button>
         {tweaked && <span className="size-1.5 rounded-full bg-primary/70" />}
       </div>
-    )
-  }
 
-  return (
-    <div className="flex w-72 shrink-0 flex-col border-s bg-card">
-      <div className="flex shrink-0 items-center gap-1 border-b px-2.5 py-2">
-        <span className="flex-1 truncate text-xs font-medium text-muted-foreground">
-          {t('settings.title')}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onToggle}
-          aria-label={t('playground.hideSettings')}
-          title={t('playground.hideSettings')}
-        >
-          <PanelRightClose className="size-4" />
-        </Button>
-      </div>
-
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-3">
-        <div className="space-y-1.5">
-          <span className="block text-xs font-medium">{t('common.model')}</span>
-          <ModelCombobox
-            value={modelValue}
-            options={modelOptions}
-            onSelect={onSelectModel}
-            ariaLabel={t('playground.selectModel')}
-            placeholder={t('playground.searchModels')}
-            emptyText={t('playground.noModelsFound')}
-            align="end"
-            triggerClassName="flex h-8 w-full items-center justify-between gap-2 whitespace-nowrap rounded-lg border border-input bg-transparent px-3 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
-            footer={
-              noModels ? (
-                // Models only appear once a platform has an enabled key. Without
-                // one, the list is just Auto/Fusion and looks broken — say why. (#269)
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">{t('playground.noModels')}</div>
-              ) : undefined
-            }
-          />
+      <div
+        className={`${LAYER} w-72 ${open ? 'visible opacity-100' : 'invisible opacity-0'}`}
+      >
+        <div className="flex shrink-0 items-center gap-1 border-b px-2.5 py-2">
+          <span className="flex-1 truncate text-xs font-medium text-muted-foreground">
+            {t('settings.title')}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggle}
+            aria-label={t('playground.hideSettings')}
+            title={t('playground.hideSettings')}
+          >
+            <PanelRightClose className="size-4" />
+          </Button>
         </div>
 
-        {/* The system prompt textarea deliberately lives BELOW the composer in
-            DOM order (the rail is the last column): `textarea` first-match
-            selectors still land on the message box. */}
-        <div className="space-y-1.5">
-          <label htmlFor="playground-system-prompt" className="flex items-center gap-1.5 text-xs font-medium">
-            {t('playground.systemPromptLabel')}
-            {systemPrompt.trim() && <span className="size-1.5 rounded-full bg-primary/70" />}
-          </label>
-          <textarea
-            id="playground-system-prompt"
-            value={systemPrompt}
-            onChange={e => onSystemPromptChange(e.target.value)}
-            placeholder={t('playground.systemPromptPlaceholder')}
-            rows={4}
-            className="max-h-64 min-h-[88px] w-full resize-y rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
-          />
-        </div>
-
-        <div className="space-y-3">
-          <div className="space-y-0.5">
-            <span className="block text-xs font-medium">{t('playground.samplingHeading')}</span>
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              {t('playground.samplingHelp')}
-            </p>
-          </div>
-          {SAMPLING_FIELDS.map(field => (
-            <SamplingControlRow
-              key={field}
-              field={field}
-              settings={sampling}
-              onChange={onSamplingChange}
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto p-3">
+          <div className="space-y-1.5">
+            <span className="block text-xs font-medium">{t('common.model')}</span>
+            <ModelCombobox
+              value={modelValue}
+              options={modelOptions}
+              onSelect={onSelectModel}
+              ariaLabel={t('playground.selectModel')}
+              placeholder={t('playground.searchModels')}
+              emptyText={t('playground.noModelsFound')}
+              align="end"
+              triggerClassName="flex h-8 w-full items-center justify-between gap-2 whitespace-nowrap rounded-lg border border-input bg-transparent px-3 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+              footer={
+                noModels ? (
+                  // Models only appear once a platform has an enabled key. Without
+                  // one, the list is just Auto/Fusion and looks broken — say why. (#269)
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground">{t('playground.noModels')}</div>
+                ) : undefined
+              }
             />
-          ))}
+          </div>
+
+          {/* The system prompt textarea deliberately lives BELOW the composer in
+              DOM order (the rail is the last column): `textarea` first-match
+              selectors still land on the message box. */}
+          <div className="space-y-1.5">
+            <label htmlFor="playground-system-prompt" className="flex items-center gap-1.5 text-xs font-medium">
+              {t('playground.systemPromptLabel')}
+              {systemPrompt.trim() && <span className="size-1.5 rounded-full bg-primary/70" />}
+            </label>
+            <textarea
+              id="playground-system-prompt"
+              value={systemPrompt}
+              onChange={e => onSystemPromptChange(e.target.value)}
+              placeholder={t('playground.systemPromptPlaceholder')}
+              rows={4}
+              className="max-h-64 min-h-[88px] w-full resize-y rounded-lg border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50"
+            />
+          </div>
+
+          <div className="space-y-3">
+            <div className="space-y-0.5">
+              <span className="block text-xs font-medium">{t('playground.samplingHeading')}</span>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                {t('playground.samplingHelp')}
+              </p>
+            </div>
+            {SAMPLING_FIELDS.map(field => (
+              <SamplingControlRow
+                key={field}
+                field={field}
+                settings={sampling}
+                onChange={onSamplingChange}
+              />
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/pages/PlaygroundPage.tsx
+++ b/client/src/pages/PlaygroundPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ChevronRight, CircleAlert, FileText, Paperclip, X } from 'lucide-react'
+import { ArrowUp, ChevronRight, CircleAlert, FileText, Paperclip, X } from 'lucide-react'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { buildModelOptions } from '@/lib/model-groups'
@@ -208,6 +208,10 @@ export default function PlaygroundPage() {
   // Files staged for the NEXT message: images already downscaled to a data URI,
   // text-like files already decoded. Cleared on send. (#325)
   const [attachments, setAttachments] = useState<Attachment[]>([])
+  // Purely cosmetic: the composer row centres its buttons against a one-line
+  // box, but pins them to the bottom once the textarea has grown, which is
+  // where the eye expects them on a tall message.
+  const [composerGrown, setComposerGrown] = useState(false)
   const [dragging, setDragging] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const transcriptRef = useRef<HTMLDivElement>(null)
@@ -990,7 +994,7 @@ export default function PlaygroundPage() {
         </div>
 
         <div
-          className={`border-t bg-background/50 p-3 transition-colors ${dragging ? 'bg-primary/5 ring-1 ring-inset ring-primary/40' : ''}`}
+          className={`bg-background/50 p-3 transition-colors ${dragging ? 'bg-primary/5 ring-1 ring-inset ring-primary/40' : ''}`}
           onDragOver={e => { e.preventDefault(); setDragging(true) }}
           onDragLeave={e => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragging(false) }}
           onDrop={e => {
@@ -1026,7 +1030,7 @@ export default function PlaygroundPage() {
               <span>{t('playground.visionWarning', { model: activeModelLabel })}</span>
             </div>
           )}
-          <div className="flex gap-2 items-end">
+          <div className={`flex gap-2 ${composerGrown ? 'items-end' : 'items-center'}`}>
             <input
               ref={fileInputRef}
               type="file"
@@ -1039,8 +1043,9 @@ export default function PlaygroundPage() {
               }}
             />
             <Button
-              variant="outline"
+              variant="ghost"
               size="icon"
+              className="text-muted-foreground hover:text-foreground"
               onClick={() => fileInputRef.current?.click()}
               disabled={loading}
               aria-label={t('playground.attach')}
@@ -1068,11 +1073,20 @@ export default function PlaygroundPage() {
               onInput={e => {
                 const el = e.target as HTMLTextAreaElement
                 el.style.height = 'auto'
-                el.style.height = Math.min(el.scrollHeight, 160) + 'px'
+                const height = Math.min(el.scrollHeight, 160)
+                el.style.height = height + 'px'
+                setComposerGrown(height > 44)
               }}
             />
-            <Button onClick={handleSend} disabled={loading || (!input.trim() && attachments.length === 0)} size="default">
-              {loading ? t('playground.sending') : t('playground.send')}
+            <Button
+              onClick={handleSend}
+              disabled={loading || (!input.trim() && attachments.length === 0)}
+              size="icon"
+              className="rounded-full"
+              aria-label={loading ? t('playground.sending') : t('playground.send')}
+              title={loading ? t('playground.sending') : t('playground.send')}
+            >
+              <ArrowUp className="size-4" />
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Both sidebars animate their collapse over 200ms with reduced motion respected, the attach button is a ghost paperclip, send is a circular up arrow button, and the composer row is vertically centered with the top border removed.