### PR TITLE
fix(proxy): always surface usage so agents show context-window counts (#1084)

### DIFF
--- a/server/src/__tests__/routes/proxy-stream-usage.test.ts
+++ b/server/src/__tests__/routes/proxy-stream-usage.test.ts
@@ -195,7 +195,7 @@ describe('Streaming usage-frame fallback injection', () => {
     expect(frames[0].usage.estimated).toBe(true);
   });
 
-  it('does NOT inject a usage frame when include_usage is not requested', async () => {
+  it('injects an estimated usage frame when the upstream never echoes one, even without include_usage', async () => {
     const origFetch = global.fetch;
     vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
       const urlStr = typeof url === 'string' ? url : url.toString();
@@ -211,7 +211,53 @@ describe('Streaming usage-frame fallback injection', () => {
     }, authHeaders());
 
     expect(status).toBe(200);
-    expect(usageFrames(raw)).toHaveLength(0);
+    // #1084: agents read `usage` for context-window display even when they
+    // never requested include_usage; a missing frame used to show 0. The
+    // estimate is injected regardless of the client's stream_options.
+    const frames = usageFrames(raw);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].choices).toEqual([]);
+    expect(frames[0].usage.prompt_tokens).toBeGreaterThan(0);
+    expect(frames[0].usage.completion_tokens).toBeGreaterThan(0);
+    expect(frames[0].usage.estimated).toBe(true);
+  });
+
+  it('injects estimated usage into a NON-streaming response when the upstream omits usage', async () => {
+    const origFetch = global.fetch;
+    vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      if (urlStr.includes('api.groq.com/openai/v1/chat/completions')) {
+        return {
+          ok: true,
+          json: () => Promise.resolve({
+            id: 'chatcmpl-nousage',
+            object: 'chat.completion',
+            created: 123,
+            model: 'openai/gpt-oss-120b',
+            choices: [{
+              index: 0,
+              message: { role: 'assistant', content: 'hi there' },
+              finish_reason: 'stop',
+            }],
+            // No `usage` block — the #1084 scenario.
+          }),
+        } as any;
+      }
+      return origFetch(url, init);
+    });
+
+    const { status, body } = await request(app, 'POST', '/v1/chat/completions', {
+      messages: [{ role: 'user', content: 'hi' }],
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(body.usage).toBeDefined();
+    expect(body.usage.prompt_tokens).toBeGreaterThan(0);
+    expect(body.usage.completion_tokens).toBeGreaterThan(0);
+    expect(body.usage.total_tokens).toBe(
+      body.usage.prompt_tokens + body.usage.completion_tokens,
+    );
+    expect(body.usage.estimated).toBe(true);
   });
 
   it('passes through the upstream usage frame unchanged when one is present', async () => {

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -2352,19 +2352,20 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           const estimatedPromptTokens = estimatedInputTokens + injectedHandoffTokens + imageCount * IMAGE_TOKEN_ESTIMATE;
           if (usageChunk) {
             writeChunk(usageChunk);
-          } else if (parsed.data.stream_options?.include_usage) {
-            // Some OpenAI-compatible upstreams (e.g. OpenCode Zen) never echo
-            // a final usage frame even when stream_options.include_usage is
-            // requested. Strict clients (Hermes, Cline, Continue) treat a
+          } else {
+            // Some OpenAI-compatible upstreams never echo a final usage
+            // frame — neither when stream_options.include_usage is requested
+            // nor otherwise. Strict clients (Hermes, Cline, Continue) treat a
             // missing usage block as "no accounting happened" and skip
-            // per-call token/cost/billing_provider writes entirely.
+            // per-call token/cost/billing_provider writes entirely; agents
+            // that read usage for context-window display (e.g. #1084) show 0.
             //
-            // Injected ONLY when the client asked for usage via
-            // stream_options.include_usage AND the upstream never sent one;
-            // the numbers are this gateway's own chars/4 estimate (the same
-            // total the accounting below records), never the upstream's
-            // accounting, so the block is flagged `estimated: true` rather
-            // than passed off as real counts.
+            // So inject the estimate whenever the upstream never sent one —
+            // regardless of whether the client asked for include_usage. The
+            // numbers are this gateway's own chars/4 estimate (the same total
+            // the accounting below records), never the upstream's accounting,
+            // so the block is flagged `estimated: true` rather than passed
+            // off as real counts.
             const completionTokens = totalOutputTokens;
             writeChunk({
               id: lastMeta.id ?? `chatcmpl-${Date.now()}`,
@@ -2596,6 +2597,20 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         // Normalize array-shaped message.content to a string on the way out (#166).
         const outboundBody = sanitizeResponse(normalizeOutboundContent(result));
         res.setHeader('X-FreeLLM-Cache', cacheKey ? 'MISS' : 'OFF');
+
+        // #1084: agents show zero context usage when the upstream omits
+        // `usage` (many free-tier providers do). Fall back to the same
+        // chars/4 estimate used for accounting above, flagged `estimated:
+        // true` so a cost-accounting client can tell it apart from the
+        // upstream's real counts.
+        if (!outboundBody.usage) {
+          outboundBody.usage = {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            total_tokens: totalTokens,
+            estimated: true,
+          };
+        }
 
         // Persist the completed response for Idempotency-Key replays. Only
         // non-streaming requests with a valid key reach here; a truncated turn

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -427,6 +427,10 @@ export interface TokenUsage {
   // to its chars/4 estimate when absent. (#764)
   completion_tokens_details?: { reasoning_tokens?: number };
   prompt_tokens_details?: { cached_tokens?: number };
+  // Gateway-synthesized block (upstream never sent usage): flagged so a
+  // cost-accounting client can tell it apart from the upstream's real
+  // counts. (#1084)
+  estimated?: boolean;
 }
 
 export interface ChatCompletionResponse {


### PR DESCRIPTION
## 背景

agent 客户端（如 CodeBuddy）通过读取 chat-completions 响应的 `usage` 块来显示上下文使用量。此前有两条路径会丢失 usage，导致 agent 一直显示 0：

1. **非流式**：出站响应体原样透传上游的 `usage`；免费 tier 提供商常省略该块，客户端就拿不到任何计数。
2. **流式**：估算 usage 帧仅在客户端显式请求 `stream_options.include_usage` 时注入；不请求但仍读取 usage 的 agent 看不到任何帧。

## Background

Agents (e.g. CodeBuddy) read the chat-completions `usage` block to display context-window usage. Two paths could previously drop it, leaving agents showing 0:

1. **Non-streaming**: the outbound body passed the upstream's `usage` through verbatim; when a free-tier provider omits the block, the client got nothing.
2. **Streaming**: the estimated usage frame was injected only when the client explicitly requested `stream_options.include_usage`; agents that never ask but still read usage saw no frame.

## 改动

1. **非流式**（`server/src/routes/proxy.ts`）：上游省略 `usage` 时，回退到内部记账用的同一 chars/4 估算值，并标记 `estimated: true`，保证客户端总能拿到 usage 块。
2. **流式**（`server/src/routes/proxy.ts`）：上游从未发送 usage 帧时，无论客户端是否请求 `include_usage` 都注入估算帧（同样带 `estimated: true`）。
3. **类型**（`shared/types.ts`）：`TokenUsage` 新增可选 `estimated?: boolean`，让网关合成块与上游真实计数可区分。

## Changes

1. **Non-streaming** (`server/src/routes/proxy.ts`): when the upstream omits `usage`, fall back to the same chars/4 estimate used for internal accounting, flagged `estimated: true`, so the client always gets a usage block.
2. **Streaming** (`server/src/routes/proxy.ts`): when the upstream never sends a usage frame, inject the estimate regardless of whether the client requested `include_usage` (also flagged `estimated: true`).
3. **Types** (`shared/types.ts`): `TokenUsage` gains optional `estimated?: boolean` so the gateway-synthesized block is distinguishable from the upstream's real counts.

## 验证

- `tsc --noEmit`（server）clean。
- `proxy-stream-usage.test.ts` 更新/新增：无 `include_usage` 时也注入估算帧；非流式响应在上游无 usage 时仍携带估算块（`estimated: true`）。
- `proxy-stream-usage.test.ts` + `proxy-stream-integrity.test.ts` 共 23 个测试全过。

## Verification

- `tsc --noEmit` (server) clean.
- `proxy-stream-usage.test.ts` updated/added: the estimate is injected even without `include_usage`, and a non-streaming response with no upstream usage still carries an estimated block (`estimated: true`).
- `proxy-stream-usage.test.ts` + `proxy-stream-integrity.test.ts`: 23 tests pass.

关联 issue #1084