### PR TITLE
Mac builds are signed and notarized — closes #373 #943

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
A **Developer ID Application** certificate now exists for the team ("Developer ID Application: Tashfeen Ahmed (345756K43U)", G2 Sub-CA, expires 2031-08-26), so `MACOS_CSC_LINK` / `MACOS_CSC_KEY_PASSWORD` are configured and the release job takes its signing path instead of the unsigned fallback. Notarization goes through the App Store Connect API key wired up in #1034.

That clears the "damaged" Gatekeeper block in #373 — the DMG through v0.8.7 was ad-hoc signed, which macOS refuses to open from a quarantined download.

Bumps `desktop/package.json` and `desktop/package-lock.json` to 0.8.8 together; the tagged run compares both against the tag and fails on drift, which is the mislabeling #943 hit.

Tagging `v0.8.8` once this lands. Closes #373, closes #943.