### PR TITLE
feat(models): show quota headroom, grey out exhausted models, fold them down

### DIFF
--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -16,6 +16,7 @@ import {
   providerLabel,
   tightestRateLimit,
   type ModelGroupRow,
+  type QuotaSummaryRow,
   type RateLimitUsageRow,
   type Row,
 } from '@/lib/routing'
@@ -270,7 +271,7 @@ export const dragDots = (
 // The collapsed header row for a logical-model group: name, provider count,
 // union vision/tools badges, the best member's axis bars + score, and a single
 // switch that enables/disables every provider in the group.
-export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRows, rateUsage }: {
+export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRows, rateUsage, quotaUsage }: {
   group: ModelGroupRow
   rank: number
   dragHandle?: ReactNode
@@ -283,6 +284,9 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   // level and passed down: a query hook here would open one observer and one
   // 15s poll timer per row, i.e. hundreds of them on a real catalog.
   rateUsage?: ReadonlyMap<number, RateLimitUsageRow>
+  // Provider-quota headroom per (platform, modelId). Drives the remaining-quota
+  // badge and the exhausted-model greying/sort.
+  quotaUsage?: ReadonlyMap<string, QuotaSummaryRow>
 }) {
   const { t } = useI18n()
   const anyEnabled = group.members.some(m => m.enabled)
@@ -295,6 +299,14 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   const rateRows = rateUsage
     ? group.members.flatMap(m => rateUsage.get(m.modelDbId) ?? [])
     : []
+  // Provider-quota exhaustion check: a group is quota-exhausted only when
+  // EVERY member reports remaining === 0. Drives the greying + sort in #1015.
+  const quotaExhausted = quotaUsage
+    ? group.members.every(m => {
+        const q = quotaUsage.get(`${m.platform}::${m.modelId}`) ?? quotaUsage.get(`${m.platform}::${null}`)
+        return q != null && q.remaining === 0
+      })
+    : false
   // Honest group display (#580): reliability/speed ranges come only from
   // members that were actually measured; when none were, show "no data" rather
   // than the shared exploration priors. Intelligence is catalog metadata, so
@@ -334,6 +346,23 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
               </span>
             )}
             <RateLimitBadge rows={rateRows} />
+            {(() => {
+              if (!quotaUsage) return null
+              const q = quotaUsage.get(`${group.members[0].platform}::${group.members[0].modelId}`)
+                ?? quotaUsage.get(`${group.members[0].platform}::${null}`)
+              if (!q || q.remaining == null) return null
+              const ratio = q.limit != null && q.limit > 0 ? 1 - (q.remaining / q.limit) : 0
+              const tone = q.remaining === 0
+                ? 'bg-red-600/15 text-red-700 dark:text-red-400'
+                : ratio >= 0.7
+                  ? 'bg-amber-600/15 text-amber-700 dark:text-amber-400'
+                  : 'bg-muted text-muted-foreground'
+              return (
+                <span className={`text-[10px] rounded-full px-1.5 py-0.5 tabular-nums ${tone}`}>
+                  {q.metric === 'tokens' ? `${Math.round(q.remaining / 1000)}k left` : `${q.remaining} left`}
+                </span>
+              )
+            })()}
             {maxCtx > 0 && (
               <span title={t('models.ctxTitle')} className="text-[10px] rounded-full px-1.5 py-0.5 bg-muted text-muted-foreground tabular-nums">
                 {t('models.ctxBadge', { size: formatContext(maxCtx) })}
@@ -380,12 +409,13 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   )
 }
 
-export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsage }: {
+export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsage, quotaUsage }: {
   group: ModelGroupRow
   rank: number
   onToggleGroup: (memberIds: number[], enabled: boolean) => void
   allRows?: readonly Row[]
   rateUsage?: ReadonlyMap<number, RateLimitUsageRow>
+  quotaUsage?: ReadonlyMap<string, QuotaSummaryRow>
 }) {
   const { t } = useI18n()
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: `grp:${group.key}` })
@@ -408,9 +438,9 @@ export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsag
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       onClick={() => navigate(`/models/chat/${detailId}`)}
-      className={`group/row border-b last:border-0 bg-card cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${isDragging ? 'opacity-50' : ''} ${anyEnabled ? '' : 'opacity-50'}`}
+      className={`group/row border-b last:border-0 bg-card cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${isDragging ? 'opacity-50' : ''} ${anyEnabled ? '' : 'opacity-50'} ${quotaExhausted ? 'opacity-40 saturate-50' : ''}`}
     >
-      <GroupHeaderCells group={group} rank={rank} dragHandle={handle} onToggleGroup={onToggleGroup} allRows={allRows} rateUsage={rateUsage} />
+      <GroupHeaderCells group={group} rank={rank} dragHandle={handle} onToggleGroup={onToggleGroup} allRows={allRows} rateUsage={rateUsage} quotaUsage={quotaUsage} />
     </tr>
   )
 }

--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -299,14 +299,6 @@ export function GroupHeaderCells({ group, rank, dragHandle, onToggleGroup, allRo
   const rateRows = rateUsage
     ? group.members.flatMap(m => rateUsage.get(m.modelDbId) ?? [])
     : []
-  // Provider-quota exhaustion check: a group is quota-exhausted only when
-  // EVERY member reports remaining === 0. Drives the greying + sort in #1015.
-  const quotaExhausted = quotaUsage
-    ? group.members.every(m => {
-        const q = quotaUsage.get(`${m.platform}::${m.modelId}`) ?? quotaUsage.get(`${m.platform}::${null}`)
-        return q != null && q.remaining === 0
-      })
-    : false
   // Honest group display (#580): reliability/speed ranges come only from
   // members that were actually measured; when none were, show "no data" rather
   // than the shared exploration priors. Intelligence is catalog metadata, so
@@ -422,6 +414,12 @@ export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsag
   const anyEnabled = group.members.some(m => m.enabled)
   const navigate = useNavigate()
   const detailId = encodeURIComponent(group.members[0].canonicalId ?? group.members[0].modelId)
+  const quotaExhausted = quotaUsage
+    ? group.members.every(m => {
+        const q = quotaUsage.get(`${m.platform}::${m.modelId}`) ?? quotaUsage.get(`${m.platform}::${null}`)
+        return q != null && q.remaining === 0
+      })
+    : false
   const handle = (
     <button
       {...attributes}

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -331,6 +331,24 @@ export interface RateLimitUsageData {
 
 export type RateLimitKind = 'RPM' | 'RPD' | 'TPM'
 
+// Provider-quota headroom for a single (platform, modelId) pair within the
+// current billing window. Drives the remaining-quota badge and the
+// exhausted-model greying/sort in #1015.
+export interface QuotaSummaryRow {
+  platform: string
+  modelId: string | null
+  metric: 'tokens' | 'requests' | 'credits'
+  remaining: number
+  limit: number | null
+}
+
+// Aggregated quota headroom across all providers. Fetched ONCE at the page
+// level and passed down, same pattern as RateLimitUsageData.
+export interface QuotaSummaryData {
+  generatedAtMs: number
+  rows: QuotaSummaryRow[]
+}
+
 // The badge answers one question: how close is this logical model to being
 // unusable? A group is unusable only when EVERY provider serving it is out of
 // headroom, so the group-level number is the BEST member, not the worst — a

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -25,6 +25,8 @@ import {
   groupMaxContext,
   type FallbackEntry,
   type ModelGroupRow,
+  type QuotaSummaryData,
+  type QuotaSummaryRow,
   type RateLimitUsageData,
   type RoutingData,
   type RoutingStrategy,
@@ -162,6 +164,21 @@ export default function FallbackPage() {
     () => new Map((rateLimitUsage?.rows ?? []).map(r => [r.modelDbId, r])),
     [rateLimitUsage],
   )
+
+  // Provider-quota headroom per (platform, modelId) for the current window.
+  const { data: quotaSummary } = useQuery<QuotaSummaryData>({
+    queryKey: ['fallback', 'quota-summary'],
+    queryFn: () => apiFetch('/api/fallback/quota-summary'),
+    refetchInterval: 15_000,
+  })
+  const quotaByModel = useMemo(() => {
+    const m = new Map<string, QuotaSummaryRow>()
+    if (!quotaSummary?.rows) return m
+    for (const row of Object.values(quotaSummary.rows)) {
+      m.set(`${row.platform}::${row.modelId ?? '*'}`, row)
+    }
+    return m
+  }, [quotaSummary])
 
   const saveMutation = useMutation({
     mutationFn: (data: { modelDbId: number; priority: number; enabled: boolean }[]) =>

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -174,7 +174,7 @@ export default function FallbackPage() {
   const quotaByModel = useMemo(() => {
     const m = new Map<string, QuotaSummaryRow>()
     if (!quotaSummary?.rows) return m
-    for (const row of Object.values(quotaSummary.rows)) {
+    for (const row of quotaSummary.rows) {
       m.set(`${row.platform}::${row.modelId ?? '*'}`, row)
     }
     return m
@@ -268,7 +268,7 @@ export default function FallbackPage() {
       return q != null && q.remaining === 0
     })
     const bExhausted = quotaByModel && b.members.every(m => {
-      const q = quotaByModel.get(`${m.platform}::${b.modelId}`) ?? quotaByModel.get(`${m.platform}::${null}`)
+      const q = quotaByModel.get(`${m.platform}::${m.modelId}`) ?? quotaByModel.get(`${m.platform}::${null}`)
       return q != null && q.remaining === 0
     })
     if (aExhausted !== bExhausted) return aExhausted ? 1 : -1

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -244,6 +244,18 @@ export default function FallbackPage() {
     if (minContext > 0 && groupMaxContext(g.members) < minContext) return false
     if (query && !groupMatchesQuery(g, query)) return false
     return true
+  }).sort((a, b) => {
+    // Exhausted models sink to the bottom (#1015).
+    const aExhausted = quotaByModel && a.members.every(m => {
+      const q = quotaByModel.get(`${m.platform}::${m.modelId}`) ?? quotaByModel.get(`${m.platform}::${null}`)
+      return q != null && q.remaining === 0
+    })
+    const bExhausted = quotaByModel && b.members.every(m => {
+      const q = quotaByModel.get(`${m.platform}::${b.modelId}`) ?? quotaByModel.get(`${m.platform}::${null}`)
+      return q != null && q.remaining === 0
+    })
+    if (aExhausted !== bExhausted) return aExhausted ? 1 : -1
+    return 0
   }), [orderedGroups, filterVision, filterTools, minContext, query])
   const draggable = isManual && !filtersActive
 
@@ -576,7 +588,7 @@ export default function FallbackPage() {
                     <SortableContext items={renderedGroups.map(g => `grp:${g.key}`)} strategy={verticalListSortingStrategy}>
                       <tbody>
                         {renderedGroups.map(g => (
-                          <SortableGroupRow key={g.key} group={g} rank={rankByKey.get(g.key) ?? 0} onToggleGroup={handleGroupToggle} allRows={rows} rateUsage={rateUsageByModel} />
+                          <SortableGroupRow key={g.key} group={g} rank={rankByKey.get(g.key) ?? 0} onToggleGroup={handleGroupToggle} allRows={rows} rateUsage={rateUsageByModel} quotaUsage={quotaByModel} />
                         ))}
                       </tbody>
                     </SortableContext>


### PR DESCRIPTION
## 改动

- `server/src/routes/fallback.ts`：新增 `/api/fallback/quota-summary` 端点，按 (platform, modelId) 暴露 `getQuotaStateForKeys()`——只读、内存缓存、无提供商调用。
- `client/src/lib/routing.ts`：新增 `QuotaSummaryRow` / `QuotaSummaryData` 类型。
- `client/src/pages/FallbackPage.tsx`：每 15s 拉取 quota-summary，并据此派生每组耗尽标志。
- `client/src/components/model-table.tsx`：在限流徽章旁渲染剩余配额徽章（0 为红、>=70% 消耗为琥珀）；配额耗尽的整行加 `opacity-40/saturate-50`；耗尽的组排到可见列表底部。

## 关联

- Closes #1015

## Changes

- `server/src/routes/fallback.ts`: new `/api/fallback/quota-summary` endpoint that exposes `getQuotaStateForKeys()` per (platform, modelId) — read‑only, in‑memory cache, no provider calls.
- `client/src/lib/routing.ts`: add `QuotaSummaryRow` / `QuotaSummaryData` types.
- `client/src/pages/FallbackPage.tsx`: fetch quota-summary every 15s and derive a per‑group exhaustion flag from it.
- `client/src/components/model-table.tsx`: render a remaining‑quota badge next to the rate‑limit badge (red when 0, amber when >=70% spent); apply `opacity-40/saturate-50` to quota‑exhausted rows; sort exhausted groups to the bottom of the visible list.

## Closes

- Closes #1015