### PR TITLE
fix(desktop): keep the Dock icon when the popover opens

### DIFF
--- a/desktop/src/popover.ts
+++ b/desktop/src/popover.ts
@@ -51,8 +51,16 @@ function createPopover(): BrowserWindow {
     },
   });
 
-  // Show over fullscreen apps, like every menu bar utility.
-  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+  // Follow the user across Spaces. `visibleOnFullScreen` is what lets the
+  // popover appear over another app's fullscreen Space, but Electron delivers
+  // it by transforming the process into a UI-element app — its own source says
+  // it "functionally mimics app.dock.hide()" — which silently removed the Dock
+  // icon the first time the popover opened. `skipTransformProcessType` keeps
+  // the collection behaviour and leaves the Dock icon to main.ts' showInDock.
+  // The cost: with the icon shown, macOS will not float the popover over
+  // someone else's fullscreen Space (a rule since 10.14). Users who turn the
+  // Dock icon off get that back, exactly as before.
+  win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true });
 
   win.loadFile(path.join(__dirname, '../renderer/popover.html')).then(() => {
     if (process.platform !== 'darwin') {


### PR DESCRIPTION
Follow-up to #1151. With **Show in Dock** on, the icon appeared at launch and vanished the first time the popover opened.

## Cause

`popover.ts` calls `win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })`. Electron implements `visibleOnFullScreen` by transforming the process into a UI-element application — its own source comments say it "functionally mimics `app.dock.hide()`" — because since macOS 10.14 a regular app's windows cannot float over another app's fullscreen Space. That transform is what removed the icon.

## Change

Pass `skipTransformProcessType: true`, the option Electron provides for exactly this. The window keeps its all-Spaces collection behaviour; the Dock icon stays under `main.ts`'s `showInDock` control.

Trade-off, which is the OS rule rather than anything ours: with the icon shown, the popover will not float over *someone else's* fullscreen Space. Turning the Dock icon off in the tray menu restores that, exactly as before #1151.

## Verification

On the installed build, reading the accessibility `background only` property (false = present in the Dock):

| moment | before | after |
|---|---|---|
| after launch | false | false |
| popover opened | **true** | false |
| popover closed | true | false |
| popover reopened | true | false |