### PR TITLE
fix(groq): strip replayed reasoning content

### DIFF
--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -413,6 +413,31 @@ describe('OpenAICompatProvider', () => {
     });
   });
 
+  it('strips replayed reasoning_content before sending messages to Groq (#1070)', async () => {
+    let body: any = null;
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      body = JSON.parse((init as any).body);
+      return {
+        ok: true,
+        json: () => Promise.resolve({
+          id: 'id', object: 'chat.completion', created: 1, model: 'm',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+      } as any;
+    });
+
+    const groq = new OpenAICompatProvider({ platform: 'groq', name: 'Groq', baseUrl: 'https://api.groq.com/openai/v1' });
+    await groq.chatCompletion(
+      'k',
+      [{ role: 'assistant', content: 'previous answer', reasoning_content: 'replayed trace' }],
+      'llama-3.3-70b-versatile',
+    );
+
+    expect(body.messages[0]).not.toHaveProperty('reasoning_content');
+    expect(body.messages[0]).toEqual({ role: 'assistant', content: 'previous answer' });
+  });
+
   it('folds reasoning into content when content is empty (Ollama style — bare `reasoning` field)', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce({
       ok: true,

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -140,9 +140,12 @@ export class OpenAICompatProvider extends BaseProvider {
 
   /** Mistral's OpenAI-compatible endpoint is strict about unknown nested fields
    * and returns 422 for provider-private replay fields that other gateways
-   * ignore. Keep the OpenAI wire shape, but strip our internal reasoning /
-   * thought-signature extensions before sending to Mistral. */
+   * ignore. Groq also rejects replayed `reasoning_content`. Keep the OpenAI wire
+   * shape, but strip only the extensions each provider does not accept. */
   private messagesForPlatform(messages: ChatMessage[]): ChatMessage[] {
+    if (this.platform === 'groq') {
+      return messages.map(({ reasoning_content: _reasoningContent, ...message }) => message);
+    }
     if (this.platform !== 'mistral') return messages;
 
     return messages.map((m) => {


### PR DESCRIPTION
## Summary
- strip the internal replay-only reasoning_content field at Groq's OpenAI-compatible request boundary
- retain the existing Mistral-specific sanitization and leave tool-call fields untouched
- add a mocked regression test for #1070

## Validation
- npm test -w server
- npm run build