### PR TITLE
fix(auth): stop upstream 401s from ending the dashboard session

### DIFF
--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// A 401 must end the dashboard session ONLY when it is our auth saying so.
+// Discover/probe endpoints relay an upstream provider's 401 with its status
+// intact ("the endpoint rejected the key"); treating any 401 as session-expired
+// signed the operator out every time they tested a bad provider key.
+
+const TOKEN_KEY = 'freellmapi_dashboard_token'
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: () => null,
+    get length() { return store.size },
+  } as Storage
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('apiFetch 401 handling', () => {
+  let events: string[]
+
+  beforeEach(() => {
+    events = []
+    vi.stubGlobal('localStorage', makeStorage())
+    vi.stubGlobal('window', { dispatchEvent: (e: Event) => { events.push(e.type); return true } })
+    // Node's CustomEvent (>=19) works; make sure it exists either way.
+    if (typeof globalThis.CustomEvent === 'undefined') {
+      vi.stubGlobal('CustomEvent', class extends Event {})
+    }
+    localStorage.setItem(TOKEN_KEY, 'session-token')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('clears the token and fires the unauthorized event on a session 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, {
+      error: { message: 'Authentication required', type: 'authentication_error' },
+    })))
+    const { apiFetch } = await import('./api')
+
+    await expect(apiFetch('/api/keys')).rejects.toMatchObject({ status: 401, code: 'authentication_error' })
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull()
+    expect(events).toContain('freellmapi:unauthorized')
+  })
+
+  it('keeps the session when a discover/probe relays an upstream 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, {
+      error: { message: 'The endpoint rejected the key (HTTP 401)', type: 'upstream_error' },
+    })))
+    const { apiFetch } = await import('./api')
+
+    await expect(apiFetch('/api/keys/custom/discover-models', { method: 'POST', body: '{}' }))
+      .rejects.toMatchObject({ status: 401, code: 'upstream_error' })
+    expect(localStorage.getItem(TOKEN_KEY)).toBe('session-token')
+    expect(events).toHaveLength(0)
+  })
+
+  it('keeps the session on an untyped 401 rather than guessing it expired', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: { message: 'nope' } })))
+    const { apiFetch } = await import('./api')
+
+    await expect(apiFetch('/api/whatever')).rejects.toMatchObject({ status: 401 })
+    expect(localStorage.getItem(TOKEN_KEY)).toBe('session-token')
+    expect(events).toHaveLength(0)
+  })
+})

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -39,13 +39,18 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
     ...options,
     headers,
   });
-  if (res.status === 401) {
-    // Session missing/expired — drop the token and let the AuthGate re-render.
-    clearToken();
-    window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
-  }
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: { message: res.statusText } }));
+    // A 401 ends the dashboard session ONLY when it is OUR auth saying so.
+    // Discover/probe endpoints deliberately relay an upstream provider's 401
+    // ("the endpoint rejected the key") with its status intact; treating those
+    // as session-expired signed the operator out every time they tested a bad
+    // provider key. The auth middleware and every session 401 carry
+    // type 'authentication_error'; upstream relays never do.
+    if (res.status === 401 && body.error?.type === 'authentication_error') {
+      clearToken();
+      window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
+    }
     // Surface the HTTP status and the machine-readable error type on the thrown
     // Error so callers can branch on them (e.g. the setup form reveals a code
     // field on a `setup_code_required` 403). `.message` behaviour is unchanged.

--- a/server/src/routes/embeddings.ts
+++ b/server/src/routes/embeddings.ts
@@ -147,7 +147,10 @@ embeddingsRouter.post('/custom', async (req: Request, res: Response) => {
     result = upsert();
   } catch (err: any) {
     if (err instanceof EmbeddingsError) {
-      res.status(err.status).json({ error: { message: err.message } });
+      // `upstream_error`, never `authentication_error`: this status is relayed
+      // from the operator's own endpoint, and a client that reads a bare 401 as
+      // "session expired" would sign the operator out for testing a bad key.
+      res.status(err.status).json({ error: { message: err.message, type: 'upstream_error' } });
       return;
     }
     throw err;

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -842,7 +842,10 @@ keysRouter.post('/custom/discover-models', async (req: Request, res: Response) =
     });
   } catch (err: any) {
     if (err instanceof ModelDiscoveryError) {
-      res.status(err.status).json({ error: { message: err.message } });
+      // `upstream_error`, never `authentication_error`: this status is relayed
+      // from the operator's own endpoint, and a client that reads a bare 401 as
+      // "session expired" would sign the operator out for testing a bad key.
+      res.status(err.status).json({ error: { message: err.message, type: 'upstream_error' } });
       return;
     }
     res.status(502).json({ error: { message: `Model discovery failed: ${err?.message ?? 'unknown error'}` } });
@@ -938,7 +941,10 @@ keysRouter.post('/custom/probe', async (req: Request, res: Response) => {
     });
   } catch (err: any) {
     if (err instanceof ModelDiscoveryError) {
-      res.status(err.status).json({ error: { message: err.message } });
+      // `upstream_error`, never `authentication_error`: this status is relayed
+      // from the operator's own endpoint, and a client that reads a bare 401 as
+      // "session expired" would sign the operator out for testing a bad key.
+      res.status(err.status).json({ error: { message: err.message, type: 'upstream_error' } });
       return;
     }
     res.status(502).json({ error: { message: `Probe failed: ${err?.message ?? 'unknown error'}` } });


### PR DESCRIPTION
Testing a provider key that the endpoint rejects (e.g. a SiliconFlow international key against api.siliconflow.cn) returned HTTP 401 from /api/keys/custom/discover-models — with the upstream status deliberately preserved — and apiFetch treated every 401 as session-expired: token cleared, operator signed out, every single attempt.

Fix: the client ends the session only on a 401 whose body carries `type: 'authentication_error'` (what the auth middleware and all session 401s send). The three upstream-relay sites (discover-models, probe, embeddings probe) now tag their errors `type: 'upstream_error'`. An untyped 401 keeps the session rather than guessing.

Reproduced and root-caused live on the test instance; 3 new client tests cover the three 401 shapes. tsc clean on both workspaces.