### PR TITLE
fix(server): honor TRUST_PROXY env var for reverse-proxy client IPs (#1024)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -93,9 +93,22 @@ function isTrustworthyOrigin(req: express.Request): boolean {
   return isHttpsRequest(req) || LOOPBACK_HOST_RE.test(req.hostname ?? '');
 }
 
+// Express only honors X-Forwarded-For when "trust proxy" is enabled. The
+// TRUST_PROXY env var opts in (issue #1024): unset/empty/"false" leaves it
+// off (the safe, default-as-shipped behavior); "true"/"1"/"yes" enables it,
+// "loopback" trusts loopback hops, and anything else is passed through to
+// Express (ip/cidr/number-of-hops). See client-context.ts for how the header
+// is then consumed.
+function configureTrustProxy(app: express.Express): void {
+  const raw = process.env.TRUST_PROXY;
+  if (!raw || raw.toLowerCase() === 'false' || raw === '0') return;
+  app.set('trust proxy', raw.toLowerCase() === 'true' || raw === '1' || raw.toLowerCase() === 'yes' ? true : raw);
+}
+
 export function createApp(config?: Config) {
   const cfg = config ?? loadConfig();
   const app = express();
+  configureTrustProxy(app);
   const allowedCorsOrigins = new Set([
     ...DEFAULT_DASHBOARD_ORIGINS,
     ...cfg.dashboardOrigins,

--- a/server/src/lib/client-context.ts
+++ b/server/src/lib/client-context.ts
@@ -15,8 +15,9 @@ const storage = new AsyncLocalStorage<ClientContext>();
 
 // Resolve the client IP from the socket peer address. The X-Forwarded-For
 // header is only trusted when Express's "trust proxy" setting is enabled
-// (opt-in via app.set('trust proxy', ...) or the TRUST_PROXY env var in
-// run.ts). Without that, a spoofed header from a LAN client is ignored.
+// (opt-in via app.set('trust proxy', ...) or the TRUST_PROXY env var, which
+// createApp() applies). Without that, a spoofed header from a LAN client is
+// ignored.
 function resolveClientIp(req: Request): string | null {
   const trustProxy = req.app?.get('trust proxy') ?? false;
   let raw: string | null;


### PR DESCRIPTION
## Summary

Fixes #1024 —  is documented in the code but never actually applied, so a reverse proxy's `X-Forwarded-For` is ignored and Analytics → Recent Calls records the proxy's socket address instead of the real client IP.

## Changes

- `server/src/app.ts`: `createApp()` now reads `TRUST_PROXY` and calls `app.set('trust proxy', ...)`:
  - unset / empty / `false` / `0` → leave it off (safe default as shipped)
  - `true` / `1` / `yes` → enable
  - any other value (`loopback`, CIDR, hop count) → passed through to Express
- `server/src/lib/client-context.ts`: fixed the stale comment (the env var is applied in `createApp`, not `run.ts`).

`client-context.ts` already consumes `trust proxy` to honor `X-Forwarded-For`, so this is the missing wiring.

## Test plan

- Run behind a trusted reverse proxy with `TRUST_PROXY=true`; the real client IP should appear in Analytics → Recent Calls.
- `TRUST_PROXY` unset → behavior unchanged (records the proxy socket address, as before).