### PR TITLE
ci: use npm ci for reproducible installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Check migration round trip
         run: npm run test:migrations


### PR DESCRIPTION
## Summary
- switch the CI dependency install step from npm install to npm ci so CI uses the committed lockfile exactly

## Verification
- git diff --check
- npm ci

Closes #1074