### PR TITLE
fix(models): let search match a custom endpoint's host and key label

### DIFF
--- a/client/src/lib/routing.test.ts
+++ b/client/src/lib/routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  groupMatchesQuery,
   isMemberSplit,
   memberEndpointTitle,
   memberOverrideKey,
@@ -258,5 +259,43 @@ describe('tightestRateLimit', () => {
       usageRow(2, { tpm: { used: 500, limit: 100_000 } }),
     ]
     expect(tightestRateLimit(rows)).toEqual({ kind: 'TPM', used: 500, limit: 100_000 })
+  })
+})
+
+// #1056: a relay added as a custom endpoint carries platform 'custom', so
+// searching the provider's name ("unorouter") found nothing even though the
+// table prints the endpoint host on the row.
+describe('groupMatchesQuery (#1056)', () => {
+  const member = (over: Record<string, unknown> = {}) => ({
+    platform: 'custom', modelId: 'glm-5.1', displayName: 'GLM 5.1',
+    source: 'custom' as const, keyLabel: null,
+    endpointScope: 'https://api.unorouter.com/v1', ...over,
+  })
+  const group = (members: ReturnType<typeof member>[]) => ({ label: 'GLM 5.1', members })
+
+  it('matches a custom endpoint host the table displays', () => {
+    expect(groupMatchesQuery(group([member()]), 'unorouter')).toBe(true)
+    expect(groupMatchesQuery(group([member()]), 'api.unorouter.com')).toBe(true)
+  })
+
+  it('matches the operator-given key label', () => {
+    const g = group([member({ endpointScope: null, keyLabel: 'My UnoRouter key' })])
+    expect(groupMatchesQuery(g, 'unorouter')).toBe(true)
+  })
+
+  it('matches when only ONE member of a multi-provider group is on that endpoint', () => {
+    const g = group([
+      member({ platform: 'zhipu', source: 'catalog' as const, endpointScope: null }),
+      member(),
+    ])
+    expect(groupMatchesQuery(g, 'unorouter')).toBe(true)
+    expect(groupMatchesQuery(g, 'zhipu')).toBe(true)
+  })
+
+  it('still matches names, ids and catalog platforms', () => {
+    const g = group([member({ platform: 'groq', source: 'catalog' as const, endpointScope: null })])
+    expect(groupMatchesQuery(g, 'glm')).toBe(true)
+    expect(groupMatchesQuery(g, 'groq')).toBe(true)
+    expect(groupMatchesQuery(g, 'mistral')).toBe(false)
   })
 })

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -441,3 +441,35 @@ export function buildGroups(rows: Row[], isManual: boolean): ModelGroupRow[] {
   )
   return groups
 }
+
+/**
+ * Whether a search query matches a logical-model group (#1056). The hay covers
+ * everything the table can DISPLAY for the group: its label, canonical id, and
+ * every member's platform, display name and model id — plus, for custom rows,
+ * the key label and endpoint host the row is actually rendered with. Those last
+ * two are the fix: a relay added as a custom endpoint (UnoRouter, say) carries
+ * platform 'custom', so searching the provider's name found nothing even
+ * though the table prints "api.unorouter.com" on the row.
+ */
+export function groupMatchesQuery(
+  g: {
+    label: string
+    members: Array<{
+      platform: string; modelId: string; displayName: string
+      canonicalId?: string; source?: 'catalog' | 'custom'
+      keyLabel?: string | null; endpointScope?: string | null
+    }>
+  },
+  query: string,
+): boolean {
+  const hay = [
+    g.label,
+    g.members[0].canonicalId ?? '',
+    ...g.members.map(m => m.platform),
+    ...g.members.map(m => m.displayName),
+    ...g.members.map(m => m.modelId),
+    ...g.members.map(m => m.keyLabel ?? ''),
+    ...g.members.map(m => m.endpointScope ? endpointShortLabel(m.endpointScope) : ''),
+  ].join(' ').toLowerCase()
+  return hay.includes(query)
+}

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -21,6 +21,7 @@ import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 import {
   buildGroups,
+  groupMatchesQuery,
   groupMaxContext,
   type FallbackEntry,
   type ModelGroupRow,
@@ -241,16 +242,7 @@ export default function FallbackPage() {
     if (filterVision && !g.members.some(m => m.supportsVision)) return false
     if (filterTools && !g.members.some(m => m.supportsTools)) return false
     if (minContext > 0 && groupMaxContext(g.members) < minContext) return false
-    if (query) {
-      const hay = [
-        g.label,
-        g.members[0].canonicalId ?? '',
-        ...g.members.map(m => m.platform),
-        ...g.members.map(m => m.displayName),
-        ...g.members.map(m => m.modelId),
-      ].join(' ').toLowerCase()
-      if (!hay.includes(query)) return false
-    }
+    if (query && !groupMatchesQuery(g, query)) return false
     return true
   }), [orderedGroups, filterVision, filterTools, minContext, query])
   const draggable = isManual && !filtersActive


### PR DESCRIPTION
Fixes #1056. A relay added as a custom endpoint (UnoRouter in the report) carries platform 'custom', so searching the provider name matched nothing even though the table prints api.unorouter.com right on the row. The group search now also covers each member's key label and endpoint host. Matcher extracted to lib/routing.ts with 4 new tests.