### PR TITLE
fix(ci): strip the certificate-type prefix from CSC_NAME

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -226,9 +226,13 @@ jobs:
             exit 1
           fi
           echo "Signing identity: $identity"
+          # electron-builder rejects a CSC_NAME carrying the certificate-type
+          # prefix ("Please remove prefix \"Developer ID Application:\" from the
+          # specified name"); it wants the common name alone and re-attaches the
+          # prefix itself when matching identities.
           {
             echo "CSC_KEYCHAIN=$keychain"
-            echo "CSC_NAME=$identity"
+            echo "CSC_NAME=${identity#Developer ID Application: }"
           } >> "$GITHUB_ENV"
 
       - name: Package installer


### PR DESCRIPTION
Follow-up to #1148, which got the macOS release build as far as this:

```
Signing identity: Developer ID Application: Tashfeen Ahmed (***)
⨯ Please remove prefix "Developer ID Application:" from the specified name — appropriate certificate will be chosen automatically
```

So the keychain import itself now works on the macos-26 runner: create, unlock, import, partition list and `find-identity` all succeeded and the identity came back. electron-builder just wants `CSC_NAME` to be the common name alone and re-attaches the certificate-type prefix itself when matching. Pass it that.