### PR TITLE
ci: use npm ci in the release workflows too (#1074)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -58,7 +58,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Resolve version
         id: version

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -88,7 +88,7 @@ jobs:
           echo "desktop/package.json $VERSION matches tag $GITHUB_REF_NAME."
 
       - name: Install workspace dependencies
-        run: npm install
+        run: npm ci
 
       # `npm ci` rather than `install`: install rewrites desktop/package-lock.json
       # in place, which would quietly repair a stale lockfile version before the


### PR DESCRIPTION
Same reasoning as #1085, which converted ci.yml: install can drift from the
lockfile, ci cannot. The tarball smoke-install in cli-release.yml stays
npm install on purpose, it installs a built artifact, not the lockfile.