### PR TITLE
fix(fallback): classify 400 'No model found' as model_not_found

### DIFF
--- a/server/src/__tests__/routes/proxy-retry.test.ts
+++ b/server/src/__tests__/routes/proxy-retry.test.ts
@@ -82,6 +82,17 @@ describe('isModelNotFoundError (drives whole-model skip within a request)', () =
     expect(isModelNotFoundError(new Error('No endpoints found for openrouter/minimax/minimax-m2.5:free'))).toBe(true);
   });
 
+  it('flags a stale/removed model reported as a 400 "No model found" (Routeway) — MODEL-level, not request shape', () => {
+    // "No model found" does NOT contain the substring "not found" (words are
+    // no/model/found), so before the phrase list it slipped through to
+    // isProviderBadRequestError and surfaced as a request-blaming 400.
+    expect(isModelNotFoundError(Object.assign(new Error('Routeway API error 400: No model found: llama-3.3-70b-instruct:free'), { status: 400 }))).toBe(true);
+    expect(isModelNotFoundError(new Error('Groq API error 400: model not found'))).toBe(true);
+    expect(isModelNotFoundError(new Error('Provider API error 400: unknown model'))).toBe(true);
+    expect(isModelNotFoundError(new Error('API error 400: model does not exist'))).toBe(true);
+    expect(isModelNotFoundError(new Error('API error 404: no such model'))).toBe(true);
+  });
+
   it('flags 410 Gone (model pulled upstream) by message or attached status — #339', () => {
     expect(isModelNotFoundError(new Error('Ollama Cloud API error 410: Gone'))).toBe(true);
     expect(isModelNotFoundError(Object.assign(new Error('Gone'), { status: 410 }))).toBe(true);

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -505,7 +505,18 @@ export function isModelNotFoundError(err: any): boolean {
   if (err?.status === 404 || err?.status === 410) return true;
   const msg = (err?.message ?? '').toLowerCase();
   return msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
-    || msg.includes('410') || msg.includes('gone');
+    || msg.includes('410') || msg.includes('gone')
+    // Some aggregators report a removed/stale model with a 400 (not a 404) whose
+    // body reads "No model found: <id>", "model not found", "unknown model" or
+    // "model does not exist" (#: Routeway 400 "No model found: llama-3.3-70b-instruct:free").
+    // Note "No model found" does NOT contain the substring "not found" (words are
+    // no/model/found), so it slipped past the checks above and fell through to
+    // isProviderBadRequestError — surfacing as a request-blaming 400 instead of a
+    // stale-catalog 404. These phrasings are MODEL-level (every sibling key fails
+    // identically), so they belong here for the whole-model skip.
+    || msg.includes('no model found') || msg.includes('model not found')
+    || msg.includes('unknown model') || msg.includes('model does not exist')
+    || msg.includes('no such model');
 }
 
 // A 403 Forbidden returned for a specific model behind an otherwise-valid key.


### PR DESCRIPTION
## Summary
Some OpenAI-compatible aggregators (observed on Routeway) report a removed or stale model with an HTTP **400** whose body reads `No model found: <id>`, rather than a 404. The failover loop classified this as `provider_bad_request` instead of `model_not_found`.

## Root cause
`isModelNotFoundError` in `server/src/lib/error-classify.ts` only matched status 404/410 or the literal substrings `not found` / `gone` / `no endpoints found`. The phrase **"No model found"** does not contain the substring `"not found"` (the words are no / model / found), so the error slipped past this predicate and fell through to `isProviderBadRequestError` (status 400 + `api error 400`).

Consequence in `exhaustedRetryError`: `model_not_found` has a dedicated `everyAttempt` aggregate branch (renders 404), but `provider_bad_request` is only a last-error-shape check (renders 400). So a chain where every hop hit a stale model surfaced as a request-blaming **400 provider_rejected_request** instead of a **404 model_not_found** pointing at the stale catalog. It also missed the whole-model-skip path (burned a fallback hop per sibling key).

## Fix
Broaden `isModelNotFoundError` to also match `no model found` / `model not found` / `unknown model` / `model does not exist` / `no such model`. `classifyAttemptError` already runs it before `isProviderBadRequestError`, so the model-level classification wins and drives the whole-model skip + honest 404 on exhaustion.

Deliberately did **not** add `invalid model` (too broad — a parameter-validation 400 could word it that way).

## Tests
- Added a regression case in `server/src/__tests__/routes/proxy-retry.test.ts` covering the 400 "No model found" phrasing and siblings.
- Verified `model-retirement` corroboration is unaffected (still requires 410 / end-of-life wording, not a bare "no model found").
- Full server suite green; `tsc` build clean.