### PR TITLE
Notarize the DMG itself, not just the app inside it

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -224,6 +224,51 @@ jobs:
           # uploads. The "Attach installer to release" step below owns publishing.
           npx --no-install electron-builder ${{ matrix.ebArgs }} --publish never
 
+      # electron-builder notarizes and staples the .app, then wraps it in a DMG
+      # it never submits. The DMG is the file users download, so it is the file
+      # macOS quarantines and assesses — until it carries its own stapled
+      # ticket, `spctl -t install` on the download reports "no usable
+      # signature", which is #373's "damaged" block. The .app is signed inside
+      # the build (dmg.sign in electron-builder.yml makes the DMG eligible to
+      # submit); this finishes the job for the container.
+      - name: Notarize and staple the DMG
+        if: steps.maccreds.outputs.signed == 'true' && steps.maccreds.outputs.apikey == 'true'
+        shell: bash
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmgs=(desktop/dist-electron/*.dmg)
+          if [ ${#dmgs[@]} -eq 0 ]; then
+            echo "::error::signing was enabled but electron-builder produced no DMG"
+            exit 1
+          fi
+          # app-builder ships the blockmap generator electron-builder itself uses.
+          app_builder=$(cd desktop && node -p "require('app-builder-bin').appBuilderPath")
+          for dmg in "${dmgs[@]}"; do
+            echo "== notarizing $(basename "$dmg") =="
+            # --wait turns a rejection into a non-zero exit, so a failed
+            # notarization fails the release instead of publishing a blocked DMG.
+            xcrun notarytool submit "$dmg" \
+              --key "$APPLE_API_KEY" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait --timeout 30m
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+            # The verdict Gatekeeper will give the download.
+            spctl -a -vv -t install "$dmg"
+            # Stapling rewrites the DMG in place, so the size, hash and blockmap
+            # electron-builder computed a moment ago no longer describe it.
+            # electron-updater verifies that hash, so leaving it stale would
+            # break updates for every installed copy.
+            node desktop/scripts/refresh-mac-update-metadata.mjs \
+              "$dmg" desktop/dist-electron/latest-mac.yml
+            "$app_builder" blockmap --input "$dmg" --output "$dmg.blockmap" --compression gzip
+          done
+
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4
         with:

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -42,6 +42,15 @@ mac:
         - arm64
   extendInfo:
     LSUIElement: 1
+# The DMG is the file people actually download, so it is the file macOS
+# quarantines and assesses. electron-builder signs and notarizes the .app inside
+# but leaves the DMG itself unsigned, which leaves `spctl -t install` on the
+# download reporting "no usable signature" — #373's "damaged" report. Signing it
+# here is also what makes it *eligible* for notarization; the release workflow
+# submits and staples it afterwards. This runs before the blockmap and
+# latest-mac.yml are computed, so those describe the signed file.
+dmg:
+  sign: true
 win:
   target:
     - target: nsis

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",

--- a/desktop/scripts/refresh-mac-update-metadata.mjs
+++ b/desktop/scripts/refresh-mac-update-metadata.mjs
@@ -1,0 +1,110 @@
+// Re-stamps latest-mac.yml after the DMG has been stapled.
+//
+// electron-builder hashes the DMG and writes latest-mac.yml as the very last
+// thing it does for that target. Stapling the notarization ticket happens after
+// electron-builder has exited and *rewrites the DMG in place*, so every byte
+// count and checksum in that manifest is stale the moment the ticket lands.
+//
+// electron-updater verifies the sha512 from this manifest against the file it
+// downloaded, so a stale hash doesn't degrade gracefully — it fails the update
+// for every existing install. Recomputing here keeps the manifest describing
+// the file users actually receive.
+//
+// Usage: node scripts/refresh-mac-update-metadata.mjs <dmg> <latest-mac.yml>
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
+
+/** sha512, base64 — the encoding electron-updater compares against. */
+export function hashFile(path) {
+  return createHash('sha512').update(readFileSync(path)).digest('base64');
+}
+
+/**
+ * Whether the manifest has an entry for `fileName`.
+ *
+ * The CLI checks this rather than "did the text change", because an unchanged
+ * manifest is ambiguous: it means either that nothing matched (a real problem)
+ * or that the recomputed hash equalled the old one (perfectly fine, and what
+ * happens on any re-run over an already-stapled DMG).
+ */
+export function describesFile(yamlText, fileName) {
+  return yamlText
+    .split('\n')
+    .some((line) => new RegExp(`^\\s*(-\\s+url|path):\\s*${escapeRegExp(fileName)}\\s*$`).test(line));
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Rewrites the sha512/size that describe `fileName` in a latest-mac.yml.
+ *
+ * Deliberately a line-level edit rather than a YAML parse-and-dump: a round
+ * trip through a YAML library reorders keys and restyles quoting, which would
+ * make every release diff noisy and risks changing a field electron-updater
+ * reads. Only the numbers that actually changed are touched.
+ *
+ * Both the `files:` entry and the legacy top-level `path`/`sha512` pair are
+ * updated — old electron-updater builds read the top-level pair, current ones
+ * read `files:`, and a release has to satisfy whichever one an installed copy
+ * happens to use.
+ */
+export function rewriteUpdateMetadata(yamlText, { fileName, sha512, size }) {
+  const lines = yamlText.split('\n');
+  let inMatchingFileEntry = false;
+  let topLevelPathMatches = false;
+
+  const out = lines.map((line) => {
+    // A `  - url: <name>` line opens a files[] entry; any other list item at
+    // that indent closes the one we were in.
+    const listItem = /^\s*-\s+url:\s*(.+?)\s*$/.exec(line);
+    if (listItem) {
+      inMatchingFileEntry = listItem[1] === fileName;
+      return line;
+    }
+
+    // Top-level keys (column 0) end the files[] block entirely.
+    if (/^\S/.test(line)) {
+      const path = /^path:\s*(.+?)\s*$/.exec(line);
+      if (path) topLevelPathMatches = path[1] === fileName;
+      if (topLevelPathMatches) {
+        if (/^sha512:/.test(line)) return `sha512: ${sha512}`;
+        if (/^size:/.test(line)) return `size: ${size}`;
+      }
+      if (!/^(files|path|sha512|size):/.test(line)) inMatchingFileEntry = false;
+      return line;
+    }
+
+    if (inMatchingFileEntry) {
+      const indent = /^\s*/.exec(line)[0];
+      if (/^\s*sha512:/.test(line)) return `${indent}sha512: ${sha512}`;
+      if (/^\s*size:/.test(line)) return `${indent}size: ${size}`;
+    }
+    return line;
+  });
+
+  return out.join('\n');
+}
+
+// Only run the CLI when invoked directly, so the test can import the helpers.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const [dmgPath, ymlPath] = process.argv.slice(2);
+  if (!dmgPath || !ymlPath) {
+    console.error('usage: refresh-mac-update-metadata.mjs <dmg> <latest-mac.yml>');
+    process.exit(1);
+  }
+  const fileName = basename(dmgPath);
+  const before = readFileSync(ymlPath, 'utf8');
+  if (!describesFile(before, fileName)) {
+    // Shipping a manifest that doesn't name the artifact means every installed
+    // copy would be told to fetch a file whose hash it can't verify.
+    console.error(`refresh-mac-update-metadata: nothing in ${ymlPath} describes ${fileName}`);
+    process.exit(1);
+  }
+  const sha512 = hashFile(dmgPath);
+  const size = statSync(dmgPath).size;
+  writeFileSync(ymlPath, rewriteUpdateMetadata(before, { fileName, sha512, size }));
+  console.log(`refresh-mac-update-metadata: ${fileName} -> size ${size}`);
+}

--- a/desktop/src/__tests__/refresh-mac-update-metadata.test.ts
+++ b/desktop/src/__tests__/refresh-mac-update-metadata.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error -- plain .mjs build script, no types
+import { rewriteUpdateMetadata, describesFile } from '../../scripts/refresh-mac-update-metadata.mjs';
+
+// Stapling the notarization ticket rewrites the DMG after electron-builder has
+// already hashed it, so latest-mac.yml has to be re-stamped or electron-updater
+// rejects the download for every installed copy. These cover the rewrite.
+
+const sample = `version: 0.8.8
+files:
+  - url: FreeLLMAPI-0.8.8-arm64.dmg
+    sha512: OLDHASH==
+    size: 111
+path: FreeLLMAPI-0.8.8-arm64.dmg
+sha512: OLDHASH==
+releaseDate: '2026-08-25T20:25:58.884Z'
+`;
+
+const fresh = { fileName: 'FreeLLMAPI-0.8.8-arm64.dmg', sha512: 'NEWHASH==', size: 222 };
+
+describe('rewriteUpdateMetadata', () => {
+  it('re-stamps both the files[] entry and the top-level pair', () => {
+    const out = rewriteUpdateMetadata(sample, fresh);
+    expect(out).toContain('    sha512: NEWHASH==');
+    expect(out).toContain('    size: 222');
+    expect(out).toContain('\nsha512: NEWHASH==');
+    expect(out).not.toContain('OLDHASH');
+    expect(out).not.toContain('111');
+  });
+
+  it('leaves every other field, and the formatting, alone', () => {
+    const out = rewriteUpdateMetadata(sample, fresh).split('\n');
+    expect(out[0]).toBe('version: 0.8.8');
+    expect(out[1]).toBe('files:');
+    expect(out[2]).toBe('  - url: FreeLLMAPI-0.8.8-arm64.dmg');
+    expect(out[5]).toBe('path: FreeLLMAPI-0.8.8-arm64.dmg');
+    // releaseDate keeps its quoting — a YAML round trip would have restyled it.
+    expect(out[7]).toBe("releaseDate: '2026-08-25T20:25:58.884Z'");
+  });
+
+  it('only touches the entry whose url matches', () => {
+    const twoFiles = `version: 0.8.8
+files:
+  - url: FreeLLMAPI-0.8.8-arm64.dmg
+    sha512: OLDHASH==
+    size: 111
+  - url: FreeLLMAPI-0.8.8-x64.dmg
+    sha512: OTHER==
+    size: 999
+path: FreeLLMAPI-0.8.8-arm64.dmg
+sha512: OLDHASH==
+`;
+    const out = rewriteUpdateMetadata(twoFiles, fresh);
+    expect(out).toContain('    sha512: OTHER==');
+    expect(out).toContain('    size: 999');
+    expect(out).not.toContain('OLDHASH');
+  });
+
+  it('does not touch the top-level pair when it names a different file', () => {
+    const zipTopLevel = `version: 0.8.8
+files:
+  - url: FreeLLMAPI-0.8.8-arm64.dmg
+    sha512: OLDHASH==
+    size: 111
+path: FreeLLMAPI-0.8.8-arm64.zip
+sha512: ZIPHASH==
+size: 333
+`;
+    const out = rewriteUpdateMetadata(zipTopLevel, fresh);
+    expect(out).toContain('    sha512: NEWHASH==');
+    expect(out).toContain('sha512: ZIPHASH==');
+    expect(out).toContain('size: 333');
+  });
+
+  it('returns the input unchanged when nothing matches', () => {
+    const out = rewriteUpdateMetadata(sample, { ...fresh, fileName: 'nope.dmg' });
+    expect(out).toBe(sample);
+  });
+
+  it('is a no-op when the recomputed hash already matches', () => {
+    // Re-running over an already-stapled DMG must be safe: identical output is
+    // the expected result, not the "nothing matched" failure.
+    const unchanged = rewriteUpdateMetadata(sample, {
+      fileName: fresh.fileName,
+      sha512: 'OLDHASH==',
+      size: 111,
+    });
+    expect(unchanged).toBe(sample);
+  });
+});
+
+describe('describesFile', () => {
+  it('finds the artifact by its files[] url and by the top-level path', () => {
+    expect(describesFile(sample, 'FreeLLMAPI-0.8.8-arm64.dmg')).toBe(true);
+    expect(describesFile('path: FreeLLMAPI-0.8.8-arm64.dmg\n', 'FreeLLMAPI-0.8.8-arm64.dmg')).toBe(
+      true,
+    );
+  });
+
+  it('is false when the manifest names a different artifact', () => {
+    expect(describesFile(sample, 'FreeLLMAPI-0.8.8-x64.dmg')).toBe(false);
+  });
+
+  it('does not match on a partial name', () => {
+    // A bare `.includes` would match the x64 name inside the arm64 one.
+    expect(describesFile(sample, '0.8.8-arm64.dmg')).toBe(false);
+  });
+});


### PR DESCRIPTION
v0.8.8 signed and notarized `FreeLLMAPI.app` correctly. The **DMG wrapping it** was neither signed nor notarized:

```
$ spctl -a -vv -t install FreeLLMAPI-0.8.8-arm64.dmg
rejected
source=no usable signature

$ xcrun stapler validate FreeLLMAPI-0.8.8-arm64.dmg
does not have a ticket stapled to it
```

(The app inside is fine: `accepted / source=Notarized Developer ID`, stapler validates.)

The DMG is the file people download, so it is the file macOS quarantines and assesses — electron-builder only ever submits the `.app`, leaving the container unsigned and #373 only half answered.

## Changes

- **`electron-builder.yml`** — `dmg.sign: true`. Signing is also what makes the DMG *eligible* to submit for notarization. It runs before the blockmap and `latest-mac.yml` are written, so those describe the signed file.
- **Workflow** — new *Notarize and staple the DMG* step (after packaging, before upload/attach): `notarytool submit --wait` (a rejection fails the release rather than publishing a blocked DMG), `stapler staple`, then `stapler validate` + `spctl -a -t install` as gates.
- **`desktop/scripts/refresh-mac-update-metadata.mjs`** + tests — stapling rewrites the DMG *after* electron-builder hashed it, so `latest-mac.yml` would otherwise carry a sha512 for the pre-staple bytes. electron-updater verifies that hash, so a stale one breaks updates for **every installed copy**. The blockmap is regenerated with the same `app-builder` binary electron-builder uses.

The rewrite is a line-level edit, not a YAML round trip (which would reorder keys and restyle quoting in every future release diff). It updates both the `files[]` entry and the legacy top-level `path`/`sha512` pair, since different electron-updater versions read different ones.

**Verified against the published v0.8.8 artifacts:** recomputing over the real unstapled DMG reproduces the shipped `latest-mac.yml` byte for byte. 26 desktop tests pass (9 new).

Releasing as v0.8.9.