### PR TITLE
feat(routing): keep unified failover aligned with provider quotas

### DIFF
--- a/client/src/components/keys/model-scope-dialog.tsx
+++ b/client/src/components/keys/model-scope-dialog.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogPopup, DialogTitle } from '@/components/ui/dialog'
@@ -7,6 +7,8 @@ import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
 import { X } from 'lucide-react'
 import type { ApiKey } from '../../../../shared/types'
+import type { FallbackEntry } from '@/lib/routing'
+import { scopeCandidates } from '@/lib/model-scope-selection'
 
 // #657: relay stations hand out keys that only serve one model group; a key
 // scoped here is skipped by the router for every model outside its list. A
@@ -24,15 +26,45 @@ export function ModelScopeDialog({
   const queryClient = useQueryClient()
   // Mounted only while open, so state seeds from the row without reset effects.
   const [ids, setIds] = useState<string[]>(apiKey.modelScope ?? [])
+  const [catalogTouched, setCatalogTouched] = useState(false)
   const [draft, setDraft] = useState('')
+  const [providerRpmLimit, setProviderRpmLimit] = useState(apiKey.providerRpmLimit?.toString() ?? '')
+  const [providerRpdLimit, setProviderRpdLimit] = useState(apiKey.providerRpdLimit?.toString() ?? '')
+  const [providerTpdLimit, setProviderTpdLimit] = useState(apiKey.providerTpdLimit?.toString() ?? '')
+
+  const { data: fallback = [], isLoading: catalogLoading, isError: catalogError } = useQuery<FallbackEntry[]>({
+    queryKey: ['fallback'],
+    queryFn: () => apiFetch('/api/fallback'),
+    enabled: apiKey.platform !== 'custom',
+  })
+  const catalogCandidates = useMemo(
+    () => scopeCandidates(fallback, apiKey.platform),
+    [fallback, apiKey.platform],
+  )
+  const liveCandidates = useMemo(() => {
+    if (apiKey.platform === 'custom' || catalogCandidates.length > 0) return []
+    const seen = new Set<string>()
+    return (apiKey.models ?? [])
+      .filter(model => model.kind === 'chat' && model.modelId && !seen.has(model.modelId) && seen.add(model.modelId))
+      .map(model => ({ modelId: model.modelId, displayName: model.displayName || model.modelId }))
+  }, [apiKey.models, apiKey.platform, catalogCandidates.length])
+  // The curated FreeLLMAPI catalogue is authoritative. Live discovery is used
+  // only when this provider has no catalogue rows at all (for example a newly
+  // added SambaNova-compatible endpoint).
+  const providerCandidates = catalogCandidates.length > 0 ? catalogCandidates : liveCandidates
+  const catalogIds = providerCandidates.map(candidate => candidate.modelId)
+  const catalogReady = apiKey.platform === 'custom' || (!catalogLoading && !catalogError)
+  const selectedCatalogIds = !catalogTouched && (apiKey.modelScope === null || apiKey.modelScope === undefined)
+    ? catalogIds
+    : catalogIds.filter(id => ids.includes(id))
 
   const suggestions = (apiKey.models ?? [])
     .filter(m => m.kind === 'chat' && !ids.includes(m.modelId))
     .map(m => m.modelId)
 
   const save = useMutation({
-    mutationFn: (modelScope: string[] | null) =>
-      apiFetch(`/api/keys/${apiKey.id}`, { method: 'PATCH', body: JSON.stringify({ modelScope }) }),
+    mutationFn: (payload: Record<string, unknown>) =>
+      apiFetch(`/api/keys/${apiKey.id}`, { method: 'PATCH', body: JSON.stringify(payload) }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['keys'] })
       onOpenChange(false)
@@ -47,11 +79,28 @@ export function ModelScopeDialog({
   }
 
   const submit = () => {
+    if (!catalogReady) return
     // A typed-but-unconfirmed id still counts — losing it on Save is the
     // classic chip-input paper cut.
     const pending = draft.trim()
     const next = pending && !ids.includes(pending) ? [...ids, pending] : ids
-    save.mutate(next.length > 0 ? next : null)
+    const modelScope = apiKey.platform === 'custom'
+      ? (next.length > 0 ? next : null)
+      : (selectedCatalogIds.length === catalogIds.length ? null : selectedCatalogIds)
+    save.mutate({
+      modelScope,
+      providerRpmLimit: providerRpmLimit === '' ? null : Number(providerRpmLimit),
+      providerRpdLimit: providerRpdLimit === '' ? null : Number(providerRpdLimit),
+      providerTpdLimit: providerTpdLimit === '' ? null : Number(providerTpdLimit),
+    })
+  }
+
+  const toggleCatalogModel = (modelId: string) => {
+    const selected = new Set(selectedCatalogIds)
+    if (selected.has(modelId)) selected.delete(modelId)
+    else selected.add(modelId)
+    setCatalogTouched(true)
+    setIds([...selected])
   }
 
   return (
@@ -62,7 +111,31 @@ export function ModelScopeDialog({
         <code className="mt-2 block truncate font-mono text-[11px] text-muted-foreground">{apiKey.maskedKey}</code>
 
         <div className="mt-4 space-y-3">
-          {ids.length === 0 ? (
+          {apiKey.platform !== 'custom' && catalogLoading ? (
+            <p className="text-xs text-muted-foreground">{t('auth.loading')}</p>
+          ) : apiKey.platform !== 'custom' && catalogError ? (
+            <p className="text-xs text-destructive">{t('keys.catalogLoadFailed')}</p>
+          ) : apiKey.platform !== 'custom' && providerCandidates.length > 0 ? (
+            <>
+            {catalogCandidates.length === 0 && (
+              <p className="text-[11px] text-muted-foreground">{t('keys.liveModelsFallback')}</p>
+            )}
+            <div className="max-h-[42vh] overflow-y-auto rounded-2xl border divide-y">
+              {providerCandidates.map(model => (
+                <label key={model.modelId} className="flex cursor-pointer items-center gap-2 px-3 py-2 text-xs hover:bg-muted/30">
+                  <input
+                    type="checkbox"
+                    checked={selectedCatalogIds.includes(model.modelId)}
+                    onChange={() => toggleCatalogModel(model.modelId)}
+                    className="size-4 accent-primary"
+                  />
+                  <span className="min-w-0 flex-1 truncate" title={model.modelId}>{model.displayName}</span>
+                  <code className="max-w-[190px] truncate text-[10px] text-muted-foreground">{model.modelId}</code>
+                </label>
+              ))}
+            </div>
+            </>
+          ) : ids.length === 0 ? (
             <p className="text-xs text-muted-foreground">{t('keys.modelScopeEmpty')}</p>
           ) : (
             <div className="flex flex-wrap gap-1.5">
@@ -82,7 +155,7 @@ export function ModelScopeDialog({
             </div>
           )}
 
-          <Input
+          {apiKey.platform === 'custom' && <Input
             value={draft}
             onChange={e => setDraft(e.target.value)}
             onKeyDown={e => {
@@ -93,9 +166,9 @@ export function ModelScopeDialog({
             }}
             placeholder={t('keys.modelScopeAdd')}
             className="h-8 font-mono text-xs"
-          />
+          />}
 
-          {suggestions.length > 0 && (
+          {apiKey.platform === 'custom' && suggestions.length > 0 && (
             <div className="flex flex-wrap gap-1.5">
               {suggestions.map(id => (
                 <button
@@ -111,6 +184,23 @@ export function ModelScopeDialog({
             </div>
           )}
 
+          <div className="rounded-xl border p-3">
+            <p className="text-xs font-medium">{t('keys.providerAccountLimits')}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">{t('keys.providerAccountLimitsHint')}</p>
+            <div className="mt-3 grid grid-cols-3 gap-2">
+              {[
+                ['RPM', providerRpmLimit, setProviderRpmLimit],
+                ['RPD', providerRpdLimit, setProviderRpdLimit],
+                ['TPD', providerTpdLimit, setProviderTpdLimit],
+              ].map(([label, value, setter]) => (
+                <label key={label as string} className="text-[11px] text-muted-foreground">
+                  {label as string}
+                  <Input type="number" min="0" step="1" value={value as string} onChange={event => (setter as (value: string) => void)(event.target.value)} className="mt-1 h-8 text-xs" />
+                </label>
+              ))}
+            </div>
+          </div>
+
           {save.isError && (
             <p className="text-xs text-destructive">{(save.error as Error).message}</p>
           )}
@@ -122,7 +212,7 @@ export function ModelScopeDialog({
                 variant="outline"
                 size="sm"
                 className="mr-auto"
-                onClick={() => save.mutate(null)}
+                onClick={() => save.mutate({ modelScope: null })}
                 disabled={save.isPending}
               >
                 {t('keys.modelScopeClear')}
@@ -131,7 +221,7 @@ export function ModelScopeDialog({
             <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
-            <Button type="button" size="sm" onClick={submit} disabled={save.isPending}>
+            <Button type="button" size="sm" onClick={submit} disabled={save.isPending || !catalogReady || (apiKey.platform !== 'custom' && catalogIds.length > 0 && selectedCatalogIds.length === 0)}>
               {save.isPending ? t('common.saving') : t('common.save')}
             </Button>
           </div>

--- a/client/src/components/keys/provider-list.tsx
+++ b/client/src/components/keys/provider-list.tsx
@@ -608,6 +608,11 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
                                 {t(k.modelScope!.length === 1 ? 'keys.modelScopeBadgeOne' : 'keys.modelScopeBadgeOther', { count: k.modelScope!.length })}
                               </Badge>
                             )}
+                            {(k.providerRpmLimit != null || k.providerRpdLimit != null || k.providerTpdLimit != null) && (
+                              <Badge variant="secondary" className="text-[10px] text-muted-foreground">
+                                {t('keys.accountLimits')}
+                              </Badge>
+                            )}
                             <div className="flex-1" />
                             {lastChecked && (
                               <span className="text-[11px] text-muted-foreground tabular-nums">
@@ -679,12 +684,12 @@ export function ProviderList({ onAddKey }: { onAddKey: () => void }) {
                               {/* Deliberately secondary (#657): a small hover-cluster affordance,
                                   not a first-fold control. */}
                               {!k.keyless && (
-                                <Tooltip text={t('keys.modelScope')}>
+                                <Tooltip text={t('keys.modelsAndAccountLimits')}>
                                   <Button
                                     variant="ghost"
                                     size="icon-xs"
                                     onClick={() => setScopeKeyId(k.id)}
-                                    aria-label={t('keys.modelScope')}
+                                    aria-label={t('keys.modelsAndAccountLimits')}
                                   >
                                     <ListFilter className="size-3" />
                                   </Button>

--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "ያልተለኩ ሞዴሎችን ያስሱ",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ወሰን አጥፋ",
     "modelScopeBadgeOne": "የተገደበ · 1 ሞዴል",
     "modelScopeBadgeOther": "የተገደበ · {count} ሞዴሎች",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ይህ ቁልፍ የትኞቹን ሞዴሎች ያገልግል?",
       "hint": "የ{provider} ቁልፍዎ ተጨምሯል እና በአሁኑ ጊዜ ከታች ያሉትን ሁሉንም ሞዴሎች ያገለግላል። ይህ ቁልፍ እንዲጠቀምባቸው ያልተፈቀደላቸውን ሞዴሎች ምልክት ያንሱ — ራውተሩ ለእነሱ ይህን ቁልፍ ያልፋል።",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -284,7 +284,11 @@
     "disableAll": "تعطيل الكل",
     "enableAllHint": "فعّل كل النماذج المعروضة ثم احفظ",
     "disableAllHint": "عطّل كل النماذج المعروضة ثم احفظ",
-    "enabledOfShown": "{enabled} من {shown} من النماذج المعروضة داخل السلسلة"
+    "enabledOfShown": "{enabled} من {shown} من النماذج المعروضة داخل السلسلة",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "استكشاف النماذج غير المقيسة",
@@ -564,6 +568,12 @@
     "modelScopeClear": "مسح النطاق",
     "modelScopeBadgeOne": "مقيّد · نموذج واحد",
     "modelScopeBadgeOther": "مقيّد · {count} نماذج",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ما النماذج التي ينبغي أن يخدمها هذا المفتاح؟",
       "hint": "تمت إضافة مفتاح {provider} الخاص بك، وهو يخدم حاليًا كل نموذج أدناه. ألغِ تحديد أي نموذج لا يُسمح لهذا المفتاح باستخدامه — سيتخطاه الموجّه لتلك النماذج.",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Ölçülməmiş modelləri araşdır",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Əhatəni təmizlə",
     "modelScopeBadgeOne": "məhdud · 1 model",
     "modelScopeBadgeOther": "məhdud · {count} model",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Bu açar hansı modellərə xidmət etsin?",
       "hint": "{provider} açarınız əlavə edildi və hazırda aşağıdakı bütün modellərə xidmət edir. Bu açarın istifadəsinə icazə verilməyən modellərin işarəsini götürün — router həmin modellər üçün bu açarı ötürəcək.",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Изследване на неизмерени модели",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Изчисти обхвата",
     "modelScopeBadgeOne": "ограничен · 1 модел",
     "modelScopeBadgeOther": "ограничен · {count} модела",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Кои модели да обслужва този ключ?",
       "hint": "Вашият ключ {provider} беше добавен и в момента обслужва всички модели по-долу. Махнете отметката от тези, които този ключ няма право да използва — за тях рутерът ще го пропуска.",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "অপরিমাপিত মডেল অন্বেষণ করুন",
@@ -564,6 +568,12 @@
     "modelScopeClear": "পরিধি মুছুন",
     "modelScopeBadgeOne": "সীমিত · 1টি মডেল",
     "modelScopeBadgeOther": "সীমিত · {count}টি মডেল",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "এই কী কোন মডেলগুলির জন্য কাজ করবে?",
       "hint": "আপনার {provider} কী যোগ করা হয়েছে এবং এটি এখন নিচের প্রতিটি মডেলের জন্য কাজ করে। যেসব মডেলে এই কী ব্যবহার করা উচিত নয়, সেগুলির টিক তুলে দিন — রাউটার সেগুলির জন্য এই কী এড়িয়ে যাবে।",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Prozkoumávat nezměřené modely",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Vymazat rozsah",
     "modelScopeBadgeOne": "omezený · 1 model",
     "modelScopeBadgeOther": "omezený · {count} modelů",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Které modely má tento klíč obsluhovat?",
       "hint": "Váš klíč {provider} byl přidán a nyní obsluhuje všechny modely níže. Odškrtněte ty, které tento klíč nesmí používat — router jej pro ně přeskočí.",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Udforsk umålte modeller",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Ryd omfang",
     "modelScopeBadgeOne": "begrænset · 1 model",
     "modelScopeBadgeOther": "begrænset · {count} modeller",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Hvilke modeller skal denne nøgle betjene?",
       "hint": "Din {provider}-nøgle er tilføjet og betjener i øjeblikket alle modeller nedenfor. Fjern fluebenet ved de modeller, nøglen ikke må bruges til — routeren springer den så over for dem.",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -284,7 +284,11 @@
     "disableAll": "Alle ausschalten",
     "enableAllHint": "Alle angezeigten Modelle einschalten, dann speichern",
     "disableAllHint": "Alle angezeigten Modelle ausschalten, dann speichern",
-    "enabledOfShown": "{enabled} von {shown} angezeigten Modellen sind in der Kette"
+    "enabledOfShown": "{enabled} von {shown} angezeigten Modellen sind in der Kette",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Unvermessene Modelle erkunden",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Bereich löschen",
     "modelScopeBadgeOne": "begrenzt · 1 Modell",
     "modelScopeBadgeOther": "begrenzt · {count} Modelle",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Welche Modelle soll dieser Schlüssel bedienen?",
       "hint": "Ihr {provider}-Schlüssel wurde hinzugefügt und bedient derzeit alle Modelle unten. Deaktivieren Sie alle Modelle, für die dieser Schlüssel nicht verwendet werden darf — der Router überspringt ihn dann für diese.",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Εξερεύνηση μη μετρημένων μοντέλων",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Καθαρισμός εύρους",
     "modelScopeBadgeOne": "περιορισμένο · 1 μοντέλο",
     "modelScopeBadgeOther": "περιορισμένο · {count} μοντέλα",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Ποια μοντέλα να εξυπηρετεί αυτό το κλειδί;",
       "hint": "Το κλειδί σας για {provider} προστέθηκε και αυτή τη στιγμή εξυπηρετεί όλα τα παρακάτω μοντέλα. Αποεπιλέξτε όσα δεν επιτρέπεται να χρησιμοποιεί αυτό το κλειδί — ο δρομολογητής θα το παρακάμπτει για αυτά.",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explore unmeasured models",
@@ -568,6 +572,12 @@
     "modelScopeClear": "Clear scope",
     "modelScopeBadgeOne": "scoped · 1 model",
     "modelScopeBadgeOther": "scoped · {count} models",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Which models should this key serve?",
       "hint": "Your {provider} key was added and currently serves every model below. Untick any this key isn't allowed to use — the router will skip it for those.",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -284,7 +284,11 @@
     "disableAll": "Desactivar todos",
     "enableAllHint": "Activa todos los modelos mostrados y luego guarda",
     "disableAllHint": "Desactiva todos los modelos mostrados y luego guarda",
-    "enabledOfShown": "{enabled} de {shown} modelos mostrados están en la cadena"
+    "enabledOfShown": "{enabled} de {shown} modelos mostrados están en la cadena",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explorar modelos sin mediciones",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Borrar alcance",
     "modelScopeBadgeOne": "limitada · 1 modelo",
     "modelScopeBadgeOther": "limitada · {count} modelos",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "¿Qué modelos debe atender esta clave?",
       "hint": "Se añadió tu clave de {provider} y ahora mismo atiende todos los modelos de abajo. Desmarca los que esta clave no tenga permiso para usar — el enrutador la omitirá para ellos.",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "کاوش مدل‌های اندازه‌گیری‌نشده",
@@ -564,6 +568,12 @@
     "modelScopeClear": "پاک کردن محدوده",
     "modelScopeBadgeOne": "محدود · 1 مدل",
     "modelScopeBadgeOther": "محدود · {count} مدل",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "این کلید به کدام مدل‌ها سرویس بدهد؟",
       "hint": "کلید {provider} شما اضافه شد و در حال حاضر به همه مدل‌های زیر سرویس می‌دهد. تیک هر مدلی را که این کلید اجازه استفاده از آن را ندارد بردارید — مسیریاب برای آن مدل‌ها از این کلید صرف‌نظر می‌کند.",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Tutki mittaamattomia malleja",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Tyhjennä rajaus",
     "modelScopeBadgeOne": "rajattu · 1 malli",
     "modelScopeBadgeOther": "rajattu · {count} mallia",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Mitä malleja tämän avaimen tulisi palvella?",
       "hint": "{provider}-avaimesi lisättiin, ja se palvelee tällä hetkellä kaikkia alla olevia malleja. Poista valinta niistä malleista, joihin avainta ei saa käyttää — reititin ohittaa avaimen niiden kohdalla.",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -284,7 +284,11 @@
     "disableAll": "Tout désactiver",
     "enableAllHint": "Activer tous les modèles affichés, puis enregistrer",
     "disableAllHint": "Désactiver tous les modèles affichés, puis enregistrer",
-    "enabledOfShown": "{enabled} des {shown} modèles affichés sont dans la chaîne"
+    "enabledOfShown": "{enabled} des {shown} modèles affichés sont dans la chaîne",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explorer les modèles non mesurés",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Effacer la portée",
     "modelScopeBadgeOne": "limitée · 1 modèle",
     "modelScopeBadgeOther": "limitée · {count} modèles",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Quels modèles cette clé doit-elle servir ?",
       "hint": "Votre clé {provider} a été ajoutée et sert actuellement tous les modèles ci-dessous. Décochez ceux que cette clé n'est pas autorisée à utiliser — le routeur l'ignorera pour ceux-là.",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "માપ્યા વગરના મોડલ્સ એક્સપ્લોર કરો",
@@ -564,6 +568,12 @@
     "modelScopeClear": "વ્યાપ દૂર કરો",
     "modelScopeBadgeOne": "મર્યાદિત · 1 મૉડલ",
     "modelScopeBadgeOther": "મર્યાદિત · {count} મૉડલ",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "આ કી કયા મૉડલ માટે કામ કરવી જોઈએ?",
       "hint": "તમારી {provider} કી ઉમેરાઈ ગઈ છે અને હાલમાં તે નીચેના દરેક મૉડલ માટે કામ કરે છે. જે મૉડલ માટે આ કીનો ઉપયોગ ન થવો જોઈએ તેની ટિક હટાવો — રાઉટર તેમના માટે આ કીને છોડી દેશે.",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Bincika samfuran da ba a auna ba",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Share iyaka",
     "modelScopeBadgeOne": "iyakantacce · samfuri 1",
     "modelScopeBadgeOther": "iyakantacce · samfura {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Waɗanne samfura wannan maɓalli zai yi wa hidima?",
       "hint": "An ƙara maɓallin {provider} naka kuma a yanzu yana yi wa duk samfuran da ke ƙasa hidima. Cire alamar duk samfurin da ba a yarda wannan maɓalli ya yi amfani da shi ba — router zai tsallake shi ga waɗannan.",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "חקירת דגמים שטרם נמדדו",
@@ -564,6 +568,12 @@
     "modelScopeClear": "נקה טווח",
     "modelScopeBadgeOne": "מוגבל · מודל 1",
     "modelScopeBadgeOther": "מוגבל · {count} מודלים",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "לאילו מודלים ישמש המפתח הזה?",
       "hint": "מפתח ה-{provider} שלך נוסף וכרגע הוא משמש את כל המודלים שלמטה. בטל את הסימון של כל מודל שהמפתח הזה אינו רשאי להשתמש בו — הנתב ידלג עליו עבור אותם מודלים.",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -284,7 +284,11 @@
     "disableAll": "सभी बंद करें",
     "enableAllHint": "दिखाए गए सभी मॉडल चालू करें, फिर सहेजें",
     "disableAllHint": "दिखाए गए सभी मॉडल बंद करें, फिर सहेजें",
-    "enabledOfShown": "दिखाए गए {shown} में से {enabled} मॉडल चेन में हैं"
+    "enabledOfShown": "दिखाए गए {shown} में से {enabled} मॉडल चेन में हैं",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "बिना मापे गए मॉडल एक्सप्लोर करें",
@@ -564,6 +568,12 @@
     "modelScopeClear": "दायरा हटाएँ",
     "modelScopeBadgeOne": "सीमित · 1 मॉडल",
     "modelScopeBadgeOther": "सीमित · {count} मॉडल",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "यह कुंजी कौन-से मॉडल के लिए काम करेगी?",
       "hint": "आपकी {provider} कुंजी जोड़ दी गई है और अभी यह नीचे दिए गए हर मॉडल के लिए काम करती है। जिन मॉडलों के लिए इस कुंजी का उपयोग नहीं होना चाहिए, उनका चयन हटा दें — राउटर उनके लिए इसे छोड़ देगा।",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Istraži nemjerene modele",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Očisti opseg",
     "modelScopeBadgeOne": "ograničen · 1 model",
     "modelScopeBadgeOther": "ograničen · {count} modela",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Za koje se modele koristi ovaj ključ?",
       "hint": "Vaš {provider} ključ je dodan i trenutačno poslužuje sve modele u nastavku. Odznačite one koje ovaj ključ ne smije koristiti — router će ga za njih preskočiti.",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Nem mért modellek felfedezése",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Kör törlése",
     "modelScopeBadgeOne": "korlátozva · 1 modell",
     "modelScopeBadgeOther": "korlátozva · {count} modell",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Mely modelleket szolgálja ki ez a kulcs?",
       "hint": "A(z) {provider} kulcs hozzáadva, és jelenleg az alábbi összes modellt kiszolgálja. Vegye ki a pipát azoknál, amelyeket ez a kulcs nem használhat — ezeknél a router kihagyja.",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -284,7 +284,11 @@
     "disableAll": "Nonaktifkan semua",
     "enableAllHint": "Aktifkan semua model yang tampil, lalu simpan",
     "disableAllHint": "Nonaktifkan semua model yang tampil, lalu simpan",
-    "enabledOfShown": "{enabled} dari {shown} model yang tampil ada di rantai"
+    "enabledOfShown": "{enabled} dari {shown} model yang tampil ada di rantai",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Jelajahi model yang belum terukur",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Hapus cakupan",
     "modelScopeBadgeOne": "dibatasi · 1 model",
     "modelScopeBadgeOther": "dibatasi · {count} model",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Model mana saja yang boleh dilayani kunci ini?",
       "hint": "Kunci {provider} Anda telah ditambahkan dan saat ini melayani semua model di bawah. Hapus centang pada model yang tidak boleh dipakai kunci ini — router akan melewatinya untuk model tersebut.",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Nyochaa ụdị a na-atụbeghị",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Hichapụ oke",
     "modelScopeBadgeOne": "oke · model 1",
     "modelScopeBadgeOther": "oke · model {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Kedu ụdị ndị igodo a kwesịrị iweta?",
       "hint": "Etinyela igodo {provider} gị, ọ na-ewetakwa ụdị niile dị n'okpuru ugbu a. Wepụ akara na nke ọ bụla igodo a na-enweghị ikike iji — rawụta ga-agafe ya maka ndị ahụ.",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -284,7 +284,11 @@
     "disableAll": "Disattiva tutti",
     "enableAllHint": "Attiva tutti i modelli mostrati, poi salva",
     "disableAllHint": "Disattiva tutti i modelli mostrati, poi salva",
-    "enabledOfShown": "{enabled} dei {shown} modelli mostrati sono nella catena"
+    "enabledOfShown": "{enabled} dei {shown} modelli mostrati sono nella catena",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Esplora i modelli non misurati",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Cancella ambito",
     "modelScopeBadgeOne": "limitata · 1 modello",
     "modelScopeBadgeOther": "limitata · {count} modelli",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Quali modelli deve servire questa chiave?",
       "hint": "La tua chiave {provider} è stata aggiunta e al momento serve tutti i modelli qui sotto. Deseleziona quelli che questa chiave non può usare — il router la salterà per quei modelli.",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -284,7 +284,11 @@
     "disableAll": "すべて無効化",
     "enableAllHint": "表示中のモデルをすべて有効にして保存します",
     "disableAllHint": "表示中のモデルをすべて無効にして保存します",
-    "enabledOfShown": "表示中の {shown} 件のうち {enabled} 件がチェーンに入っています"
+    "enabledOfShown": "表示中の {shown} 件のうち {enabled} 件がチェーンに入っています",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "未計測のモデルを探索",
@@ -564,6 +568,12 @@
     "modelScopeClear": "スコープを解除",
     "modelScopeBadgeOne": "限定 · 1 モデル",
     "modelScopeBadgeOther": "限定 · {count} モデル",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "このキーをどのモデルで使用しますか？",
       "hint": "{provider} のキーを追加しました。現在は以下のすべてのモデルで使用されます。このキーを使用できないモデルはチェックを外してください。それらのモデルではルーターがこのキーをスキップします。",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "გაუზომავი მოდელების შესწავლა",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ფარგლების გასუფთავება",
     "modelScopeBadgeOne": "შეზღუდული · 1 მოდელი",
     "modelScopeBadgeOther": "შეზღუდული · {count} მოდელი",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "რომელ მოდელებს უნდა ემსახუროს ეს გასაღები?",
       "hint": "თქვენი {provider}-ის გასაღები დაემატა და ამჟამად ემსახურება ქვემოთ ჩამოთვლილ ყველა მოდელს. მოხსენით მონიშვნა იმ მოდელებს, რომლებზეც ამ გასაღების გამოყენება ნებადართული არ არის — რაუტერი მათთვის ამ გასაღებს გამოტოვებს.",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "ស្វែងរកម៉ូដែលដែលមិនទាន់វាស់វែង",
@@ -564,6 +568,12 @@
     "modelScopeClear": "លុបវិសាលភាព",
     "modelScopeBadgeOne": "កំណត់ · ម៉ូដែល 1",
     "modelScopeBadgeOther": "កំណត់ · ម៉ូដែល {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "តើកូនសោនេះគួរបម្រើម៉ូដែលណាខ្លះ?",
       "hint": "កូនសោ {provider} របស់អ្នកត្រូវបានបន្ថែម ហើយបច្ចុប្បន្នវាបម្រើម៉ូដែលទាំងអស់ខាងក្រោម។ សូមដកសញ្ញាធីកចេញពីម៉ូដែលណាដែលកូនសោនេះមិនត្រូវបានអនុញ្ញាតឱ្យប្រើ — រ៉ោតទ័រនឹងរំលងវាសម្រាប់ម៉ូដែលទាំងនោះ។",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "ಅಳೆಯದ ಮಾದರಿಗಳನ್ನು ಅನ್ವೇಷಿಸಿ",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ವ್ಯಾಪ್ತಿ ತೆಗೆದುಹಾಕಿ",
     "modelScopeBadgeOne": "ಸೀಮಿತ · 1 ಮಾಡೆಲ್",
     "modelScopeBadgeOther": "ಸೀಮಿತ · {count} ಮಾಡೆಲ್‌ಗಳು",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ಈ ಕೀ ಯಾವ ಮಾಡೆಲ್‌ಗಳಿಗೆ ಸೇವೆ ಸಲ್ಲಿಸಬೇಕು?",
       "hint": "ನಿಮ್ಮ {provider} ಕೀ ಸೇರಿಸಲಾಗಿದೆ ಮತ್ತು ಸದ್ಯಕ್ಕೆ ಅದು ಕೆಳಗಿನ ಪ್ರತಿಯೊಂದು ಮಾಡೆಲ್‌ಗೂ ಸೇವೆ ಸಲ್ಲಿಸುತ್ತದೆ. ಈ ಕೀ ಬಳಸಬಾರದ ಮಾಡೆಲ್‌ಗಳ ಆಯ್ಕೆಯನ್ನು ತೆಗೆದುಹಾಕಿ — ಅವುಗಳಿಗೆ ರೂಟರ್ ಇದನ್ನು ಬಿಟ್ಟುಬಿಡುತ್ತದೆ.",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -284,7 +284,11 @@
     "disableAll": "전체 해제",
     "enableAllHint": "표시된 모델을 모두 켠 뒤 저장하세요",
     "disableAllHint": "표시된 모델을 모두 끈 뒤 저장하세요",
-    "enabledOfShown": "표시된 {shown}개 중 {enabled}개가 체인에 있습니다"
+    "enabledOfShown": "표시된 {shown}개 중 {enabled}개가 체인에 있습니다",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "미측정 모델 탐색",
@@ -564,6 +568,12 @@
     "modelScopeClear": "범위 지우기",
     "modelScopeBadgeOne": "제한됨 · 모델 1개",
     "modelScopeBadgeOther": "제한됨 · 모델 {count}개",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "이 키로 어떤 모델을 제공할까요?",
       "hint": "{provider} 키가 추가되었으며 현재 아래의 모든 모델에 사용됩니다. 이 키를 사용할 수 없는 모델은 체크를 해제하세요. 해당 모델에는 라우터가 이 키를 건너뜁니다.",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Tyrinėti neišmatuotus modelius",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Išvalyti aprėptį",
     "modelScopeBadgeOne": "apribotas · 1 modelis",
     "modelScopeBadgeOther": "apribotas · {count} modeliai",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Kuriuos modelius turėtų aptarnauti šis raktas?",
       "hint": "Jūsų {provider} raktas pridėtas ir šiuo metu aptarnauja visus toliau pateiktus modelius. Atžymėkite tuos, kurių šiam raktui naudoti negalima — maršrutizatorius jį jiems praleis.",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "അളക്കാത്ത മോഡലുകൾ പര്യവേക്ഷണം ചെയ്യുക",
@@ -564,6 +568,12 @@
     "modelScopeClear": "പരിധി നീക്കം ചെയ്യുക",
     "modelScopeBadgeOne": "പരിമിതം · 1 മോഡൽ",
     "modelScopeBadgeOther": "പരിമിതം · {count} മോഡലുകൾ",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ഈ കീ ഏതൊക്കെ മോഡലുകൾക്കായി പ്രവർത്തിക്കണം?",
       "hint": "നിങ്ങളുടെ {provider} കീ ചേർത്തു, ഇപ്പോൾ അത് താഴെയുള്ള എല്ലാ മോഡലുകൾക്കും സേവനം നൽകുന്നു. ഈ കീ ഉപയോഗിക്കാൻ പാടില്ലാത്ത മോഡലുകളുടെ ടിക് ഒഴിവാക്കുക — അവയ്ക്കായി റൂട്ടർ ഇത് ഒഴിവാക്കും.",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "न मोजलेले मॉडेल्स एक्सप्लोर करा",
@@ -564,6 +568,12 @@
     "modelScopeClear": "व्याप्ती काढा",
     "modelScopeBadgeOne": "मर्यादित · 1 मॉडेल",
     "modelScopeBadgeOther": "मर्यादित · {count} मॉडेल",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ही की कोणत्या मॉडेल्ससाठी वापरली जावी?",
       "hint": "तुमची {provider} की जोडली गेली आहे आणि सध्या ती खालील प्रत्येक मॉडेलसाठी वापरली जाते. ज्या मॉडेल्ससाठी ही की वापरता येणार नाही त्यांची निवड काढून टाका — राउटर त्यांच्यासाठी ती वगळेल.",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Teroka model yang belum diukur",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Kosongkan skop",
     "modelScopeBadgeOne": "terhad · 1 model",
     "modelScopeBadgeOther": "terhad · {count} model",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Model manakah yang patut dilayan oleh kunci ini?",
       "hint": "Kunci {provider} anda telah ditambah dan kini melayani setiap model di bawah. Nyahtanda mana-mana model yang kunci ini tidak dibenarkan guna — penghala akan melangkaunya untuk model tersebut.",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "မတိုင်းတာရသေးသော မော်ဒယ်များကို စူးစမ်းရန်",
@@ -564,6 +568,12 @@
     "modelScopeClear": "အတိုင်းအတာ ဖယ်ရှားရန်",
     "modelScopeBadgeOne": "ကန့်သတ် · မော်ဒယ် 1 ခု",
     "modelScopeBadgeOther": "ကန့်သတ် · မော်ဒယ် {count} ခု",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ဤကီးသည် မည်သည့်မော်ဒယ်များကို ဝန်ဆောင်ပေးသင့်သလဲ?",
       "hint": "သင်၏ {provider} ကီးကို ထည့်ပြီးပါပြီ၊ လက်ရှိတွင် အောက်ပါ မော်ဒယ်အားလုံးကို ဝန်ဆောင်ပေးနေပါသည်။ ဤကီးကို အသုံးပြုခွင့်မရှိသည့် မော်ဒယ်များ၏ အမှန်ခြစ်ကို ဖြုတ်ပါ — router သည် ထိုမော်ဒယ်များအတွက် ၎င်းကို ကျော်သွားပါမည်။",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "नमापिएका मोडेलहरू अन्वेषण गर्नुहोस्",
@@ -564,6 +568,12 @@
     "modelScopeClear": "दायरा हटाउनुहोस्",
     "modelScopeBadgeOne": "सीमित · 1 मोडेल",
     "modelScopeBadgeOther": "सीमित · {count} मोडेल",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "यो कुञ्जीले कुन मोडेलहरूलाई सेवा दिनुपर्छ?",
       "hint": "तपाईंको {provider} कुञ्जी थपियो र यसले हाल तलका सबै मोडेललाई सेवा दिन्छ। यो कुञ्जीले प्रयोग गर्न नहुने कुनै पनि मोडेलको चिन्ह हटाउनुहोस् — राउटरले ती मोडेलका लागि यो कुञ्जी छोड्नेछ।",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -284,7 +284,11 @@
     "disableAll": "Alles uit",
     "enableAllHint": "Zet alle getoonde modellen aan en sla op",
     "disableAllHint": "Zet alle getoonde modellen uit en sla op",
-    "enabledOfShown": "{enabled} van {shown} getoonde modellen zitten in de keten"
+    "enabledOfShown": "{enabled} van {shown} getoonde modellen zitten in de keten",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Ongemeten modellen verkennen",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Bereik wissen",
     "modelScopeBadgeOne": "beperkt · 1 model",
     "modelScopeBadgeOther": "beperkt · {count} modellen",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Welke modellen moet deze sleutel bedienen?",
       "hint": "Je {provider}-sleutel is toegevoegd en bedient op dit moment alle modellen hieronder. Vink de modellen uit waarvoor deze sleutel niet gebruikt mag worden — de router slaat de sleutel daarvoor over.",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Utforsk umålte modeller",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Fjern avgrensning",
     "modelScopeBadgeOne": "begrenset · 1 modell",
     "modelScopeBadgeOther": "begrenset · {count} modeller",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Hvilke modeller skal denne nøkkelen betjene?",
       "hint": "{provider}-nøkkelen din er lagt til og betjener for øyeblikket alle modellene nedenfor. Fjern haken ved modellene nøkkelen ikke får brukes til — ruteren hopper da over den for disse.",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "ମପାଯାଇନଥିବା ମଡେଲଗୁଡ଼ିକୁ ଅନୁସନ୍ଧାନ କରନ୍ତୁ",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ପରିସର ହଟାନ୍ତୁ",
     "modelScopeBadgeOne": "ସୀମିତ · 1 ମଡେଲ",
     "modelScopeBadgeOther": "ସୀମିତ · {count} ମଡେଲ",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ଏହି କୀ କେଉଁ ମଡେଲଗୁଡିକ ପାଇଁ କାମ କରିବ?",
       "hint": "ଆପଣଙ୍କ {provider} କୀ ଯୋଡାଗଲା ଏବଂ ବର୍ତ୍ତମାନ ଏହା ତଳେ ଥିବା ପ୍ରତ୍ୟେକ ମଡେଲ ପାଇଁ କାମ କରୁଛି। ଯେଉଁ ମଡେଲଗୁଡିକ ପାଇଁ ଏହି କୀ ବ୍ୟବହାର ହେବା ଉଚିତ ନୁହେଁ, ସେଗୁଡିକର ଚୟନ ହଟାଇଦିଅନ୍ତୁ — ରାଉଟର ସେଗୁଡିକ ପାଇଁ ଏହାକୁ ଛାଡ଼ିଦେବ।",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "ਬਿਨਾਂ ਮਾਪੇ ਮਾਡਲਾਂ ਦੀ ਖੋਜ ਕਰੋ",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ਦਾਇਰਾ ਹਟਾਓ",
     "modelScopeBadgeOne": "ਸੀਮਤ · 1 ਮਾਡਲ",
     "modelScopeBadgeOther": "ਸੀਮਤ · {count} ਮਾਡਲ",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ਇਹ ਕੁੰਜੀ ਕਿਹੜੇ ਮਾਡਲਾਂ ਲਈ ਕੰਮ ਕਰੇ?",
       "hint": "ਤੁਹਾਡੀ {provider} ਕੁੰਜੀ ਸ਼ਾਮਲ ਕਰ ਦਿੱਤੀ ਗਈ ਹੈ ਅਤੇ ਇਸ ਵੇਲੇ ਇਹ ਹੇਠਾਂ ਦਿੱਤੇ ਹਰ ਮਾਡਲ ਲਈ ਕੰਮ ਕਰਦੀ ਹੈ। ਜਿਨ੍ਹਾਂ ਮਾਡਲਾਂ ਲਈ ਇਹ ਕੁੰਜੀ ਨਹੀਂ ਵਰਤੀ ਜਾਣੀ ਚਾਹੀਦੀ, ਉਹਨਾਂ ਦੀ ਚੋਣ ਹਟਾ ਦਿਓ — ਰਾਊਟਰ ਉਹਨਾਂ ਲਈ ਇਸਨੂੰ ਛੱਡ ਦੇਵੇਗਾ।",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -284,7 +284,11 @@
     "disableAll": "Wyłącz wszystkie",
     "enableAllHint": "Włącz wszystkie pokazane modele, potem zapisz",
     "disableAllHint": "Wyłącz wszystkie pokazane modele, potem zapisz",
-    "enabledOfShown": "{enabled} z {shown} pokazanych modeli jest w łańcuchu"
+    "enabledOfShown": "{enabled} z {shown} pokazanych modeli jest w łańcuchu",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Eksploruj niezmierzone modele",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Wyczyść zakres",
     "modelScopeBadgeOne": "ograniczony · 1 model",
     "modelScopeBadgeOther": "ograniczony · {count} modeli",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Które modele ma obsługiwać ten klucz?",
       "hint": "Twój klucz {provider} został dodany i obsługuje obecnie wszystkie modele poniżej. Odznacz te, których ten klucz nie może używać — router pominie go dla nich.",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -284,7 +284,11 @@
     "disableAll": "Desativar todos",
     "enableAllHint": "Ative todos os modelos exibidos e salve",
     "disableAllHint": "Desative todos os modelos exibidos e salve",
-    "enabledOfShown": "{enabled} de {shown} modelos exibidos estão na cadeia"
+    "enabledOfShown": "{enabled} de {shown} modelos exibidos estão na cadeia",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explorar modelos sem medições",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Limpar escopo",
     "modelScopeBadgeOne": "restrita · 1 modelo",
     "modelScopeBadgeOther": "restrita · {count} modelos",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Quais modelos esta chave deve atender?",
       "hint": "Sua chave da {provider} foi adicionada e no momento atende todos os modelos abaixo. Desmarque os que esta chave não pode usar — o roteador vai ignorá-la para esses modelos.",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -284,7 +284,11 @@
     "disableAll": "Desativar todos",
     "enableAllHint": "Ative todos os modelos apresentados e guarde",
     "disableAllHint": "Desative todos os modelos apresentados e guarde",
-    "enabledOfShown": "{enabled} de {shown} modelos apresentados estão na cadeia"
+    "enabledOfShown": "{enabled} de {shown} modelos apresentados estão na cadeia",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explorar modelos sem medições",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Limpar âmbito",
     "modelScopeBadgeOne": "restrita · 1 modelo",
     "modelScopeBadgeOther": "restrita · {count} modelos",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Que modelos deve esta chave servir?",
       "hint": "A sua chave {provider} foi adicionada e serve atualmente todos os modelos abaixo. Desmarque os que esta chave não pode utilizar — o router ignora-a para esses modelos.",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Explorează modelele nemăsurate",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Șterge domeniul",
     "modelScopeBadgeOne": "limitată · 1 model",
     "modelScopeBadgeOther": "limitată · {count} modele",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Ce modele ar trebui să deservească această cheie?",
       "hint": "Cheia ta {provider} a fost adăugată și deservește momentan toate modelele de mai jos. Debifează-le pe cele pe care această cheie nu are voie să le folosească — routerul o va sări pentru ele.",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -284,7 +284,11 @@
     "disableAll": "Выключить все",
     "enableAllHint": "Включить все показанные модели, затем сохранить",
     "disableAllHint": "Выключить все показанные модели, затем сохранить",
-    "enabledOfShown": "В цепочке {enabled} из {shown} показанных моделей"
+    "enabledOfShown": "В цепочке {enabled} из {shown} показанных моделей",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Исследовать неизмеренные модели",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Очистить область",
     "modelScopeBadgeOne": "ограничен · 1 модель",
     "modelScopeBadgeOther": "ограничен · {count} моделей",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Какие модели должен обслуживать этот ключ?",
       "hint": "Ваш ключ {provider} добавлен и сейчас обслуживает все модели ниже. Снимите отметки с тех, которые этому ключу использовать нельзя — для них маршрутизатор его пропустит.",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "නොමැනූ ආකෘති ගවේෂණය කරන්න",
@@ -564,6 +568,12 @@
     "modelScopeClear": "පරාසය හිස් කරන්න",
     "modelScopeBadgeOne": "සීමිත · මොඩල 1",
     "modelScopeBadgeOther": "සීමිත · මොඩල {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "මෙම යතුර සේවය කළ යුත්තේ කුමන මොඩල සඳහාද?",
       "hint": "ඔබගේ {provider} යතුර එක් කරන ලද අතර දැනට පහත සෑම මොඩලයකටම සේවය කරයි. මෙම යතුරට භාවිත කිරීමට අවසර නැති ඒවායේ ලකුණ ඉවත් කරන්න — රවුටරය එම මොඩල සඳහා එය මඟහරියි.",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Preskúmavať nezmerané modely",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Vymazať rozsah",
     "modelScopeBadgeOne": "obmedzený · 1 model",
     "modelScopeBadgeOther": "obmedzený · {count} modelov",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Ktoré modely má tento kľúč obsluhovať?",
       "hint": "Váš kľúč {provider} bol pridaný a momentálne obsluhuje všetky modely nižšie. Odškrtnite tie, ktoré tento kľúč nesmie používať — router ho pre ne preskočí.",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Истражи неизмерене моделе",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Очисти опсег",
     "modelScopeBadgeOne": "ограничен · 1 модел",
     "modelScopeBadgeOther": "ограничен · {count} модела",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "За које се моделе користи овај кључ?",
       "hint": "Ваш {provider} кључ је додат и тренутно опслужује све моделе испод. Одзначите оне које овај кључ не сме да користи — рутер ће га за њих прескочити.",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Utforska omätta modeller",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Rensa omfång",
     "modelScopeBadgeOne": "begränsad · 1 modell",
     "modelScopeBadgeOther": "begränsad · {count} modeller",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Vilka modeller ska den här nyckeln betjäna?",
       "hint": "Din {provider}-nyckel har lagts till och betjänar just nu alla modeller nedan. Avmarkera de modeller som nyckeln inte får användas för — routern hoppar då över den för dessa.",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Chunguza mifano isiyopimwa",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Futa wigo",
     "modelScopeBadgeOne": "imezuiliwa · modeli 1",
     "modelScopeBadgeOther": "imezuiliwa · modeli {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Ufunguo huu unapaswa kuhudumia modeli zipi?",
       "hint": "Ufunguo wako wa {provider} umeongezwa na kwa sasa unahudumia kila modeli iliyo hapa chini. Ondoa alama kwenye modeli yoyote ambayo ufunguo huu hauruhusiwi kutumia — kipanga njia kitaruka ufunguo huu kwa modeli hizo.",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "அளவிடப்படாத மாதிரிகளை ஆராயுங்கள்",
@@ -564,6 +568,12 @@
     "modelScopeClear": "வரம்பை நீக்கு",
     "modelScopeBadgeOne": "வரம்பிடப்பட்டது · 1 மாடல்",
     "modelScopeBadgeOther": "வரம்பிடப்பட்டது · {count} மாடல்கள்",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "இந்த விசை எந்த மாடல்களுக்குச் சேவை செய்ய வேண்டும்?",
       "hint": "உங்கள் {provider} விசை சேர்க்கப்பட்டது, தற்போது இது கீழே உள்ள எல்லா மாடல்களுக்கும் சேவை செய்கிறது. இந்த விசை பயன்படுத்தக் கூடாத மாடல்களின் தேர்வை நீக்கவும் — அவற்றுக்கு ரூட்டர் இதைத் தவிர்க்கும்.",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "కొలవని మోడల్స్‌ను అన్వేషించండి",
@@ -564,6 +568,12 @@
     "modelScopeClear": "పరిధిని తొలగించండి",
     "modelScopeBadgeOne": "పరిమితం · 1 మోడల్",
     "modelScopeBadgeOther": "పరిమితం · {count} మోడళ్లు",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "ఈ కీ ఏ మోడల్‌లకు సేవ అందించాలి?",
       "hint": "మీ {provider} కీ జోడించబడింది, ప్రస్తుతం ఇది కింది ప్రతి మోడల్‌కు సేవ అందిస్తుంది. ఈ కీని ఉపయోగించకూడని మోడల్‌ల ఎంపికను తీసివేయండి — వాటికి రూటర్ ఈ కీని దాటవేస్తుంది.",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "สำรวจโมเดลที่ยังไม่ได้วัดผล",
@@ -564,6 +568,12 @@
     "modelScopeClear": "ล้างขอบเขต",
     "modelScopeBadgeOne": "จำกัด · 1 โมเดล",
     "modelScopeBadgeOther": "จำกัด · {count} โมเดล",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "คีย์นี้ควรให้บริการโมเดลใดบ้าง",
       "hint": "เพิ่มคีย์ {provider} ของคุณแล้ว และตอนนี้ให้บริการทุกโมเดลด้านล่าง ยกเลิกการเลือกโมเดลที่ไม่อนุญาตให้คีย์นี้ใช้ — เราเตอร์จะข้ามคีย์นี้สำหรับโมเดลเหล่านั้น",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "I-explore ang mga hindi pa nasusukat na modelo",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Burahin ang saklaw",
     "modelScopeBadgeOne": "limitado · 1 modelo",
     "modelScopeBadgeOther": "limitado · {count} na modelo",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Aling mga modelo ang dapat pagsilbihan ng key na ito?",
       "hint": "Naidagdag na ang iyong {provider} key at kasalukuyan nitong pinagsisilbihan ang lahat ng modelo sa ibaba. Alisan ng tsek ang alinmang hindi pinapayagang gamitin ng key na ito — laktawan ito ng router para sa mga iyon.",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -284,7 +284,11 @@
     "disableAll": "Tümünü kapat",
     "enableAllHint": "Gösterilen tüm modelleri açın, sonra kaydedin",
     "disableAllHint": "Gösterilen tüm modelleri kapatın, sonra kaydedin",
-    "enabledOfShown": "Gösterilen {shown} modelden {enabled} tanesi zincirde"
+    "enabledOfShown": "Gösterilen {shown} modelden {enabled} tanesi zincirde",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Ölçülmemiş modelleri keşfet",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Kapsamı temizle",
     "modelScopeBadgeOne": "sınırlı · 1 model",
     "modelScopeBadgeOther": "sınırlı · {count} model",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Bu anahtar hangi modellere hizmet versin?",
       "hint": "{provider} anahtarınız eklendi ve şu anda aşağıdaki tüm modellere hizmet veriyor. Bu anahtarın kullanmasına izin verilmeyen modellerin işaretini kaldırın — yönlendirici o modeller için bu anahtarı atlar.",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -284,7 +284,11 @@
     "disableAll": "Вимкнути всі",
     "enableAllHint": "Увімкніть усі показані моделі, потім збережіть",
     "disableAllHint": "Вимкніть усі показані моделі, потім збережіть",
-    "enabledOfShown": "У ланцюжку {enabled} із {shown} показаних моделей"
+    "enabledOfShown": "У ланцюжку {enabled} із {shown} показаних моделей",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Досліджувати невиміряні моделі",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Очистити область",
     "modelScopeBadgeOne": "обмежено · 1 модель",
     "modelScopeBadgeOther": "обмежено · {count} моделей",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Які моделі має обслуговувати цей ключ?",
       "hint": "Ваш ключ {provider} додано, і зараз він обслуговує всі моделі нижче. Зніміть позначки з тих, які цьому ключу використовувати не можна — для них маршрутизатор його пропускатиме.",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "غیر پیمائش شدہ ماڈلز دریافت کریں",
@@ -564,6 +568,12 @@
     "modelScopeClear": "دائرہ صاف کریں",
     "modelScopeBadgeOne": "محدود · 1 ماڈل",
     "modelScopeBadgeOther": "محدود · {count} ماڈلز",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "یہ کلید کن ماڈلز کے لیے استعمال ہو؟",
       "hint": "آپ کی {provider} کلید شامل کر دی گئی ہے اور فی الحال نیچے دیے گئے ہر ماڈل کے لیے استعمال ہو رہی ہے۔ جن ماڈلز کے لیے اس کلید کو اجازت نہیں، ان کا نشان ہٹا دیں — راؤٹر ان کے لیے اسے چھوڑ دے گا۔",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "O'lchanmagan modellarni o'rganish",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Doirani tozalash",
     "modelScopeBadgeOne": "cheklangan · 1 model",
     "modelScopeBadgeOther": "cheklangan · {count} model",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Bu kalit qaysi modellarga xizmat qilsin?",
       "hint": "{provider} kalitingiz qo‘shildi va hozirda quyidagi barcha modellarga xizmat qilmoqda. Bu kalitdan foydalanishga ruxsat berilmagan modellardan belgini olib tashlang — router ular uchun bu kalitni o‘tkazib yuboradi.",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -284,7 +284,11 @@
     "disableAll": "Tắt tất cả",
     "enableAllHint": "Bật mọi mô hình đang hiển thị rồi lưu",
     "disableAllHint": "Tắt mọi mô hình đang hiển thị rồi lưu",
-    "enabledOfShown": "{enabled} trong {shown} mô hình đang hiển thị nằm trong chuỗi"
+    "enabledOfShown": "{enabled} trong {shown} mô hình đang hiển thị nằm trong chuỗi",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Khám phá các mô hình chưa được đo",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Xóa phạm vi",
     "modelScopeBadgeOne": "giới hạn · 1 mô hình",
     "modelScopeBadgeOther": "giới hạn · {count} mô hình",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Khóa này nên phục vụ những mô hình nào?",
       "hint": "Khóa {provider} của bạn đã được thêm và hiện phục vụ mọi mô hình bên dưới. Hãy bỏ chọn những mô hình mà khóa này không được phép dùng — bộ định tuyến sẽ bỏ qua khóa này với chúng.",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -284,7 +284,11 @@
     "disableAll": "Disable all",
     "enableAllHint": "Turn on every model shown, then Save",
     "disableAllHint": "Turn off every model shown, then Save",
-    "enabledOfShown": "{enabled} of {shown} shown models are in the chain"
+    "enabledOfShown": "{enabled} of {shown} shown models are in the chain",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "Ṣawari awọn awoṣe ti a ko ti wọn",
@@ -564,6 +568,12 @@
     "modelScopeClear": "Pa àgbègbè rẹ́",
     "modelScopeBadgeOne": "ní ààlà · awoṣe 1",
     "modelScopeBadgeOther": "ní ààlà · awoṣe {count}",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "Àwọn awoṣe wo ni bọtìnì yìí gbọdọ̀ ṣe ìránṣẹ́ fún?",
       "hint": "A ti ṣàfikún bọtìnì {provider} rẹ, ó sì ń ṣe ìránṣẹ́ fún gbogbo àwọn awoṣe tí ó wà nísàlẹ̀ báyìí. Yọ àmì kúrò nínú èyíkéyìí tí bọtìnì yìí kò ní ààyè láti lò — olulana yóò fò ó kọjá fún àwọn wọ̀nyẹn.",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -284,7 +284,11 @@
     "disableAll": "全部停用",
     "enableAllHint": "启用所有显示的模型，然后保存",
     "disableAllHint": "停用所有显示的模型，然后保存",
-    "enabledOfShown": "显示的 {shown} 个模型中有 {enabled} 个在链中"
+    "enabledOfShown": "显示的 {shown} 个模型中有 {enabled} 个在链中",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "探索未测模型",
@@ -568,6 +572,12 @@
     "modelScopeClear": "清除范围",
     "modelScopeBadgeOne": "限定 · 1 个模型",
     "modelScopeBadgeOther": "限定 · {count} 个模型",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "此密钥应服务哪些模型？",
       "hint": "您的 {provider} 密钥已添加，目前可服务下方全部模型。请取消勾选此密钥不可使用的模型——路由器会为这些模型跳过此密钥。",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -284,7 +284,11 @@
     "disableAll": "全部停用",
     "enableAllHint": "啟用所有顯示的模型，然後儲存",
     "disableAllHint": "停用所有顯示的模型，然後儲存",
-    "enabledOfShown": "顯示的 {shown} 個模型中有 {enabled} 個在鏈中"
+    "enabledOfShown": "顯示的 {shown} 個模型中有 {enabled} 個在鏈中",
+    "providerRouting": "Provider routing",
+    "providerRoutingDescription": "Automatic uses live routing scores. Preferred order tries your list first while retaining health, quota, cooldown and failover protections.",
+    "providerRoutingAutomatic": "Automatic",
+    "providerRoutingPreferred": "Preferred order"
   },
   "strategies": {
     "explore": "探索未測模型",
@@ -568,6 +572,12 @@
     "modelScopeClear": "清除範圍",
     "modelScopeBadgeOne": "限定 · 1 個模型",
     "modelScopeBadgeOther": "限定 · {count} 個模型",
+    "catalogLoadFailed": "Could not load the curated model catalog.",
+    "liveModelsFallback": "No curated rows are available for this provider, so these models come from its live API.",
+    "providerAccountLimits": "Provider account limits",
+    "providerAccountLimitsHint": "Blank inherits the provider default. Zero disables that account-wide gate.",
+    "accountLimits": "account limits",
+    "modelsAndAccountLimits": "Models & account limits",
     "modelPicker": {
       "title": "此金鑰應服務哪些模型？",
       "hint": "您的 {provider} 金鑰已新增，目前可服務下方所有模型。請取消勾選此金鑰不可使用的模型——路由器會為這些模型略過此金鑰。",

--- a/client/src/lib/provider-preferences.test.ts
+++ b/client/src/lib/provider-preferences.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { moveProviderMember, orderedProviderMembers, providerOrderForSave } from './provider-preferences'
+
+const members = [{ id: 'groq' }, { id: 'nvidia' }, { id: 'ollama' }]
+
+describe('provider preference ordering', () => {
+  it('preserves automatic order when no preference was configured', () => {
+    expect(orderedProviderMembers(members, undefined, member => member.id).map(member => member.id))
+      .toEqual(['groq', 'nvidia', 'ollama'])
+  })
+
+  it('puts explicit members first and leaves newly discovered members in automatic order', () => {
+    const ordered = orderedProviderMembers(
+      members,
+      { mode: 'preferred', memberOrder: ['nvidia', 'groq'] },
+      member => member.id,
+    )
+    expect(ordered.map(member => member.id)).toEqual(['nvidia', 'groq', 'ollama'])
+  })
+
+  it('moves one member without mutating the source list', () => {
+    expect(moveProviderMember(members, 1, -1).map(member => member.id)).toEqual(['nvidia', 'groq', 'ollama'])
+    expect(members.map(member => member.id)).toEqual(['groq', 'nvidia', 'ollama'])
+  })
+
+  it('retains temporarily absent provider identities when saving visible order', () => {
+    expect(providerOrderForSave(
+      [{ id: 'nvidia' }, { id: 'groq' }],
+      ['groq', 'sambanova', 'nvidia'],
+      member => member.id,
+    )).toEqual(['nvidia', 'groq', 'sambanova'])
+  })
+})

--- a/client/src/lib/provider-preferences.ts
+++ b/client/src/lib/provider-preferences.ts
@@ -1,0 +1,38 @@
+export interface ProviderPreference {
+  mode: 'automatic' | 'preferred'
+  memberOrder: string[]
+}
+
+export function orderedProviderMembers<T>(
+  members: readonly T[],
+  preference: ProviderPreference | undefined,
+  identity: (member: T) => string,
+): T[] {
+  if (!preference || preference.mode !== 'preferred') return [...members]
+  const byId = new Map(members.map(member => [identity(member), member]))
+  return [
+    ...preference.memberOrder.map(id => byId.get(id)).filter((member): member is T => member !== undefined),
+    ...members.filter(member => !preference.memberOrder.includes(identity(member))),
+  ]
+}
+
+export function moveProviderMember<T>(members: readonly T[], index: number, delta: -1 | 1): T[] {
+  const target = index + delta
+  if (index < 0 || index >= members.length || target < 0 || target >= members.length) return [...members]
+  const next = [...members]
+  ;[next[index], next[target]] = [next[target], next[index]]
+  return next
+}
+
+/** Save the visible order without discarding temporarily absent providers.
+ * Stale identities stay after visible members and resume their saved relative
+ * order when catalogue/key state makes them visible again. */
+export function providerOrderForSave<T>(
+  visibleMembers: readonly T[],
+  previousOrder: readonly string[] | undefined,
+  identity: (member: T) => string,
+): string[] {
+  const visible = visibleMembers.map(identity)
+  const visibleSet = new Set(visible)
+  return [...visible, ...(previousOrder ?? []).filter(id => !visibleSet.has(id))]
+}

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useParams } from 'react-router-dom'
-import { ChevronLeft, Merge, Save, Split, Trash2 } from 'lucide-react'
+import { ArrowDown, ArrowUp, ChevronLeft, Merge, Save, Split, Trash2 } from 'lucide-react'
 import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 import { addAlias, aliasesFor, removeAlias } from '@/lib/alias-merge'
+import { moveProviderMember, orderedProviderMembers, providerOrderForSave } from '@/lib/provider-preferences'
 import { Button } from '@/components/ui/button'
 import { ConfirmButton } from '@/components/confirm-button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { SegmentedControl } from '@/components/ui/segmented-control'
 import { CopyButton } from '@/components/copy-button'
 import { TableSkeleton } from '@/components/ui/skeleton'
 import { Tooltip } from '@/components/tooltip'
@@ -46,6 +48,11 @@ type UnifyOverrides = {
   splits: { member: string; groupKey?: string }[]
 }
 
+type ProviderPreferences = {
+  version: 1
+  groups: Record<string, { mode: 'automatic' | 'preferred'; memberOrder: string[] }>
+}
+
 // What the per-provider split control should do for one member row.
 export type SplitAction = {
   kind: 'split' | 'undo'
@@ -74,7 +81,7 @@ export default function ModelDetailPage() {
     queryKey: ['unified-key'],
     queryFn: () => apiFetch('/api/settings/api-key'),
   })
-  const { data: unify } = useQuery<{ enabled: boolean; overrides: UnifyOverrides }>({
+  const { data: unify } = useQuery<{ enabled: boolean; overrides: UnifyOverrides; providerPreferences: ProviderPreferences }>({
     queryKey: ['unify'],
     queryFn: () => apiFetch('/api/settings/unify'),
   })
@@ -154,6 +161,15 @@ export default function ModelDetailPage() {
     },
   })
 
+  const providerPreferenceMutation = useMutation({
+    mutationFn: (providerPreferences: ProviderPreferences) =>
+      apiFetch('/api/settings/unify', {
+        method: 'PUT',
+        body: JSON.stringify({ providerPreferences }),
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['unify'] }),
+  })
+
   const splits = unify?.overrides.splits ?? []
   // New splits are written against ONE row: an unqualified "platform:modelId"
   // matches every relay that serves the id, so splitting one relay's card used
@@ -187,6 +203,29 @@ export default function ModelDetailPage() {
     .filter(e => e.keyCount > 0 && (e.canonicalId ?? e.modelId) === canonicalId)
     .map(e => ({ ...(scoreById.get(e.modelDbId) ?? {}), ...e }))
     .sort((a, b) => (isManual ? a.priority - b.priority : (b.score ?? 0) - (a.score ?? 0)))
+
+  const groupKey = members[0]?.groupKey ?? ''
+  const savedPreference = groupKey ? unify?.providerPreferences?.groups[groupKey] : undefined
+  const preferenceMode = savedPreference?.mode ?? 'automatic'
+  const preferredMembers = orderedProviderMembers(members, savedPreference, memberOverrideKey)
+
+  function saveProviderPreference(mode: 'automatic' | 'preferred', ordered: Row[] = preferredMembers) {
+    if (!groupKey) return
+    providerPreferenceMutation.mutate({
+      version: 1,
+      groups: {
+        ...(unify?.providerPreferences?.groups ?? {}),
+        [groupKey]: {
+          mode,
+          memberOrder: providerOrderForSave(ordered, savedPreference?.memberOrder, memberOverrideKey),
+        },
+      },
+    })
+  }
+
+  function movePreferredMember(index: number, delta: -1 | 1) {
+    saveProviderPreference('preferred', moveProviderMember(preferredMembers, index, delta))
+  }
   // Endpoint disambiguation keys on (platform, model_id) across EVERY configured
   // row — a relay whose copy was renamed sits in a DIFFERENT display group, so
   // `members` is not a complete sibling set and scoping to it would hide the
@@ -262,6 +301,44 @@ export default function ModelDetailPage() {
               <RateLimitBadge size="md" rows={members.flatMap(m => rateUsageByModel.get(m.modelDbId) ?? [])} />
               {vision && <span title={t('models.visionTitle')} className="text-[11px] rounded-full px-2 py-0.5 bg-cyan-600/15 text-cyan-700 dark:bg-cyan-400/15 dark:text-cyan-400">{t('models.vision')}</span>}
               {tools && <span title={t('models.toolsTitle')} className="text-[11px] rounded-full px-2 py-0.5 bg-violet-600/15 text-violet-700 dark:bg-violet-400/15 dark:text-violet-400">{t('models.tools')}</span>}
+            </div>
+
+            <div className="rounded-2xl border bg-card p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-medium">{t('models.providerRouting')}</h2>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {t('models.providerRoutingDescription')}
+                  </p>
+                </div>
+                <SegmentedControl
+                  value={preferenceMode}
+                  onValueChange={mode => saveProviderPreference(mode)}
+                  options={[
+                    { value: 'automatic', label: t('models.providerRoutingAutomatic') },
+                    { value: 'preferred', label: t('models.providerRoutingPreferred') },
+                  ]}
+                  ariaLabel={t('models.providerRouting')}
+                />
+              </div>
+              {preferenceMode === 'preferred' && (
+                <ol className="mt-4 space-y-1.5">
+                  {preferredMembers.map((member, index) => (
+                    <li key={member.modelDbId} className="flex items-center gap-2 rounded-xl border bg-background px-3 py-2 text-xs">
+                      <span className="w-5 text-right tabular-nums text-muted-foreground">{index + 1}</span>
+                      <span className="min-w-0 flex-1 truncate" title={memberEndpointTitle(member, siblings)}>
+                        {memberProviderLabel(member, siblings)}
+                      </span>
+                      <Button variant="ghost" size="icon-xs" disabled={index === 0 || providerPreferenceMutation.isPending} onClick={() => movePreferredMember(index, -1)} aria-label={t('embeddings.moveUp')}>
+                        <ArrowUp className="size-3" />
+                      </Button>
+                      <Button variant="ghost" size="icon-xs" disabled={index === preferredMembers.length - 1 || providerPreferenceMutation.isPending} onClick={() => movePreferredMember(index, 1)} aria-label={t('embeddings.moveDown')}>
+                        <ArrowDown className="size-3" />
+                      </Button>
+                    </li>
+                  ))}
+                </ol>
+              )}
             </div>
 
             {/* Per-provider stats (same columns as the Models table) */}

--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -35,6 +35,7 @@ const PROFILE_AUTO_INCLUDE_FILENAME = '20260823_000004_profile_auto_include.ts';
 const IDEMPOTENCY_CLAIMS_FILENAME = '20260901_000001_idempotency_claims.ts';
 const QUOTA_OBSERVATION_LOOKUP_FILENAME = '20260901_000002_quota_observation_lookup.ts';
 const ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME = '20260902_000001_analytics_latency_percentile_index.ts';
+const PROVIDER_ACCOUNT_LIMITS_FILENAME = '20260902_000002_provider_account_limits.ts';
 
 interface SchemaRow {
   type: string;
@@ -116,6 +117,7 @@ describe('migration round trip', () => {
         IDEMPOTENCY_CLAIMS_FILENAME,
         QUOTA_OBSERVATION_LOOKUP_FILENAME,
         ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME,
+        PROVIDER_ACCOUNT_LIMITS_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/anthropic.test.ts
+++ b/server/src/__tests__/routes/anthropic.test.ts
@@ -148,6 +148,8 @@ describe('Anthropic-compatible /v1/messages', () => {
     db.prepare('DELETE FROM requests').run();
     db.prepare('DELETE FROM rate_limit_cooldowns').run();
     db.prepare('DELETE FROM rate_limit_usage').run();
+    db.prepare('DELETE FROM provider_quota_state').run();
+    db.prepare('DELETE FROM provider_quota_observations').run();
     db.prepare("DELETE FROM settings WHERE key = 'anthropic_model_map'").run();
     db.prepare(`
       INSERT INTO settings (key, value)
@@ -187,6 +189,41 @@ describe('Anthropic-compatible /v1/messages', () => {
     expect(body.usage).toEqual({ input_tokens: 11, output_tokens: 7 });
     expect(body.id).toMatch(/^msg_/);
     expect(headers.get('x-routed-via')).toMatch(/^groq\//);
+  });
+
+  it('attributes Anthropic quota observations to the actual credential and model pool', async () => {
+    const original = globalThis.fetch;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+      if (String(url).includes('api.groq.com/openai/v1/chat/completions')) {
+        return new Response(JSON.stringify(textCompletion('quota context')), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'x-ratelimit-limit-requests': '100',
+            'x-ratelimit-remaining-requests': '75',
+            'x-ratelimit-reset-requests': '60',
+          },
+        });
+      }
+      return original(url as any, init);
+    });
+
+    const { status } = await request(app, '/v1/messages', {
+      model: 'claude-sonnet-4-5', max_tokens: 64,
+      messages: [{ role: 'user', content: 'hi' }],
+    }, anthropicHeaders());
+    expect(status).toBe(200);
+
+    const key = getDb().prepare("SELECT id FROM api_keys WHERE platform = 'groq'").get() as { id: number };
+    const observation = getDb().prepare(`
+      SELECT key_id AS keyId, model_id AS modelId, quota_pool_key AS poolKey, endpoint
+        FROM provider_quota_observations
+       WHERE platform = 'groq' AND metric = 'requests'
+       ORDER BY created_at DESC LIMIT 1
+    `).get() as { keyId: number; modelId: string; poolKey: string; endpoint: string };
+    expect(observation.keyId).toBe(key.id);
+    expect(observation.poolKey).toBe(`groq::model::${observation.modelId}`);
+    expect(observation.endpoint).toBe('chat/completions');
   });
 
   it('forwards the system prompt and tools, returns a tool_use block (stop_reason tool_use)', async () => {

--- a/server/src/__tests__/routes/free-tier.test.ts
+++ b/server/src/__tests__/routes/free-tier.test.ts
@@ -51,6 +51,7 @@ function observe(row: {
 describe('free-tier pool overview (#905)', () => {
   let app: Express;
   let groqKey = 0;
+  let groqModelIds: string[] = [];
   let cerebrasA = 0;
   let cerebrasB = 0;
 
@@ -64,13 +65,14 @@ describe('free-tier pool overview (#905)', () => {
     // Narrow the catalog down to a handful of rows across three platforms.
     db.prepare('UPDATE models SET enabled = 0').run();
     const groq = db.prepare("SELECT id, model_id FROM models WHERE platform = 'groq' ORDER BY id LIMIT 3").all() as { id: number; model_id: string }[];
+    groqModelIds = groq.map(model => model.model_id);
     const cerebras = db.prepare("SELECT id FROM models WHERE platform = 'cerebras' ORDER BY id LIMIT 2").all() as { id: number }[];
     const google = db.prepare("SELECT id FROM models WHERE platform = 'google' ORDER BY id LIMIT 1").all() as { id: number }[];
     const on = db.prepare('UPDATE models SET enabled = 1 WHERE id = ?');
     for (const m of [...groq, ...cerebras, ...google]) on.run(m.id);
 
-    // Three groq models in ONE pool with different labels: the pool takes the
-    // largest documented budget once, never the sum of the three.
+    // Groq publishes independent per-model allowances, so each model's label
+    // belongs to a separate pool even though one credential serves all three.
     const budget = db.prepare('UPDATE models SET monthly_token_budget = ? WHERE id = ?');
     budget.run('~6M', groq[0].id);
     budget.run('~15M', groq[1].id);
@@ -95,23 +97,22 @@ describe('free-tier pool overview (#905)', () => {
 
     // groq: an older `tokens` reading and a newer `requests` one (a 429 writes
     // exactly this). Latest-wins would report 5,000 requests as the headroom.
-    observe({ platform: 'groq', keyId: groqKey, pool: 'groq::account', metric: 'tokens', limit: 15_000_000, remaining: 12_400_000, resetAt: future(600), observedAt: '2026-01-01 00:00:00' });
-    observe({ platform: 'groq', keyId: groqKey, pool: 'groq::account', metric: 'requests', limit: 14_400, remaining: 5_000, resetAt: future(120), observedAt: '2026-01-02 00:00:00' });
+    const observedGroqPool = `groq::model::${groqModelIds[1]}`;
+    observe({ platform: 'groq', keyId: groqKey, pool: observedGroqPool, metric: 'tokens', limit: 15_000_000, remaining: 12_400_000, resetAt: future(600), observedAt: '2026-01-01 00:00:00' });
+    observe({ platform: 'groq', keyId: groqKey, pool: observedGroqPool, metric: 'requests', limit: 14_400, remaining: 5_000, resetAt: future(120), observedAt: '2026-01-02 00:00:00' });
     // cerebras: the same pool seen through two keys — two accounts, two allowances.
     observe({ platform: 'cerebras', keyId: cerebrasA, pool: 'cerebras::shared', metric: 'tokens', limit: 30_000_000, remaining: 20_000_000, resetAt: future(300), observedAt: '2026-01-01 00:00:00' });
     observe({ platform: 'cerebras', keyId: cerebrasB, pool: 'cerebras::shared', metric: 'tokens', limit: 30_000_000, remaining: 8_000_000, resetAt: future(180), observedAt: '2026-01-03 00:00:00' });
   });
 
-  it('reports one row per pool with a single deduped budget', async () => {
+  it('reports independent Groq model pools without collapsing their budgets', async () => {
     const { status, body } = await get(app, '/api/free-tier');
     expect(status).toBe(200);
 
-    const groq = body.pools.find((p: any) => p.poolKey === 'groq::account');
-    expect(groq).toBeDefined();
-    // Three models, ONE budget: the largest label in the pool (~15M), scaled by
-    // the single usable key — not 6M + 15M + 6M.
-    expect(groq.modelCount).toBe(3);
-    expect(groq.documentedBudget).toBe(15_000_000);
+    const groq = body.pools.filter((p: any) => p.platform === 'groq');
+    expect(groq).toHaveLength(3);
+    expect(groq.map((p: any) => p.modelCount)).toEqual([1, 1, 1]);
+    expect(groq.reduce((sum: number, p: any) => sum + p.documentedBudget, 0)).toBe(27_000_000);
     expect(body.summary.poolCount).toBe(body.pools.length);
   });
 
@@ -121,12 +122,12 @@ describe('free-tier pool overview (#905)', () => {
     // Two healthy keys = two accounts = twice the documented ~30M allowance.
     expect(cerebras.keyCount).toBe(2);
     expect(cerebras.documentedBudget).toBe(60_000_000);
-    expect(body.summary.documentedMonthlyTokens).toBe(60_000_000 + 15_000_000);
+    expect(body.summary.documentedMonthlyTokens).toBe(60_000_000 + 27_000_000);
   });
 
   it('prefers the tokens observation over a newer requests one and always names the metric', async () => {
     const { body } = await get(app, '/api/free-tier');
-    const groq = body.pools.find((p: any) => p.poolKey === 'groq::account');
+    const groq = body.pools.find((p: any) => p.poolKey === `groq::model::${groqModelIds[1]}`);
     expect(groq.quota.metric).toBe('tokens');
     expect(groq.quota.remaining).toBe(12_400_000);
     expect(groq.quota.limit).toBe(15_000_000);
@@ -148,28 +149,26 @@ describe('free-tier pool overview (#905)', () => {
 
   it('keeps chain-disabled rows in the pool but marks them', async () => {
     const { body } = await get(app, '/api/free-tier');
-    const groq = body.pools.find((p: any) => p.poolKey === 'groq::account');
-    expect(groq.modelCount).toBe(3);
-    expect(groq.disabledModelCount).toBe(1);
-    // The disabled row does not reduce the pool's documented budget.
-    expect(groq.documentedBudget).toBe(15_000_000);
+    const disabledGroq = body.pools.find((p: any) => p.poolKey === `groq::model::${groqModelIds[2]}`);
+    expect(disabledGroq.modelCount).toBe(1);
+    expect(disabledGroq.disabledModelCount).toBe(1);
+    expect(disabledGroq.documentedBudget).toBe(6_000_000);
   });
 
   it('names the models in each pool so the legend can group its rows', async () => {
     const { body } = await get(app, '/api/free-tier');
-    const groq = body.pools.find((p: any) => p.poolKey === 'groq::account');
-    // The legend joins its own per-model rows on platform + model id, so the
-    // pool has to name its members; the count has to agree with modelCount, and
-    // the chain-disabled row is a member like any other.
-    expect(groq.memberModelIds).toHaveLength(groq.modelCount);
-    expect(new Set(groq.memberModelIds).size).toBe(groq.modelCount);
+    const groqPools = body.pools.filter((p: any) => p.platform === 'groq');
+    for (const pool of groqPools) {
+      expect(pool.memberModelIds).toHaveLength(1);
+      expect(pool.memberModelIds).toHaveLength(pool.modelCount);
+    }
 
     const usage = await get(app, '/api/fallback/token-usage');
     const chainIds = (usage.body.models as any[])
       .filter(m => m.platform === 'groq')
       .map(m => m.modelId)
       .sort();
-    expect([...groq.memberModelIds].sort()).toEqual(chainIds);
+    expect(groqPools.flatMap((pool: any) => pool.memberModelIds).sort()).toEqual(chainIds);
 
     // Every model of every pool maps back to exactly one pool: the join the
     // legend does cannot put one row under two headers.

--- a/server/src/__tests__/routes/keys-model-scope.test.ts
+++ b/server/src/__tests__/routes/keys-model-scope.test.ts
@@ -101,9 +101,35 @@ describe('Keys API — model scope', () => {
     expect(list.body.find((k: any) => k.id === id).modelScope).toEqual(['m1']);
   });
 
+  it('persists and surfaces per-account provider limits independently', async () => {
+    const id = insertKey();
+    const patch = await request(app, 'PATCH', `/api/keys/${id}`, {
+      providerRpmLimit: 30,
+      providerRpdLimit: 750,
+      providerTpdLimit: 125000,
+    });
+    expect(patch.status).toBe(200);
+
+    const list = await request(app, 'GET', '/api/keys');
+    const key = list.body.find((candidate: any) => candidate.id === id);
+    expect(key).toMatchObject({
+      providerRpmLimit: 30,
+      providerRpdLimit: 750,
+      providerTpdLimit: 125000,
+    });
+
+    const clear = await request(app, 'PATCH', `/api/keys/${id}`, {
+      providerRpmLimit: null,
+      providerRpdLimit: 0,
+      providerTpdLimit: null,
+    });
+    expect(clear.status).toBe(200);
+    expect(clear.body).toMatchObject({ providerRpmLimit: null, providerRpdLimit: 0, providerTpdLimit: null });
+  });
+
   it('rejects malformed payloads', async () => {
     const id = insertKey();
-    for (const modelScope of ['not-an-array', [''], [42], [{ id: 'x' }], ['x'.repeat(201)], Array.from({ length: 101 }, (_, i) => `m${i}`)]) {
+    for (const modelScope of ['not-an-array', [''], [42], [{ id: 'x' }], ['x'.repeat(201)], Array.from({ length: 501 }, (_, i) => `m${i}`)]) {
       const patch = await request(app, 'PATCH', `/api/keys/${id}`, { modelScope });
       expect(patch.status, JSON.stringify(modelScope).slice(0, 60)).toBe(400);
     }

--- a/server/src/__tests__/routes/proxy-model-groups.test.ts
+++ b/server/src/__tests__/routes/proxy-model-groups.test.ts
@@ -3,7 +3,7 @@ import type { Express } from 'express';
 import { createApp } from '../../app.js';
 import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
 import { encrypt } from '../../lib/crypto.js';
-import { setUnifyEnabled, setUnifyOverrides } from '../../services/model-groups.js';
+import { setUnifyEnabled, setUnifyOverrides, setProviderPreferences } from '../../services/model-groups.js';
 import { setRoutingStrategy } from '../../services/router.js';
 import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 
@@ -82,8 +82,11 @@ describe('Model unification (group the same model across providers)', () => {
     db.prepare('DELETE FROM api_keys').run();
     db.prepare('DELETE FROM rate_limit_cooldowns').run();
     db.prepare('DELETE FROM rate_limit_usage').run();
+    db.prepare('DELETE FROM provider_quota_state').run();
+    db.prepare('DELETE FROM provider_quota_observations').run();
     setUnifyEnabled(true);
     setUnifyOverrides({ merges: [], splits: [] });
+    setProviderPreferences({ version: 1, groups: {} });
     setRoutingStrategy('priority');
     addModel('groq', 'tum-groq', 'Test Unify Model', 1);
     addModel('cerebras', 'tum-cerebras', 'Test Unify Model', 2);
@@ -264,6 +267,98 @@ describe('Model unification (group the same model across providers)', () => {
     expect(undo.status).toBe(200);
     const after = await request(app, 'GET', '/v1/models', undefined, authHeaders());
     expect(after.body.data.filter((m: any) => m.name === 'Test Unify Model')).toHaveLength(1);
+  });
+
+  it('persists preferred provider order and uses it without changing the unified model id', async () => {
+    const put = await request(app, 'PUT', '/api/settings/unify', {
+      providerPreferences: {
+        version: 1,
+        groups: {
+          'test unify model': {
+            mode: 'preferred',
+            memberOrder: ['cerebras:tum-cerebras', 'groq:tum-groq'],
+          },
+        },
+      },
+    });
+    expect(put.status).toBe(200);
+    expect(put.body.providerPreferences.groups['test unify model'].memberOrder)
+      .toEqual(['cerebras:tum-cerebras', 'groq:tum-groq']);
+
+    const orig = globalThis.fetch;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any, init: any) => {
+      if (String(url).includes('localhost') || String(url).includes('127.0.0.1')) return orig(url, init);
+      if (String(url).includes('api.cerebras.ai')) return completion('tum-cerebras', 'preferred');
+      return completion('tum-groq', 'automatic');
+    });
+
+    const response = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'test-unify-model',
+      messages: [{ role: 'user', content: 'hi' }],
+    }, authHeaders());
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-routed-via')).toContain('cerebras');
+  });
+
+  it('preferred order still fails over when the first provider is unavailable', async () => {
+    setProviderPreferences({
+      version: 1,
+      groups: {
+        'test unify model': {
+          mode: 'preferred',
+          memberOrder: ['cerebras:tum-cerebras', 'groq:tum-groq'],
+        },
+      },
+    });
+    getDb().prepare("UPDATE api_keys SET enabled = 0 WHERE platform = 'cerebras'").run();
+
+    const orig = globalThis.fetch;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any, init: any) => {
+      if (String(url).includes('localhost') || String(url).includes('127.0.0.1')) return orig(url, init);
+      return completion('tum-groq', 'fallback');
+    });
+
+    const response = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'test-unify-model',
+      messages: [{ role: 'user', content: 'hi' }],
+    }, authHeaders());
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-routed-via')).toContain('groq');
+  });
+
+  it('preferred order skips a provider whose applicable quota pool is known exhausted', async () => {
+    setProviderPreferences({
+      version: 1,
+      groups: {
+        'test unify model': {
+          mode: 'preferred',
+          memberOrder: ['cerebras:tum-cerebras', 'groq:tum-groq'],
+        },
+      },
+    });
+    const key = getDb().prepare("SELECT id FROM api_keys WHERE platform = 'cerebras'").get() as { id: number };
+    getDb().prepare(`
+      INSERT INTO provider_quota_state
+        (platform, key_id, quota_pool_key, metric, limit_value, remaining_value, reset_at, source, confidence)
+      VALUES ('cerebras', ?, 'cerebras::shared', 'requests', 30, 0, ?, 'header', 1)
+    `).run(key.id, new Date(Date.now() + 60_000).toISOString());
+
+    const upstreams: string[] = [];
+    const orig = globalThis.fetch;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url: any, init: any) => {
+      const target = String(url);
+      if (target.includes('localhost') || target.includes('127.0.0.1')) return orig(url, init);
+      upstreams.push(target);
+      return completion('tum-groq', 'quota fallback');
+    });
+
+    const response = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'test-unify-model',
+      messages: [{ role: 'user', content: 'hi' }],
+    }, authHeaders());
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-routed-via')).toContain('groq');
+    expect(upstreams.some(url => url.includes('api.cerebras.ai'))).toBe(false);
   });
 
   it('unification is always on: the toggle was removed, so /v1/models stays collapsed even after setUnifyEnabled(false)', async () => {

--- a/server/src/__tests__/routes/routing-semantics.test.ts
+++ b/server/src/__tests__/routes/routing-semantics.test.ts
@@ -290,11 +290,11 @@ describe('key selection by remaining quota (#919)', () => {
     expect(picks).toEqual([first, second, first]);
   });
 
-  it('does not reorder keys on an account-scoped quota pool', () => {
+  it('orders distinct provider accounts by their observed shared-pool headroom', () => {
     clearChain();
-    // groq pools every key of the account into one budget ('groq::account'), so
-    // per-key headroom is the same number for all of them and reordering would
-    // only churn the rotation.
+    // Each configured credential represents a distinct account. A pool may be
+    // shared across models inside one account, but headroom still differs
+    // between accounts and the roomier credential should win.
     const firstKey = addKey('groq', 'first');
     const secondKey = addKey('groq', 'second');
     observeQuota('groq', firstKey, 'groq::account', 10);
@@ -304,10 +304,10 @@ describe('key selection by remaining quota (#919)', () => {
 
     const routed = routeRequest(100);
     routed.release?.();
-    expect(routed.keyId).toBe(firstKey);
+    expect(routed.keyId).toBe(secondKey);
   });
 
-  it('still confines a custom model to its own endpoint\'s keys', () => {
+  it('keeps local custom endpoints unmetered and confined to their own keys', () => {
     clearChain();
     const endpointA = 'http://127.0.0.1:11434/v1';
     const endpointB = 'http://127.0.0.1:8080/v1';
@@ -325,7 +325,11 @@ describe('key selection by remaining quota (#919)', () => {
     const routed = routeRequest(100);
     routed.release?.();
     expect(routed.platform).toBe('custom');
-    expect(routed.keyId).toBe(aRoomy);
+    // Loopback inference is unmetered: quota observations must not reorder its
+    // normal rotation. Endpoint isolation still excludes the even-roomier key
+    // belonging to endpoint B.
+    expect(routed.keyId).toBe(aDrained);
+    expect(routed.keyId).not.toBe(aRoomy);
     expect(routed.keyId).not.toBe(bRoomiest);
   });
 

--- a/server/src/__tests__/services/provider-minute-cap.test.ts
+++ b/server/src/__tests__/services/provider-minute-cap.test.ts
@@ -45,6 +45,18 @@ describe('provider-wide per-minute request cap', () => {
     expect(getProviderMinuteRequestCap('nvidia')).toBeNull();
   });
 
+  it('uses a per-account override ahead of provider defaults and env settings', () => {
+    process.env.PROVIDER_MINUTE_REQUEST_CAP_NVIDIA = '5';
+    const row = getDb().prepare(`
+      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, provider_rpm_limit)
+      VALUES ('nvidia', 'account', 'x', 'x', 'x', 'healthy', 1, 12)
+    `).run();
+    const id = Number(row.lastInsertRowid);
+    expect(getProviderMinuteRequestCap('nvidia', id)).toBe(12);
+    getDb().prepare('UPDATE api_keys SET provider_rpm_limit = 0 WHERE id = ?').run(id);
+    expect(getProviderMinuteRequestCap('nvidia', id)).toBeNull();
+  });
+
   it('sums usage across every model on the same account+key', () => {
     const now = Date.now();
     // The whole point: three different models, one shared budget.

--- a/server/src/__tests__/services/provider-quota.test.ts
+++ b/server/src/__tests__/services/provider-quota.test.ts
@@ -5,6 +5,10 @@ import {
   getQuotaStateForKeys,
   parseQuotaObservationsFromResponse,
   inferQuotaPoolKey,
+  resolveQuotaPolicy,
+  isQuotaPoolAvailable,
+  getKeyQuotaHeadroom,
+  invalidateKeyQuotaHeadroom,
 } from '../../services/provider-quota.js';
 import { pruneQuotaObservations } from '../../services/request-retention.js';
 
@@ -19,9 +23,12 @@ function insertState(row: {
 }) {
   getDb().prepare(`
     INSERT INTO provider_quota_state
-      (platform, key_id, quota_pool_key, metric, limit_value, remaining_value, reset_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+      (platform, key_id, quota_pool_key, metric, limit_value, remaining_value, reset_at, source, confidence)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'header', 1)
   `).run(row.platform, row.keyId, row.pool, row.metric, row.limit, row.remaining, row.resetAt);
+  // Production writes go through recordQuotaObservation, which performs this
+  // invalidation. Direct fixture inserts must preserve the same boundary.
+  invalidateKeyQuotaHeadroom(row.platform as any);
 }
 
 function readState(platform: string, keyId: number, pool: string, metric: string) {
@@ -38,10 +45,15 @@ describe('provider-quota: pool inference', () => {
     initDb(':memory:');
   });
 
-  it('buckets shared-pool providers per account and openrouter free vs account', () => {
-    expect(inferQuotaPoolKey('groq')).toBe('groq::account');
+  it('distinguishes shared pools from independent model pools', () => {
+    expect(inferQuotaPoolKey('groq', 'openai/gpt-oss-120b')).toBe('groq::model::openai/gpt-oss-120b');
+    expect(inferQuotaPoolKey('groq', 'qwen/qwen3-32b')).toBe('groq::model::qwen/qwen3-32b');
+    expect(inferQuotaPoolKey('google', 'gemini-2.5-flash')).toBe('google::project-model::gemini-2.5-flash');
     expect(inferQuotaPoolKey('openrouter', 'meta-llama/llama-3.1-8b-instruct:free')).toBe('openrouter::free');
+    expect(inferQuotaPoolKey('openrouter', 'qwen/qwen3:free')).toBe('openrouter::free');
     expect(inferQuotaPoolKey('openrouter', 'openai/gpt-4o')).toBe('openrouter::account');
+    expect(inferQuotaPoolKey('huggingface', 'openai/gpt-oss-120b')).toBe('huggingface::router');
+    expect(inferQuotaPoolKey('custom', 'remote-model', 'https://relay.example/v1')).toBe('custom::remote-model');
     // AnyAPI's 100K tokens/day is one account-wide budget, so every model on
     // the platform shares a single pool.
     expect(inferQuotaPoolKey('anyapi')).toBe('anyapi::free');
@@ -49,6 +61,90 @@ describe('provider-quota: pool inference', () => {
     // Unknown platform falls back to platform::model or platform::account.
     expect(inferQuotaPoolKey('acme' as any, 'x')).toBe('acme::x');
     expect(inferQuotaPoolKey('acme' as any)).toBe('acme::account');
+  });
+
+  it('describes quota economics without conflating scope and accounting', () => {
+    expect(resolveQuotaPolicy('openrouter', 'qwen/qwen3:free')).toMatchObject({
+      scope: 'shared_pool', accounting: 'metered', metrics: ['requests'],
+    });
+    expect(resolveQuotaPolicy('groq', 'openai/gpt-oss-120b')).toMatchObject({
+      scope: 'model', accounting: 'metered', metrics: ['requests', 'tokens'],
+    });
+    expect(resolveQuotaPolicy('google', 'gemini-2.5-flash')).toMatchObject({
+      scope: 'project', accounting: 'metered', metrics: ['requests', 'tokens'],
+    });
+    expect(resolveQuotaPolicy('huggingface', 'openai/gpt-oss-120b')).toMatchObject({
+      scope: 'shared_pool', accounting: 'metered', metrics: ['credits'],
+    });
+    expect(resolveQuotaPolicy('sail', 'zai-org/GLM-5.2-FP8')).toMatchObject({
+      poolKey: 'sail::monthly-credit',
+      scope: 'shared_pool',
+      accounting: 'metered',
+      metrics: ['credits'],
+      reset: { strategy: 'fixed_calendar', period: 'month' },
+    });
+    expect(resolveQuotaPolicy('opencode', 'nemotron-3-ultra-free')).toMatchObject({
+      accounting: 'unknown', reset: { strategy: 'unknown' },
+    });
+    expect(resolveQuotaPolicy('custom', 'llama3', 'http://127.0.0.1:11434/v1')).toMatchObject({
+      accounting: 'unmetered', metrics: [],
+    });
+  });
+});
+
+describe('provider-quota: routing eligibility', () => {
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM provider_quota_state').run();
+    getDb().prepare('DELETE FROM provider_quota_observations').run();
+  });
+
+  it('shared OpenRouter exhaustion applies to every free model on the credential', () => {
+    const resetAt = new Date(Date.now() + 60_000).toISOString();
+    insertState({ platform: 'openrouter', keyId: 8, pool: 'openrouter::free', metric: 'requests', limit: 50, remaining: 0, resetAt });
+
+    expect(isQuotaPoolAvailable('openrouter', 8, 'qwen/qwen3:free')).toBe(false);
+    expect(isQuotaPoolAvailable('openrouter', 8, 'nvidia/nemotron:free')).toBe(false);
+  });
+
+  it('Groq model exhaustion does not suppress another model on the same credential', () => {
+    const resetAt = new Date(Date.now() + 60_000).toISOString();
+    insertState({ platform: 'groq', keyId: 9, pool: 'groq::model::model-a', metric: 'requests', limit: 100, remaining: 0, resetAt });
+
+    expect(isQuotaPoolAvailable('groq', 9, 'model-a')).toBe(false);
+    expect(isQuotaPoolAvailable('groq', 9, 'model-b')).toBe(true);
+  });
+
+  it('headroom is calculated for the applicable pool rather than the provider-wide worst pool', () => {
+    const resetAt = new Date(Date.now() + 60_000).toISOString();
+    insertState({ platform: 'groq', keyId: 10, pool: 'groq::model::model-a', metric: 'requests', limit: 100, remaining: 0, resetAt });
+    insertState({ platform: 'groq', keyId: 10, pool: 'groq::model::model-b', metric: 'requests', limit: 100, remaining: 80, resetAt });
+
+    expect(getKeyQuotaHeadroom('groq', 'groq::model::model-a').get(10)).toBe(0);
+    expect(getKeyQuotaHeadroom('groq', 'groq::model::model-b').get(10)).toBe(0.8);
+  });
+
+  it('reads legacy Groq account observations until exact model-pool data arrives', () => {
+    const resetAt = new Date(Date.now() + 60_000).toISOString();
+    insertState({ platform: 'groq', keyId: 11, pool: 'groq::account', metric: 'requests', limit: 100, remaining: 0, resetAt });
+
+    expect(isQuotaPoolAvailable('groq', 11, 'model-a')).toBe(false);
+    expect(getKeyQuotaHeadroom('groq', 'groq::model::model-a').get(11)).toBe(0);
+
+    insertState({ platform: 'groq', keyId: 11, pool: 'groq::model::model-a', metric: 'requests', limit: 100, remaining: 75, resetAt });
+    expect(isQuotaPoolAvailable('groq', 11, 'model-a')).toBe(true);
+    expect(getKeyQuotaHeadroom('groq', 'groq::model::model-a').get(11)).toBe(0.75);
+  });
+
+  it('reads legacy Google project exhaustion for a project/model pool', () => {
+    const resetAt = new Date(Date.now() + 60_000).toISOString();
+    insertState({ platform: 'google', keyId: 12, pool: 'google::project', metric: 'requests', limit: 20, remaining: 0, resetAt });
+
+    expect(isQuotaPoolAvailable('google', 12, 'gemini-2.5-flash')).toBe(false);
   });
 });
 

--- a/server/src/__tests__/services/ratelimit.test.ts
+++ b/server/src/__tests__/services/ratelimit.test.ts
@@ -306,6 +306,19 @@ describe('Rate Limiter', () => {
       recordRequest('openrouter', 'model-c', testId);
       expect(canUseProvider('openrouter', testId)).toBe(false); // 3 >= 3
     });
+
+    it('applies a per-account RPD override before the platform default', () => {
+      initDb(':memory:');
+      const key = getDb().prepare(`
+        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, provider_rpd_limit)
+        VALUES ('openrouter', 'limited', 'x', 'x', 'x', 'healthy', 1, 2)
+      `).run();
+      const keyId = Number(key.lastInsertRowid);
+      recordRequest('openrouter', 'model-a', keyId);
+      expect(canUseProvider('openrouter', keyId)).toBe(true);
+      recordRequest('openrouter', 'model-b', keyId);
+      expect(canUseProvider('openrouter', keyId)).toBe(false);
+    });
   });
 
   describe('provider-wide daily token cap (NavyAI)', () => {
@@ -377,6 +390,17 @@ describe('Rate Limiter', () => {
 
       expect(canUseProviderTokens('navy', testId, 'gemini-2.5-flash', 400)).toBe(true);
       expect(canUseProviderTokens('navy', testId, 'gemini-2.5-flash', 600)).toBe(false);
+    });
+
+    it('applies a per-account TPD override independently of the model cap', () => {
+      const key = getDb().prepare(`
+        INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled, provider_tpd_limit)
+        VALUES ('groq', 'limited', 'x', 'x', 'x', 'healthy', 1, 100)
+      `).run();
+      const keyId = Number(key.lastInsertRowid);
+      recordTokens('groq', 'model-a', keyId, 90);
+      expect(canUseProviderTokens('groq', keyId, 'model-b', 10)).toBe(true);
+      expect(canUseProviderTokens('groq', keyId, 'model-b', 11)).toBe(false);
     });
   });
 });

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -30,6 +30,7 @@ import * as profileAutoInclude from '../migrations/20260823_000004_profile_auto_
 import * as idempotencyClaims from '../migrations/20260901_000001_idempotency_claims.js';
 import * as quotaObservationLookup from '../migrations/20260901_000002_quota_observation_lookup.js';
 import * as analyticsLatencyPercentileIndex from '../migrations/20260902_000001_analytics_latency_percentile_index.js';
+import * as providerAccountLimits from '../migrations/20260902_000002_provider_account_limits.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -72,6 +73,7 @@ export const PROFILE_AUTO_INCLUDE_FILENAME = '20260823_000004_profile_auto_inclu
 export const IDEMPOTENCY_CLAIMS_FILENAME = '20260901_000001_idempotency_claims.ts';
 export const QUOTA_OBSERVATION_LOOKUP_FILENAME = '20260901_000002_quota_observation_lookup.ts';
 export const ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME = '20260902_000001_analytics_latency_percentile_index.ts';
+export const PROVIDER_ACCOUNT_LIMITS_FILENAME = '20260902_000002_provider_account_limits.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -105,4 +107,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: IDEMPOTENCY_CLAIMS_FILENAME, module: idempotencyClaims },
   { filename: QUOTA_OBSERVATION_LOOKUP_FILENAME, module: quotaObservationLookup },
   { filename: ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME, module: analyticsLatencyPercentileIndex },
+  { filename: PROVIDER_ACCOUNT_LIMITS_FILENAME, module: providerAccountLimits },
 ];

--- a/server/src/db/migrations/20260902_000002_provider_account_limits.ts
+++ b/server/src/db/migrations/20260902_000002_provider_account_limits.ts
@@ -1,0 +1,24 @@
+import type { Db } from '../types.js';
+
+const COLUMNS = [
+  ['provider_rpm_limit', 'INTEGER'],
+  ['provider_rpd_limit', 'INTEGER'],
+  ['provider_tpd_limit', 'INTEGER'],
+] as const;
+
+function hasColumn(db: Db, column: string): boolean {
+  const columns = db.prepare('PRAGMA table_info(api_keys)').all() as { name: string }[];
+  return columns.some(candidate => candidate.name === column);
+}
+
+export function up(db: Db): void {
+  for (const [column, type] of COLUMNS) {
+    if (!hasColumn(db, column)) db.prepare(`ALTER TABLE api_keys ADD COLUMN ${column} ${type}`).run();
+  }
+}
+
+export function down(db: Db): void {
+  for (const [column] of [...COLUMNS].reverse()) {
+    if (hasColumn(db, column)) db.prepare(`ALTER TABLE api_keys DROP COLUMN ${column}`).run();
+  }
+}

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -29,6 +29,8 @@ import type { ReasoningEffort } from '../lib/sampling-params.js';
 import { buildModelListing } from '../services/model-listing.js';
 import { compressRequest, formatCompressionHeader } from '../services/compression/pipeline.js';
 import { normalizeMessageImages } from '../lib/image-normalize.js';
+import { inferQuotaPoolKey, type QuotaObservationContext } from '../services/provider-quota.js';
+import type { Platform } from '@freellmapi/shared/types.js';
 
 // Anthropic-compatible Messages API (`POST /v1/messages`). This is a thin
 // translation layer over the SAME router/fallback/analytics machinery the
@@ -49,6 +51,17 @@ const MAX_RETRIES = 20;
 // default when a client somehow omits it.
 const DEFAULT_MAX_TOKENS = 1024;
 const IMAGE_TOKEN_ESTIMATE = 1000;
+
+function quotaContextForRoute(route: RouteResult, endpoint: string): QuotaObservationContext {
+  return {
+    platform: route.platform as Platform,
+    keyId: route.keyId,
+    modelId: route.modelId,
+    quotaPoolKey: inferQuotaPoolKey(route.platform as Platform, route.modelId, route.providerBaseUrl),
+    endpoint,
+    origin: 'proxy',
+  };
+}
 
 // ── Request schema ──────────────────────────────────────────────────────────
 // Permissive on purpose: the Anthropic content-block vocabulary grows over
@@ -630,7 +643,13 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
         }
       }
 
-      const result = await route.provider.chatCompletion(route.apiKey, messages, route.modelId, dispatchOptions);
+      const result = await route.provider.chatCompletion(
+        route.apiKey,
+        messages,
+        route.modelId,
+        dispatchOptions,
+        quotaContextForRoute(route, 'messages'),
+      );
       const respMsg = result.choices?.[0]?.message;
       const respText = contentToString(respMsg?.content ?? '');
       let respToolCalls = respMsg?.tool_calls ?? [];
@@ -844,7 +863,13 @@ async function streamCompletion(
   };
 
   try {
-    const gen = route.provider.streamChatCompletion(route.apiKey, messages, route.modelId, options);
+    const gen = route.provider.streamChatCompletion(
+      route.apiKey,
+      messages,
+      route.modelId,
+      options,
+      quotaContextForRoute(route, 'messages'),
+    );
 
     for await (const chunk of gen) {
       if (ctx.clientGone()) break; // client hung up: stop pulling; reader.cancel() aborts upstream

--- a/server/src/routes/keys.ts
+++ b/server/src/routes/keys.ts
@@ -73,11 +73,15 @@ const addKeySchema = z.object({
 const updateKeySchema = z.object({
   enabled: z.boolean().optional(),
   label: z.string().optional(),
-  modelScope: z.array(z.string().trim().min(1).max(200)).max(100).nullable().optional(),
+  modelScope: z.array(z.string().trim().min(1).max(200)).max(500).nullable().optional(),
   // #590: '' clears the per-key proxy; absent leaves it unchanged.
   proxyUrl: proxyUrlSchema.optional(),
-}).refine(data => data.enabled !== undefined || data.label !== undefined || data.modelScope !== undefined || data.proxyUrl !== undefined, {
-  message: 'At least one of enabled, label, modelScope or proxyUrl must be provided',
+  providerRpmLimit: z.number().int().min(0).nullable().optional(),
+  providerRpdLimit: z.number().int().min(0).nullable().optional(),
+  providerTpdLimit: z.number().int().min(0).nullable().optional(),
+}).refine(data => data.enabled !== undefined || data.label !== undefined || data.modelScope !== undefined || data.proxyUrl !== undefined
+  || data.providerRpmLimit !== undefined || data.providerRpdLimit !== undefined || data.providerTpdLimit !== undefined, {
+  message: 'At least one key setting must be provided',
 });
 
 const importKeySchema = z.object({
@@ -326,6 +330,9 @@ keysRouter.get('/', (_req: Request, res: Response) => {
       lastHealthError: row.last_health_error ?? null,
       // The model_id list this key is limited to; null = serves everything (#657).
       modelScope: scope ? [...scope] : null,
+      providerRpmLimit: row.provider_rpm_limit ?? null,
+      providerRpdLimit: row.provider_rpd_limit ?? null,
+      providerTpdLimit: row.provider_tpd_limit ?? null,
       // The per-key proxy override with its password masked (#590). '' = no
       // override. Enough for the dashboard to show that a key routes through
       // its own exit, without handing the proxy credentials back out.
@@ -1512,7 +1519,7 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     return;
   }
 
-  const { enabled, label, modelScope, proxyUrl } = parsed.data;
+  const { enabled, label, modelScope, proxyUrl, providerRpmLimit, providerRpdLimit, providerTpdLimit } = parsed.data;
   const updates: string[] = [];
   const values: (string | number | null)[] = [];
 
@@ -1537,6 +1544,16 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
     updates.push('model_scope_json = ?');
     values.push(scopeIds.length > 0 ? JSON.stringify(scopeIds) : null);
   }
+  for (const [column, value] of [
+    ['provider_rpm_limit', providerRpmLimit],
+    ['provider_rpd_limit', providerRpdLimit],
+    ['provider_tpd_limit', providerTpdLimit],
+  ] as const) {
+    if (value !== undefined) {
+      updates.push(`${column} = ?`);
+      values.push(value);
+    }
+  }
 
   values.push(id);
 
@@ -1553,5 +1570,8 @@ keysRouter.patch('/:id', (req: Request, res: Response) => {
   if (label !== undefined) response.label = label;
   if (proxyUrl !== undefined) response.maskedProxyUrl = maskProxyUrl(proxyUrl);
   if (modelScope !== undefined) response.modelScope = scopeIds.length > 0 ? scopeIds : null;
+  if (providerRpmLimit !== undefined) response.providerRpmLimit = providerRpmLimit;
+  if (providerRpdLimit !== undefined) response.providerRpdLimit = providerRpdLimit;
+  if (providerTpdLimit !== undefined) response.providerTpdLimit = providerTpdLimit;
   res.json(response);
 });

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -89,7 +89,7 @@ function quotaContextForRoute(route: RouteResult, endpoint: string): QuotaObserv
     platform: route.platform as Platform,
     keyId: route.keyId,
     modelId: route.modelId,
-    quotaPoolKey: inferQuotaPoolKey(route.platform as Platform, route.modelId),
+    quotaPoolKey: inferQuotaPoolKey(route.platform as Platform, route.modelId, route.providerBaseUrl),
     endpoint,
     origin: 'proxy',
   };

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -503,7 +503,7 @@ function quotaContextForRoute(route: RouteResult, endpoint: string): QuotaObserv
     platform: route.platform as Platform,
     keyId: route.keyId,
     modelId: route.modelId,
-    quotaPoolKey: inferQuotaPoolKey(route.platform as Platform, route.modelId),
+    quotaPoolKey: inferQuotaPoolKey(route.platform as Platform, route.modelId, route.providerBaseUrl),
     endpoint,
     origin: 'responses',
   };

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -6,7 +6,7 @@ import { getProvider } from '../providers/index.js';
 import type { Platform } from '@freellmapi/shared/types.js';
 import type { ProxyMode } from '@freellmapi/shared/types.js';
 import { getSavedFusionConfig, setSavedFusionConfig, savedFusionConfigSchema, getFusionMaxK } from '../services/fusion.js';
-import { isUnifyEnabled, setUnifyEnabled, getUnifyOverrides, setUnifyOverrides, unifyOverridesSchema } from '../services/model-groups.js';
+import { isUnifyEnabled, setUnifyEnabled, getUnifyOverrides, setUnifyOverrides, unifyOverridesSchema, getProviderPreferences, setProviderPreferences, providerPreferencesSchema } from '../services/model-groups.js';
 import { getClaudeModelMap, setClaudeModelMap } from '../services/anthropic-map.js';
 import { getGeminiModelMap, setGeminiModelMap } from '../services/gemini-map.js';
 import { getOllamaEmulationMode } from './ollama.js';
@@ -91,12 +91,13 @@ settingsRouter.put('/compression', (req: Request, res: Response) => {
 // merge/split overrides. Governs the dashboard grouping, /v1/models grouping,
 // and cross-provider pin failover.
 settingsRouter.get('/unify', (_req: Request, res: Response) => {
-  res.json({ enabled: isUnifyEnabled(), overrides: getUnifyOverrides() });
+  res.json({ enabled: isUnifyEnabled(), overrides: getUnifyOverrides(), providerPreferences: getProviderPreferences() });
 });
 
 const unifyPutSchema = z.object({
   enabled: z.boolean().optional(),
   overrides: unifyOverridesSchema.optional(),
+  providerPreferences: providerPreferencesSchema.optional(),
 });
 
 // Update the unify toggle and/or overrides. Partial: send just `enabled` to
@@ -110,7 +111,8 @@ settingsRouter.put('/unify', (req: Request, res: Response) => {
   }
   if (parsed.data.enabled !== undefined) setUnifyEnabled(parsed.data.enabled);
   if (parsed.data.overrides) setUnifyOverrides(parsed.data.overrides);
-  res.json({ enabled: isUnifyEnabled(), overrides: getUnifyOverrides() });
+  if (parsed.data.providerPreferences) setProviderPreferences(parsed.data.providerPreferences);
+  res.json({ enabled: isUnifyEnabled(), overrides: getUnifyOverrides(), providerPreferences: getProviderPreferences() });
 });
 
 // Get the saved fusion default config (panel mode, models, judge, k, strategy).

--- a/server/src/services/model-groups.ts
+++ b/server/src/services/model-groups.ts
@@ -24,6 +24,7 @@ import {
 // ── Settings keys ────────────────────────────────────────────────────────────
 export const UNIFY_ENABLED_KEY = 'unify_models_enabled';
 export const UNIFY_OVERRIDES_KEY = 'model_unify_overrides';
+export const PROVIDER_PREFERENCES_KEY = 'model_provider_preferences';
 
 export const unifyOverridesSchema = z.object({
   // Coalesce several grouping tokens into one group keyed by `into`. Each key is
@@ -42,7 +43,18 @@ export const unifyOverridesSchema = z.object({
 
 export type UnifyOverrides = z.infer<typeof unifyOverridesSchema>;
 
+export const providerPreferencesSchema = z.object({
+  version: z.literal(1).default(1),
+  groups: z.record(z.string().min(1), z.object({
+    mode: z.enum(['automatic', 'preferred']).default('automatic'),
+    memberOrder: z.array(z.string().min(1)).default([]),
+  })).default({}),
+}).default({ version: 1, groups: {} });
+
+export type ProviderPreferences = z.infer<typeof providerPreferencesSchema>;
+
 const EMPTY_OVERRIDES: UnifyOverrides = { merges: [], splits: [] };
+const EMPTY_PROVIDER_PREFERENCES: ProviderPreferences = { version: 1, groups: {} };
 
 // ── Types ────────────────────────────────────────────────────────────────────
 // The minimal row shape grouping needs. Catalog queries select more columns;
@@ -111,6 +123,22 @@ export function setUnifyOverrides(input: unknown): UnifyOverrides {
   return norm;
 }
 
+export function getProviderPreferences(): ProviderPreferences {
+  const raw = getSetting(PROVIDER_PREFERENCES_KEY);
+  if (!raw) return EMPTY_PROVIDER_PREFERENCES;
+  try {
+    const parsed = providerPreferencesSchema.safeParse(JSON.parse(raw));
+    if (parsed.success) return parsed.data;
+  } catch { /* corrupt JSON -> safe automatic routing */ }
+  return EMPTY_PROVIDER_PREFERENCES;
+}
+
+export function setProviderPreferences(input: unknown): ProviderPreferences {
+  const norm = providerPreferencesSchema.parse(input);
+  setSetting(PROVIDER_PREFERENCES_KEY, JSON.stringify(norm));
+  return norm;
+}
+
 // ── Normalization ────────────────────────────────────────────────────────────
 // Catalog display names tag the provider/variant in a trailing parenthetical:
 // "GPT-OSS 120B (Groq)", "Llama 3.3 70B (HF)", "... (free)". Strip ONE trailing
@@ -155,6 +183,11 @@ export function slugifyGroupLabel(label: string): string {
 // ── Grouping ─────────────────────────────────────────────────────────────────
 function memberId(row: GroupableRow): string {
   return `${row.platform}:${row.model_id}`;
+}
+
+/** Stable persisted identity for provider preference ordering. */
+export function routingMemberId(row: GroupableRow): string {
+  return qualifiedMemberId(row) ?? memberId(row);
 }
 
 /**

--- a/server/src/services/provider-quota.ts
+++ b/server/src/services/provider-quota.ts
@@ -10,7 +10,9 @@ import type {
   QuotaResetStrategy,
   ProviderQuotaObservation,
   ProviderQuotaState,
+  QuotaPolicy,
 } from '@freellmapi/shared/types.js';
+import { isLoopbackOrPrivateUrl } from '../lib/url-guard.js';
 
 export interface QuotaObservationContext {
   platform: Platform;
@@ -109,61 +111,108 @@ function pickBetterSource(existing: QuotaObservationSource | null | undefined, n
   return SOURCE_PRIORITY[next] >= SOURCE_PRIORITY[existing] ? next : existing;
 }
 
-function inferPoolForPlatform(platform: Platform, modelId?: string | null): string {
+function modelPool(platform: Platform, modelId?: string | null, prefix = 'model'): string {
   const normalizedModelId = modelId?.trim() ?? '';
-  if (platform === 'openrouter') return normalizedModelId.endsWith(':free') ? 'openrouter::free' : 'openrouter::account';
-  if (platform === 'google') return 'google::project';
-  if (platform === 'groq') return 'groq::account';
-  if (platform === 'cerebras') return 'cerebras::shared';
-  if (platform === 'sail') return 'sail::monthly-credit';
-  if (platform === 'bai') return 'bai::promo';
-  if (platform === 'sambanova') return 'sambanova::shared';
-  if (platform === 'nvidia') return 'nvidia::credit-pool';
-  if (platform === 'mistral') return 'mistral::experiment-pool';
-  if (platform === 'github') return 'github::account';
-  if (platform === 'cohere') return 'cohere::trial-pool';
-  if (platform === 'cloudflare') return 'cloudflare::account';
-  if (platform === 'zhipu') return 'zhipu::account';
-  if (platform === 'ollama') return 'ollama::cloud';
-  if (platform === 'kilo') return 'kilo::anonymous';
-  if (platform === 'pollinations') return 'pollinations::account';
-  if (platform === 'llm7') return 'llm7::anonymous';
+  return normalizedModelId ? `${platform}::${prefix}::${normalizedModelId}` : `${platform}::account`;
+}
+
+/** Pool names used before quota scope became explicit. Only providers whose
+ * corrected economics required a new identity need a read fallback. Once an
+ * exact new-pool observation exists for a key, it takes precedence. */
+function legacyPoolKey(platform: Platform, poolKey: string): string | null {
+  if (platform === 'groq' && poolKey.startsWith('groq::model::')) return 'groq::account';
+  if (platform === 'google' && poolKey.startsWith('google::project-model::')) return 'google::project';
+  return null;
+}
+
+/**
+ * Resolve quota economics for one provider endpoint. This is intentionally a
+ * small provider-knowledge table, not a cost optimiser: Phase 1 only needs a
+ * stable pool identity and enough metadata to avoid treating shared and
+ * independent allowances as the same thing.
+ */
+export function resolveQuotaPolicy(
+  platform: Platform,
+  modelId?: string | null,
+  endpoint?: string | null,
+): QuotaPolicy {
+  const normalizedModelId = modelId?.trim() ?? '';
+  const policy = (
+    poolKey: string,
+    scope: QuotaPolicy['scope'],
+    accounting: QuotaPolicy['accounting'],
+    metrics: QuotaPolicy['metrics'],
+    strategy: QuotaPolicy['reset']['strategy'] = 'unknown',
+    period?: QuotaPolicy['reset']['period'],
+  ): QuotaPolicy => ({ poolKey, scope, accounting, metrics, reset: { strategy, ...(period ? { period } : {}) } });
+
+  if (platform === 'custom' && endpoint && isLoopbackOrPrivateUrl(endpoint)) {
+    return policy(`custom::local::${endpoint}`, 'account', 'unmetered', []);
+  }
+  if (platform === 'openrouter') {
+    return normalizedModelId.endsWith(':free')
+      ? policy('openrouter::free', 'shared_pool', 'metered', ['requests'], 'provider_reported')
+      : policy('openrouter::account', 'account', 'metered', ['requests', 'tokens'], 'provider_reported');
+  }
+  // Groq publishes independent model limits at organisation/account level.
+  if (platform === 'groq') return policy(modelPool(platform, modelId), 'model', 'metered', ['requests', 'tokens'], 'provider_reported');
+  // The key identifies the Google project; the model suffix preserves each
+  // model's independently published project allowance.
+  if (platform === 'google') return policy(modelPool(platform, modelId, 'project-model'), 'project', 'metered', ['requests', 'tokens'], 'provider_reported');
+  if (platform === 'huggingface') return policy('huggingface::router', 'shared_pool', 'metered', ['credits'], 'provider_reported', 'month');
+  if (platform === 'opencode') return policy('opencode::promo', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'cerebras') return policy('cerebras::shared', 'shared_pool', 'metered', ['requests', 'tokens'], 'provider_reported');
+  if (platform === 'sail') return policy('sail::monthly-credit', 'shared_pool', 'metered', ['credits'], 'fixed_calendar', 'month');
+  if (platform === 'bai') return policy('bai::promo', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'sambanova') return policy('sambanova::shared', 'shared_pool', 'metered', ['requests', 'tokens'], 'provider_reported');
+  if (platform === 'nvidia') return policy('nvidia::credit-pool', 'shared_pool', 'metered', ['requests'], 'provider_reported');
+  if (platform === 'mistral') return policy('mistral::experiment-pool', 'shared_pool', 'metered', ['requests', 'tokens'], 'provider_reported');
+  if (platform === 'github') return policy('github::account', 'account', 'metered', ['requests'], 'provider_reported');
+  if (platform === 'cohere') return policy('cohere::trial-pool', 'shared_pool', 'metered', ['requests', 'tokens'], 'provider_reported');
+  if (platform === 'cloudflare') return policy('cloudflare::account', 'account', 'metered', ['neurons'], 'provider_reported');
+  if (platform === 'zhipu') return policy('zhipu::account', 'account', 'metered', ['tokens'], 'provider_reported');
+  if (platform === 'ollama') return policy('ollama::cloud', 'account', 'metered', ['requests'], 'provider_reported');
+  if (platform === 'kilo') return policy('kilo::anonymous', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'pollinations') return policy('pollinations::account', 'account', 'unknown', [], 'unknown');
+  if (platform === 'llm7') return policy('llm7::anonymous', 'shared_pool', 'unknown', [], 'unknown');
   // AI Horde: anonymous requests share one queue priority (the 0000000000 key),
   // so they pool together; a registered key has its own kudos priority but we
   // still bucket per-platform here.
-  if (platform === 'aihorde') return 'aihorde::anonymous';
-  if (platform === 'huggingface') return 'huggingface::router';
-  if (platform === 'opencode') return 'opencode::promo';
+  if (platform === 'aihorde') return policy('aihorde::anonymous', 'shared_pool', 'unknown', ['neurons'], 'unknown');
   // Aggregators with a single shared free pool across all ':free'/'auto:free' models.
-  if (platform === 'routeway') return 'routeway::free';
-  if (platform === 'bazaarlink') return 'bazaarlink::free';
-  if (platform === 'ainative') return 'ainative::account';
-  if (platform === 'aion') return 'aion::free';
-  if (platform === 'requesty') return 'requesty::free';
-  if (platform === 'navy') return 'navy::free';
-  if (platform === 'nara') return 'nara::free';
-  if (platform === 'sealion') return 'sealion::free';
+  if (platform === 'routeway') return policy('routeway::free', 'shared_pool', 'metered', ['requests'], 'provider_reported');
+  if (platform === 'bazaarlink') return policy('bazaarlink::free', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'ainative') return policy('ainative::account', 'account', 'metered', ['tokens'], 'provider_reported', 'month');
+  if (platform === 'aion') return policy('aion::free', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'requesty') return policy('requesty::free', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'navy') return policy('navy::free', 'shared_pool', 'metered', ['tokens'], 'fixed_calendar', 'day');
+  if (platform === 'nara') return policy('nara::free', 'shared_pool', 'unknown', [], 'unknown');
+  if (platform === 'sealion') return policy('sealion::free', 'shared_pool', 'metered', ['requests'], 'provider_reported');
   // OrcaRouter: one rate-limited free allowance across all `*-free` aliases
   // and the `orcarouter/free` auto route (limits unpublished; 429 on cap).
-  if (platform === 'orcarouter') return 'orcarouter::free';
+  if (platform === 'orcarouter') return policy('orcarouter::free', 'shared_pool', 'unknown', [], 'unknown');
   // UnoRouter: the docs say 1 req/min per free model, but live-probed
   // 2026-08-23 a burst across many `:free` models put the whole account into
   // 429 on every model for several minutes — so one pool, and a 429 on any
   // model backs off the platform as a whole.
-  if (platform === 'unorouter') return 'unorouter::free';
+  if (platform === 'unorouter') return policy('unorouter::free', 'shared_pool', 'metered', ['requests'], 'provider_reported');
   // xkiro: one account-level allowance shared across its free models (the
   // free tier is a per-account grant, not per-model), so one pool.
-  if (platform === 'xkiro') return 'xkiro::free';
+  if (platform === 'xkiro') return policy('xkiro::free', 'shared_pool', 'metered', ['tokens'], 'fixed_calendar', 'day');
   // AnyAPI: the free tier is one 100K-tokens/day budget for the whole account,
   // shared across every free/basic model — so one pool, not one per model.
-  if (platform === 'anyapi') return 'anyapi::free';
+  if (platform === 'anyapi') return policy('anyapi::free', 'shared_pool', 'metered', ['tokens'], 'fixed_calendar', 'day');
   // ModelScope: one 2000-requests/day quota across the whole account.
-  if (platform === 'modelscope') return 'modelscope::account';
-  return normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`;
+  if (platform === 'modelscope') return policy('modelscope::account', 'account', 'metered', ['requests'], 'fixed_calendar', 'day');
+  // Volcengine's recurring reward is published per model; other unknown
+  // providers retain the legacy per-model pool fallback when a model is known.
+  if (platform === 'volcengine') return policy(normalizedModelId ? `volcengine::${normalizedModelId}` : 'volcengine::account', 'model', 'metered', ['tokens'], 'fixed_calendar', 'day');
+  if (platform === 'custom') return policy(normalizedModelId ? `custom::${normalizedModelId}` : 'custom::account', 'model', 'unknown', [], 'unknown');
+  return policy(normalizedModelId ? `${platform}::${normalizedModelId}` : `${platform}::account`, normalizedModelId ? 'model' : 'account', 'unknown', [], 'unknown');
 }
 
 function isSharedPool(platform: Platform): boolean {
-  return ['openrouter', 'google', 'groq', 'cerebras', 'sail', 'bai', 'sambanova', 'nvidia', 'mistral', 'github', 'cohere', 'cloudflare', 'zhipu', 'ollama', 'kilo', 'pollinations', 'llm7', 'huggingface', 'opencode', 'routeway', 'bazaarlink', 'ainative', 'aion', 'requesty', 'navy', 'nara', 'sealion', 'orcarouter', 'unorouter', 'xkiro', 'anyapi', 'modelscope', 'aihorde'].includes(platform);
+  return resolveQuotaPolicy(platform).scope !== 'model';
 }
 
 type HeaderSpec = { metric: QuotaMetric; limit: string; remaining?: string; reset?: string; strategy?: QuotaResetStrategy };
@@ -203,7 +252,7 @@ function extractContext(opts: Pick<QuotaObservationInput, 'platform' | 'modelId'
     keyId: opts.keyId ?? context?.keyId ?? 0,
     providerAccountId: opts.providerAccountId ?? context?.providerAccountId ?? null,
     modelId: opts.modelId ?? context?.modelId ?? null,
-    quotaPoolKey: opts.quotaPoolKey ?? context?.quotaPoolKey ?? inferPoolForPlatform(platform, opts.modelId ?? context?.modelId),
+    quotaPoolKey: opts.quotaPoolKey ?? context?.quotaPoolKey ?? resolveQuotaPolicy(platform, opts.modelId ?? context?.modelId, opts.endpoint ?? context?.endpoint).poolKey,
     endpoint: opts.endpoint ?? context?.endpoint ?? null,
   };
 }
@@ -233,8 +282,8 @@ function maybeAddObservation(
   });
 }
 
-export function inferQuotaPoolKey(platform: Platform, modelId?: string | null): string {
-  return inferPoolForPlatform(platform, modelId);
+export function inferQuotaPoolKey(platform: Platform, modelId?: string | null, endpoint?: string | null): string {
+  return resolveQuotaPolicy(platform, modelId, endpoint).poolKey;
 }
 
 export function parseQuotaObservationsFromResponse(
@@ -308,7 +357,7 @@ export function recordQuotaObservation(input: QuotaObservationInput): ProviderQu
   if (!platform) return null;
 
   const keyId = input.keyId ?? context?.keyId ?? 0;
-  const quotaPoolKey = input.quotaPoolKey ?? context?.quotaPoolKey ?? inferPoolForPlatform(platform, input.modelId ?? context?.modelId);
+  const quotaPoolKey = input.quotaPoolKey ?? context?.quotaPoolKey ?? resolveQuotaPolicy(platform, input.modelId ?? context?.modelId, input.endpoint ?? context?.endpoint).poolKey;
   const metric = input.metric ?? 'requests';
   const source = input.source ?? 'probe';
   const resetStrategy = input.resetStrategy ?? 'unknown';
@@ -476,7 +525,7 @@ const headroomCache = new Map<string, { db: unknown; at: number; map: Map<number
  * constraint is what 429s, so a key with 90% of its requests but 2% of its
  * tokens left has 2% of headroom, not 90%.
  */
-export function getKeyQuotaHeadroom(platform: Platform): Map<number, number> {
+export function getKeyQuotaHeadroom(platform: Platform, quotaPoolKey?: string): Map<number, number> {
   let db;
   try {
     db = getDb();
@@ -484,27 +533,35 @@ export function getKeyQuotaHeadroom(platform: Platform): Map<number, number> {
     return new Map();
   }
   const now = Date.now();
-  const cached = headroomCache.get(platform);
+  const cacheKey = `${platform}\u0000${quotaPoolKey ?? '*'}`;
+  const cached = headroomCache.get(cacheKey);
   if (cached && cached.db === db && now - cached.at < HEADROOM_TTL_MS) return cached.map;
 
+  const legacyPool = quotaPoolKey ? legacyPoolKey(platform, quotaPoolKey) : null;
   const rows = db.prepare(`
     SELECT key_id AS keyId,
+           quota_pool_key AS poolKey,
            limit_value AS limitValue,
            remaining_value AS remainingValue,
            CASE WHEN reset_at IS NOT NULL AND julianday(reset_at) < julianday('now')
                 THEN 1 ELSE 0 END AS expired
       FROM provider_quota_state
      WHERE platform = ?
+       AND (? IS NULL OR quota_pool_key = ? OR quota_pool_key = ?)
        AND confidence >= ?
        AND limit_value IS NOT NULL
        AND limit_value > 0
        AND remaining_value IS NOT NULL
-  `).all(platform, HEADROOM_MIN_CONFIDENCE) as {
-    keyId: number; limitValue: number; remainingValue: number; expired: number;
+  `).all(platform, quotaPoolKey ?? null, quotaPoolKey ?? null, legacyPool, HEADROOM_MIN_CONFIDENCE) as {
+    keyId: number; poolKey: string; limitValue: number; remainingValue: number; expired: number;
   }[];
 
   const map = new Map<number, number>();
+  const exactKeys = quotaPoolKey
+    ? new Set(rows.filter(row => row.poolKey === quotaPoolKey).map(row => row.keyId))
+    : new Set<number>();
   for (const row of rows) {
+    if (quotaPoolKey && exactKeys.has(row.keyId) && row.poolKey !== quotaPoolKey) continue;
     // A window that already reset is a full budget again. Same rule as
     // normalizeExpiredQuotaState, minus the write — this path must not take
     // one just to answer a routing question.
@@ -514,15 +571,65 @@ export function getKeyQuotaHeadroom(platform: Platform): Map<number, number> {
     const prev = map.get(row.keyId);
     if (prev === undefined || ratio < prev) map.set(row.keyId, ratio);
   }
-  headroomCache.set(platform, { db, at: now, map });
+  headroomCache.set(cacheKey, { db, at: now, map });
   return map;
+}
+
+/** Whether the exact pool consumed by this endpoint has a high-confidence,
+ * still-active exhaustion observation. Unknown capacity remains eligible;
+ * only a concrete zero with a future reset is a hard routing gate, avoiding
+ * permanent lockout when a provider omits reset metadata. */
+export function isQuotaPoolAvailable(
+  platform: Platform,
+  keyId: number,
+  modelId?: string | null,
+  endpoint?: string | null,
+): boolean {
+  const quota = resolveQuotaPolicy(platform, modelId, endpoint);
+  if (quota.accounting === 'unmetered') return true;
+  let db;
+  try {
+    db = getDb();
+  } catch {
+    return true;
+  }
+  const legacyPool = legacyPoolKey(platform, quota.poolKey);
+  const exactExists = db.prepare(`
+    SELECT 1
+      FROM provider_quota_state
+     WHERE platform = ?
+       AND key_id = ?
+       AND quota_pool_key = ?
+       AND confidence >= ?
+       AND remaining_value IS NOT NULL
+     LIMIT 1
+  `).get(platform, keyId, quota.poolKey, HEADROOM_MIN_CONFIDENCE);
+  const poolKey = exactExists || !legacyPool ? quota.poolKey : legacyPool;
+  const exhausted = db.prepare(`
+    SELECT 1
+      FROM provider_quota_state
+     WHERE platform = ?
+       AND key_id = ?
+       AND quota_pool_key = ?
+       AND confidence >= ?
+       AND remaining_value = 0
+       AND reset_at IS NOT NULL
+       AND julianday(reset_at) >= julianday('now')
+     LIMIT 1
+  `).get(platform, keyId, poolKey, HEADROOM_MIN_CONFIDENCE);
+  return !exhausted;
 }
 
 /** Drop the memoised headroom for one platform (or all of them). Called on
  *  every write so a fresh observation is visible to the very next route. */
 export function invalidateKeyQuotaHeadroom(platform?: Platform): void {
-  if (platform) headroomCache.delete(platform);
-  else headroomCache.clear();
+  if (!platform) {
+    headroomCache.clear();
+    return;
+  }
+  for (const key of headroomCache.keys()) {
+    if (key.startsWith(`${platform}\u0000`)) headroomCache.delete(key);
+  }
 }
 
 export function getQuotaStateForKeys(): QuotaObservationView[] {

--- a/server/src/services/ratelimit.ts
+++ b/server/src/services/ratelimit.ts
@@ -583,7 +583,22 @@ const DEFAULT_PROVIDER_MINUTE_REQUEST_CAPS: Record<string, number> = {
   nvidia: 40,
 };
 
-export function getProviderDailyRequestCap(platform: string): number | null {
+function getKeyProviderLimit(keyId: number | undefined, column: 'provider_rpm_limit' | 'provider_rpd_limit' | 'provider_tpd_limit'): number | undefined {
+  if (keyId === undefined) return undefined;
+  return withDb(db => {
+    const row = db.prepare(`SELECT ${column} AS value FROM api_keys WHERE id = ?`).get(keyId) as { value: number | null } | undefined;
+    return row?.value ?? undefined;
+  });
+}
+
+function normalizedProviderLimit(value: number | undefined): number | null | undefined {
+  if (value === undefined) return undefined;
+  return value === 0 ? null : value;
+}
+
+export function getProviderDailyRequestCap(platform: string, keyId?: number): number | null {
+  const account = normalizedProviderLimit(getKeyProviderLimit(keyId, 'provider_rpd_limit'));
+  if (account !== undefined) return account;
   const raw = process.env[`PROVIDER_DAILY_REQUEST_CAP_${platform.toUpperCase()}`];
   if (raw !== undefined && raw.trim() !== '') {
     const n = Number(raw);
@@ -594,7 +609,9 @@ export function getProviderDailyRequestCap(platform: string): number | null {
 
 /** Account-wide requests-per-minute cap, or null when the provider has none.
  *  `PROVIDER_MINUTE_REQUEST_CAP_<PLATFORM>=0` disables the gate for that platform. */
-export function getProviderMinuteRequestCap(platform: string): number | null {
+export function getProviderMinuteRequestCap(platform: string, keyId?: number): number | null {
+  const account = normalizedProviderLimit(getKeyProviderLimit(keyId, 'provider_rpm_limit'));
+  if (account !== undefined) return account;
   const raw = process.env[`PROVIDER_MINUTE_REQUEST_CAP_${platform.toUpperCase()}`];
   if (raw !== undefined && raw.trim() !== '') {
     const n = Number(raw);
@@ -603,7 +620,9 @@ export function getProviderMinuteRequestCap(platform: string): number | null {
   return DEFAULT_PROVIDER_MINUTE_REQUEST_CAPS[platform] ?? null;
 }
 
-export function getProviderDailyTokenCap(platform: string): number | null {
+export function getProviderDailyTokenCap(platform: string, keyId?: number): number | null {
+  const account = normalizedProviderLimit(getKeyProviderLimit(keyId, 'provider_tpd_limit'));
+  if (account !== undefined) return account;
   const raw = process.env[`PROVIDER_DAILY_TOKEN_CAP_${platform.toUpperCase()}`];
   if (raw !== undefined && raw.trim() !== '') {
     const n = Number(raw);
@@ -654,7 +673,7 @@ export function providerDailyRequestCount(platform: string, keyId: number, now =
 // False when this provider account+key has hit its shared daily request cap, so
 // the router skips every model on that provider for this key until UTC-ish reset.
 export function canUseProvider(platform: string, keyId: number, now = Date.now()): boolean {
-  const cap = getProviderDailyRequestCap(platform);
+  const cap = getProviderDailyRequestCap(platform, keyId);
   if (cap === null) return true;
   const used = providerDailyRequestCount(platform, keyId, now) + provisionalProviderRequests(platform, keyId, now);
   return used < cap;
@@ -678,7 +697,7 @@ export function providerMinuteRequestCount(platform: string, keyId: number, now 
 // budget, so the router skips every model on that provider rather than learning
 // the limit again from a 429 on each one in turn.
 export function canUseProviderMinute(platform: string, keyId: number, now = Date.now()): boolean {
-  const cap = getProviderMinuteRequestCap(platform);
+  const cap = getProviderMinuteRequestCap(platform, keyId);
   if (cap === null) return true;
   const used = providerMinuteRequestCount(platform, keyId, now) + provisionalProviderRequests(platform, keyId, now);
   return used < cap;
@@ -713,11 +732,14 @@ function getProviderTokenMultiplier(platform: string, modelId: string, dailyCap:
   }) ?? 1;
 }
 
-function providerBilledTokens(platform: string, modelId: string, rawTokens: number): number {
+function providerBilledTokens(platform: string, keyId: number, modelId: string, rawTokens: number): number {
   if (rawTokens <= 0) return 0;
-  const dailyCap = getProviderDailyTokenCap(platform);
+  const dailyCap = getProviderDailyTokenCap(platform, keyId);
   if (dailyCap === null) return rawTokens;
-  const multiplier = getProviderTokenMultiplier(platform, modelId, dailyCap);
+  // A per-account cap changes the size of the pool, not the provider's billing
+  // multiplier. Keep multiplier inference anchored to the provider/env cap.
+  const billingCap = getProviderDailyTokenCap(platform) ?? dailyCap;
+  const multiplier = getProviderTokenMultiplier(platform, modelId, billingCap);
   return Math.ceil(rawTokens * multiplier);
 }
 
@@ -727,8 +749,9 @@ function sumPersistedProviderTokens(
   windowMs: number,
   now: number,
 ): number | undefined {
-  const dailyCap = getProviderDailyTokenCap(platform);
+  const dailyCap = getProviderDailyTokenCap(platform, keyId);
   if (dailyCap === null) return 0;
+  const billingCap = getProviderDailyTokenCap(platform) ?? dailyCap;
 
   return withDb(db => {
     const rows = db.prepare(`
@@ -744,7 +767,7 @@ function sumPersistedProviderTokens(
     `).all(platform, keyId, now - windowMs) as (ModelQuotaRow & { model_id: string; used: number })[];
 
     return rows.reduce((sum, row) => {
-      const multiplier = platform === 'navy' ? multiplierFromQuotaRow(row, dailyCap) : 1;
+      const multiplier = platform === 'navy' ? multiplierFromQuotaRow(row, billingCap) : 1;
       return sum + Math.ceil(row.used * multiplier);
     }, 0);
   });
@@ -766,7 +789,7 @@ export function providerDailyTokenCount(platform: string, keyId: number, now = D
     const raw = w.tokenTimestamps
       .filter(t => t.ts > now - windowMs)
       .reduce((sum, t) => sum + t.tokens, 0);
-    total += providerBilledTokens(platform, modelId, raw);
+    total += providerBilledTokens(platform, keyId, modelId, raw);
   }
   return total;
 }
@@ -778,11 +801,11 @@ export function canUseProviderTokens(
   estimatedTokens: number,
   now = Date.now(),
 ): boolean {
-  const cap = getProviderDailyTokenCap(platform);
+  const cap = getProviderDailyTokenCap(platform, keyId);
   if (cap === null) return true;
   const used = providerDailyTokenCount(platform, keyId, now)
-    + providerBilledTokens(platform, modelId, provisionalProviderTokens(platform, keyId, now));
-  return used + providerBilledTokens(platform, modelId, estimatedTokens) <= cap;
+    + providerBilledTokens(platform, keyId, modelId, provisionalProviderTokens(platform, keyId, now));
+  return used + providerBilledTokens(platform, keyId, modelId, estimatedTokens) <= cap;
 }
 
 // ── Degraded-mode memory windows ─────────────────────────────────────────────

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -31,13 +31,13 @@ import { applyModelWeightOverride, getModelWeightOverrides } from './model-weigh
 import { modelsWithOverriddenField } from './model-state.js';
 import { parseBudget } from '../lib/budget.js';
 import { platformDropsResponseFormat } from '../lib/sampling-params.js';
-import { isUnifyEnabled, getModelGroups, resolveRequestedIdForDispatch } from './model-groups.js';
+import { isUnifyEnabled, getModelGroups, resolveRequestedIdForDispatch, getProviderPreferences, routingMemberId } from './model-groups.js';
 import { getActiveProfileId } from './profile-models.js';
 import { customEndpointKeyIds } from './custom-endpoint.js';
 import { isDegraded } from './degradation.js';
 import { modelStatsKey, endpointScopeForBaseUrl } from '../lib/endpoint-scope.js';
 import { parseModelScope, scopeAllows } from '../lib/model-scope.js';
-import { getKeyQuotaHeadroom, inferQuotaPoolKey } from './provider-quota.js';
+import { getKeyQuotaHeadroom, inferQuotaPoolKey, isQuotaPoolAvailable, resolveQuotaPolicy } from './provider-quota.js';
 import type { BaseProvider } from '../providers/base.js';
 import type { Platform } from '@freellmapi/shared/types.js';
 import type { Db } from '../db/types.js';
@@ -99,7 +99,7 @@ export function summarizeExhaustion(
     else if (l.includes('no tool-calling support')) bump('model lacks tool-calling');
     else if (l.includes('drops response_format')) bump('platform cannot honor response_format');
     else if (/ruled out|already-failed/.test(l)) bump('failed earlier this request');
-    else if (/cooldown|rpm|rpd|tpm|tpd|provider-daily-cap/.test(l)) bump('rate-limited or on cooldown');
+    else if (/cooldown|rpm|rpd|tpm|tpd|provider-daily-cap|quota-exhausted/.test(l)) bump('rate-limited or on cooldown');
     else bump('unavailable');
   }
   // Most actionable buckets first.
@@ -172,6 +172,8 @@ export interface ChainRow {
    * answering on score alone would be a silent substitution (#651).
    */
   match_tier?: number;
+  /** Explicit per-unified-model order. Absent means preserve automatic routing. */
+  provider_preference_rank?: number;
 }
 
 export interface RouteResult {
@@ -195,6 +197,9 @@ export interface RouteResult {
    * to ONE relay instead of every relay serving the same model id.
    */
   endpointScope: string;
+  /** Raw custom-provider base URL for quota locality classification. Never
+   * exposed to clients; empty for built-in providers. */
+  providerBaseUrl?: string;
   /**
    * This key's own proxy URL, already decrypted, '' when it has none (#590).
    *
@@ -1027,6 +1032,7 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
   // to override (see ChainRow.match_tier). Zero for every chain built anywhere
   // else, so this is a no-op outside slug-fallback resolution.
   const tier = (e: ChainRow) => e.match_tier ?? 0;
+  const preference = (e: ChainRow) => e.provider_preference_rank ?? 0;
   const weights = weightsFor(strategy);
   if (!weights) {
     // Legacy priority mode: manual chain order + the 429/failure penalty,
@@ -1060,7 +1066,7 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
       .map((e, i) => ({ e, i }))
       .sort((a, b) => a.e.priority - b.e.priority || a.i - b.i)
       .map(({ e, i }, rank) => ({ e, i, eff: rank + 1 + getPenalty(e.model_db_id) }))
-      .sort((a, b) => tier(a.e) - tier(b.e) || a.eff - b.eff || a.e.priority - b.e.priority || a.i - b.i)
+      .sort((a, b) => tier(a.e) - tier(b.e) || preference(a.e) - preference(b.e) || a.eff - b.eff || a.e.priority - b.e.priority || a.i - b.i)
       .map(x => x.e);
   }
 
@@ -1074,7 +1080,7 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
     .map(e => ({ e, s: scoreChainEntry(e, weights, intelMin, intelMax, sampled, keyCounts, headroomCfg).score }))
     // Higher score first WITHIN a tier; manual priority breaks ties so the chain
     // still matters.
-    .sort((a, b) => tier(a.e) - tier(b.e) || b.s - a.s || a.e.priority - b.e.priority)
+    .sort((a, b) => tier(a.e) - tier(b.e) || preference(a.e) - preference(b.e) || b.s - a.s || a.e.priority - b.e.priority)
     .map(x => x.e);
 }
 
@@ -1316,7 +1322,7 @@ const UNKNOWN_QUOTA_HEADROOM = 0.5;
  */
 function quotaWeightingApplies(entry: ChainRow): boolean {
   if (getKeySelectionStrategy() !== 'least-remaining') return false;
-  return !inferQuotaPoolKey(entry.platform as Platform, entry.model_id).endsWith('::account');
+  return resolveQuotaPolicy(entry.platform as Platform, entry.model_id).accounting === 'metered';
 }
 
 /**
@@ -1332,7 +1338,8 @@ function quotaWeightingApplies(entry: ChainRow): boolean {
  * walk that follows.
  */
 function orderKeysByRemainingQuota(entry: ChainRow, ordered: KeyRow[]): KeyRow[] {
-  const headroom = getKeyQuotaHeadroom(entry.platform as Platform);
+  const poolKey = inferQuotaPoolKey(entry.platform as Platform, entry.model_id);
+  const headroom = getKeyQuotaHeadroom(entry.platform as Platform, poolKey);
   if (headroom.size === 0) return ordered;
   // Hoisted out of the comparator: sort calls it O(n log n) times, and the
   // lookup below must not re-derive anything per comparison.
@@ -1430,6 +1437,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
     if (skipKeys?.has(skipId)) { note('already-failed-this-request'); continue; }
 
     if (isOnCooldown(entry.platform, entry.model_id, key.id)) { note('cooldown'); continue; }
+    if (!isQuotaPoolAvailable(entry.platform as Platform, key.id, entry.model_id, key.base_url)) { note('observed-quota-exhausted'); continue; }
     if (!canUseProvider(entry.platform, key.id)) { note('provider-daily-cap'); continue; }
     // Account-wide per-minute budget, checked before the per-model gates: a model
     // with a NULL rpm_limit would otherwise sail past them and spend a budget its
@@ -1474,6 +1482,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
       platform: entry.platform,
       displayName: entry.display_name,
       endpointScope: entry.endpoint_scope ?? '',
+      providerBaseUrl: entry.platform === 'custom' ? (key.base_url ?? '') : '',
       rpdLimit: limits.rpd,
       tpdLimit: limits.tpd,
       release: () => releaseLease(leaseId),
@@ -1517,8 +1526,8 @@ export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, ski
 
   const limits = { rpm: m.rpm_limit, rpd: m.rpd_limit, tpm: m.tpm_limit, tpd: m.tpd_limit };
   const keys = db.prepare(
-    "SELECT id, model_scope_json FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')"
-  ).all(m.platform) as { id: number; model_scope_json: string | null }[];
+    "SELECT id, model_scope_json, base_url FROM api_keys WHERE platform = ? AND enabled = 1 AND status IN ('healthy', 'unknown')"
+  ).all(m.platform) as { id: number; model_scope_json: string | null; base_url: string | null }[];
 
   // Keys of the model's own custom endpoint (#212, #619); a key belonging to a
   // DIFFERENT endpoint cannot serve it, so it doesn't count as an alternative.
@@ -1534,6 +1543,7 @@ export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, ski
     if (!scopeAllows(parseModelScope(k.model_scope_json), m.model_id)) continue;
     if (skipKeys?.has(`${m.platform}:${m.model_id}:${k.id}`)) continue;
     if (isOnCooldown(m.platform, m.model_id, k.id)) continue;
+    if (!isQuotaPoolAvailable(m.platform as Platform, k.id, m.model_id, k.base_url)) continue;
     if (!canUseProvider(m.platform, k.id)) continue;
     if (!canUseProviderMinute(m.platform, k.id)) continue;
     if (!canMakeRequest(m.platform, m.model_id, k.id, limits)) continue;
@@ -1720,6 +1730,23 @@ export function resolveModelGroupCandidates(
     if (!row) continue;
     row.match_tier = demotedDbIds?.has(id) ? 1 : 0;
     rows.push(row);
+  }
+
+  // Preferences are attached to the rows so routeRequest's second orderChain
+  // pass cannot discard them. Each group is independent; unlisted/new members
+  // follow explicitly listed members, then retain the normal automatic order.
+  const preferences = getProviderPreferences().groups;
+  const memberIdSet = new Set(memberDbIds);
+  for (const group of getModelGroups()) {
+    const configured = preferences[group.groupKey];
+    if (!configured || configured.mode !== 'preferred') continue;
+    const rank = new Map(configured.memberOrder.map((id, index) => [id, index]));
+    const fallbackRank = configured.memberOrder.length;
+    for (const member of group.members) {
+      if (!memberIdSet.has(member.model_db_id)) continue;
+      const row = rows.find(candidate => candidate.model_db_id === member.model_db_id);
+      if (row) row.provider_preference_rank = rank.get(routingMemberId(member)) ?? fallbackRank;
+    }
   }
   return orderChain(rows, strategy);
 }
@@ -1909,7 +1936,9 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
     // bandit draw, so it would stay under EXPLORE_MIN_SAMPLES forever and become
     // a perpetual probe target — the explicit ban outranks exploration.
     const overrides = getModelWeightOverrides();
+    const preferredRank = sortedChain[0]?.provider_preference_rank;
     const unmeasured = sortedChain.filter(e => {
+      if (preferredRank !== undefined && e.provider_preference_rank !== preferredRank) return false;
       if (overrides.get(e.model_id) === 0) return false;
       const stats = statsCache?.get(modelStatsKey(e.platform, e.model_id, e.endpoint_scope));
       if ((stats?.successes ?? 0) + (stats?.failures ?? 0) >= EXPLORE_MIN_SAMPLES) return false;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -289,6 +289,11 @@ export interface ApiKey {
   /** Model ids this key is limited to; null = serves every model of its
    *  platform (#657). */
   modelScope?: string[] | null;
+  /** Per-account provider quota overrides. NULL inherits provider/env defaults;
+   *  zero explicitly disables that account-wide gate. */
+  providerRpmLimit?: number | null;
+  providerRpdLimit?: number | null;
+  providerTpdLimit?: number | null;
   models?: ApiKeyModel[];
   cooldowns?: ApiKeyCooldown[];
 }
@@ -525,6 +530,20 @@ export interface RateLimitStatus {
 export type QuotaMetric = 'requests' | 'tokens' | 'credits' | 'neurons';
 export type QuotaResetStrategy = 'fixed_calendar' | 'rolling_window' | 'token_bucket' | 'provider_reported' | 'unknown';
 export type QuotaObservationSource = 'header' | 'quota_api' | 'error_body' | 'local_usage' | 'documentation' | 'probe';
+export type QuotaScope = 'model' | 'account' | 'project' | 'shared_pool';
+export type QuotaAccounting = 'metered' | 'unknown' | 'unmetered';
+export type QuotaResetPeriod = 'minute' | 'day' | 'month';
+
+/** Describes the resource an endpoint consumes. Scope and accounting are
+ * deliberately separate: an account can be unmetered, and a shared pool can
+ * have unknown capacity. */
+export interface QuotaPolicy {
+  poolKey: string;
+  scope: QuotaScope;
+  accounting: QuotaAccounting;
+  metrics: QuotaMetric[];
+  reset: { strategy: QuotaResetStrategy; period?: QuotaResetPeriod };
+}
 
 export interface ProviderQuotaState {
   platform: Platform;


### PR DESCRIPTION
## Why

A unified model can span several providers with fundamentally different free-quota economics, but FreeLLMAPI could not express a preferred provider order and could treat shared account pools, independent model quotas, project quotas, monetary credits, and unmetered local inference as though they were equivalent. That can waste scarce capacity or send traffic to a pool already known to be exhausted.

## What changed

- Preserve existing automatic routing as the default.
- Add an opt-in preferred provider order per unified model while retaining health, quota, cooldown, scoring, and failover protections.
- Persist quota policy metadata that distinguishes model, account, project, and shared pools, including metered, unknown, and unmetered accounting.
- Gate only on high-confidence exhaustion of the exact applicable pool, with legacy read fallbacks for existing Groq and Google observations.
- Let each provider key be limited to selected catalogue models, using live discovery only when that provider has no catalogue rows.
- Add per-provider-key RPM, RPD, and TPD account limits with a reversible migration.
- Apply the same quota context across Chat Completions, Responses, and Anthropic-compatible requests.
- Add dashboard controls for preferred ordering, model selection, and account limits.

Existing installations remain in automatic mode until a preference is explicitly saved. Public unified model IDs and the existing failover contract are unchanged.

## Verification

- Full server suite: 2,848 passed, 5 skipped
- Full CLI suite: 107 passed
- Full client suite: 259 passed
- i18n validation: 60 locales, 1,036 keys
- Full production build: server, CLI, and client passed
- Migration up/down/up round trip passed

## Provenance

Produced with OpenAI GPT-5 via Codex desktop.