### PR TITLE
fix(ratelimit): ModelScope free tier switched to magic-grain (魔粒) metering; daily account cap 1800→100

### DIFF
--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -280,8 +280,8 @@ describe('Rate Limiter', () => {
     it('defaults to OpenRouter ~1000/day and allows env override / disable', () => {
       delete process.env[ENV];
       expect(getProviderDailyRequestCap('openrouter')).toBe(1000);
-      // ModelScope: 2000/day account-wide upstream, shipped as 1800 for margin (#581).
-      expect(getProviderDailyRequestCap('modelscope')).toBe(1800);
+      // ModelScope: ~250 魔粒/day ÷ 2 per request ≈ 125/day upstream, shipped as 100 for margin.
+      expect(getProviderDailyRequestCap('modelscope')).toBe(100);
       expect(getProviderDailyRequestCap('groq')).toBeNull(); // no shared cap
       process.env[ENV] = '50';
       expect(getProviderDailyRequestCap('openrouter')).toBe(50);

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -417,8 +417,10 @@ register(new OpenAICompatProvider({
 }));
 
 // ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
-// (api-inference.modelscope.cn/v1, Bearer auth). Free tier: 2000 requests/day
-// account-wide. Token from modelscope.cn/my/myaccesstoken, BUT calls only work
+// (api-inference.modelscope.cn/v1, Bearer auth). Free tier moved to magic-grain
+// (魔粒) metering in 2026-08: ~250 魔粒/day account-wide at ~2 魔粒 per request
+// (observed 2026-08-14) ≈ 125 requests/day. Token from
+// modelscope.cn/my/myaccesstoken, BUT calls only work
 // after binding the ModelScope account to an Alibaba Cloud CHINA-site (cn)
 // account with Chinese real-name verification — unbound tokens 401 on every
 // call ("please bind your alibaba cloud account before use"). Dedicated

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -560,10 +560,11 @@ export function modelWindowUsedFraction(
 //   PROVIDER_DAILY_REQUEST_CAP_OPENROUTER=50   (set 0 to disable the cap)
 const DEFAULT_PROVIDER_DAILY_REQUEST_CAPS: Record<string, number> = {
   openrouter: 1000,
-  // ModelScope's free tier is 2000 requests/day across the whole account (all
-  // models share it). 1800 leaves margin for validation probes and for drift
+  // ModelScope's free tier moved to magic-grain (魔粒) metering in 2026-08:
+  // ~250 魔粒/day account-wide at ~2 魔粒 per request (observed 2026-08-14)
+  // ≈ 125 requests/day. 100 leaves margin for validation probes and for drift
   // between our ledger and the provider's own daily boundary (#581).
-  modelscope: 1800,
+  modelscope: 100,
 };
 
 const DEFAULT_PROVIDER_DAILY_TOKEN_CAPS: Record<string, number> = {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -149,11 +149,13 @@ export type Platform =
   // in the hosted catalog (premium now, free after the 30-day model-age gate).
   | 'xkiro'
   // ModelScope (魔搭社区, Alibaba) — OpenAI-compatible inference API
-  // (api-inference.modelscope.cn/v1). Free tier is 2000 requests/day
-  // account-wide, but calls only work after the ModelScope account is bound to
-  // an Alibaba Cloud CHINA-site (cn) account with Chinese real-name
-  // verification — tokens mint without binding, then every call 401s. Catalog
-  // rows land after community testing confirms per-model behavior (#581).
+  // (api-inference.modelscope.cn/v1). Free tier moved to magic-grain (魔粒)
+  // metering in 2026-08: ~250 魔粒/day account-wide at ~2 魔粒 per request
+  // (observed 2026-08-14) ≈ 125 requests/day, but calls only work after the
+  // ModelScope account is bound to an Alibaba Cloud CHINA-site (cn) account
+  // with Chinese real-name verification — tokens mint without binding, then
+  // every call 401s. Catalog rows land after community testing confirms
+  // per-model behavior (#581).
   | 'modelscope'
   // ── Chinese domestic providers (#922/#923/#924) ────────────────────────────
   // All four need Chinese real-name verification (实名认证) on the cloud account


### PR DESCRIPTION
## 改动（4 个文件，+17/−12）

- `server/src/services/ratelimit.ts`：`DEFAULT_PROVIDER_DAILY_REQUEST_CAPS.modelscope` 1800 → 100（125/天留校验探测余量），注释更新为魔粒数字。
- `server/src/providers/index.ts`：ModelScope 注册注释改为魔粒计费（~250/天、~2/请求），替换过时的 2000 次/天。
- `shared/types.ts`：Platform 联合类型文档中的同一注释修复。
- `server/src/__tests__/services/ratelimit.test.ts`：断言 1800 → 100。

## 验证

- `npx vitest run src/__tests__/services/ratelimit.test.ts` — 34 通过
- `npx tsc --noEmit`（server）— clean

## 摘要

ModelScope 免费层已于 2026-08 改为魔粒计费（每日约 250 魔粒、每请求约 2 魔粒 ≈ 125 次/日），而非历史口径的每日 2000 次。本 PR 将账号级每日请求上限 1800→100 并同步 4 处注释/断言，避免按旧上限打满后触发上游 429。

## What & why

ModelScope's free tier moved from "2000 requests/day" to magic‑grain (魔粒) metering in 2026‑08: ~250 魔粒/day account‑wide at ~2 魔粒 per request (observed 2026‑08‑14) ≈ 125 requests/day. The code still documented and capped the old quota, letting the router fire up to 1800 requests/day and eat real 429s well before the account is drained.

## Changes (4 files, +17/−12)

- `server/src/services/ratelimit.ts`: `DEFAULT_PROVIDER_DAILY_REQUEST_CAPS.modelscope` 1800 → 100 (125/day with margin for validation probes), comment updated to the magic‑grain numbers.
- `server/src/providers/index.ts`: ModelScope registration comment now states 魔粒 metering (~250/day, ~2/request) instead of the stale 2000 requests/day.
- `shared/types.ts`: same comment fix in the Platform union docs.
- `server/src/__tests__/services/ratelimit.test.ts`: assertion 1800 → 100.

## Verification

- `npx vitest run src/__tests__/services/ratelimit.test.ts` — 34 passed
- `npx tsc --noEmit` (server) — clean