### PR TITLE
fix(ci): attach release installers with gh, not action-gh-release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -337,8 +337,39 @@ jobs:
           path: ${{ matrix.glob }}
           if-no-files-found: error
 
+      # Upload the assets and nothing else. softprops/action-gh-release always
+      # PATCHes the release (name, body, draft state, target commitish) before it
+      # uploads, and that PATCH started coming back
+      # "403 Resource not accessible by integration" on the v0.9.6 rebuilds —
+      # every platform, while `GITHUB_TOKEN Permissions` in the same logs read
+      # `Contents: write` and the release was not immutable. Asset upload itself
+      # has never been refused: it is what attached the v0.9.6 Windows and Linux
+      # installers. So upload directly and leave the release metadata, which this
+      # job has no business rewriting, exactly as the release author left it.
       - name: Attach installer to release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
-        with:
-          files: ${{ matrix.glob }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GLOB: ${{ matrix.glob }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=()
+          while IFS= read -r pattern; do
+            [ -n "$pattern" ] || continue
+            files+=($pattern)
+          done <<< "$GLOB"
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::no installers matched the patterns for this platform"
+            exit 1
+          fi
+          printf 'attaching %s\n' "${files[@]}"
+          # The release is created before the tag is pushed (see the release
+          # recipe), so it exists by now; create it rather than dropping the
+          # installers on the floor if someone pushed a tag on its own.
+          if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "::warning::no release for $GITHUB_REF_NAME yet — creating one"
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          fi
+          gh release upload "$GITHUB_REF_NAME" "${files[@]}" --clobber


### PR DESCRIPTION
Every v0.9.6 rebuild failed after a completely clean build, on all three platforms:

```
##[error]Resource not accessible by integration
https://docs.github.com/rest/releases/releases#update-a-release
```

The macOS DMG in that last run was signed, notarized, stapled and `spctl`-accepted, and the job still failed — purely on attaching.

## Why

`softprops/action-gh-release` PATCHes the release (name, body, draft state, target commitish) before uploading, and that PATCH is what gets refused.

Ruled out:
- **Token scope.** The `GITHUB_TOKEN Permissions` block reads `Contents: write` in both the run that successfully attached the Windows installer and the runs that failed.
- **Immutable releases.** `immutable: false` on the release object.
- **Asset upload.** That has never been refused; it is how the v0.9.6 Windows and Linux installers reached the release.

## Change

Upload the assets with `gh release upload --clobber` and touch nothing else. The job has no business rewriting release metadata: the release is authored before the tag is pushed and its notes are written by hand. A bare tag push with no release still gets one created, which is what the action used to do.

## Verification

The glob parsing (multi-line `matrix.glob`, `nullglob`, empty-match guard) was tested locally against a fixture tree: three patterns, three files, and a clean error when nothing matches. The attach path only runs on tags, so the real proof is the v0.9.6 rebuild after this merges.