### PR TITLE
Notarize the Mac build with an App Store Connect key, not an app password

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -119,11 +119,9 @@ jobs:
         shell: bash
         env:
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
         run: |
@@ -139,13 +137,8 @@ jobs:
           fi
 
           has_api_key_creds=false
-          if [ -n "${APPLE_API_KEY:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
+          if [ -n "${APPLE_API_KEY_P8:-}" ] && [ -n "${APPLE_API_KEY_ID:-}" ] && [ -n "${APPLE_API_ISSUER:-}" ]; then
             has_api_key_creds=true
-          fi
-
-          has_apple_id_creds=false
-          if [ -n "${APPLE_ID:-}" ] && [ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ] && [ -n "${APPLE_TEAM_ID:-}" ]; then
-            has_apple_id_creds=true
           fi
 
           has_keychain_creds=false
@@ -153,11 +146,35 @@ jobs:
             has_keychain_creds=true
           fi
 
-          if [ "$has_api_key_creds" != true ] && [ "$has_apple_id_creds" != true ] && [ "$has_keychain_creds" != true ]; then
-            echo "Missing Apple notarization secrets. Provide APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER, APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID, or APPLE_KEYCHAIN_PROFILE."
+          if [ "$has_api_key_creds" != true ] && [ "$has_keychain_creds" != true ]; then
+            echo "Missing Apple notarization secrets. Provide APPLE_API_KEY_P8/APPLE_API_KEY_ID/APPLE_API_ISSUER (an App Store Connect API key), or APPLE_KEYCHAIN_PROFILE."
+            exit 1
+          fi
+          if [ "$has_api_key_creds" = true ] && [ -z "${APPLE_TEAM_ID:-}" ]; then
+            echo "APPLE_TEAM_ID is required alongside the API key so codesign picks the right Developer ID identity."
             exit 1
           fi
           echo "signed=true" >> "$GITHUB_OUTPUT"
+          echo "apikey=$has_api_key_creds" >> "$GITHUB_OUTPUT"
+
+      # notarytool takes the App Store Connect key as a FILE (`--key <path>`), but
+      # a GitHub secret is a string, so the .p8 has to be materialised on disk
+      # first. $RUNNER_TEMP is job-scoped and wiped when the job ends, and the
+      # runner is ephemeral, so the key never outlives this build. Writing it
+      # before the package step (rather than inlining a path into that step's
+      # `env:`) keeps the "which credential wins" logic in one place.
+      - name: Write the App Store Connect API key
+        if: steps.maccreds.outputs.signed == 'true' && steps.maccreds.outputs.apikey == 'true'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s\n' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+          # electron-builder reads APPLE_API_KEY as the path to hand notarytool.
+          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
 
       - name: Package installer
         shell: bash
@@ -166,14 +183,20 @@ jobs:
           # release builds sign + notarize when the Apple secrets are configured
           # (so the downloaded DMG opens without Gatekeeper's "damaged" quarantine
           # block) and fall back to an unsigned DMG when they aren't.
+          #
+          # Notarization goes through the App Store Connect API key, not an
+          # app-specific password. electron-builder checks APPLE_ID FIRST and
+          # returns as soon as it is set, so leaving that pair configured would
+          # silently shadow the API key — the two cannot coexist. The API key
+          # also does not expire the way an app-specific password does.
           CSC_IDENTITY_AUTODISCOVERY: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/tags/') && steps.maccreds.outputs.signed == 'true' && 'true' || 'false' }}
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          # APPLE_API_KEY is deliberately absent here: the step above exports the
+          # on-disk key path through $GITHUB_ENV, and a step-level `env:` entry
+          # would override it with the raw PEM text.
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_KEYCHAIN: ${{ secrets.APPLE_KEYCHAIN }}
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
@@ -184,7 +207,7 @@ jobs:
           # with "<dir> not a file" on any non-PR build (PR builds never hit it
           # because electron-builder skips signing for pull requests). Drop empty
           # signing vars so unsigned builds actually build unsigned.
-          for v in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_ID APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID APPLE_KEYCHAIN APPLE_KEYCHAIN_PROFILE; do
+          for v in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID APPLE_KEYCHAIN APPLE_KEYCHAIN_PROFILE; do
             if [ -z "${!v:-}" ]; then unset "$v"; fi
           done
           # Run electron-builder with desktop/ as its own project root. Invoked


### PR DESCRIPTION
The macOS release job offered three notarization credentials and picked the wrong one. electron-builder’s `getNotarizeOptions` checks `APPLE_ID` **first** and returns the moment it is set, so with both pairs configured the App Store Connect API key was dead config — the build would always have taken the app-specific-password path, which expires and cannot be minted headlessly.

The API key was also wired up in a way that could never have worked. `notarytool` takes it as `--key <path>`, a *file*, but the workflow passed the secret’s PEM text straight through as `APPLE_API_KEY`, so `notarytool` would have been handed a private key where it expected a filename.

## What changed

- New **Write the App Store Connect API key** step: writes `secrets.APPLE_API_KEY_P8` to `$RUNNER_TEMP/AuthKey.p8` (mode 600, job-scoped, ephemeral runner) and exports `APPLE_API_KEY=<that path>` via `$GITHUB_ENV`.
- `APPLE_API_KEY` is deliberately **not** declared in the package step’s `env:` — a step-level entry would override the `$GITHUB_ENV` path with the raw PEM text again.
- The `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` pair is removed rather than kept as a fallback: it cannot coexist with the key it shadows.
- `APPLE_TEAM_ID` is now required alongside the key so `codesign` resolves the right Developer ID identity.
- `APPLE_KEYCHAIN_PROFILE` stays as the local-keychain option (electron-builder checks it after the key, so it does not shadow).

Secrets already configured on the repo: `APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_TEAM_ID`.

## What this does *not* fix yet

This is the CI half of the “damaged” Gatekeeper reports (#373, #943). The other half is a **Developer ID Application** certificate in `MACOS_CSC_LINK`. Creating one over the App Store Connect API is refused:

```
403 FORBIDDEN_ERROR — This operation can only be performed by the Account Holder.
```

so it has to be minted once through the web portal. Until `MACOS_CSC_LINK` exists the job still warns and ships an unsigned DMG, exactly as before — no behaviour change for the current secret set.

## Risk

Low. With no `MACOS_CSC_LINK`, `maccreds` exits early with `signed=false`, the new step is skipped by its `if:`, and the package step is unchanged. PR and `workflow_dispatch` builds never reach the signing path at all.