### PR TITLE
fix(sse): accept no-space data: frames in the Google stream parser too

### DIFF
--- a/server/src/providers/google.ts
+++ b/server/src/providers/google.ts
@@ -710,8 +710,9 @@ export class GoogleProvider extends BaseProvider {
 
         for (const line of lines) {
           const trimmed = line.trim();
-          if (!trimmed || !trimmed.startsWith('data: ')) continue;
-          const raw = trimmed.slice(6);
+          // `data:` with or without the space, same as BaseProvider (#1087).
+          if (!trimmed || !trimmed.startsWith('data:')) continue;
+          const raw = trimmed.slice(5).replace(/^ /, '');
           if (raw === '[DONE]') {
             if (!emittedFinish) {
               emittedFinish = true;


### PR DESCRIPTION
GoogleProvider has its own SSE loop with the same hard-coded `data: ` prefix that #1089 fixed in BaseProvider. Same one-line treatment. Spotted in #1092 by @suantea.