### PR TITLE
Add Infisical launcher for provider keys

### DIFF
--- a/INFISICAL.md
+++ b/INFISICAL.md
@@ -1,0 +1,73 @@
+# Run FreeLLMAPI with provider keys from Infisical
+
+Turnkey startup: pull your free-tier provider keys straight from Infisical at
+launch, feed them to the router, and never write them to disk. Works anywhere,
+as long as your Infisical account/project still has the keys.
+
+## Prerequisites (once per machine)
+
+1. **Node 20+** and **git**.
+2. **Infisical CLI** — `brew install infisical/get-cli/infisical` (macOS/Linux),
+   then `infisical login`.
+3. Clone + build:
+   ```bash
+   git clone https://github.com/SuZhou-Joe/freellmapi.git
+   cd freellmapi
+   npm install
+   npm run build
+   ```
+
+No `.env` needed: if `ENCRYPTION_KEY` is unset the server auto-generates one and
+stores it next to the SQLite DB (`server/data/.encryption-key`). Back that file
+up if you want your stored keys to survive a reset.
+
+## Start
+
+```bash
+npm run start:infisical
+```
+
+That runs:
+
+```bash
+infisical run --projectId <PROJECT_ID> --env dev -- node start-with-infisical.mjs
+```
+
+- Dashboard + API: http://localhost:3001  (API base URL: `.../v1`)
+- The unified `freellmapi-…` bearer token is printed in the logs on first boot
+  and shown on the dashboard **Keys** page.
+
+### Overriding project / environment
+
+Defaults are baked into the `start:infisical` script but can be overridden:
+
+```bash
+INFISICAL_PROJECT_ID=<other-id> INFISICAL_ENV=staging npm run start:infisical
+```
+
+## How keys are mapped
+
+`start-with-infisical.mjs` maps Infisical secret names to FreeLLMAPI platform
+slugs and injects them via `FREEAPI_CONFIG_JSON` (in-memory only):
+
+| Infisical secret          | Platform slug |
+| ------------------------- | ------------- |
+| `GROQ_API_KEY`            | `groq`        |
+| `GOOGLE_AI_STUDIO_API_KEY`| `google`      |
+| `COHERE_API_KEY`          | `cohere`      |
+| `CLOUDFLARE_API_TOKEN`    | `cloudflare`  |
+| `HUGGINGFACE_API_TOKEN`   | `huggingface` |
+| `OPENROUTER_API_KEY`      | `openrouter`  |
+| `CEREBRAS_API_KEY`        | `cerebras`    |
+
+Add a provider by adding its `SECRET_NAME: 'slug'` entry to the `MAP` in
+`start-with-infisical.mjs`. Missing secrets are skipped silently.
+
+## Smoke test
+
+```bash
+KEY=<unified-key-from-logs>
+curl -s http://127.0.0.1:3001/v1/chat/completions \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"ping"}],"max_tokens":20}'
+```

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "npm run build -w server && npm run build -w cli && npm run build -w client",
     "lint": "npm run lint -w server && npm run lint -w cli",
     "build:server": "npm run build -w server",
+    "start:infisical": "infisical run --projectId ${INFISICAL_PROJECT_ID:-e55d0f7f-f095-4146-b022-db74aa0c5ca6} --env ${INFISICAL_ENV:-dev} -- node start-with-infisical.mjs",
     "test:migrations": "npm run test:migrations -w server",
     "desktop:dev": "npm run build -w client && npm --prefix desktop run dev",
     "desktop:dist": "npm run build -w client && npm --prefix desktop run dist",

--- a/start-with-infisical.mjs
+++ b/start-with-infisical.mjs
@@ -4,10 +4,16 @@
 import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-// Load .env (ENCRYPTION_KEY, PORT) without a dep.
-for (const line of readFileSync(new URL('./.env', import.meta.url), 'utf8').split('\n')) {
-  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
-  if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+// Load .env (ENCRYPTION_KEY, PORT) if present. It is gitignored, so a fresh
+// clone won't have one — that's fine: the server auto-generates an at-rest
+// encryption key (written next to the SQLite DB) when ENCRYPTION_KEY is unset.
+try {
+  for (const line of readFileSync(new URL('./.env', import.meta.url), 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+  }
+} catch {
+  console.log('[launcher] no .env found — server will auto-generate an encryption key');
 }
 
 // Map Infisical secret names -> FreeLLMAPI platform slugs.

--- a/start-with-infisical.mjs
+++ b/start-with-infisical.mjs
@@ -1,0 +1,38 @@
+// Launcher: reads provider keys from env (injected by `infisical run`),
+// builds FREEAPI_CONFIG_JSON in-memory, and starts the FreeLLMAPI server.
+// Keys never touch disk or argv.
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+// Load .env (ENCRYPTION_KEY, PORT) without a dep.
+for (const line of readFileSync(new URL('./.env', import.meta.url), 'utf8').split('\n')) {
+  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+  if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+
+// Map Infisical secret names -> FreeLLMAPI platform slugs.
+const MAP = {
+  GROQ_API_KEY: 'groq',
+  GOOGLE_AI_STUDIO_API_KEY: 'google',
+  COHERE_API_KEY: 'cohere',
+  CLOUDFLARE_API_TOKEN: 'cloudflare',
+  HUGGINGFACE_API_TOKEN: 'huggingface',
+  OPENROUTER_API_KEY: 'openrouter',
+  CEREBRAS_API_KEY: 'cerebras',
+};
+
+const keys = [];
+for (const [envName, platform] of Object.entries(MAP)) {
+  const v = process.env[envName];
+  if (v && v.trim()) keys.push({ platform, key: v.trim(), label: 'infisical', enabled: true });
+}
+
+console.log(`[launcher] seeding ${keys.length} provider keys: ${keys.map((k) => k.platform).join(', ')}`);
+process.env.FREEAPI_CONFIG_JSON = JSON.stringify({ keys });
+
+const child = spawn(process.execPath, ['server/dist/index.js'], {
+  cwd: new URL('.', import.meta.url).pathname,
+  stdio: 'inherit',
+  env: process.env,
+});
+child.on('exit', (code) => process.exit(code ?? 0));


### PR DESCRIPTION
Reads provider API keys injected by `infisical run` from env, maps them to FreeLLMAPI platform slugs, and starts the server via FREEAPI_CONFIG_JSON so keys never touch disk or argv.

Usage:
  infisical run --projectId <id> --env dev -- node start-with-infisical.mjs