### PR TITLE
Add release-notes template with the tagged premium footer

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,8 @@
+# Release notes template
+
+Write the changes as usual, then ALWAYS end the notes with the tagged
+premium footer (swap in the tag), so every release page carries a
+conversion path — the release pages get thousands of views per tag:
+
+---
+⭐ Like the free router? [Go Premium](https://freellmapi.co/?utm_source=github&utm_medium=release&utm_campaign=premium&utm_content=vX.Y.Z#pricing) — the live signed catalog, $19/yr, cancel anytime.


### PR DESCRIPTION
All 25 existing releases now end with a Go Premium link tagged `utm_source=github&utm_medium=release&utm_campaign=premium&utm_content=<tag>`. This template keeps future tags in step. Watch /channels for a github/release/premium row in about a week.