### PR TITLE
chore(release): bump desktop to v0.9.4

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
Release v0.9.4: the dashboard premium upsell shows $19/yr again (v0.9.3 shipped the $29 copy; corrected on main in 01e5af93 but never released).