### PR TITLE
chore(release): bump desktop to v0.9.1

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
Patch release. Headline fix: the dashboard no longer signs the operator out when a provider endpoint rejects a key (upstream 401s were read as session expiry). Also carries the SSE no-space parsing fix, the Groq/Cerebras reasoning_content strip, chain-switch performance and cache fixes, non-chat model classification, system proxy autodetect, Idempotency-Key support, and the custom-endpoint search fix.