### PR TITLE
Release template: Premium price $19/yr -> $29/yr

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -5,4 +5,4 @@ premium footer (swap in the tag), so every release page carries a
 conversion path — the release pages get thousands of views per tag:
 
 ---
-⭐ Like the free router? [Go Premium](https://freellmapi.co/?utm_source=github&utm_medium=release&utm_campaign=premium&utm_content=vX.Y.Z#pricing) — the live signed catalog, $19/yr, cancel anytime.
+⭐ Like the free router? [Go Premium](https://freellmapi.co/?utm_source=github&utm_medium=release&utm_campaign=premium&utm_content=vX.Y.Z#pricing) — the live signed catalog, $29/yr, cancel anytime.


### PR DESCRIPTION
The GitHub release template still advertised Premium at $19/yr after #1130 changed the price to $29/yr. Sweep of the router repo found no other stale price strings (client locales, README, docs, desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqKDgEiNL5npWVpez3Wj2C