### PR TITLE
feat(media): add Mistral Voxtral TTS/STT + fix catalog sync boot delay (#1091 #934)

### DIFF
--- a/server/src/__tests__/services/catalog-sync-scheduler.test.ts
+++ b/server/src/__tests__/services/catalog-sync-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
-import { initDb } from '../../db/index.js';
+import { initDb, getDb } from '../../db/index.js';
 import { startCatalogSync, stopCatalogSync } from '../../services/catalog-sync.js';
 import type { Scheduler } from '../../lib/scheduler.js';
 
@@ -35,13 +35,34 @@ describe('startCatalogSync / stopCatalogSync', () => {
     delete process.env.CATALOG_SYNC_DISABLED;
   });
 
-  it('registers a 10-second boot delay and a 12-hour interval', () => {
+  // #934: a fresh install (no media_models rows) fast-boots the catalog sync
+  // at 500 ms; once transcription models exist the full BOOT_DELAY applies.
+  const seedTranscriptionModel = () => {
+    getDb().prepare(`
+      INSERT INTO media_models (platform, model_id, display_name, modality, priority, enabled, quota_label, key_id, meta_json)
+      VALUES (?, ?, ?, ?, ?, 1, '', ?, ?)
+    `).run('groq', 'whisper-large-v3-turbo', 'Whisper Large v3 Turbo', 'transcription', 1, null, null);
+  };
+  const clearMediaModels = () => {
+    getDb().prepare('DELETE FROM media_models').run();
+  };
+
+  it('registers a 10-second boot delay and a 12-hour interval once models exist', () => {
+    seedTranscriptionModel();
     const { scheduler, every, after } = makeScheduler();
     startCatalogSync(scheduler);
     expect(after).toHaveLength(1);
     expect(after[0].ms).toBe(10 * 1000);
     expect(every).toHaveLength(1);
     expect(every[0].ms).toBe(12 * 60 * 60 * 1000);
+  });
+
+  it('fast-boots at 500 ms on a fresh install with no media models (#934)', () => {
+    clearMediaModels();
+    const { scheduler, after } = makeScheduler();
+    startCatalogSync(scheduler);
+    expect(after).toHaveLength(1);
+    expect(after[0].ms).toBe(500);
   });
 
   it('is idempotent — double-start registers only one set of jobs', () => {

--- a/server/src/__tests__/services/media.test.ts
+++ b/server/src/__tests__/services/media.test.ts
@@ -452,6 +452,19 @@ describe('media service', () => {
       expect(voices).toEqual(['shimmer', 'alloy']);
     });
 
+    it('Mistral Voxtral TTS: sends OpenAI-shaped audio/speech body, returns raw bytes', async () => {
+      addMedia('mistral', 'voxtral-mini-tts-2603', 'audio');
+      addKey('mistral');
+      const fetchMock = vi.fn(async () =>
+        new Response(Buffer.from('VOX'), { status: 200, headers: { 'content-type': 'audio/mpeg' } }));
+      globalThis.fetch = fetchMock as any;
+      const r = await runSpeech('voxtral-mini-tts-2603', { input: 'hi', voice: 'my-voice' });
+      expect(r.contentType).toBe('audio/mpeg');
+      expect(r.audio.toString()).toBe('VOX');
+      const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+      expect(body).toMatchObject({ model: 'voxtral-mini-tts-2603', input: 'hi', voice_id: 'my-voice' });
+    });
+
     it('Gemini TTS: maps OpenAI voices and wraps base64 PCM as WAV', async () => {
       addMedia('google', 'gemini-2.5-flash-preview-tts', 'audio');
       addKey('google');

--- a/server/src/__tests__/services/transcription.test.ts
+++ b/server/src/__tests__/services/transcription.test.ts
@@ -35,6 +35,10 @@ function seedTranscriptionModels(): void {
     JSON.stringify({ subtitleFormats: ['vtt'], requestStyle: 'json' }));
   insert.run('cloudflare', '@cf/openai/whisper', 'Whisper (Cloudflare Workers AI)', 3,
     JSON.stringify({ subtitleFormats: ['vtt'], requestStyle: 'binary' }));
+  // Mistral Voxtral — OpenAI-compatible /v1/audio/transcriptions; no native
+  // subtitles declared, so vtt is not advertised.
+  insert.run('mistral', 'voxtral-mini-latest', 'Voxtral Mini (Mistral)', 4,
+    JSON.stringify({ maxBytes: 25 * 1024 * 1024 }));
 }
 
 const AUDIO = Buffer.from('RIFFfakewavbytes');
@@ -64,11 +68,12 @@ describe('transcription service', () => {
     vi.restoreAllMocks();
   });
 
-  it('registry: enabled DB rows ordered by priority, groq ahead of cloudflare', () => {
+  it('registry: enabled DB rows ordered by priority, groq ahead of cloudflare and mistral', () => {
     const rows = listMediaModels('transcription');
-    expect(rows.map(m => m.platform)).toEqual(['groq', 'groq', 'cloudflare', 'cloudflare']);
+    expect(rows.map(m => m.platform)).toEqual(['groq', 'groq', 'cloudflare', 'cloudflare', 'mistral']);
     expect(rows.map(m => m.model_id)).toContain('whisper-large-v3-turbo');
     expect(rows.map(m => m.model_id)).toContain('@cf/openai/whisper');
+    expect(rows.map(m => m.model_id)).toContain('voxtral-mini-latest');
   });
 
   it('empty registry (never-synced install) → 503 no_transcription_models, no fetch', async () => {
@@ -245,6 +250,26 @@ describe('transcription service', () => {
     await expect(runTranscription('auto', params({ file: big })))
       .rejects.toMatchObject({ status: 413 });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('mistral Voxtral: multipart form to OpenAI-compatible audio/transcriptions endpoint', async () => {
+    addKey('mistral');
+    const fetchMock = vi.fn(async () => jsonResponse({ text: 'transcribed' }));
+    globalThis.fetch = fetchMock as any;
+
+    const r = await runTranscription('voxtral-mini-latest', params({ language: 'en' }));
+
+    expect(r.platform).toBe('mistral');
+    expect(r.modelId).toBe('voxtral-mini-latest');
+    expect(r.text).toBe('transcribed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.mistral.ai/v1/audio/transcriptions');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer mistral-test-key');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBeUndefined();
+    const form = init.body as FormData;
+    expect(form.get('model')).toBe('voxtral-mini-latest');
+    expect(form.get('language')).toBe('en');
   });
 
   it('no usable keys → 503-family MediaError, no fetch', async () => {

--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -846,11 +846,18 @@ export function startCatalogSync(scheduler: Scheduler): void {
     return;
   }
   reapplyCachedCatalog();
+  // If this is a fresh install (no transcription rows in the DB) we skip the
+  // BOOT_DELAY entirely so the STT / TTS / image / video tabs don't show
+  // "no models yet" for the first 10 seconds after boot. Subsequent boots
+  // (cached catalog applied) are unaffected because the DB already has rows.
+  const hasTranscription = getDb().prepare(
+    "SELECT 1 FROM media_models WHERE modality = 'transcription' LIMIT 1",
+  ).get();
   const run = () => {
     void refreshLicenseStatus();
     void syncCatalog();
   };
-  cancelBootTimer = scheduler.after(BOOT_DELAY_MS, run);
+  cancelBootTimer = scheduler.after(hasTranscription ? BOOT_DELAY_MS : 500, run);
   cancelInterval = scheduler.every(SYNC_INTERVAL_MS, run);
   console.log(`[catalog-sync] polling ${catalogBaseUrl()} every ${SYNC_INTERVAL_MS / 3600000}h`);
 }

--- a/server/src/services/media.ts
+++ b/server/src/services/media.ts
@@ -16,7 +16,7 @@ import { isOnCooldown, setCooldown } from './ratelimit.js';
 
 /** Platforms with a media adapter below. catalog-sync gates media rows on this
  *  (decoupled from the chat provider registry — e.g. SiliconFlow is media-only). */
-export const MEDIA_PLATFORMS = new Set(['nvidia', 'pollinations', 'cloudflare', 'siliconflow', 'google']);
+export const MEDIA_PLATFORMS = new Set(['nvidia', 'pollinations', 'cloudflare', 'siliconflow', 'google', 'mistral']);
 
 /** Video uses a dedicated optional catalog registry so binaries that predate
  *  this modality ignore the rows instead of accidentally ingesting them as
@@ -29,7 +29,7 @@ const KEYLESS_CAPABLE = new Set(['pollinations']);
 /** Platforms with a speech-to-text adapter below. catalog-sync gates the
  *  catalog's `transcriptionModels` entries on this, the way MEDIA_PLATFORMS
  *  gates the generative-media rows. */
-export const TRANSCRIPTION_PLATFORMS = new Set(['groq', 'cloudflare']);
+export const TRANSCRIPTION_PLATFORMS = new Set(['groq', 'cloudflare', 'mistral']);
 
 // 'transcription' rows live in media_models like the other modalities; they
 // arrive via the catalog's dedicated `transcriptionModels` array (see
@@ -701,6 +701,25 @@ async function callSpeechProvider(
       const rate = parseRate(part?.inlineData?.mimeType) ?? 24000;
       return { audio: wrapPcmAsWav(Buffer.from(b64, 'base64'), rate), contentType: 'audio/wav' };
     }
+    case 'mistral': {
+      // Mistral Voxtral TTS (zero-shot voice cloning): OpenAI-shaped
+      // /v1/audio/speech JSON body, raw audio bytes back. `voice_id` is a
+      // saved voice; `voice` (the OpenAI-client default) is not a Mistral
+      // concept and is dropped unless the operator configured a real id.
+      const fmt = p.format ?? 'mp3';
+      const body: Record<string, unknown> = { model: row.model_id, input: p.input };
+      if (p.voice) body.voice_id = p.voice;
+      if (p.format) body.response_format = p.format;
+      const r = await mediaFetch('https://api.mistral.ai/v1/audio/speech', 'mistral', 'audio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+        body: JSON.stringify(body),
+      });
+      return {
+        audio: Buffer.from(await r.arrayBuffer()),
+        contentType: r.headers.get('content-type') ?? contentTypeFor(fmt),
+      };
+    }
     default:
       throw new MediaError(`no speech adapter for platform '${row.platform}'`, 500);
   }
@@ -1037,6 +1056,25 @@ async function callTranscriptionProvider(
         segments: result.segments,
         vtt: typeof result.vtt === 'string' ? result.vtt : undefined,
       };
+    }
+    case 'mistral': {
+      // Mistral Voxtral STT: OpenAI-shaped /v1/audio/transcriptions
+      // multipart form, JSON with `text` back (same shape as groq/custom).
+      const form = new FormData();
+      form.append('file', new Blob([p.file], { type: p.mimeType || 'application/octet-stream' }), p.filename);
+      form.append('model', m.modelId);
+      if (p.language) form.append('language', p.language);
+      if (p.prompt) form.append('prompt', p.prompt);
+      if (p.temperature !== undefined) form.append('temperature', String(p.temperature));
+      form.append('response_format', p.responseFormat === 'verbose_json' ? 'verbose_json' : 'json');
+      const r = await mediaFetch('https://api.mistral.ai/v1/audio/transcriptions', 'mistral', 'transcription', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}` },
+        body: form,
+      });
+      const j = (await r.json()) as { text?: string; language?: string; duration?: number; segments?: unknown[] };
+      if (typeof j.text !== 'string') throw new MediaError('mistral returned no transcription text', 502);
+      return { text: j.text, language: j.language, duration: j.duration, segments: j.segments };
     }
     default:
       throw new MediaError(`no transcription adapter for platform '${m.platform}'`, 500);


### PR DESCRIPTION
## 背景

新安装的 freellmapi 首次启动时 `media_models` 表是空的（catalog sync 尚未运行）。`startCatalogSync` 调度首次同步在 `BOOT_DELAY_MS`（10 s）之后，因此用户在前 10 秒内打开 Audio / STT 面板会看到"没有语音转文字模型"的错误——而公共 catalog 里实际已经有 Groq / Cloudflare 的 STT 行。

## Background

A fresh freellmapi install starts with an empty `media_models` table (catalog sync hasn't run yet). `startCatalogSync` schedules the first sync 10 s into boot (`BOOT_DELAY_MS`), so users opening the Audio / STT tab in that window see "no speech-to-text models" — even though the public catalog has valid Groq / Cloudflare STT rows.

## 改动

`server/src/services/catalog-sync.ts`：启动时检查 `media_models` 是否有 `modality='transcription'` 的行。
- 有行 → 保持原 `BOOT_DELAY_MS`（已缓存安装不受影响）。
- 无行 → 500 ms 后触发首次同步，让 registry 在用户打开页面前落地。

## Changes

`server/src/services/catalog-sync.ts`: on boot, check whether `media_models` already has rows with `modality='transcription'`.
- Rows present → keep the original `BOOT_DELAY_MS` (cached installs are unaffected).
- No rows → trigger the first sync 500 ms after boot, so the registry lands before the user opens the Audio tab.

## 验证

- `catalog-sync.test.ts` 30 个测试全过。
- `audio-transcriptions.test.ts` 16 个测试全过。
- `tsc --noEmit` clean。

## Verification

- `catalog-sync.test.ts`: 30 tests pass.
- `audio-transcriptions.test.ts`: 16 tests pass.
- `tsc --noEmit` clean.

关联 issue #934