### PR TITLE
Revert "fix(fallback): count shared pools once in the monthly token budget bar" (#1071)

### DIFF
--- a/client/dev/mockApi.ts
+++ b/client/dev/mockApi.ts
@@ -138,19 +138,10 @@ export function mockApiPlugin(): Plugin {
         }
 
         if (url === '/api/fallback/token-usage') {
-          // Pool-deduped like the server (#1065): one budget per shared
-          // allowance. The mock approximates inferQuotaPoolKey by grouping
-          // per platform.
-          const modelBudgets = models.map(m => ({ displayName: m.displayName, platform: m.platform, modelId: m.modelId, budget: budgetTokens(m.monthlyTokenBudget) }))
-          const pools = new Map<string, { poolKey: string; platform: string; budget: number; used: number }>()
-          for (const m of modelBudgets) {
-            let p = pools.get(m.platform)
-            if (!p) { p = { poolKey: `${m.platform}::account`, platform: m.platform, budget: 0, used: 0 }; pools.set(m.platform, p) }
-            if (m.budget > p.budget) p.budget = m.budget
-          }
-          const poolList = [...pools.values()]
-          const totalBudget = poolList.reduce((s, p) => s + p.budget, 0)
-          return send({ totalBudget, totalUsed: Math.round(totalBudget * 0.18), pools: poolList, models: modelBudgets })
+          const withKeys = models
+          const modelBudgets = withKeys.map(m => ({ displayName: m.displayName, platform: m.platform, budget: budgetTokens(m.monthlyTokenBudget) }))
+          const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0)
+          return send({ totalBudget, totalUsed: Math.round(totalBudget * 0.18), models: modelBudgets })
         }
 
         // Anything else under /api → empty 200 so pages don't hard-crash.

--- a/client/src/components/token-usage-bar.tsx
+++ b/client/src/components/token-usage-bar.tsx
@@ -26,9 +26,7 @@ const METRIC_KEYS: Record<string, string> = {
 // extracted from FallbackPage.
 export function TokenUsageBar({ data }: { data: TokenUsageData }) {
   const { t } = useI18n()
-  // `pools` is new in this payload (#1065); an older server, or a cached
-  // response from one, simply has no segments to draw.
-  const { totalBudget, totalUsed, pools = [], models } = data
+  const { totalBudget, totalUsed, models } = data
   const remaining = Math.max(0, totalBudget - totalUsed)
   const remainingPct = totalBudget > 0 ? formatPercent(remaining / totalBudget) : '0%'
 
@@ -43,24 +41,6 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
     }
   })
   const usedPct = totalBudget > 0 ? Math.min(100, (totalUsed / totalBudget) * 100) : 0
-
-  // One segment per pool (#1065): the total counts each shared platform
-  // allowance once, so per-model segments would overflow the bar — every
-  // model on a platform draws on the same segment.
-  const poolSegments = pools.map(p => {
-    const remainingTokens = Math.max(0, p.budget - p.used)
-    const scope = poolScopeWords(p.poolKey)
-    return {
-      ...p,
-      remainingTokens,
-      // The raw key ("mistral::experiment-pool") is server vocabulary; the
-      // legend headers already say it in words, so the segment does too.
-      label: scope
-        ? t('freeTier.poolLabel', { platform: p.platform, scope })
-        : t('freeTier.poolLabelBare', { platform: p.platform }),
-      widthPct: totalBudget > 0 ? (remainingTokens / totalBudget) * 100 : 0,
-    }
-  })
 
   // Provider pools (#905): many models on one platform share a single free
   // allowance, so the legend groups its rows under the pool they draw from
@@ -114,13 +94,13 @@ export function TokenUsageBar({ data }: { data: TokenUsageData }) {
       </div>
 
       <div className="flex h-2.5 rounded-full overflow-hidden bg-muted">
-        {poolSegments.map(p => (
+        {modelsWithWidth.map((m, i) => (
           <div
-            key={p.poolKey}
-            title={`${p.label}: ${formatTokens(p.remainingTokens)} ${t('models.remaining')}, ${formatTokens(p.used)} ${t('models.used')}`}
+            key={i}
+            title={`${m.displayName} (${m.platform}): ${formatTokens(m.remainingTokens)} ${t('models.remaining')}, ${formatTokens(m.usedTokens)} ${t('models.used')}`}
             style={{
-              width: `${p.widthPct}%`,
-              backgroundColor: platformColors[p.platform] ?? '#94a3b8',
+              width: `${m.widthPct}%`,
+              backgroundColor: platformColors[m.platform] ?? '#94a3b8',
             }}
           />
         ))}

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -112,10 +112,6 @@ export type Row = FallbackEntry & Partial<RoutingScore>
 export interface TokenUsageData {
   totalBudget: number
   totalUsed: number
-  // One row per quota pool (#1065): the total counts each shared platform
-  // allowance once, so the bar segments are per pool, not per model. Optional
-  // because a response from a server older than #1065 carries no such field.
-  pools?: { poolKey: string; platform: string; budget: number; used: number }[]
   models: { displayName: string; platform: string; modelId?: string; budget: number; used?: number }[]
 }
 

--- a/server/src/__tests__/routes/fallback.test.ts
+++ b/server/src/__tests__/routes/fallback.test.ts
@@ -105,59 +105,6 @@ describe('Fallback API', () => {
     });
   });
 
-  // Regression #1065: every model row on a platform repeats that platform's
-  // one account-pool label, so summing per model counted a single 100M Mistral
-  // allowance once per catalog model (13 models read as 1.3B). The headline
-  // must take one budget per pool; per-model rows keep their own figures.
-  it('GET /api/fallback/token-usage counts a shared platform pool once in totalBudget', async () => {
-    const db = getDb();
-    // Exactly one usable key ⇒ the pool budget is unscaled (×1).
-    db.prepare(`DELETE FROM api_keys WHERE platform = 'mistral'`).run();
-    const secret = encrypt('pool-test-key');
-    db.prepare(`
-      INSERT INTO api_keys (platform, label, encrypted_key, iv, auth_tag, status, enabled)
-      VALUES ('mistral', 'pool', ?, ?, ?, 'healthy', 1)
-    `).run(secret.encrypted, secret.iv, secret.authTag);
-    // Three chain models on the shared pool, all repeating the same label.
-    // The seed activates profile 1, so the chain is profile_models (insert into
-    // both tables so the test holds whichever mode a later seed change picks).
-    const insertModel = db.prepare(`
-      INSERT INTO models (platform, model_id, display_name, intelligence_rank, speed_rank, monthly_token_budget)
-      VALUES ('mistral', ?, ?, 5, 5, '~100M')
-    `);
-    for (const modelId of ['pool-a', 'pool-b', 'pool-c']) {
-      const res = insertModel.run(modelId, modelId.toUpperCase());
-      const id = Number(res.lastInsertRowid);
-      db.prepare(`INSERT OR IGNORE INTO fallback_config (model_db_id, priority) VALUES (?, 900)`).run(id);
-      db.prepare(`INSERT OR IGNORE INTO profile_models (profile_id, model_db_id, priority) VALUES (1, ?, 900)`).run(id);
-    }
-    db.prepare(`
-      INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, request_type)
-      VALUES ('mistral', 'pool-a', NULL, 'success', 10, 5, 10, NULL, 'chat')
-    `).run();
-
-    const { status, body } = await request(app, 'GET', '/api/fallback/token-usage');
-
-    expect(status).toBe(200);
-    // All mistral models — mine plus any seeded ones — collapse to ONE pool row.
-    const mistralModels = body.models.filter((m: any) => m.platform === 'mistral');
-    expect(mistralModels.length).toBeGreaterThanOrEqual(3);
-    const mistralPools = body.pools.filter((p: any) => p.platform === 'mistral');
-    expect(mistralPools).toHaveLength(1);
-    // The pool takes the largest documented budget, not the per-model sum.
-    const pool = mistralPools[0];
-    expect(pool.poolKey).toBe('mistral::experiment-pool');
-    expect(pool.budget).toBe(Math.max(...mistralModels.map((m: any) => m.budget)));
-    expect(pool.budget).toBeLessThan(mistralModels.reduce((s: number, m: any) => s + m.budget, 0));
-    // Pool `used` aggregates the per-model spend.
-    expect(pool.used).toBe(mistralModels.reduce((s: number, m: any) => s + (m.used ?? 0), 0));
-    // Per-model rows keep repeating the label and their own usage.
-    expect(mistralModels.find((m: any) => m.modelId === 'pool-a')).toMatchObject({
-      budget: 100_000_000,
-      used: 15,
-    });
-  });
-
   // Regression: GET /routing must always carry customWeights, even before the
   // user has saved any — the dashboard's custom-weight sliders dereference it
   // and a missing field white-screened the Fallback page.

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -16,8 +16,6 @@ import { getActiveProfileId } from '../services/profile-models.js';
 import { qualifiedModelMemberId } from '../lib/endpoint-scope.js';
 import { overriddenFieldNames } from '../services/model-state.js';
 import { parseModelScope, scopeAllows } from '../lib/model-scope.js';
-import { inferQuotaPoolKey } from '../services/provider-quota.js';
-import type { Platform } from '@freellmapi/shared/types.js';
 
 export const fallbackRouter = Router();
 
@@ -523,38 +521,13 @@ fallbackRouter.get('/token-usage', (_req: Request, res: Response) => {
       };
     });
 
-  // One budget per pool (#1065): many models on one platform draw from the
-  // same free allowance (see inferQuotaPoolKey), and every model row repeats
-  // that account pool's label — so summing per model counts one 100M Mistral
-  // allowance once per catalog model (13 models read as 1.3B). Take the
-  // largest documented value per pool, scaled by usable keys exactly like the
-  // per-model budget above; this matches /api/free-tier (#905), which reports
-  // the same pools for the same account.
-  const pools = new Map<string, { poolKey: string; platform: string; budget: number; used: number }>();
-  for (const m of modelBudgets) {
-    const poolKey = inferQuotaPoolKey(m.platform as Platform, m.modelId);
-    let pool = pools.get(poolKey);
-    if (!pool) {
-      pool = { poolKey, platform: m.platform, budget: 0, used: 0 };
-      pools.set(poolKey, pool);
-    }
-    if (m.budget > pool.budget) pool.budget = m.budget;
-    pool.used += m.used;
-  }
-  const poolList = [...pools.values()];
-
-  // Pools count all chain models (enabled or disabled — they contribute to the
-  // pool); `used` stays the per-model sum, since actual spend per model really
-  // is separate.
-  const totalBudget = poolList.reduce((s, p) => s + p.budget, 0);
+  // Total budget counts all models (both enabled and disabled — they contribute to the pool)
+  const totalBudget = modelBudgets.reduce((s, m) => s + m.budget, 0);
   const totalUsed = modelBudgets.reduce((s, m) => s + m.used, 0);
 
   res.json({
     totalBudget,
     totalUsed,
-    // One segment per pool for the stacked bar (#1065): per-model segments
-    // would overflow the pooled total by the catalog's model count.
-    pools: poolList,
     models: modelBudgets,
   });
 });


### PR DESCRIPTION
Restores the per-model sum in the monthly token budget bar. The bar is meant to add up every model's documented allowance rather than collapse shared pools to one figure.