### PR TITLE
chore(release): desktop v0.9.7

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freellmapi-desktop",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "dependencies": {
         "better-sqlite3": "^12.10.0"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freellmapi-desktop",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "FreeLLMAPI menu-bar app — local OpenAI-compatible LLM router",
   "author": {
     "name": "tashfeenahmed",


### PR DESCRIPTION
Version bump for v0.9.7.

Since v0.9.6:
- #1153 — desktop: keep the Dock icon when the popover opens
- #1151 — desktop: show the app in the Dock, with a tray toggle
- #1152 — auth: stop rejecting the desktop account's own email at login
- #1148 #1149 #1150 — release CI: sign on the macos-26 runner image, attach installers with gh