### PR TITLE
fix(auth): stop rejecting the desktop account's own email at login

### DIFF
--- a/server/src/__tests__/routes/auth-login-identifier.test.ts
+++ b/server/src/__tests__/routes/auth-login-identifier.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import express, { type Express } from 'express';
+import { authRouter } from '../../routes/auth.js';
+import { initDb, getDb } from '../../db/index.js';
+import { createUser } from '../../services/auth.js';
+
+// The desktop app seeds its hidden account as `desktop@localhost`
+// (desktop/src/server-host.ts). That address has no TLD, so while /login shared
+// the signup schema's z.email() every sign-in on a desktop install was rejected
+// with "A valid email is required" before the password was ever checked — which
+// also made the reset-then-sign-in-from-a-browser workaround in #807 impossible.
+// Logging in is a lookup, so the address is matched, not validated.
+
+function app(): Express {
+  const a = express();
+  a.use(express.json());
+  a.use('/api/auth', authRouter);
+  return a;
+}
+
+async function postLogin(body: unknown) {
+  const server = app().listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
+  const addr = server.address() as { port: number };
+  const res = await fetch(`http://127.0.0.1:${addr.port}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => null);
+  server.close();
+  return { status: res.status, body: data as any };
+}
+
+describe('login accepts the identifier the desktop app actually seeds', () => {
+  beforeAll(() => {
+    initDb(':memory:');
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM sessions').run();
+    getDb().prepare('DELETE FROM users').run();
+  });
+
+  it('signs in an account whose email has no TLD', async () => {
+    createUser('desktop@localhost', 'a-long-random-password');
+    const res = await postLogin({ email: 'desktop@localhost', password: 'a-long-random-password' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeTruthy();
+  });
+
+  it('still rejects the wrong password for that account, with the credential error', async () => {
+    createUser('desktop@localhost', 'a-long-random-password');
+    const res = await postLogin({ email: 'desktop@localhost', password: 'not-the-password' });
+    expect(res.status).toBe(401);
+    // Not a 400 about the address shape — the address was fine, the password was not.
+    expect(res.body.error.message).toBe('Invalid email or password');
+  });
+
+  it('signs in an account created under an older, shorter password policy', async () => {
+    createUser('someone@example.com', 'short');
+    const res = await postLogin({ email: 'someone@example.com', password: 'short' });
+    expect(res.status).toBe(200);
+  });
+
+  it('still requires both fields', async () => {
+    const res = await postLogin({ email: '', password: '' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -23,9 +23,23 @@ const failedPasswordAttempts = new Map<number, number>();
 // /status, /setup and /login are reachable without a session (bootstrap);
 // /logout and /me validate the token themselves.
 
-const credentialsSchema = z.object({
+// Signing up is the one place the address has to look like an address.
+const signupSchema = z.object({
   email: z.string().email('A valid email is required'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+// Logging in is a lookup, not a registration, so the address is matched rather
+// than validated. The desktop app seeds its hidden account as
+// `desktop@localhost` (server-host.ts), which has no TLD and so could never
+// satisfy z.email() — every login attempt on a desktop install failed with
+// "A valid email is required" before the password was even checked, including
+// the reset-then-sign-in-from-a-browser route suggested in #807. Length rules
+// belong to signup too: an account created under an older policy must still be
+// able to get in.
+const loginSchema = z.object({
+  email: z.string().min(1, 'Email is required'),
+  password: z.string().min(1, 'Password is required'),
 });
 
 // ── Brute-force throttle ──────────────────────────────────────────────────
@@ -104,7 +118,7 @@ authRouter.post('/setup', (req: Request, res: Response) => {
     return;
   }
 
-  const parsed = credentialsSchema.safeParse(req.body);
+  const parsed = signupSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
     return;
@@ -116,7 +130,7 @@ authRouter.post('/setup', (req: Request, res: Response) => {
 });
 
 authRouter.post('/login', (req: Request, res: Response) => {
-  const parsed = credentialsSchema.safeParse(req.body);
+  const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) {
     res.status(400).json({ error: { message: parsed.error.errors.map(e => e.message).join(', ') } });
     return;


### PR DESCRIPTION
Found while helping a user sign in to the desktop dashboard: their correct credentials were refused.

```
POST /api/auth/login {"email":"desktop@localhost","password":"<correct>"}
→ 400 {"error":{"message":"A valid email is required"}}
```

The desktop app seeds its hidden machine account as `desktop@localhost` (`desktop/src/server-host.ts`), and `/login` shared the signup schema, whose `z.email()` rejects an address with no TLD. So on a desktop install the password was never even reached: **no desktop user could ever sign in to their own dashboard**. It is also why the workaround suggested on #807 — reset the password, then sign in from a browser — could not have worked for anyone who tried it.

## Change

Split the schema. Signup still demands a real address; login matches an identifier rather than validating its shape, which is all a lookup needs. The minimum-length rule moves to signup along with it: an account created under an older policy must stay able to sign in.

The route still answers a bad password with the same `401 Invalid email or password`, so nothing about enumeration or the brute-force throttle changes.

## Tests

Four new route tests in `server/src/__tests__/routes/auth-login-identifier.test.ts`:

- signs in an account whose email has no TLD (the desktop case)
- the wrong password for that account still 401s on the credential message, rather than 400ing on the address shape
- an account created under an older, shorter password policy can still sign in
- both fields are still required

`src/__tests__/routes/` is green: 103 files, 1019 tests.