### PR TITLE
fix(server): outlive the reverse proxy's idle connection pool

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -102,7 +102,20 @@ async function main() {
     });
   };
 
+  // Keep idle sockets open LONGER than any fronting reverse proxy keeps them
+  // in its pool. Node's default keepAliveTimeout is 5s while Caddy (and nginx)
+  // reuse idle upstream connections for 30-60s, so the proxy periodically
+  // writes a request into a socket this server just closed and surfaces it to
+  // the user as a 502 "connection reset by peer". 75s clears both defaults;
+  // headersTimeout must stay above keepAliveTimeout or Node times the
+  // keep-alive socket out while the next request's headers are in flight.
+  const tuneKeepAlive = (s: ReturnType<typeof app.listen>) => {
+    s.keepAliveTimeout = 75_000;
+    s.headersTimeout = 76_000;
+  };
+
   const server = app.listen(Number(PORT), HOST, onReady(HOST));
+  tuneKeepAlive(server);
   server.on('error', (err: NodeJS.ErrnoException) => {
     // The default '::' bind fails where IPv6 is disabled (kernel
     // ipv6.disable=1 and the like) — retry IPv4-only rather than dying.
@@ -110,7 +123,7 @@ async function main() {
     // fail-fast posture documented in main().catch below.
     if (!process.env.HOST && (err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')) {
       console.warn('[server] IPv6 unavailable on this host — falling back to 0.0.0.0 (IPv4-only)');
-      app.listen(Number(PORT), '0.0.0.0', onReady('0.0.0.0'));
+      tuneKeepAlive(app.listen(Number(PORT), '0.0.0.0', onReady('0.0.0.0')));
       return;
     }
     console.error('\n[server] Failed to start:\n  ' + (err?.message ?? err) + '\n');


### PR DESCRIPTION
Intermittent 502s (connection reset by peer) behind Caddy, observed in prod Caddy logs across several days and worst during event-loop-busy windows: Node's default keepAliveTimeout is 5s, Caddy reuses idle upstream sockets for ~30s, so the proxy races requests into just-closed sockets. keepAliveTimeout 75s, headersTimeout 76s, applied on both listen paths. Includes the desktop bump to 0.9.2 for the tagged release.