### PR TITLE
Bump desktop to v0.9.0

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.8.9",
+      "version": "0.9.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
Release prep for v0.9.0: opt-in Fetch Relay transport (#975), root Docker entrypoint that fixes PaaS volume permissions (#972), estimated usage frame for streaming clients (#686), signed and notarized Mac builds (#1034, #1035, #1036).