### PR TITLE
Loosen the compression timing caps off CI

### DIFF
--- a/server/src/__tests__/services/compression.test.ts
+++ b/server/src/__tests__/services/compression.test.ts
@@ -377,6 +377,14 @@ describe('compression engines', () => {
     expect(savedChars).toBeGreaterThan(0);
   });
 
+  // The wall-clock caps below are calibrated to GitHub's hosted runners, where
+  // they gate every push. Off CI they are only a courtesy, and a laptop
+  // running the suite inside Docker measures 2-3x slower than a runner (an
+  // outside verification on Node 22 saw a 10-11 ms median and 252-277 ms on
+  // the linearity payload), so the same numbers there only produce false
+  // failures. Loosen them where nothing depends on them; CI keeps them exact.
+  const slack = process.env.CI ? 1 : 3;
+
   it('stays within the 100 KB synchronous performance budget', () => {
     const payload = `${'plain status line without protected tokens\n'.repeat(2_500)}tail`;
     const samples: number[] = [];
@@ -392,8 +400,8 @@ describe('compression engines', () => {
     // 5 ms flaky (Node 22 measured 5.54–5.77 ms in otherwise-green CI runs).
     // Keep a tight median guard while the p99/adversarial 25 ms caps below
     // continue to catch material synchronous regressions.
-    expect(p50).toBeLessThan(8);
-    expect(p99).toBeLessThan(25);
+    expect(p50).toBeLessThan(8 * slack);
+    expect(p99).toBeLessThan(25 * slack);
 
     const unbalancedJson = '['.repeat(100_000);
     const adversarialStarted = performance.now();
@@ -401,7 +409,7 @@ describe('compression engines', () => {
       config: config('lossless'),
       recordStats: false,
     });
-    expect(performance.now() - adversarialStarted).toBeLessThan(25);
+    expect(performance.now() - adversarialStarted).toBeLessThan(25 * slack);
 
     const manyBalancedArrays = '[]'.repeat(50_000);
     const balancedStarted = performance.now();
@@ -409,7 +417,7 @@ describe('compression engines', () => {
       config: config('lossless'),
       recordStats: false,
     });
-    expect(performance.now() - balancedStarted).toBeLessThan(25);
+    expect(performance.now() - balancedStarted).toBeLessThan(25 * slack);
   });
 
   it('stays linear on protected-token-heavy adversarial payloads', () => {
@@ -427,7 +435,7 @@ describe('compression engines', () => {
     ], { config: config('standard'), recordStats: false });
     const traceStarted = performance.now();
     call(traceLines.join('\n'));
-    expect(performance.now() - traceStarted).toBeLessThan(250);
+    expect(performance.now() - traceStarted).toBeLessThan(250 * slack);
 
     // Distinct numeric literals are the highest-cardinality protected kind;
     // the fidelity survival scan once rescanned the output per literal.
@@ -435,6 +443,6 @@ describe('compression engines', () => {
     for (let i = 0; i < 12_000; i += 1) numberLines.push(`metric row ${i * 7 + 1_000_003} value ok`);
     const numbersStarted = performance.now();
     call(numberLines.join('\n'));
-    expect(performance.now() - numbersStarted).toBeLessThan(250);
+    expect(performance.now() - numbersStarted).toBeLessThan(250 * slack);
   });
 });


### PR DESCRIPTION
The wall-clock caps in `compression.test.ts` (8 ms median, 25 ms p99/adversarial, 250 ms linearity) are calibrated to GitHub's hosted runners, where they gate every push. Anywhere slower they only produce false failures: an independent verification of the suite on Node 22 inside Docker reported a 10-11 ms median and 252-277 ms on the linearity payload, with every functional test green.

This multiplies the caps by three when `CI` is not set. CI keeps the exact numbers, so the guard that catches real regressions is unchanged; local and container runs stop failing on hardware speed. Verified the file passes both with and without `CI=1`.