### PR TITLE
docs(clients): add QwenPaw setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ Contributors very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev lo
 <a href="https://github.com/n3dhir"><img src="https://images.weserv.nl/?url=github.com/n3dhir.png&w=40&h=40&fit=cover&mask=circle" width="40" alt="@n3dhir" /></a>
 <a href="https://github.com/ksp2000"><img src="https://images.weserv.nl/?url=github.com/ksp2000.png&w=40&h=40&fit=cover&mask=circle" width="40" alt="@ksp2000" /></a>
 <a href="https://github.com/quabynahdavis"><img src="https://images.weserv.nl/?url=github.com/quabynahdavis.png&w=40&h=40&fit=cover&mask=circle" width="40" alt="@quabynahdavis" /></a>
+<a href="https://github.com/qinghuanandejiangshi"><img src="https://images.weserv.nl/?url=github.com/qinghuanandejiangshi.png&w=40&h=40&fit=cover&mask=circle" width="40" alt="@qinghuanandejiangshi" /></a>
 
 ## Disclaimer
 

--- a/docs/clients/01-agent-clients.md
+++ b/docs/clients/01-agent-clients.md
@@ -147,20 +147,22 @@ unified key from its dashboard, then open **Settings → Models** in the QwenPaw
 Console:
 
 1. Under **Providers**, choose **Add Provider**.
-2. Give it an id such as `freellmapi` and a display name such as `FreeLLMAPI`.
-3. Select the OpenAI `chat.completions` compatibility mode.
-4. Set **Base URL** to `http://localhost:3001/v1` and **API Key** to your
-   FreeLLMAPI unified key.
-5. Add a model under this provider. Use `auto` to let FreeLLMAPI route the
-   request, or copy a current model id from `GET http://localhost:3001/v1/models`.
-6. Select the new provider and model, then use **Test Connection** before
-   saving.
+2. Give it a **Provider ID** such as `freellmapi` and a **Provider Name** such
+   as `FreeLLMAPI`, and set the API compatibility mode to OpenAI
+   `chat.completions`.
+3. Open the new provider's settings and set **Base URL** to
+   `http://localhost:3001/v1` and **API Key** to your FreeLLMAPI unified key.
+4. On the provider's models page, add a model. Use `auto` as the **Model ID**
+   to let FreeLLMAPI route the request, or copy a current id from
+   `GET http://localhost:3001/v1/models`.
+5. Save, then pick the model as the default (or per chat) and send a test
+   message.
 
 If QwenPaw runs in a container, `localhost` refers to that container rather
 than the host running FreeLLMAPI. Use a hostname or host-gateway address that
 the QwenPaw container can reach, while keeping the `/v1` suffix. Do not put the
 unified key in a URL, screenshot, or issue report. See QwenPaw's
-[official model configuration guide](https://qwenpaw.agentscope.io/docs/models/)
+[official model configuration guide](https://qwenpaw.agentscope.io/docs/models)
 for the current Console field names.
 
 ## Native Gemini clients

--- a/docs/clients/01-agent-clients.md
+++ b/docs/clients/01-agent-clients.md
@@ -4,6 +4,7 @@
 
 - [OpenAI-compatible clients](#openai-compatible-clients)
 - [Coding agents](#coding-agents)
+- [QwenPaw](#qwenpaw)
 - [Native Gemini clients](#native-gemini-clients)
 - [Ollama clients](#ollama-clients)
 - [Headerless clients](#headerless-clients)
@@ -52,13 +53,14 @@ context windows.
 | **DeepSeek Harness** | `setup-dsh` | `http://localhost:3001/v1` | OpenAI Chat (`api: openai-completions`) |
 | **MiMo Code** | `setup-mimo` | `http://localhost:3001/v1` | OpenAI Chat |
 | **AtomCode** | `setup-atomcode` | `http://localhost:3001/v1` | OpenAI Chat (`type = "openai"`) |
+| **QwenPaw** | Manual setup | `http://localhost:3001/v1` | OpenAI Chat (`chat.completions`) |
 | **Cursor** | `setup-cursor` prints the guide | public `https://…/v1` | OpenAI Chat |
 | **Anything else** | `setup-generic` prints a ready block | `http://localhost:3001/v1` | OpenAI Chat |
 
 The root-vs-`/v1` distinction matters: Claude Code expects the server root
 because it appends the Anthropic Messages path. OpenAI-compatible clients in
 this table—including Cline, Aider, Goose, Codex, Continue, OpenCode, Qwen,
-Roo, Kilo, Crush, MiMo Code, AtomCode, and DeepSeek Harness—expect their configured
+Roo, Kilo, Crush, MiMo Code, AtomCode, QwenPaw, and DeepSeek Harness—expect their configured
 base URL to include `/v1`.
 
 ### DeepSeek Harness (`dsh`)
@@ -136,6 +138,30 @@ AtomCode has no environment-variable fallback for the key, so it is written
 into the config file; the file is created with mode 0600 and a timestamped
 backup is taken before an existing one is changed. `--model <id>` pins the
 default model.
+
+### QwenPaw
+
+[QwenPaw](https://github.com/agentscope-ai/QwenPaw) supports custom providers
+that use the OpenAI `chat.completions` API. Start FreeLLMAPI, create or copy a
+unified key from its dashboard, then open **Settings → Models** in the QwenPaw
+Console:
+
+1. Under **Providers**, choose **Add Provider**.
+2. Give it an id such as `freellmapi` and a display name such as `FreeLLMAPI`.
+3. Select the OpenAI `chat.completions` compatibility mode.
+4. Set **Base URL** to `http://localhost:3001/v1` and **API Key** to your
+   FreeLLMAPI unified key.
+5. Add a model under this provider. Use `auto` to let FreeLLMAPI route the
+   request, or copy a current model id from `GET http://localhost:3001/v1/models`.
+6. Select the new provider and model, then use **Test Connection** before
+   saving.
+
+If QwenPaw runs in a container, `localhost` refers to that container rather
+than the host running FreeLLMAPI. Use a hostname or host-gateway address that
+the QwenPaw container can reach, while keeping the `/v1` suffix. Do not put the
+unified key in a URL, screenshot, or issue report. See QwenPaw's
+[official model configuration guide](https://qwenpaw.agentscope.io/docs/models/)
+for the current Console field names.
 
 ## Native Gemini clients
 

--- a/docs/i18n/zh-CN/docs/clients/01-agent-clients.md
+++ b/docs/i18n/zh-CN/docs/clients/01-agent-clients.md
@@ -6,6 +6,7 @@
 
 - [OpenAI 兼容客户端](#openai-兼容客户端)
 - [编程智能体](#编程智能体)
+- [QwenPaw](#qwenpaw)
 - [原生 Gemini 客户端](#原生-gemini-客户端)
 - [Ollama 客户端](#ollama-客户端)
 - [无头客户端](#无头客户端)
@@ -48,10 +49,11 @@ npx freellmapi setup-dsh --url http://localhost:3001 --api-key <统一密钥>
 | **Kilo Code** | `setup-kilo` | `http://localhost:3001/v1` | OpenAI Chat |
 | **Crush** | `setup-crush` | `http://localhost:3001/v1` | OpenAI Chat |
 | **DeepSeek Harness** | `setup-dsh` | `http://localhost:3001/v1` | OpenAI Chat (`api: openai-completions`) |
+| **QwenPaw** | 手动配置 | `http://localhost:3001/v1` | OpenAI Chat (`chat.completions`) |
 | **Cursor** | `setup-cursor` 打印指引 | 公共 `https://…/v1` | OpenAI Chat |
 | **其他** | `setup-generic` 打印现成配置块 | `http://localhost:3001/v1` | OpenAI Chat |
 
-根路径与 `/v1` 的区别很重要：Claude Code 期望服务器根路径，因为它会追加 Anthropic Messages 路径。本表中兼容 OpenAI 的客户端——包括 Cline、Aider、Goose、Codex、Continue、OpenCode、Qwen、Roo、Kilo、Crush 和 DeepSeek Harness——期望它们配置的 base URL 包含 `/v1`。
+根路径与 `/v1` 的区别很重要：Claude Code 期望服务器根路径，因为它会追加 Anthropic Messages 路径。本表中兼容 OpenAI 的客户端——包括 Cline、Aider、Goose、Codex、Continue、OpenCode、Qwen、Roo、Kilo、Crush、QwenPaw 和 DeepSeek Harness——期望它们配置的 base URL 包含 `/v1`。
 
 ### DeepSeek Harness (`dsh`)
 
@@ -65,6 +67,26 @@ npx @deepseek-ai/dsh web
 ```
 
 设置是热重载的，所以运行中的 `dsh` 下一次请求就会用上这条路由。`--profile <name>` 添加第二条路由（`freellmapi-<name>`）而不改变默认模型；`--model <id>` 固定默认值。路由只声明文本——在 `freellmapi.models` 下给某模型条目加上 `input: [text, image]` 即可发图。尊重 `DSH_HOME`。
+
+### QwenPaw
+
+[QwenPaw](https://github.com/agentscope-ai/QwenPaw) 支持使用 OpenAI
+`chat.completions` API 的自定义提供方。先启动 FreeLLMAPI，并从其仪表盘创建或复制统一密钥，
+然后在 QwenPaw Console 中打开 **Settings → Models**：
+
+1. 在 **Providers** 下选择 **Add Provider**。
+2. 将 id 设为 `freellmapi` 等便于识别的值，显示名称可设为 `FreeLLMAPI`。
+3. 兼容模式选择 OpenAI `chat.completions`。
+4. 将 **Base URL** 设为 `http://localhost:3001/v1`，将 **API Key** 设为
+   FreeLLMAPI 统一密钥。
+5. 在该提供方下添加模型。可使用 `auto` 让 FreeLLMAPI 自动路由，或从
+   `GET http://localhost:3001/v1/models` 复制当前可用的模型 id。
+6. 选中新提供方和模型，保存前先执行 **Test Connection**。
+
+如果 QwenPaw 在容器中运行，`localhost` 指向的是该容器，而不是运行 FreeLLMAPI 的宿主机。
+请改用 QwenPaw 容器能够访问的主机名或宿主机网关地址，并保留 `/v1` 后缀。不要把统一密钥
+放进 URL、截图或 issue 报告。当前 Console 字段名称以 QwenPaw 的
+[官方模型配置指南](https://qwenpaw.agentscope.io/docs/models/)为准。
 
 ## 原生 Gemini 客户端
 

--- a/docs/i18n/zh-CN/docs/clients/01-agent-clients.md
+++ b/docs/i18n/zh-CN/docs/clients/01-agent-clients.md
@@ -71,22 +71,22 @@ npx @deepseek-ai/dsh web
 ### QwenPaw
 
 [QwenPaw](https://github.com/agentscope-ai/QwenPaw) 支持使用 OpenAI
-`chat.completions` API 的自定义提供方。先启动 FreeLLMAPI，并从其仪表盘创建或复制统一密钥，
-然后在 QwenPaw Console 中打开 **Settings → Models**：
+`chat.completions` API 的自定义提供商。先启动 FreeLLMAPI，并从其仪表盘创建或复制统一密钥，
+然后在 QwenPaw Console 中打开 **设置 → 模型**：
 
-1. 在 **Providers** 下选择 **Add Provider**。
-2. 将 id 设为 `freellmapi` 等便于识别的值，显示名称可设为 `FreeLLMAPI`。
-3. 兼容模式选择 OpenAI `chat.completions`。
-4. 将 **Base URL** 设为 `http://localhost:3001/v1`，将 **API Key** 设为
-   FreeLLMAPI 统一密钥。
-5. 在该提供方下添加模型。可使用 `auto` 让 FreeLLMAPI 自动路由，或从
-   `GET http://localhost:3001/v1/models` 复制当前可用的模型 id。
-6. 选中新提供方和模型，保存前先执行 **Test Connection**。
+1. 在 **提供商** 下选择 **添加提供商**。
+2. 填写 **提供商 ID**（例如 `freellmapi`）和 **提供商名称**（例如 `FreeLLMAPI`），
+   并将 API 兼容模式设为 OpenAI `chat.completions`。
+3. 进入该提供商的设置页，将 **Base URL** 设为 `http://localhost:3001/v1`，
+   将 **API 密钥** 设为 FreeLLMAPI 统一密钥。
+4. 在该提供商的模型页面添加模型。**模型 ID** 可填 `auto` 让 FreeLLMAPI 自动路由，
+   或从 `GET http://localhost:3001/v1/models` 复制当前可用的模型 id。
+5. 保存后把该模型设为默认（或在单次对话中选用），并发一条消息验证。
 
 如果 QwenPaw 在容器中运行，`localhost` 指向的是该容器，而不是运行 FreeLLMAPI 的宿主机。
 请改用 QwenPaw 容器能够访问的主机名或宿主机网关地址，并保留 `/v1` 后缀。不要把统一密钥
 放进 URL、截图或 issue 报告。当前 Console 字段名称以 QwenPaw 的
-[官方模型配置指南](https://qwenpaw.agentscope.io/docs/models/)为准。
+[官方模型配置指南](https://qwenpaw.agentscope.io/docs/models)为准。
 
 ## 原生 Gemini 客户端
 


### PR DESCRIPTION
## Summary

- document QwenPaw as a manually configured OpenAI-compatible client
- add matching English and Simplified Chinese setup steps
- cover model discovery, connection testing, and container networking

Closes #1064

## Validation

- `git diff --check`
- documentation content checks for both language files
- `npm.cmd run test:hooks` (9 passed)
- `npm.cmd run test:bootstrap` (2 pre-existing Windows environment failures: the spawned `powershell.exe` cannot resolve `Get-FileHash`; unrelated to this documentation-only change)