### PR TITLE
feat: improve rank routing and provider model lifecycle

### DIFF
--- a/client/src/i18n/locales/am.json
+++ b/client/src/i18n/locales/am.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ፍጥነት",
     "weightIntelligence": "አእምሮ",
     "weightRequired": "ቢያንስ አንድ ክብደት ከዜሮ በላይ መሆን አለበት.",
-    "scoreColumn": "ውጤት"
+    "scoreColumn": "ውጤት",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "የራውተር ግፊት",

--- a/client/src/i18n/locales/ar.json
+++ b/client/src/i18n/locales/ar.json
@@ -331,7 +331,9 @@
     "weightSpeed": "السرعة",
     "weightIntelligence": "الذكاء",
     "weightRequired": "يجب أن يكون وزن واحد على الأقل أعلى من الصفر.",
-    "scoreColumn": "النتيجة"
+    "scoreColumn": "النتيجة",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ضغط جهاز التوجيه",

--- a/client/src/i18n/locales/az.json
+++ b/client/src/i18n/locales/az.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Sürət",
     "weightIntelligence": "Kəşfiyyat",
     "weightRequired": "Ən azı bir ağırlıq sıfırdan yuxarı olmalıdır.",
-    "scoreColumn": "Musiqi"
+    "scoreColumn": "Musiqi",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Router təzyiqi",

--- a/client/src/i18n/locales/bg.json
+++ b/client/src/i18n/locales/bg.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Скорост",
     "weightIntelligence": "Разузнаване",
     "weightRequired": "Поне едно тегло трябва да е над нула.",
-    "scoreColumn": "Партитура"
+    "scoreColumn": "Партитура",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Налягане в рутера",

--- a/client/src/i18n/locales/bn.json
+++ b/client/src/i18n/locales/bn.json
@@ -331,7 +331,9 @@
     "weightSpeed": "গতি",
     "weightIntelligence": "বুদ্ধিমত্তা",
     "weightRequired": "কমপক্ষে একটি ওজন শূন্যের উপরে হতে হবে।",
-    "scoreColumn": "স্কোর"
+    "scoreColumn": "স্কোর",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "রাউটারের চাপ",

--- a/client/src/i18n/locales/cs.json
+++ b/client/src/i18n/locales/cs.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Rychlost",
     "weightIntelligence": "Zpravodajství",
     "weightRequired": "Alespoň jedno závaží musí být nad nulou.",
-    "scoreColumn": "Hudba"
+    "scoreColumn": "Hudba",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Tlak frézky",

--- a/client/src/i18n/locales/da.json
+++ b/client/src/i18n/locales/da.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Hastighed",
     "weightIntelligence": "Intelligens",
     "weightRequired": "Mindst én vægt skal være over nul.",
-    "scoreColumn": "Score"
+    "scoreColumn": "Score",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Fræsertryk",

--- a/client/src/i18n/locales/de.json
+++ b/client/src/i18n/locales/de.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Geschwindigkeit",
     "weightIntelligence": "Intelligenz",
     "weightRequired": "Mindestens ein Gewicht muss über Null liegen.",
-    "scoreColumn": "Punktzahl"
+    "scoreColumn": "Punktzahl",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Router-Druck",

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Ταχύτητα",
     "weightIntelligence": "Ευφυΐα",
     "weightRequired": "Τουλάχιστον ένα βάρος πρέπει να είναι πάνω από το μηδέν.",
-    "scoreColumn": "Σκορ"
+    "scoreColumn": "Σκορ",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Πίεση δρομολογητή",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Speed",
     "weightIntelligence": "Intelligence",
     "weightRequired": "At least one weight must be above zero.",
-    "scoreColumn": "Score"
+    "scoreColumn": "Score",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Router pressure",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Velocidad",
     "weightIntelligence": "Inteligencia",
     "weightRequired": "Al menos un peso debe ser mayor que cero.",
-    "scoreColumn": "Puntuación"
+    "scoreColumn": "Puntuación",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Presión del router",

--- a/client/src/i18n/locales/fa.json
+++ b/client/src/i18n/locales/fa.json
@@ -331,7 +331,9 @@
     "weightSpeed": "سرعت",
     "weightIntelligence": "هوش",
     "weightRequired": "حداقل یک وزن باید بالای صفر باشد.",
-    "scoreColumn": "امتیاز"
+    "scoreColumn": "امتیاز",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "فشار روتر",

--- a/client/src/i18n/locales/fi.json
+++ b/client/src/i18n/locales/fi.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Nopeus",
     "weightIntelligence": "Tiedustelu",
     "weightRequired": "Vähintään yhden painon täytyy olla yli nollan.",
-    "scoreColumn": "Musiikki"
+    "scoreColumn": "Musiikki",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Jyrsimen paine",

--- a/client/src/i18n/locales/fr.json
+++ b/client/src/i18n/locales/fr.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Vitesse",
     "weightIntelligence": "Intelligence",
     "weightRequired": "Au moins une pondération doit être supérieure à zéro.",
-    "scoreColumn": "Score"
+    "scoreColumn": "Score",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Pression sur le routeur",

--- a/client/src/i18n/locales/gu.json
+++ b/client/src/i18n/locales/gu.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ઝડપ",
     "weightIntelligence": "બુદ્ધિ",
     "weightRequired": "ઓછામાં ઓછું એક વજન શૂન્યથી ઉપર હોવું જોઈએ.",
-    "scoreColumn": "સ્કોર"
+    "scoreColumn": "સ્કોર",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "રાઉટર દબાણ",

--- a/client/src/i18n/locales/ha.json
+++ b/client/src/i18n/locales/ha.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Gudu",
     "weightIntelligence": "Hankali",
     "weightRequired": "Aƙalla nauyi ɗaya dole ne ya kasance sama da sifili.",
-    "scoreColumn": "Maki"
+    "scoreColumn": "Maki",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Matsin na'ura mai ba da hanya tsakanin hanyoyin sadarwa",

--- a/client/src/i18n/locales/he.json
+++ b/client/src/i18n/locales/he.json
@@ -331,7 +331,9 @@
     "weightSpeed": "מהירות",
     "weightIntelligence": "מודיעין",
     "weightRequired": "לפחות משקל אחד חייב להיות מעל אפס.",
-    "scoreColumn": "פסקול"
+    "scoreColumn": "פסקול",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "לחץ הנתב",

--- a/client/src/i18n/locales/hi.json
+++ b/client/src/i18n/locales/hi.json
@@ -331,7 +331,9 @@
     "weightSpeed": "गति",
     "weightIntelligence": "बुद्धि",
     "weightRequired": "कम से कम एक वज़न शून्य से ऊपर होना चाहिए.",
-    "scoreColumn": "स्कोर"
+    "scoreColumn": "स्कोर",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "राउटर का दबाव",

--- a/client/src/i18n/locales/hr.json
+++ b/client/src/i18n/locales/hr.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Brzina",
     "weightIntelligence": "Obavještajna služba",
     "weightRequired": "Najmanje jedna težina mora biti iznad nule.",
-    "scoreColumn": "Glazba"
+    "scoreColumn": "Glazba",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Tlak glodalice",

--- a/client/src/i18n/locales/hu.json
+++ b/client/src/i18n/locales/hu.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Sebesség",
     "weightIntelligence": "Intelligencia",
     "weightRequired": "Legalább egy súlynak nulla felett kell lennie.",
-    "scoreColumn": "Zene"
+    "scoreColumn": "Zene",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Router nyomás",

--- a/client/src/i18n/locales/id.json
+++ b/client/src/i18n/locales/id.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Kecepatan",
     "weightIntelligence": "Intelijen",
     "weightRequired": "Setidaknya satu bobot harus di atas nol.",
-    "scoreColumn": "Skor"
+    "scoreColumn": "Skor",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Tekanan router",

--- a/client/src/i18n/locales/ig.json
+++ b/client/src/i18n/locales/ig.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Ọsọ",
     "weightIntelligence": "ọgụgụ isi",
     "weightRequired": "Opekempe otu arọ ga-adị n'elu efu.",
-    "scoreColumn": "Akara"
+    "scoreColumn": "Akara",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Nrụgide rawụta",

--- a/client/src/i18n/locales/it.json
+++ b/client/src/i18n/locales/it.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Velocità",
     "weightIntelligence": "Intelligenza",
     "weightRequired": "Almeno un peso deve essere maggiore di zero.",
-    "scoreColumn": "Punteggio"
+    "scoreColumn": "Punteggio",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Pressione del router",

--- a/client/src/i18n/locales/ja.json
+++ b/client/src/i18n/locales/ja.json
@@ -331,7 +331,9 @@
     "weightSpeed": "速度",
     "weightIntelligence": "インテリジェンス",
     "weightRequired": "少なくとも 1 つの重みがゼロより大きくなければなりません。",
-    "scoreColumn": "スコア"
+    "scoreColumn": "スコア",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ルーターの圧力",

--- a/client/src/i18n/locales/ka.json
+++ b/client/src/i18n/locales/ka.json
@@ -331,7 +331,9 @@
     "weightSpeed": "სიჩქარე",
     "weightIntelligence": "დაზვერვა",
     "weightRequired": "მინიმუმ ერთი წონა უნდა იყოს ნულის ზემოთ.",
-    "scoreColumn": "ქულა"
+    "scoreColumn": "ქულა",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "როუტერის წნევა",

--- a/client/src/i18n/locales/km.json
+++ b/client/src/i18n/locales/km.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ល្បឿន",
     "weightIntelligence": "បញ្ញា",
     "weightRequired": "យ៉ាងហោចណាស់ទម្ងន់មួយត្រូវតែខ្ពស់ជាងសូន្យ។",
-    "scoreColumn": "ពិន្ទុ"
+    "scoreColumn": "ពិន្ទុ",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "សំពាធរ៉ោទ័រ",

--- a/client/src/i18n/locales/kn.json
+++ b/client/src/i18n/locales/kn.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ವೇಗ",
     "weightIntelligence": "ಗುಪ್ತಚರ",
     "weightRequired": "ಕನಿಷ್ಠ ಒಂದು ತೂಕವು ಶೂನ್ಯಕ್ಕಿಂತ ಹೆಚ್ಚಿರಬೇಕು.",
-    "scoreColumn": "ಸ್ಕೋರ್"
+    "scoreColumn": "ಸ್ಕೋರ್",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ರೂಟರ್ ಒತ್ತಡ",

--- a/client/src/i18n/locales/ko.json
+++ b/client/src/i18n/locales/ko.json
@@ -331,7 +331,9 @@
     "weightSpeed": "속도",
     "weightIntelligence": "지능",
     "weightRequired": "하나 이상의 가중치가 0보다 커야 합니다.",
-    "scoreColumn": "점수"
+    "scoreColumn": "점수",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "라우터 압력",

--- a/client/src/i18n/locales/lt.json
+++ b/client/src/i18n/locales/lt.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Greitis",
     "weightIntelligence": "Intelektas",
     "weightRequired": "Bent vienas svoris turi būti virš nulio.",
-    "scoreColumn": "Muzika"
+    "scoreColumn": "Muzika",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Maršrutizatoriaus slėgis",

--- a/client/src/i18n/locales/ml.json
+++ b/client/src/i18n/locales/ml.json
@@ -331,7 +331,9 @@
     "weightSpeed": "വേഗത",
     "weightIntelligence": "ഇൻ്റലിജൻസ്",
     "weightRequired": "കുറഞ്ഞത് ഒരു ഭാരമെങ്കിലും പൂജ്യത്തിന് മുകളിലായിരിക്കണം.",
-    "scoreColumn": "സ്കോർ"
+    "scoreColumn": "സ്കോർ",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "റൂട്ടർ മർദ്ദം",

--- a/client/src/i18n/locales/mr.json
+++ b/client/src/i18n/locales/mr.json
@@ -331,7 +331,9 @@
     "weightSpeed": "गती",
     "weightIntelligence": "बुद्धिमत्ता",
     "weightRequired": "किमान एक वजन शून्यापेक्षा जास्त असणे आवश्यक आहे.",
-    "scoreColumn": "स्कोअर"
+    "scoreColumn": "स्कोअर",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "राउटर दबाव",

--- a/client/src/i18n/locales/ms.json
+++ b/client/src/i18n/locales/ms.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Kelajuan",
     "weightIntelligence": "Perisikan",
     "weightRequired": "Sekurang-kurangnya satu berat mesti melebihi sifar.",
-    "scoreColumn": "Skor"
+    "scoreColumn": "Skor",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Tekanan penghala",

--- a/client/src/i18n/locales/my.json
+++ b/client/src/i18n/locales/my.json
@@ -331,7 +331,9 @@
     "weightSpeed": "အမြန်နှုန်း",
     "weightIntelligence": "ဉာဏ်ရည်",
     "weightRequired": "အနည်းဆုံး အလေးချိန်တစ်ခုသည် သုညထက် မြင့်ရမည်။",
-    "scoreColumn": "အမှတ်"
+    "scoreColumn": "အမှတ်",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ရောတာဖိအား",

--- a/client/src/i18n/locales/ne.json
+++ b/client/src/i18n/locales/ne.json
@@ -331,7 +331,9 @@
     "weightSpeed": "गति",
     "weightIntelligence": "इन्टेलिजेन्स",
     "weightRequired": "कम्तीमा एउटा तौल शून्यभन्दा माथि हुनुपर्छ ।",
-    "scoreColumn": "प्राप्ताङ्क"
+    "scoreColumn": "प्राप्ताङ्क",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "राउटरको चाप",

--- a/client/src/i18n/locales/nl.json
+++ b/client/src/i18n/locales/nl.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Snelheid",
     "weightIntelligence": "Intelligentie",
     "weightRequired": "Minstens één gewicht moet boven nul liggen.",
-    "scoreColumn": "Partituur"
+    "scoreColumn": "Partituur",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Routerdruk",

--- a/client/src/i18n/locales/no.json
+++ b/client/src/i18n/locales/no.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Hastighet",
     "weightIntelligence": "Etterretning",
     "weightRequired": "Minst én vekt må være over null.",
-    "scoreColumn": "Poengsum"
+    "scoreColumn": "Poengsum",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Frestrykk",

--- a/client/src/i18n/locales/or.json
+++ b/client/src/i18n/locales/or.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ବେଗ",
     "weightIntelligence": "ବୁଦ୍ଧିମତା",
     "weightRequired": "ଅତିକମରେ ଗୋଟିଏ ଓଜନ ଶୂନ୍ୟରୁ ଅଧିକ ହେବା ଆବଶ୍ୟକ।",
-    "scoreColumn": "ସ୍କୋର"
+    "scoreColumn": "ସ୍କୋର",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ରାଉଟର ଚାପ",

--- a/client/src/i18n/locales/pa.json
+++ b/client/src/i18n/locales/pa.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ਗਤੀ",
     "weightIntelligence": "ਬੁੱਧੀ",
     "weightRequired": "ਘੱਟੋ-ਘੱਟ ਇੱਕ ਭਾਰ ਜ਼ੀਰੋ ਤੋਂ ਉੱਪਰ ਹੋਣਾ ਚਾਹੀਦਾ ਹੈ।",
-    "scoreColumn": "ਸਕੋਰ"
+    "scoreColumn": "ਸਕੋਰ",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "ਰਾਊਟਰ ਦਾ ਦਬਾਅ",

--- a/client/src/i18n/locales/pl.json
+++ b/client/src/i18n/locales/pl.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Prędkość",
     "weightIntelligence": "Inteligencja",
     "weightRequired": "Przynajmniej jedna waga musi być powyżej zera.",
-    "scoreColumn": "Wynik"
+    "scoreColumn": "Wynik",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Ciśnienie routera",

--- a/client/src/i18n/locales/pt-BR.json
+++ b/client/src/i18n/locales/pt-BR.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Velocidade",
     "weightIntelligence": "Inteligência",
     "weightRequired": "Pelo menos um peso deve ser maior que zero.",
-    "scoreColumn": "Pontuação"
+    "scoreColumn": "Pontuação",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Pressão do roteador",

--- a/client/src/i18n/locales/pt-PT.json
+++ b/client/src/i18n/locales/pt-PT.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Velocidade",
     "weightIntelligence": "Inteligência",
     "weightRequired": "Pelo menos um peso deve estar acima de zero.",
-    "scoreColumn": "Banda sonora"
+    "scoreColumn": "Banda sonora",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Pressão do router",

--- a/client/src/i18n/locales/ro.json
+++ b/client/src/i18n/locales/ro.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Viteză",
     "weightIntelligence": "Inteligență",
     "weightRequired": "Cel puțin o greutate trebuie să fie peste zero.",
-    "scoreColumn": "Scorul"
+    "scoreColumn": "Scorul",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Presiunea routerului",

--- a/client/src/i18n/locales/ru.json
+++ b/client/src/i18n/locales/ru.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Скорость",
     "weightIntelligence": "Интеллект",
     "weightRequired": "Хотя бы один вес должен быть больше нуля.",
-    "scoreColumn": "Оценка"
+    "scoreColumn": "Оценка",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Давление маршрутизатора",

--- a/client/src/i18n/locales/si.json
+++ b/client/src/i18n/locales/si.json
@@ -331,7 +331,9 @@
     "weightSpeed": "වේගය",
     "weightIntelligence": "බුද්ධිය",
     "weightRequired": "අවම වශයෙන් එක් බරක් බිංදුවට වඩා වැඩි විය යුතුය.",
-    "scoreColumn": "ලකුණු"
+    "scoreColumn": "ලකුණු",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "රවුටරයේ පීඩනය",

--- a/client/src/i18n/locales/sk.json
+++ b/client/src/i18n/locales/sk.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Rýchlosť",
     "weightIntelligence": "Spravodajstvo",
     "weightRequired": "Aspoň jedno závažie musí byť nad nulou.",
-    "scoreColumn": "Hudba"
+    "scoreColumn": "Hudba",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Tlak frézky",

--- a/client/src/i18n/locales/sr.json
+++ b/client/src/i18n/locales/sr.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Брзина",
     "weightIntelligence": "Интелигенција",
     "weightRequired": "Најмање једна тежина мора бити изнад нуле.",
-    "scoreColumn": "Резултат"
+    "scoreColumn": "Резултат",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Притисак рутера",

--- a/client/src/i18n/locales/sv.json
+++ b/client/src/i18n/locales/sv.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Hastighet",
     "weightIntelligence": "Underrättelse",
     "weightRequired": "Minst en vikt måste vara över noll.",
-    "scoreColumn": "Poäng"
+    "scoreColumn": "Poäng",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Frästryck",

--- a/client/src/i18n/locales/sw.json
+++ b/client/src/i18n/locales/sw.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Kasi",
     "weightIntelligence": "Akili",
     "weightRequired": "Angalau uzito mmoja lazima uwe juu ya sifuri.",
-    "scoreColumn": "Alama"
+    "scoreColumn": "Alama",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Shinikizo la router",

--- a/client/src/i18n/locales/ta.json
+++ b/client/src/i18n/locales/ta.json
@@ -331,7 +331,9 @@
     "weightSpeed": "வேகம்",
     "weightIntelligence": "உளவுத்துறை",
     "weightRequired": "குறைந்தபட்சம் ஒரு எடை பூஜ்ஜியத்திற்கு மேல் இருக்க வேண்டும்.",
-    "scoreColumn": "மதிப்பெண்"
+    "scoreColumn": "மதிப்பெண்",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "திசைவி அழுத்தம்",

--- a/client/src/i18n/locales/te.json
+++ b/client/src/i18n/locales/te.json
@@ -331,7 +331,9 @@
     "weightSpeed": "వేగం",
     "weightIntelligence": "ఇంటెలిజెన్స్",
     "weightRequired": "కనీసం ఒక బరువు తప్పనిసరిగా సున్నా కంటే ఎక్కువగా ఉండాలి.",
-    "scoreColumn": "స్కోర్"
+    "scoreColumn": "స్కోర్",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "రూటర్ ఒత్తిడి",

--- a/client/src/i18n/locales/th.json
+++ b/client/src/i18n/locales/th.json
@@ -331,7 +331,9 @@
     "weightSpeed": "ความเร็ว",
     "weightIntelligence": "ความฉลาด",
     "weightRequired": "อย่างน้อยหนึ่งน้ำหนักต้องมากกว่าศูนย์",
-    "scoreColumn": "คะแนน"
+    "scoreColumn": "คะแนน",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "แรงดันเราเตอร์",

--- a/client/src/i18n/locales/tl.json
+++ b/client/src/i18n/locales/tl.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Bilis",
     "weightIntelligence": "Intelihensiya",
     "weightRequired": "Dapat may isang timbang na higit sa zero.",
-    "scoreColumn": "Iskor"
+    "scoreColumn": "Iskor",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Presyon ng router",

--- a/client/src/i18n/locales/tr.json
+++ b/client/src/i18n/locales/tr.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Hız",
     "weightIntelligence": "İstihbarat",
     "weightRequired": "En az bir ağırlık sıfırın üzerinde olmalıdır.",
-    "scoreColumn": "Puan"
+    "scoreColumn": "Puan",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Yönlendirici basıncı",

--- a/client/src/i18n/locales/uk.json
+++ b/client/src/i18n/locales/uk.json
@@ -331,7 +331,9 @@
     "weightSpeed": "швидкість",
     "weightIntelligence": "Інтелект",
     "weightRequired": "Принаймні одна вага повинна бути вище нуля.",
-    "scoreColumn": "Оцінка"
+    "scoreColumn": "Оцінка",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Тиск фрезера",

--- a/client/src/i18n/locales/ur.json
+++ b/client/src/i18n/locales/ur.json
@@ -331,7 +331,9 @@
     "weightSpeed": "رفتار",
     "weightIntelligence": "ذہانت",
     "weightRequired": "کم از کم ایک وزن صفر سے اوپر ہونا چاہیے۔",
-    "scoreColumn": "سکور"
+    "scoreColumn": "سکور",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "راؤٹر کا دباؤ",

--- a/client/src/i18n/locales/uz.json
+++ b/client/src/i18n/locales/uz.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Tezlik",
     "weightIntelligence": "Intellekt",
     "weightRequired": "Kamida bitta vazn noldan yuqori bo'lishi kerak.",
-    "scoreColumn": "Gol"
+    "scoreColumn": "Gol",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Router bosimi",

--- a/client/src/i18n/locales/vi.json
+++ b/client/src/i18n/locales/vi.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Tốc độ",
     "weightIntelligence": "Tình báo",
     "weightRequired": "Ít nhất một trọng lượng phải trên 0.",
-    "scoreColumn": "Điểm"
+    "scoreColumn": "Điểm",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Áp lực bộ định tuyến",

--- a/client/src/i18n/locales/yo.json
+++ b/client/src/i18n/locales/yo.json
@@ -331,7 +331,9 @@
     "weightSpeed": "Iyara",
     "weightIntelligence": "Imọye",
     "weightRequired": "O kere ju iwuwo kan gbọdọ jẹ loke odo.",
-    "scoreColumn": "Dimegilio"
+    "scoreColumn": "Dimegilio",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "Ipa olulana",

--- a/client/src/i18n/locales/zh-CN.json
+++ b/client/src/i18n/locales/zh-CN.json
@@ -331,7 +331,9 @@
     "weightSpeed": "速度",
     "weightIntelligence": "智能",
     "weightRequired": "至少一个权重必须大于零。",
-    "scoreColumn": "评分"
+    "scoreColumn": "评分",
+    "manualSmart": "手动智能",
+    "manualSmartBlurb": "按自定义 intelligence_rank 路由。模型按排名排序，失败时惩罚，成功时恢复。"
   },
   "penaltyInspector": {
     "title": "路由压力",

--- a/client/src/i18n/locales/zh-TW.json
+++ b/client/src/i18n/locales/zh-TW.json
@@ -331,7 +331,9 @@
     "weightSpeed": "速度",
     "weightIntelligence": "智慧",
     "weightRequired": "至少一個權重必須大於零。",
-    "scoreColumn": "分數"
+    "scoreColumn": "分數",
+    "manualSmart": "Manual Smart",
+    "manualSmartBlurb": "Route by your custom intelligence_rank. Models are ordered by rank, penalized on failures, and recovered on success."
   },
   "penaltyInspector": {
     "title": "路由壓力",

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -56,7 +56,7 @@ export interface FallbackEntry {
   groupLabel?: string
 }
 
-export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom'
+export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom' | 'manual-smart'
 
 // How the gateway picks between several keys of ONE platform, once a model has
 // been chosen (#919). Separate from RoutingStrategy, which ranks models: the

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -57,6 +57,7 @@ const STRATEGIES: { key: RoutingStrategy; tKey: string }[] = [
   { key: 'fastest', tKey: 'fastest' },
   { key: 'reliable', tKey: 'reliable' },
   { key: 'custom', tKey: 'custom' },
+  { key: 'manual-smart', tKey: 'manualSmart' },
 ]
 
 // Minimum-context filter buckets for the Models page toolbar. `key` is the token
@@ -151,7 +152,7 @@ export default function FallbackPage() {
   })
 
   // Time-window rate-limit usage (#876). One observer and one poll timer for the
-  // whole table — the row component reads it from a map instead of subscribing
+  // whole table 鈥?the row component reads it from a map instead of subscribing
   // per row, which on a large catalog was hundreds of observers and timers.
   const { data: rateLimitUsage } = useQuery<RateLimitUsageData>({
     queryKey: ['fallback', 'rate-limit-usage'],
@@ -184,7 +185,7 @@ export default function FallbackPage() {
 
   const strategy: RoutingStrategy = routing?.strategy ?? 'balanced'
   const keySelection: KeySelectionStrategy = routing?.keySelectionStrategy ?? 'auto'
-  const isManual = strategy === 'priority'
+  const isManual = strategy === 'priority' || strategy === 'manual-smart'
 
   // Merge fallback metadata with live scores, keyed by model. Memoized (#1047):
   // recomputing these over the whole catalog on every render — and the page
@@ -327,7 +328,7 @@ export default function FallbackPage() {
         {/* First-run checklist: hides itself once the install has keys + a request */}
         <GettingStarted />
 
-        {/* Monthly token budget — moved to the top */}
+        {/* Monthly token budget 鈥?moved to the top */}
         {tokenUsage && tokenUsage.totalBudget > 0 && <TokenUsageBar data={tokenUsage} />}
 
         {/* Strategy selector */}
@@ -401,7 +402,7 @@ export default function FallbackPage() {
             <div className="mt-3 flex flex-col items-start gap-2 border-t pt-3">
               {/* Key selection (#919). A separate knob from the strategy above:
                   that one ranks MODELS, this one picks between several keys of
-                  the same provider. Shown in every mode — manual chain order
+                  the same provider. Shown in every mode 鈥?manual chain order
                   still leaves the choice of key open. */}
               <label className="inline-flex items-center gap-2 text-xs text-muted-foreground">
                 <span>{t('strategies.keySelection')}</span>
@@ -441,8 +442,7 @@ export default function FallbackPage() {
 
               {/* Peak-hours adjustment (#760): an opt-in tweak to the preset
                   weights, and off it does nothing at all. Its "(peak hours)"
-                  marker on the weight summary above stays visible either way —
-                  that one explains live behaviour. */}
+                  marker on the weight summary above stays visible either way 鈥?                  that one explains live behaviour. */}
               {!isManual && routing && (
                 <PeakHoursControls
                   routing={routing}
@@ -606,7 +606,7 @@ export default function FallbackPage() {
                 renders. Present only while rows remain, so IO never fires idle. */}
             {hasMoreRows && <div ref={sentinelRef} className="h-px" aria-hidden="true" />}
 
-            {/* Floating action bar — fixed to the viewport so it's always visible,
+            {/* Floating action bar 鈥?fixed to the viewport so it's always visible,
                 sliding up when there are unsaved changes and back down on save/discard. */}
             <FloatingBar show={hasChanges}>
               <span className="text-xs text-muted-foreground">{t('common.unsavedChanges')}</span>

--- a/server/src/__tests__/services/catalog-sync.test.ts
+++ b/server/src/__tests__/services/catalog-sync.test.ts
@@ -200,6 +200,7 @@ describe('applyCatalog', () => {
       displayName: 'Local Name',
       contextWindow: 12345,
       supportsTools: true,
+      intelligenceRank: 198,
     });
 
     const refreshed = existingAsCatalogModels().filter((m) => m.modelId !== 'override-model');
@@ -212,11 +213,11 @@ describe('applyCatalog', () => {
     applyCatalog(getDb(), catalogOf(refreshed));
 
     const row = getDb().prepare(`
-      SELECT display_name, context_window, supports_tools
+      SELECT display_name, context_window, supports_tools, intelligence_rank
         FROM models
        WHERE platform = 'groq' AND model_id = 'override-model'
-    `).get() as { display_name: string; context_window: number; supports_tools: number };
-    expect(row).toEqual({ display_name: 'Local Name', context_window: 12345, supports_tools: 1 });
+    `).get() as { display_name: string; context_window: number; supports_tools: number; intelligence_rank: number };
+    expect(row).toEqual({ display_name: 'Local Name', context_window: 12345, supports_tools: 1, intelligence_rank: 198 });
   });
 
   it('keeps user-deleted catalog models deleted across catalog refreshes', () => {

--- a/server/src/__tests__/services/model-retirement.test.ts
+++ b/server/src/__tests__/services/model-retirement.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { initDb, getDb } from '../../db/index.js';
-import { modelRetirementSignal } from '../../lib/error-classify.js';
+import { isPermanentModelUnavailableError, modelRetirementSignal } from '../../lib/error-classify.js';
 import {
   noteModelRetirementSignal,
   resetModelRetirementObservations,
@@ -58,6 +58,11 @@ const NVIDIA_EOL = Object.assign(
     + 'on 2026-07-27T00:00:00Z and is no longer available.',
   ),
   { status: 410 },
+);
+
+const FREE_PLAN_ENDED = Object.assign(
+  new Error('Provider API error 403: this model is not available on the free plan'),
+  { status: 403 },
 );
 
 // The transient shape from the same issue thread: a load balancer that cannot
@@ -122,6 +127,23 @@ describe('modelRetirementSignal (conservative end-of-life detection — #634)', 
     ))).toBe('probable');
   });
 
+  it('recognizes an explicit permanent free-plan gate but not resettable quota', () => {
+    const permanent = Object.assign(
+      new Error('Provider API error 403: this model is not available on the free plan'),
+      { status: 403 },
+    );
+    const resettable = Object.assign(
+      new Error('Provider API error 402: free tier quota resets monthly; upgrade is optional'),
+      { status: 402 },
+    );
+
+    expect(isPermanentModelUnavailableError(permanent)).toBe(true);
+    expect(modelRetirementSignal(permanent)).toBe('definitive');
+    expect(isPermanentModelUnavailableError(resettable)).toBe(false);
+    expect(modelRetirementSignal(resettable)).toBeNull();
+    expect(isPermanentModelUnavailableError(Object.assign(new Error('insufficient balance'), { status: 402 }))).toBe(false);
+  });
+
   it('never fires on transient 404s, empty not-found bodies, or unrelated failures', () => {
     expect(modelRetirementSignal(TRANSIENT_404)).toBeNull();
     expect(modelRetirementSignal(new Error('OpenRouter API error 404: Provider returned error'))).toBeNull();
@@ -141,14 +163,26 @@ describe('noteModelRetirementSignal (auto-disable with a reason — #634)', () =
     getDb().prepare("DELETE FROM catalog_model_tombstones WHERE model_id LIKE 'eol-test-%'").run();
   });
 
-  it('auto-disables the model on a single explicit 410 end-of-life response', () => {
+  it('deletes the model on a single explicit 410 end-of-life response', () => {
     const id = seedModel();
     expect(noteModelRetirementSignal(routeFor(id), NVIDIA_EOL, {})).toBe(true);
     expect(isRoutable(id)).toBe(false);
+    expect(getDb().prepare('SELECT id FROM models WHERE id = ?').get(id)).toBeUndefined();
 
     const tombstone = getCatalogModelTombstone(getDb(), 'chat', PLATFORM, MODEL_ID);
-    expect(tombstone?.source).toBe('upstream_eol');
+    expect(tombstone?.source).toBe('upstream_permanent');
     expect(tombstone?.reason).toContain('end of life');
+  });
+
+  it('deletes a model when the provider permanently ends free-plan access', () => {
+    const id = seedModel('eol-test-paywalled');
+    expect(noteModelRetirementSignal(routeFor(id, 'eol-test-paywalled'), FREE_PLAN_ENDED, {})).toBe(true);
+    expect(getDb().prepare('SELECT id FROM models WHERE id = ?').get(id)).toBeUndefined();
+
+    const tombstone = getCatalogModelTombstone(getDb(), 'chat', PLATFORM, 'eol-test-paywalled');
+    expect(tombstone?.source).toBe('upstream_permanent');
+    expect(tombstone?.reason).toContain('not available on the free plan');
+
   });
 
   it('leaves a transient 404 alone no matter how often it repeats', () => {
@@ -229,10 +263,12 @@ describe('catalog sync vs. upstream retirement (#634)', () => {
     } as unknown as Parameters<typeof applyCatalog>[1];
   }
 
-  it('re-enables an auto-retired model when a later catalog still lists it', () => {
+  it('re-enables a corroborated probable 404 when a later catalog still lists it', () => {
     resetModelRetirementObservations();
     const id = seedModel('eol-test-relisted');
-    noteModelRetirementSignal(routeFor(id, 'eol-test-relisted'), NVIDIA_EOL, {});
+    const err = Object.assign(new Error('API error 404: this model is no longer available'), { status: 404 });
+    noteModelRetirementSignal(routeFor(id, 'eol-test-relisted'), err, {});
+    noteModelRetirementSignal(routeFor(id, 'eol-test-relisted'), err, {});
     expect(isRoutable(id)).toBe(false);
 
     applyCatalog(getDb(), catalogWith('eol-test-relisted', true));
@@ -241,6 +277,18 @@ describe('catalog sync vs. upstream retirement (#634)', () => {
     expect(getCatalogModelTombstone(getDb(), 'chat', PLATFORM, 'eol-test-relisted')).toBeUndefined();
     expect(getDb().prepare('SELECT id FROM models WHERE platform = ? AND model_id = ?')
       .get(PLATFORM, 'eol-test-relisted')).toBeDefined();
+  });
+
+  it('does not resurrect a permanently paywalled model from the catalog', () => {
+    resetModelRetirementObservations();
+    const id = seedModel('eol-test-paywalled-relisted');
+    noteModelRetirementSignal(routeFor(id, 'eol-test-paywalled-relisted'), FREE_PLAN_ENDED, {});
+    expect(getDb().prepare('SELECT id FROM models WHERE id = ?').get(id)).toBeUndefined();
+
+    applyCatalog(getDb(), catalogWith('eol-test-paywalled-relisted', true));
+
+    expect(getDb().prepare('SELECT id FROM models WHERE platform = ? AND model_id = ?')
+      .get(PLATFORM, 'eol-test-paywalled-relisted')).toBeUndefined();
   });
 
   it('still deletes models the USER tombstoned (unchanged behavior)', () => {

--- a/server/src/__tests__/services/router-bandit.test.ts
+++ b/server/src/__tests__/services/router-bandit.test.ts
@@ -164,8 +164,8 @@ describe('bandit router', () => {
 
   it('smartest vs fastest flips which model wins, at equal reliability', () => {
     // Smart: frontier tier, slow. Fast: small tier, high throughput. Equal success.
-    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
-    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 9, sizeLabel: 'Small', budget: '~50M', priority: 2 });
+    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 200, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 1, sizeLabel: 'Small', budget: '~50M', priority: 2 });
     addHistory('google', 'smart', { successes: 40, failures: 1, outTokens: 100, latencyMs: 3000, ttfbMs: 2500 });
     addHistory('groq', 'fast', { successes: 40, failures: 1, outTokens: 1000, latencyMs: 1000, ttfbMs: 150 });
 
@@ -461,12 +461,10 @@ describe('bandit router', () => {
   it('a saved intelligence_rank override visibly moves the axis (#673)', () => {
     // Regression for #673. A realistic chain: a Frontier flagship on top, a
     // Medium model at the bottom, and the Large model in between — the one the
-    // user re-ranks from 6 to 1 ("this is actually the best model I have").
+    // user re-ranks from 6 to 200 ("this is actually the best model I have").
     //
-    // Under the old LINEAR rank term that edit shifted the Large model's
-    // normalized axis by ~0.25 points out of 100, i.e. the dashboard rendered
-    // the SAME integer before and after and the edit looked like a no-op. The
-    // sqrt-compressed term moves it ~2 points, which is visible.
+    // Intelligence Rank is the authoritative static intelligence axis: higher
+    // rank means more capable, and the normalized score must visibly move.
     addModel({ platform: 'google', modelId: 'flagship', name: 'Flagship', intelligenceRank: 1, sizeLabel: 'Frontier', budget: '~50M', priority: 1 });
     addModel({ platform: 'groq', modelId: 'workhorse', name: 'Workhorse', intelligenceRank: 6, sizeLabel: 'Large', budget: '~50M', priority: 2 });
     addModel({ platform: 'meta', modelId: 'compact', name: 'Compact', intelligenceRank: 50, sizeLabel: 'Medium', budget: '~50M', priority: 3 });
@@ -475,12 +473,12 @@ describe('bandit router', () => {
 
     const before = getRoutingScores().scores.find(s => s.modelId === 'workhorse')!;
 
-    // PATCH /api/models/:id { intelligenceRank: 1 } bottoms out in exactly this
+    // PATCH /api/models/:id { intelligenceRank: 200 } writes exactly this
     // UPDATE (routes/models.ts maps intelligenceRank → the intelligence_rank
     // column); this suite drives the router directly and has no HTTP harness,
     // so write the column and refresh the cache the same way the route does.
     const row = getDb().prepare('SELECT id FROM models WHERE platform = ? AND model_id = ?').get('groq', 'workhorse') as { id: number };
-    getDb().prepare('UPDATE models SET intelligence_rank = 1 WHERE id = ?').run(row.id);
+    getDb().prepare('UPDATE models SET intelligence_rank = 200 WHERE id = ?').run(row.id);
     refreshStatsCache(getDb(), true);
 
     const after = getRoutingScores().scores.find(s => s.modelId === 'workhorse')!;

--- a/server/src/__tests__/services/router-task-type.test.ts
+++ b/server/src/__tests__/services/router-task-type.test.ts
@@ -85,8 +85,8 @@ const TASK_RUNS = 400;
 // it is always 1 vs 0, and the speed axis must out-weigh that for the chat
 // bias to flip the pick.
 function seedSmartVsFast() {
-  addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 1, speedRank: 9, sizeLabel: 'Large', budget: '~50M', priority: 1 });
-  addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 2, speedRank: 1, sizeLabel: 'Large', budget: '~50M', priority: 2 });
+  addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 200, speedRank: 9, sizeLabel: 'Large', budget: '~50M', priority: 1 });
+  addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 1, speedRank: 1, sizeLabel: 'Large', budget: '~50M', priority: 2 });
   addHistory('google', 'smart', { successes: 100, failures: 0, outTokens: 1, latencyMs: 60000, ttfbMs: 4999 });
   addHistory('groq', 'fast', { successes: 100, failures: 0, outTokens: 10000, latencyMs: 100, ttfbMs: 10 });
 }
@@ -141,8 +141,8 @@ describe('task-type-aware routing', () => {
   // axis to sit, so a per-request header does not get to rewrite them (#1127).
   // The other two exempt strategies are covered exactly in scoring.test.ts.
   function seedSmartVsFlakyFast() {
-    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 1, speedRank: 9, sizeLabel: 'Large', budget: '~50M', priority: 1 });
-    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 2, speedRank: 1, sizeLabel: 'Large', budget: '~50M', priority: 2 });
+    addModel({ platform: 'google', modelId: 'smart', name: 'Smart', intelligenceRank: 200, speedRank: 9, sizeLabel: 'Large', budget: '~50M', priority: 1 });
+    addModel({ platform: 'groq', modelId: 'fast', name: 'Fast', intelligenceRank: 1, speedRank: 1, sizeLabel: 'Large', budget: '~50M', priority: 2 });
     addHistory('google', 'smart', { successes: 100, failures: 0, outTokens: 1, latencyMs: 60000, ttfbMs: 4999 });
     addHistory('groq', 'fast', { successes: 50, failures: 50, outTokens: 10000, latencyMs: 100, ttfbMs: 10 });
   }

--- a/server/src/__tests__/services/scoring.test.ts
+++ b/server/src/__tests__/services/scoring.test.ts
@@ -70,53 +70,43 @@ describe('scoring: speed axis', () => {
 });
 
 describe('scoring: intelligence axis', () => {
-  it('maps min→0, max→1', () => {
-    expect(intelligenceScore(1000, 1000, 4000)).toBeCloseTo(0, 5);
-    expect(intelligenceScore(4000, 1000, 4000)).toBeCloseTo(1, 5);
-    expect(intelligenceScore(2500, 1000, 4000)).toBeCloseTo(0.5, 5);
+  it('maps the static 1–200 Intelligence Rank directly to the axis', () => {
+    expect(intelligenceScore(1, 1, 200)).toBeCloseTo(0.005, 5);
+    expect(intelligenceScore(200, 1, 200)).toBeCloseTo(1, 5);
+    expect(intelligenceScore(100, 1, 200)).toBeCloseTo(0.5, 5);
   });
 
-  it('returns neutral-high when all models are equal', () => {
-    expect(intelligenceScore(5, 5, 5)).toBe(1);
+  it('keeps the configured rank even when the chain has one model', () => {
+    expect(intelligenceScore(200, 200, 200)).toBe(1);
   });
 });
 
 describe('scoring: intelligence_rank is visible on the axis (#673)', () => {
-  // A realistic three-tier chain. The Frontier model pins the top of the
-  // min-max normalization and the Medium model pins the bottom; the Large
-  // model in between is the one the user re-ranks, so the span is unchanged by
-  // the edit and the whole move comes from the rank term.
-  const top = intelligenceComposite('Frontier', 1);
-  const bottom = intelligenceComposite('Medium', 50);
-  const axis = (rank: number) => intelligenceScore(intelligenceComposite('Large', rank), bottom, top);
+  const axis = (rank: number) => intelligenceScore(intelligenceComposite('Large', rank), 1, 200);
   // The dashboard renders Math.round(value * 100) (client AxisBar).
   const shown = (rank: number) => Math.round(axis(rank) * 100);
 
-  it('a rank 6 → 1 edit moves the displayed axis by at least 2 points', () => {
-    // Under the old linear `tier*1000 - rank` term this move was ~0.25 points,
-    // i.e. the same rendered integer — the edit looked like it did nothing.
-    expect(shown(1) - shown(6)).toBeGreaterThanOrEqual(2);
+  it('a rank 6 → 200 edit moves the displayed axis visibly', () => {
+    expect(shown(200) - shown(6)).toBeGreaterThanOrEqual(2);
   });
 
-  it('even a small rank improvement is worth more than a rounding artifact', () => {
-    // 10 → 3 is a typical "promote this model" edit.
-    expect(shown(3) - shown(10)).toBeGreaterThanOrEqual(2);
+  it('a higher rank always improves the displayed axis', () => {
+    expect(shown(30) - shown(10)).toBeGreaterThanOrEqual(2);
   });
 
-  it('stays monotonic: a better rank never scores lower', () => {
+  it('stays monotonic: a higher rank never scores lower', () => {
     for (let rank = 2; rank <= 200; rank++) {
-      expect(intelligenceComposite('Large', rank)).toBeLessThan(intelligenceComposite('Large', rank - 1));
+      expect(intelligenceComposite('Large', rank)).toBeGreaterThan(intelligenceComposite('Large', rank - 1));
     }
   });
 
-  it('keeps tier dominance: the worst rank in a tier still beats the best rank below it', () => {
-    for (const [better, worse] of [['Frontier', 'Large'], ['Large', 'Medium'], ['Medium', 'Small']] as const) {
-      expect(intelligenceComposite(better, 1000)).toBeGreaterThan(intelligenceComposite(worse, 1));
-    }
+  it('uses Intelligence Rank as the sole static intelligence baseline across tiers', () => {
+    expect(intelligenceComposite('Frontier', 42)).toBe(42);
+    expect(intelligenceComposite('Small', 42)).toBe(42);
   });
 
-  it('an unrecognized size label still scores below every real tier', () => {
-    expect(intelligenceComposite('', 1)).toBeLessThan(intelligenceComposite('Small', 1000));
+  it('does not change the static baseline for an unrecognized size label', () => {
+    expect(intelligenceComposite('', 120)).toBe(120);
   });
 });
 

--- a/server/src/lib/error-classify.ts
+++ b/server/src/lib/error-classify.ts
@@ -1,7 +1,6 @@
-// Upstream-error classification shared by the proxy chat path, the responses
-// path, and the fusion panel. Pure functions over an error's message/status —
-// no I/O — so they live in a neutral lib module that any of those can import
-// without forming an import cycle (fusion ↔ proxy in particular).
+﻿// Upstream-error classification shared by the proxy chat path, the responses
+// path, and the fusion panel. Pure functions over an error's message/status 鈥?// no I/O 鈥?so they live in a neutral lib module that any of those can import
+// without forming an import cycle (fusion 鈫?proxy in particular).
 
 export function isRetryableError(err: any): boolean {
   const msg = (err.message ?? '').toLowerCase();
@@ -10,9 +9,9 @@ export function isRetryableError(err: any): boolean {
   // This structured check is the robust primary signal; the message-substring
   // rules below are the fallback for errors that carry a code in their text but
   // no numeric status. It's the fix for #337/#339: an Ollama "410 Gone", or any
-  // upstream 5xx the substring allowlist never enumerated (502/504/507…), used to
+  // upstream 5xx the substring allowlist never enumerated (502/504/507鈥?, used to
   // fall through to a 502 and STRAND the healthy paid routes still queued later in
-  // the chain — because the old code matched specific substrings and ignored
+  // the chain 鈥?because the old code matched specific substrings and ignored
   // err.status for every code except 403. 408 (request timeout), 409 (conflict),
   // 410 (model pulled upstream), 429 (rate limit) and all 5xx are transient or
   // fail-over-able; 400/401 stay fatal (status 0 here, handled by the absence of a
@@ -40,23 +39,22 @@ export function isRetryableError(err: any): boolean {
     || msg.includes('request entity too large') || msg.includes('content too large')
     // Context/prompt-too-large in all its provider wordings (Anthropic "prompt
     // is too long", Google "input token count ... exceeds", OpenAI "maximum
-    // context length", …): another candidate may have a larger window, so fail
+    // context length", 鈥?: another candidate may have a larger window, so fail
     // over; if EVERY candidate rejects it the exhaustion ladder renders an
     // honest 413 instead of a generic failure.
     || isContextTooLargeError(err)
     // 404: model deprecated/removed upstream (e.g. OpenRouter's "no endpoints found"
-    // for a model that's been pulled). Rotate to the next model in the chain —
-    // setCooldown + the health checker will avoid this model on subsequent requests.
+    // for a model that's been pulled). Rotate to the next model in the chain 鈥?    // setCooldown + the health checker will avoid this model on subsequent requests.
     || msg.includes('404') || msg.includes('not found') || msg.includes('no endpoints found')
     // 410: the model/endpoint was permanently removed upstream (e.g. Ollama Cloud
     // "API error 410: Gone", #339). Like a 404 it won't return on this provider, so
     // rotate to the next route; isModelNotFoundError benches the whole model. The
     // structured status check above already catches the 410 when the provider
-    // attaches err.status — this is the text fallback for errors that don't.
+    // attaches err.status 鈥?this is the text fallback for errors that don't.
     || msg.includes('410') || msg.includes('gone')
     // 403: the key is valid (it passed validateKey, and the health checker
     // disables truly-forbidden keys) but this specific model is off-limits to
-    // the key's tier — e.g. gpt-4o on GitHub Models' free tier, subscription-only
+    // the key's tier 鈥?e.g. gpt-4o on GitHub Models' free tier, subscription-only
     // models on Cloudflare. Another model in the chain is reachable, so fail over
     // instead of 502-ing the whole request. Paired with isModelAccessForbiddenError
     // to rule the model out for this request and a day-long bench. See issue #256.
@@ -77,17 +75,18 @@ export function isRetryableError(err: any): boolean {
     // of killing the workflow. Paired with a long cooldown (isPaymentRequiredError)
     // so we don't re-hammer the broke key every retry.
     || isPaymentRequiredError(err)
+    || isPermanentModelUnavailableError(err)
     // Dead-turn classes from the stream turn-integrity layer (#231 audit):
     // all thrown before any byte reached the client, so another model can
     // serve the request invisibly.
     || msg.includes('empty completion')
     // The model answered in prose despite a response_format request (and the
-    // JSON couldn't be healed out of the text) — thrown before any byte
+    // JSON couldn't be healed out of the text) 鈥?thrown before any byte
     // reached the client, so the next candidate can serve it invisibly.
     || msg.includes('ignored response_format')
     // The model DID emit JSON but ran out of max_tokens mid-value
     // (finish_reason 'length'). A terser model may fit the same schema in the
-    // same budget, so fail over — but the thrower marks the model skipped for
+    // same budget, so fail over 鈥?but the thrower marks the model skipped for
     // this request: retrying the same model would truncate identically.
     || msg.includes('truncated json')
     || msg.includes('in-band provider error')
@@ -100,7 +99,7 @@ export function isRetryableError(err: any): boolean {
     // The model emitted a tool call whose arguments violate the schema the
     // caller declared (opt-in check, lib/tool-validate.ts). Thrown before any
     // byte reached the client, and a different model usually gets the same
-    // call right — the thrower marks the model skipped for this request, since
+    // call right 鈥?the thrower marks the model skipped for this request, since
     // a sibling key would misbehave identically.
     || msg.includes('invalid tool arguments')
     // A transport failure undici buried in `err.cause` rather than the
@@ -110,12 +109,19 @@ export function isRetryableError(err: any): boolean {
     || isTransportError(err);
 }
 
-// ── Transport failures hidden in the cause chain (undici) ────────────────────
+export function isUpstreamAuthenticationError(err: any): boolean {
+  if (err?.status === 401) return true;
+  const msg = (err?.message ?? '').toLowerCase();
+  return msg.includes('401') || msg.includes('unauthorized') || msg.includes('invalid api key');
+}
+
+
+// 鈹€鈹€ Transport failures hidden in the cause chain (undici) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Every rule in isRetryableError above reads the TOP-LEVEL message, and undici
 // does not always put the real failure there. The INITIAL-CONNECT case is
 // covered by luck: undici words a connection that never opened "fetch failed",
 // and the allowlist matches that string. A socket that dies MID-request does
-// not get the same treatment — it surfaces as a generic wrapper (a bare
+// not get the same treatment 鈥?it surfaces as a generic wrapper (a bare
 // `TypeError: terminated`, or an adapter's own re-throw) whose `.cause` carries
 // the actual ECONNRESET / EPIPE / "socket hang up" / "premature close" /
 // "other side closed" error, sometimes nested a link or two deeper still.
@@ -140,7 +146,7 @@ const TRANSPORT_ERROR_CODES = new Set([
 
 // undici stamps its own transport failures with a `UND_ERR_*` code
 // (UND_ERR_SOCKET, UND_ERR_CONNECT_TIMEOUT, UND_ERR_HEADERS_TIMEOUT,
-// UND_ERR_BODY_TIMEOUT, …). Matched by PREFIX rather than enumerated: the list
+// UND_ERR_BODY_TIMEOUT, 鈥?. Matched by PREFIX rather than enumerated: the list
 // grows with undici releases, and every member of it is a transport condition.
 const UNDICI_ERROR_CODE_PREFIX = 'UND_ERR_';
 
@@ -148,7 +154,7 @@ const TRANSPORT_MESSAGE_HINTS = [
   'socket hang up',
   'premature close',
   'other side closed',
-  // A socket dropped before the TLS handshake finished — undici's full wording
+  // A socket dropped before the TLS handshake finished 鈥?undici's full wording
   // is "Client network socket disconnected before secure TLS connection was
   // established". The peer closed the TCP connection mid-handshake; transient.
   'client network socket disconnected',
@@ -178,13 +184,13 @@ function errorChainLinks(err: unknown): Array<{ code: string; message: string }>
   return links;
 }
 
-/** True when the error — or anything in its bounded cause chain — is a
+/** True when the error 鈥?or anything in its bounded cause chain 鈥?is a
  * transient network transport failure: a reset, dropped, refused or timed-out
  * socket, a failed TLS handshake, or an undici transport code. */
 export function isTransportError(err: any): boolean {
   if (err == null) return false;
   // A client hang-up and the fallback time-budget hedge BOTH reach undici as an
-  // aborted socket, and undici labels that abort UND_ERR_ABORTED — the very
+  // aborted socket, and undici labels that abort UND_ERR_ABORTED 鈥?the very
   // same code a genuine mid-flight socket death carries. Neither is provider
   // health, so classifying either retryable would resurrect exactly what the
   // two marked abort errors exist to prevent (no cooldown, no health penalty,
@@ -212,8 +218,8 @@ export function isTransportError(err: any): boolean {
 // The null-limits exhaustion heuristic in getCooldownDecisionForLimit (services/
 // ratelimit.ts) keys off this: only an actual quota signal may feed its
 // "effectively daily-exhausted" escalation ladder. Before this split, a slow
-// local Ollama route timing out twice classified retryable → recorded as a
-// null-limit "429" → escalated 2m→10m→1h→24h and 429'd every request while the
+// local Ollama route timing out twice classified retryable 鈫?recorded as a
+// null-limit "429" 鈫?escalated 2m鈫?0m鈫?h鈫?4h and 429'd every request while the
 // server was merely busy generating (#592).
 // Mirrors the other classifiers: trust the structured status when the adapter
 // attached one (providerHttpError sets err.status everywhere); fall back to
@@ -226,20 +232,20 @@ export function isRateLimitSignal(err: any): boolean {
     || msg.includes('quota') || msg.includes('resource_exhausted');
 }
 
-// ── Timeout wording ─────────────────────────────────────────────────────────
+// 鈹€鈹€ Timeout wording 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // The message markers that mean "this attempt ran out of time", in every
 // wording the stack produces: the per-attempt HTTP deadline ("The operation was
-// aborted (groq, chat, 120s)" — enrichAbort in lib/proxy.ts), the mid-stream
-// inactivity watchdog ("… stream stalled: no data for 90000ms (timeout)"), the
+// aborted (groq, chat, 120s)" 鈥?enrichAbort in lib/proxy.ts), the mid-stream
+// inactivity watchdog ("鈥?stream stalled: no data for 90000ms (timeout)"), the
 // first-byte grace budget, and a raw socket ETIMEDOUT.
 //
 // A client hang-up is deliberately NOT in here: newClientAbortError's message
-// ("client disconnected — upstream request canceled") carries none of these
+// ("client disconnected 鈥?upstream request canceled") carries none of these
 // markers precisely so a vanished client is never read as provider slowness.
 //
 // Single source of truth for two consumers: the attempt-trail classifier
 // (classifyAttemptError) and the analytics query that folds timeouts into the
-// speed score (refreshStatsCache, #619) — so the trail and the score always
+// speed score (refreshStatsCache, #619) 鈥?so the trail and the score always
 // agree about what a timeout is.
 export const TIMEOUT_ERROR_MARKERS = ['timeout', 'stalled', 'etimedout', 'aborted'] as const;
 
@@ -250,17 +256,17 @@ export function isTimeoutErrorText(message: unknown): boolean {
   return TIMEOUT_ERROR_MARKERS.some(marker => msg.includes(marker));
 }
 
-// ── Client-caused aborts ─────────────────────────────────────────────────────
+// 鈹€鈹€ Client-caused aborts 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // When the gateway's OWN client hangs up, the proxy surfaces abort the composed
 // fetch signal with this marked error, and undici rejects the in-flight fetch /
 // body read / stream read with the same object (fetch propagates the signal's
 // abort reason). It is deliberately NOT an AbortError and its message contains
 // neither "aborted" nor "timeout": enrichAbort (lib/proxy.ts) must pass it
 // through untouched, and it must never classify as a retryable provider
-// timeout — a vanished client says nothing about provider health, so the
+// timeout 鈥?a vanished client says nothing about provider health, so the
 // fallback loop stops without a cooldown, health penalty, or failure stats.
 export function newClientAbortError(): Error {
-  const err = new Error('client disconnected — upstream request canceled');
+  const err = new Error('client disconnected 鈥?upstream request canceled');
   (err as Error & { clientAbort?: boolean }).clientAbort = true;
   return err;
 }
@@ -276,16 +282,16 @@ export function isClientAbortError(err: any): boolean {
   return msg.includes('client disconnected');
 }
 
-// ── Fallback time-budget hedging (fallback-v2) ──────────────────────────────
+// 鈹€鈹€ Fallback time-budget hedging (fallback-v2) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // When the wall-clock retry budget expires MID-FLIGHT (the current attempt is
 // still waiting on a stalled upstream), the fallback loop aborts the composed
 // fetch signal with this marked error. Same rationale as the client abort: it
 // is NOT a provider-health signal, so it must never bench/cooldown/penalize
 // the model+key, and enrichAbort must pass it through untouched. The loop
-// catches it, renders timedOut exhaustion (the budget is spent — nothing left
+// catches it, renders timedOut exhaustion (the budget is spent 鈥?nothing left
 // to try), and stops without failure bookkeeping.
 export function newHedgeAbortError(): Error {
-  const err = new Error('fallback time budget expired — upstream request canceled');
+  const err = new Error('fallback time budget expired 鈥?upstream request canceled');
   (err as Error & { hedgeAbort?: boolean }).hedgeAbort = true;
   return err;
 }
@@ -298,7 +304,7 @@ export function isHedgeAbortError(err: any): boolean {
   return msg.includes('fallback time budget expired');
 }
 
-/** True for any fetch-abort rejection surfacing out of a body read — the
+/** True for any fetch-abort rejection surfacing out of a body read 鈥?the
  * per-attempt timeout ('request'-bounds deadline in fetchWithTimeout), an
  * AbortSignal.timeout, or the client disconnect above. Adapters that wrap
  * res.json() in a diagnostic catch (openai-compat's non-JSON-body split) must
@@ -314,20 +320,20 @@ export function isAbortLikeError(err: any): boolean {
 // so the fallback loop rotates past the bad key (and triggers an immediate
 // health revalidation) instead of 502-ing the whole request. Deliberately NOT
 // added to isRetryableError: a bad key must be skipped and revalidated, not
-// blindly re-benched like a rate limit — the loop handles it as its own class.
+// blindly re-benched like a rate limit 鈥?the loop handles it as its own class.
 //
 // Status handling: every provider adapter attaches err.status (providerHttpError
 // in providers/base.ts), so the structured status is the primary signal.
-//   - 401 → always key-auth.
-//   - 400 → key-auth ONLY for Google-style key-specific phrasings: Google
+//   - 401 鈫?always key-auth.
+//   - 400 鈫?key-auth ONLY for Google-style key-specific phrasings: Google
 //     reports a bad/expired key as HTTP 400 INVALID_ARGUMENT with "API key not
 //     valid" / "API key expired" / API_KEY_INVALID (#268, providers/google.ts).
 //     Without this a dead Google key classified as a provider bad-request and
 //     could exhaust into a client-blaming 400 "rejected the request as invalid".
 //     Generic auth wording (unauthorized etc.) stays excluded on a 400 so
 //     ordinary payload rejections never classify as key-auth.
-//   - any other status → not key-auth (e.g. a 403 stays model-forbidden).
-//   - no status at all → key-specific OR generic auth substrings.
+//   - any other status 鈫?not key-auth (e.g. a 403 stays model-forbidden).
+//   - no status at all 鈫?key-specific OR generic auth substrings.
 export function isKeyAuthError(err: any): boolean {
   const status = typeof err?.status === 'number' ? err.status : 0;
   if (status === 401) return true;
@@ -361,7 +367,7 @@ export function isDailyQuotaExhaustedError(err: any): boolean {
 // A provider-side "this hosted model is temporarily degraded" condition dressed
 // up as a 400. Observed live on NVIDIA NIM (issue #522): a degraded function
 // returns `400 {"detail":"Function id '...': DEGRADED function cannot be
-// invoked"}` — the request is fine; the deployment is sick. Must NOT classify
+// invoked"}` 鈥?the request is fine; the deployment is sick. Must NOT classify
 // as a provider bad-request: exhausting on it would render a client-blaming
 // 400 invalid_request_error for what is capacity/health, not request shape.
 export function isProviderDegradedError(err: any): boolean {
@@ -369,24 +375,24 @@ export function isProviderDegradedError(err: any): boolean {
   return msg.includes('degraded');
 }
 
-// #788: provider-level failures — 5xx, timeouts, transport/network errors, a
-// degraded deployment — are symptoms of the PROVIDER being sick, not of this
+// #788: provider-level failures 鈥?5xx, timeouts, transport/network errors, a
+// degraded deployment 鈥?are symptoms of the PROVIDER being sick, not of this
 // particular key. Retrying the same provider with a sibling key would fail
 // identically, so the fallback loop must skip the WHOLE platform for the
 // request instead of burning one failover hop per key. Key-scoped failures
 // (auth, quota, 403 tier) stay out of here so a dead key can still rotate to
 // a healthy sibling on the same platform.
 //
-// Classified on the STRUCTURED status — every adapter attaches one to an HTTP
-// failure (providerHttpError in providers/base.ts) — plus the two families that
+// Classified on the STRUCTURED status 鈥?every adapter attaches one to an HTTP
+// failure (providerHttpError in providers/base.ts) 鈥?plus the two families that
 // carry no status at all: a timeout and a transport-level failure. Deliberately
 // NO bare '500' / '503' / 'unavailable' / 'internal server error' substrings: a
-// token count, a duration ("… took 5003ms") or a key-scoped message naming an
+// token count, a duration ("鈥?took 5003ms") or a key-scoped message naming an
 // unavailable model would each condemn a healthy platform for the whole request.
 // A message check therefore only runs when there is no status to trust.
 export function isProviderLevelError(err: any): boolean {
   // A failure the thrower explicitly scoped to the MODEL (`skipModelForRequest`
-  // — an ignored response_format, invalid tool arguments) is never provider
+  // 鈥?an ignored response_format, invalid tool arguments) is never provider
   // health, and its message quotes caller- and model-supplied text: a tool
   // named `set_timeout`, or an Ajv complaint about an instance path `/timeout`,
   // would otherwise trip the substring checks below and condemn a healthy
@@ -396,7 +402,7 @@ export function isProviderLevelError(err: any): boolean {
   const status = typeof err?.status === 'number' ? err.status : 0;
   if (status >= 500) return true;
   // A DEGRADED hosted deployment (NVIDIA NIM, #522) is provider health wearing
-  // a 400 — same source of truth as everywhere else, not a second substring.
+  // a 400 鈥?same source of truth as everywhere else, not a second substring.
   if (isProviderDegradedError(err)) return true;
   if (status !== 0) return false;
   const msg = (err?.message ?? '').toLowerCase();
@@ -406,7 +412,7 @@ export function isProviderLevelError(err: any): boolean {
 }
 
 // #809: kilo's free relay occasionally answers with a bare classification
-// word ("safe" / "unsafe") instead of a real reply — an upstream content
+// word ("safe" / "unsafe") instead of a real reply 鈥?an upstream content
 // filter, not the requested model. Such a turn is a dead turn: treat it like
 // an empty completion so the fallback loop fails over to the next provider
 // instead of surfacing "safe"/"unsafe" as the answer.
@@ -439,22 +445,22 @@ export function isProviderBadRequestError(err: any): boolean {
 
 // A "this request/prompt is too large" rejection. Providers word it very
 // differently and even disagree on the HTTP status:
-//   - OpenAI-compat: 400 with code `context_length_exceeded` — "This model's
+//   - OpenAI-compat: 400 with code `context_length_exceeded` 鈥?"This model's
 //     maximum context length is 8192 tokens. However, your messages resulted
 //     in 10001 tokens. Please reduce the length of the messages."
-//   - Anthropic: 400 invalid_request_error — "prompt is too long: 210000
+//   - Anthropic: 400 invalid_request_error 鈥?"prompt is too long: 210000
 //     tokens > 200000 maximum" (Bedrock words it "Input is too long for
 //     requested model.")
-//   - Google/Gemini: 400 INVALID_ARGUMENT — "The input token count (1200000)
+//   - Google/Gemini: 400 INVALID_ARGUMENT 鈥?"The input token count (1200000)
 //     exceeds the maximum number of tokens allowed (1048576)."
-//   - Groq: a literal HTTP 413 — "Request too large for model `x` ... on
+//   - Groq: a literal HTTP 413 鈥?"Request too large for model `x` ... on
 //     tokens per minute (TPM): Limit 30000, Requested 33476". Requested >
 //     Limit can never fit that candidate's window, so it belongs here (too
 //     large for the candidate), not with transient per-minute 429s.
 //   - Reverse proxies / gateways: 413 "Payload Too Large" / "request entity
 //     too large" / "content too large".
 // Structured status first (providerHttpError attaches err.status on every
-// adapter), then the code field, then message markers — mirroring how the
+// adapter), then the code field, then message markers 鈥?mirroring how the
 // other classifiers in this file work. Retryable (a sibling candidate may have
 // a larger window), but when EVERY attempt dies this way the exhaustion ladder
 // renders an honest 413 instead of a generic failure.
@@ -492,6 +498,39 @@ export function isPaymentRequiredError(err: any): boolean {
     || msg.includes('insufficient balance');
 }
 
+// Some providers explicitly end free access instead of returning a resettable
+// quota. Only these unambiguous plan-level messages are permanent; ordinary
+// payment/credit/quota errors stay on the cooldown path.
+const PERMANENT_FREE_ACCESS_PHRASES = [
+  'free plan has ended',
+  'free tier has ended',
+  'free access has ended',
+  'free promotion has ended',
+  'free plan is no longer available',
+  'free tier is no longer available',
+  'free access is no longer available',
+  'not available on the free plan',
+  'not available on the free tier',
+  'requires a paid plan',
+  'paid plan required',
+  'upgrade to a paid plan',
+];
+
+const RESETTABLE_QUOTA_PHRASES = [
+  'reset', 'resets', 'daily', 'per day', 'weekly', 'per week', 'monthly', 'per month',
+  'tomorrow', 'retry after', 'try again in', 'rate limit', 'quota exceeded',
+  'allocation', 'used up',
+];
+
+/** True only for an explicit permanent free-plan/paywall response. */
+export function isPermanentModelUnavailableError(err: any): boolean {
+  const status = typeof err?.status === 'number' ? err.status : 0;
+  if (status !== 0 && status !== 400 && status !== 402 && status !== 403) return false;
+  const msg = (err?.message ?? '').toLowerCase();
+  if (RESETTABLE_QUOTA_PHRASES.some((phrase) => msg.includes(phrase))) return false;
+  return PERMANENT_FREE_ACCESS_PHRASES.some((phrase) => msg.includes(phrase));
+}
+
 // A 404 "model removed/deprecated upstream" error. It's a MODEL-level failure,
 // not a key-level one: every key for the platform will 404 the same way, so the
 // retry loop skips the entire model for the rest of the request instead of
@@ -511,8 +550,7 @@ export function isModelNotFoundError(err: any): boolean {
 // A 403 Forbidden returned for a specific model behind an otherwise-valid key.
 // Drives the same whole-model skip as a 404: every key on this platform's tier
 // would be forbidden the same model, so rule it out for the rest of the request
-// rather than trying it again with a sibling key. Distinct from a dead key —
-// validateKey returns false on 401/403, so the health checker disables genuinely
+// rather than trying it again with a sibling key. Distinct from a dead key 鈥?// validateKey returns false on 401/403, so the health checker disables genuinely
 // forbidden keys; a 403 reaching here is model-not-on-this-tier. See issue #256.
 export function isModelAccessForbiddenError(err: any): boolean {
   if (err?.status === 403) return true;
@@ -521,7 +559,7 @@ export function isModelAccessForbiddenError(err: any): boolean {
   // Not every provider spells "this key may not use this model" as a 403 (issue
   // #618): observed live as a 400 whose body reads "user is not allowed to
   // access model kat-coder-pro-v2.5", and as plan-gate wordings like "action
-  // plan limited". Classified transient, those took the 90s bench — and the
+  // plan limited". Classified transient, those took the 90s bench 鈥?and the
   // auto-router re-picked the same permanently-unreachable model the moment it
   // expired, failing and re-benching forever with an ever-growing penalty.
   // Deliberately narrow: only 400/401 (or a status-less error), and only for
@@ -551,7 +589,7 @@ const MODEL_ACCESS_DENIED_PHRASES = [
   'action plan limited',
 ];
 
-// ── Permanent upstream retirement (issue #634) ───────────────────────────────
+// 鈹€鈹€ Permanent upstream retirement (issue #634) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // isModelNotFoundError above rules a 404/410 model out for ONE request. That is
 // right for a load balancer hiccup and wrong for a model the provider RETIRED:
 // NVIDIA's "The model 'minimaxai/minimax-m2.7' has reached its end of life on
@@ -559,12 +597,12 @@ const MODEL_ACCESS_DENIED_PHRASES = [
 // persisted it, so the corpse burned a fallback slot on every later request.
 //
 // This classifier says how much a failure should be TRUSTED as permanent:
-//   - 'definitive' — an explicit 410 Gone, or unmistakable end-of-life wording.
+//   - 'definitive' 鈥?an explicit 410 Gone, or unmistakable end-of-life wording.
 //     Acting on one response is safe.
-//   - 'probable'   — a 404 whose body says the model is gone in so many words.
+//   - 'probable'   鈥?a 404 whose body says the model is gone in so many words.
 //     Real, but a provider can also word a transient outage this way, so the
 //     caller corroborates across distinct requests before acting.
-//   - null         — everything else, including every bare 404 ("Not found",
+//   - null         鈥?everything else, including every bare 404 ("Not found",
 //     "Provider returned error", OpenRouter's "No endpoints found", NVIDIA's
 //     per-account "Function '<uuid>': Not found for account '<id>'"). A
 //     transient 404 must NEVER retire a healthy model.
@@ -594,10 +632,11 @@ const MODEL_GONE_PHRASES = [
 export function modelRetirementSignal(err: any): ModelRetirementConfidence | null {
   const msg = (err?.message ?? '').toLowerCase();
   const status = typeof err?.status === 'number' ? err.status : 0;
+  if (isPermanentModelUnavailableError(err)) return 'definitive';
   const gone = status === 410 || /\berror 410\b/.test(msg) || /\b410 gone\b/.test(msg);
   // An end-of-life phrase is only definitive when the status agrees the model
   // is not there. On its own it is just text, and 'definitive' skips the
-  // corroboration gate in noteModelRetirementSignal — so a 429 or 500 whose
+  // corroboration gate in noteModelRetirementSignal 鈥?so a 429 or 500 whose
   // body happens to mention a retirement (an advisory notice, a status-page
   // quote, a message about a DIFFERENT model) disabled a live model on one
   // response. Unmatched here means it falls through and teaches nothing.

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -16,7 +16,8 @@
 // the fire-and-forget key revalidation kicked off on an upstream 401 (below).
 
 import type { RouteResult } from '../services/router.js';
-import { recordRateLimitHit, recordModelFailure, recordSuccess, hasOtherUsableKey, routableKeyIdsForModel, formatResetEta } from '../services/router.js';
+import { getDb } from '../db/index.js';
+import { recordRateLimitHit, recordModelFailure, recordSuccess, hasOtherUsableKey, routableKeyIdsForModel, formatResetEta, recordHealthFailure, recordHealthSuccess, getRoutingStrategy } from '../services/router.js';
 import { safeHeaderValue } from './header-value.js';
 import {
   recordRequest,
@@ -291,34 +292,46 @@ function consumeSkipBenchExemption(route: RouteResult, err: any): boolean {
  * Callers add the just-failed key to skipKeys via this function (do not pre-add).
  */
 export function recordRetryableFailure(route: RouteResult, err: any, state: FallbackState, now: number = Date.now()): boolean {
-  // `skipModelForRequest: true` = the failure is MODEL behavior, not key
-  // state (ignored response_format, JSON truncated at max_tokens): a sibling
-  // key would reproduce it exactly, so rule out the whole model for this
-  // request instead of burning one failover hop per key.
-  // Context-too-large is MODEL-level too: a sibling key serves the same model
-  // with the same context window (and, for Groq-style per-key TPM 413s, the
-  // same tier ceiling), so it would reject the same request identically.
-  if (isModelNotFoundError(err) || isModelAccessForbiddenError(err) || isContextTooLargeError(err) || err?.skipModelForRequest === true) {
-    state.skipModels.add(route.modelDbId);
-  }
-  // A model-level 404/410 that says the model is GONE (not merely missing right
-  // now) outlives this request: persist it once the evidence is strong enough,
-  // or the retired model burns a fallback slot on every request forever (#634).
-  // The trace object identifies the request, so one request's failover across
-  // sibling keys counts as the single observation it is.
-  noteModelRetirementSignal(route, err, getRequestTrace());
-  state.skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
-  // #788: provider-level failures (5xx / timeout / transport / degraded) mean
-  // the PROVIDER is sick, not this key — every key AND every model of that
-  // platform would fail identically. Rule out the whole platform for this
-  // request so the loop moves to the NEXT provider instead of burning one
-  // failover hop per key. Key-scoped failures (auth/quota) stay on the
-  // single-key path, and the per-key cooldown below is still the only thing
-  // that outlives the request.
-  if (isProviderLevelError(err)) {
-    state.skipPlatforms.add(route.platform);
-  }
-  if (consumeSkipBenchExemption(route, err)) return true;
+    // `skipModelForRequest: true` = the failure is MODEL behavior, not key
+    // state (ignored response_format, JSON truncated at max_tokens): a sibling
+    // key would reproduce it exactly, so rule out the whole model for this
+    // request instead of burning one failover hop per key.
+    // Context-too-large is MODEL-level too: a sibling key serves the same model
+    // with the same context window (and, for Groq-style per-key TPM 413s, the
+    // same tier ceiling), so it would reject the same request identically.
+    if (isModelNotFoundError(err) || isModelAccessForbiddenError(err) || isContextTooLargeError(err) || err?.skipModelForRequest === true) {
+      state.skipModels.add(route.modelDbId);
+    }
+    // A model-level 404/410 that says the model is GONE (not merely missing right
+    // now) outlives this request: persist it once the evidence is strong enough,
+    // or the retired model burns a fallback slot on every request forever (#634).
+    // The trace object identifies the request, so one request's failover across
+    // sibling keys counts as the single observation it is.
+    noteModelRetirementSignal(route, err, getRequestTrace());
+    state.skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
+    // #788: provider-level failures (5xx / timeout / transport / degraded) mean
+    // the PROVIDER is sick, not this key — every key AND every model of that
+    // platform would fail identically. Rule out the whole platform for this
+    // request so the loop moves to the NEXT provider instead of burning one
+    // failover hop per key. Key-scoped failures (auth/quota) stay on the
+    // single-key path, and the per-key cooldown below is still the only thing
+    // that outlives the request.
+    if (isProviderLevelError(err)) {
+      state.skipPlatforms.add(route.platform);
+    }
+    // Manual-smart health recording: record failure for manual-smart strategy
+    if (getRoutingStrategy() === 'manual-smart') {
+      let failureType: 'rate-limit' | 'transient' | 'client-error' | 'provider-error' = 'transient';
+      if (isRateLimitSignal(err)) {
+        failureType = 'rate-limit';
+      } else if (isModelNotFoundError(err) || isModelAccessForbiddenError(err) || isContextTooLargeError(err)) {
+        failureType = 'client-error';
+      } else if (isProviderLevelError(err)) {
+        failureType = 'provider-error';
+      }
+      recordHealthFailure(route.modelDbId, failureType, route.platform);
+    }
+    if (consumeSkipBenchExemption(route, err)) return true;
   const decision = cooldownDecisionForError(route, err);
   setCooldown(route.platform, route.modelId, route.keyId, decision.durationMs, decision.source);
   // Model-level failure benching: a model failing across keys (or repeatedly on
@@ -387,6 +400,10 @@ export function recordUpstreamSuccess(route: RouteResult, rateLimitTokens: numbe
   recordRequest(route.platform, route.modelId, route.keyId);
   recordTokens(route.platform, route.modelId, route.keyId, rateLimitTokens);
   recordSuccess(route.modelDbId);
+  // Manual-smart health recovery: record success for manual-smart strategy
+  if (getRoutingStrategy() === 'manual-smart') {
+    recordHealthSuccess(route.modelDbId);
+  }
   // A served request proves the model+key can complete: the empty-completion
   // streak (#751) starts over.
   emptyCompletionStreaks.delete(`${route.platform}:${route.modelId}:${route.keyId}`);

--- a/server/src/routes/fallback.ts
+++ b/server/src/routes/fallback.ts
@@ -287,12 +287,11 @@ fallbackRouter.get('/', (req: Request, res: Response) => {
       // Which fields the local override actually replaces, so the model page
       // can mark the individual inputs it edits (#551).
       overrideFields: overriddenFieldNames(r.overrides_json),
-      // Why the switch is off: a model auto-disabled because the provider
-      // retired it upstream (410 / end of life, #634) is a different state from
-      // one the user turned off, and the dashboard says so. The reason is the
-      // provider's own (redacted) wording.
-      retiredUpstream: r.tombstone_source === 'upstream_eol',
-      retiredReason: r.tombstone_source === 'upstream_eol' ? (r.tombstone_reason ?? null) : null,
+      // Why the switch is off: a model removed because the provider retired it
+      // or permanently ended free access is distinct from a user disable.
+      retiredUpstream: r.tombstone_source === 'upstream_eol' || r.tombstone_source === 'upstream_permanent',
+      retiredReason: r.tombstone_source === 'upstream_eol' || r.tombstone_source === 'upstream_permanent'
+        ? (r.tombstone_reason ?? null) : null,
       keyCount: keyCountMap.get(r.platform) ?? 0,
     };
   }));

--- a/server/src/services/catalog-sync.ts
+++ b/server/src/services/catalog-sync.ts
@@ -266,9 +266,10 @@ function routableContextWindow(platform: string, modelId: string, contextWindow:
  *    declarative config, admin adds) are never updated, never deleted, and
  *    never adopted — on a platform:model_id collision the user row wins and
  *    the catalog entry is skipped outright;
- *  - catalog models the user deleted stay deleted via tombstones, while models
- *    auto-retired from an upstream 410/end-of-life response (#634) are only
- *    disabled — a catalog that still lists them lifts the retirement;
+ *  - catalog models the user deleted stay deleted via tombstones; models
+ *    auto-retired from an upstream 410/end-of-life response (#634) are
+ *    disabled and may be reinstated by newer catalog evidence, while models
+ *    proven permanently unavailable are removed and suppressed from resync;
  *  - models that vanished from the catalog are deleted, exactly like the
  *    dead-model migrations do (fallback_config row first, FK order).
  */
@@ -394,9 +395,10 @@ function applyCatalogInner(db: Db, catalog: Catalog): NonNullable<SyncResult['co
         continue;
       }
       if (isCatalogModelTombstoned(db, 'chat', m.platform, m.modelId)) continue;
-      // A model auto-retired from a 410/end-of-life response (#634) is disabled,
-      // not deleted. A catalog that STILL lists it — and lists it enabled — is
-      // newer evidence than that one provider response, so lift the retirement.
+      // Recoverable upstream retirements are disabled, not deleted. A catalog
+      // that STILL lists one — and lists it enabled — is newer evidence than
+      // that provider response, so lift the retirement. Permanent tombstones
+      // were filtered above and never reach this path.
       if (m.enabled) reinstateUpstreamRetiredCatalogModel(db, m.platform, m.modelId);
       inCatalog.add(`${m.platform}:${m.modelId}`);
 

--- a/server/src/services/model-retirement.ts
+++ b/server/src/services/model-retirement.ts
@@ -6,12 +6,11 @@
 // so the next request tried it again, and the next, forever, each one paying a
 // round trip and a fallback slot for a model that is never coming back.
 //
-// The fix persists the verdict: a definitive end-of-life response disables the
-// model right away, and a merely-probable one waits for corroboration from a
-// second distinct request first, so a single flaky 404 from a load balancer can
-// never kill a healthy model. The disable is reversible in both directions —
-// the user can switch the model back on, and a catalog refresh that still lists
-// it lifts the retirement (services/catalog-sync.ts).
+// The fix persists the verdict: a definitive end-of-life or permanent free-plan
+// response removes the model right away, and a merely-probable one waits for
+// corroboration from a second distinct request first, so a single flaky 404
+// from a load balancer can never remove a healthy model. Probable retirements
+// remain reversible when a later catalog still lists the model.
 
 import { getDb } from '../db/index.js';
 import { modelRetirementSignal } from '../lib/error-classify.js';
@@ -59,7 +58,7 @@ export interface RetirementRoute {
 
 /**
  * Record one upstream failure against the retirement heuristic and, when the
- * evidence is strong enough, auto-disable the model. Returns true iff this call
+ * evidence is strong enough, remove or disable the model. Returns true iff this call
  * retired it. Never throws: it runs on the proxy's failure path, where a DB
  * hiccup must not turn a failover into a crash.
  */
@@ -85,14 +84,15 @@ export function noteModelRetirementSignal(
     // Only catalog-managed rows: a model the user added by hand is their state,
     // not the catalog's, and the tombstone table has no meaning for it.
     if (!row || !isCatalogManagedModel(row)) return false;
-    if (!retireCatalogModelUpstream(db, row.id, row.platform, row.model_id, reason)) return false;
+    const source = confidence === 'definitive' ? 'upstream_permanent' : 'upstream_eol';
+    if (!retireCatalogModelUpstream(db, row.id, row.platform, row.model_id, reason, source)) return false;
     observations.delete(key);
     // Retiring a model changes routing permanently, so it is a warn (which the
     // dashboard viewer persists across restarts) carrying the platform/model it
     // acted on. Still printed to stdout by providerLog.
     providerLog(
       'warn',
-      `[ModelRetirement] ${row.platform}/${row.model_id} disabled — upstream reports it retired: ${reason}`,
+      `[ModelRetirement] ${row.platform}/${row.model_id} ${source === 'upstream_permanent' ? 'removed' : 'disabled'} — upstream reports it retired: ${reason}`,
       { provider: row.platform, model: row.model_id, event: 'model_retired' },
     );
     return true;

--- a/server/src/services/model-state.ts
+++ b/server/src/services/model-state.ts
@@ -84,11 +84,11 @@ export function isCatalogManagedModel(row: { platform: string; key_id?: number |
 //   'user'        — deleted in the dashboard. Stays deleted across syncs, and
 //                   the row is removed from `models` on the next catalog apply.
 //   'upstream_eol' — the provider reported it permanently gone (410 / end of
-//                   life, issue #634). The row SURVIVES and is only disabled,
-//                   so the dashboard can show "retired upstream" instead of
-//                   silently losing the model, and so a later catalog that
-//                   still lists it can lift the retirement.
-export type CatalogTombstoneSource = 'user' | 'upstream_eol';
+//                   life, issue #634). The row survives and can be reinstated
+//                   by a later catalog.
+//   'upstream_permanent' — the provider explicitly ended free access or made
+//                   the model paywalled. The row is removed and not resurrected.
+export type CatalogTombstoneSource = 'user' | 'upstream_eol' | 'upstream_permanent';
 
 export interface CatalogModelTombstone {
   source: CatalogTombstoneSource;
@@ -107,17 +107,18 @@ export function getCatalogModelTombstone(
     .get(kind, platform, modelId) as { source: string; reason: string | null; created_at: string } | undefined;
   if (!row) return undefined;
   return {
-    source: row.source === 'upstream_eol' ? 'upstream_eol' : 'user',
+    source: row.source === 'upstream_eol'
+      ? 'upstream_eol'
+      : row.source === 'upstream_permanent' ? 'upstream_permanent' : 'user',
     reason: row.reason ?? null,
     createdAt: row.created_at,
   };
 }
 
 /**
- * True only for models the USER deleted — the "keep it deleted" contract every
- * caller here means. An upstream-retirement tombstone deliberately does NOT
- * count: those models stay in the catalog's write path so a refreshed catalog
- * can reinstate them (see reinstateUpstreamRetiredCatalogModel).
+ * True for user-deleted models and upstream models explicitly marked permanent.
+ * A normal upstream-retirement tombstone does NOT count: those models stay in
+ * the catalog's write path so a refreshed catalog can reinstate them.
  */
 export function isCatalogModelTombstoned(
   db: Db,
@@ -125,7 +126,8 @@ export function isCatalogModelTombstoned(
   platform: string,
   modelId: string,
 ): boolean {
-  return getCatalogModelTombstone(db, kind, platform, modelId)?.source === 'user';
+  const source = getCatalogModelTombstone(db, kind, platform, modelId)?.source;
+  return source === 'user' || source === 'upstream_permanent';
 }
 
 export function recordCatalogModelTombstone(
@@ -167,12 +169,18 @@ export function retireCatalogModelUpstream(
   platform: string,
   modelId: string,
   reason: string,
+  source: Extract<CatalogTombstoneSource, 'upstream_eol' | 'upstream_permanent'> = 'upstream_eol',
 ): boolean {
   const existing = getCatalogModelTombstone(db, 'chat', platform, modelId);
   if (existing) return false;
-  recordCatalogModelTombstone(db, 'chat', platform, modelId, { source: 'upstream_eol', reason });
-  db.prepare('UPDATE fallback_config SET enabled = 0 WHERE model_db_id = ?').run(modelDbId);
-  db.prepare('UPDATE profile_models SET enabled = 0 WHERE model_db_id = ?').run(modelDbId);
+  recordCatalogModelTombstone(db, 'chat', platform, modelId, { source, reason });
+  if (source === 'upstream_permanent') {
+    db.prepare('DELETE FROM fallback_config WHERE model_db_id = ?').run(modelDbId);
+    db.prepare('DELETE FROM models WHERE id = ?').run(modelDbId);
+  } else {
+    db.prepare('UPDATE fallback_config SET enabled = 0 WHERE model_db_id = ?').run(modelDbId);
+    db.prepare('UPDATE profile_models SET enabled = 0 WHERE model_db_id = ?').run(modelDbId);
+  }
   return true;
 }
 
@@ -293,9 +301,8 @@ export function applyAllModelOverrides(db: Db): number {
   return applied;
 }
 
-// Only USER tombstones delete rows. An upstream-retirement tombstone disables
-// its model and keeps it (see retireCatalogModelUpstream), so deleting here
-// would throw away both the row and the reason the dashboard shows for it.
+// User and upstream-permanent tombstones delete rows. Normal upstream-retirement
+// tombstones keep their row so a later catalog can reinstate them.
 export function deleteTombstonedCatalogModels(db: Db): number {
   const chatRows = db.prepare(`
     SELECT m.id, m.platform, m.model_id

--- a/server/src/services/penalty-inspector.ts
+++ b/server/src/services/penalty-inspector.ts
@@ -1,5 +1,5 @@
-import { getDb } from '../db/index.js';
-import { getAllPenalties } from './router.js';
+﻿import { getDb } from '../db/index.js';
+import { getAllManualSmartHealth, getAllPenalties, getRoutingStrategy } from './router.js';
 import { rateLimitFactor } from './scoring.js';
 
 const INSPECTOR_LOOKBACK_MINUTES = 30;
@@ -38,7 +38,6 @@ export interface InspectorRow {
   recentErrorCount: number;
   reasons: InspectorReason[];
 }
-
 export interface PenaltyInspectorSnapshot {
   generatedAtMs: number;
   lookbackMinutes: number;
@@ -96,7 +95,11 @@ export function getPenaltyInspector(): PenaltyInspectorSnapshot {
   const now = Date.now();
   const rows = new Map<string, InspectorRow>();
 
-  const penalties = getAllPenalties();
+  const manualSmart = getRoutingStrategy() === 'manual-smart';
+  const manualHealth = manualSmart ? getAllManualSmartHealth() : [];
+  const penalties = manualSmart
+    ? manualHealth.map(h => ({ modelDbId: h.modelDbId, count: h.rateLimitHits, penalty: h.penalty }))
+    : getAllPenalties();
   if (penalties.length > 0) {
     const placeholders = penalties.map(() => '?').join(',');
     const models = db.prepare(`
@@ -127,7 +130,11 @@ export function getPenaltyInspector(): PenaltyInspectorSnapshot {
         fallbackEnabled: model.fallback_enabled,
         priority: model.priority,
       });
-      row.penalty = { hits: p.count, value: p.penalty, rateLimitFactor: rateLimitFactor(p.penalty) };
+      row.penalty = {
+        hits: p.count,
+        value: manualSmart ? Math.round(p.penalty * 100) : p.penalty,
+        rateLimitFactor: manualSmart ? 1 - p.penalty : rateLimitFactor(p.penalty),
+      };
       addReason(row, 'penalty');
     }
   }

--- a/server/src/services/router.ts
+++ b/server/src/services/router.ts
@@ -46,7 +46,7 @@ class RouteError extends Error {
   status: number;
   // Per-model disposition of the chain at the moment routing gave up: one line
   // per considered model with the reason it could not serve (no key, cooldown,
-  // provider cap, rpm/rpd, tpm/tpd, context too small, …). Populated only on the
+  // provider cap, rpm/rpd, tpm/tpd, context too small, 鈥?. Populated only on the
   // synchronous "all exhausted" throw, where NO upstream was tried and nothing
   // else logs WHY the pool was empty (issue _1: opaque routing_error 429).
   diagnostics?: string[];
@@ -75,7 +75,7 @@ const EXHAUSTION_ADVICE = 'Add more API keys or wait for rate limits to reset.';
 // Roll the per-model diagnostics (see RouteError.diagnostics) up into a short,
 // client-safe summary so an exhausted caller learns WHY the pool was empty
 // instead of a bare "All models exhausted" (#423). Buckets are aggregate
-// counts only — no key material, no per-key detail. Classifies off the whole
+// counts only 鈥?no key material, no per-key detail. Classifies off the whole
 // line (model ids can contain ':' so splitting label from reason is unsafe).
 export function summarizeExhaustion(
   diag: string[] | undefined,
@@ -167,7 +167,7 @@ export interface ChainRow {
    * Ordering TIER, ahead of score. 0 (the default, and what every other chain
    * builder produces) is a normal candidate. A higher number is a fallback that
    * may only serve once every lower tier is exhausted, however good its live
-   * numbers are — currently set only for a member reached through a group's
+   * numbers are 鈥?currently set only for a member reached through a group's
    * auto-derived slug rather than the model id the client actually wrote, where
    * answering on score alone would be a silent substitution (#651).
    */
@@ -201,7 +201,7 @@ export interface RouteResult {
    * It rides the route rather than being looked up at dispatch time on
    * purpose: selectKeyForModel already reads the whole api_keys row and
    * already decrypts on it, so the override costs one extra AES-GCM open per
-   * ROUTE — not a prepared SELECT plus a decrypt per ATTEMPT, on the hot path
+   * ROUTE 鈥?not a prepared SELECT plus a decrypt per ATTEMPT, on the hot path
    * of every request. Optional so test doubles and any future construction
    * path simply mean "no override".
    */
@@ -213,8 +213,7 @@ export interface RouteResult {
   /**
    * Frees the in-flight lease taken when this route was selected. Idempotent.
    *
-   * Callers should invoke it once the attempt is finished, however it finished —
-   * the shared fallback loop does so from a `finally` so no exit path can leak.
+   * Callers should invoke it once the attempt is finished, however it finished 鈥?   * the shared fallback loop does so from a `finally` so no exit path can leak.
    *
    * Optional, and every call site uses `release?.()`, for a specific reason: the
    * invocation sits in a `finally`, and a TypeError thrown there would *replace*
@@ -226,7 +225,7 @@ export interface RouteResult {
   release?: () => void;
 }
 
-// ── Routing token estimate: cap the reserved OUTPUT, not the full max_tokens ──
+// 鈹€鈹€ Routing token estimate: cap the reserved OUTPUT, not the full max_tokens 鈹€鈹€
 // A client can request a huge max_tokens (e.g. 32000) it will never actually
 // emit. Reserving that full amount against every model's context window and TPM
 // budget falsely excludes the entire free pool (TPM 6k-30k) and returns a bogus
@@ -252,8 +251,8 @@ export function routingReserveTokens(requestedMaxTokens: number | null | undefin
 // Round-robin index per platform
 const roundRobinIndex = new Map<string, number>();
 
-// ── Dynamic priority: track 429s per model and demote accordingly ──
-// Key: model_db_id → { count, lastHit, penalty }
+// 鈹€鈹€ Dynamic priority: track 429s per model and demote accordingly 鈹€鈹€
+// Key: model_db_id 鈫?{ count, lastHit, penalty }
 const rateLimitPenalties = new Map<number, { count: number; lastHit: number; penalty: number }>();
 
 // Penalty decays over time so models recover
@@ -262,12 +261,136 @@ const PENALTY_PER_FAIL = 1;       // each non-limit upstream failure (5xx/timeou
 const MAX_PENALTY = 10;            // cap so a model doesn't sink forever
 const DECAY_INTERVAL_MS = 2 * 60 * 1000; // penalty decays every 2 minutes
 const DECAY_AMOUNT = 1;            // remove this much penalty per decay interval
+// Manual-smart health cooldown
+const MANUAL_SMART_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes cooldown
+const MANUAL_SMART_RECOVERY_RATE = 0.10; // Recovery rate per cooldown period
+
+type HealthFailure = 'rate-limit' | 'transient' | 'client-error' | 'provider-error';
+const RATE_LIMIT_PENALTIES = [0, 0.15, 0.30, 0.50, 1.0]; // 1st, 2nd, 3rd, 4th+ 429
+const TRANSIENT_FAILURE_PENALTY = 0.10; // timeout/5xx
+const CLIENT_ERROR_PENALTY = 0.05; // 400, 410, etc.
+const PROVIDER_ERROR_PENALTY = 0.08; // other provider errors
+
+const MANUAL_SMART_HEALTH_KEY = 'manual_smart_health';
+type ManualSmartHealth = { rateLimitHits: number; penalty: number; lastFailureTime: number; provider?: string };
+const manualSmartHealth = new Map<number, ManualSmartHealth>();
+let manualSmartHealthLoaded = false;
+const HEALTH_RECOVERY_PER_SUCCESS = 0.10;
+
+function loadManualSmartHealth(): void {
+  if (manualSmartHealthLoaded) return;
+  manualSmartHealthLoaded = true;
+  try {
+    const rows = JSON.parse(getSetting(MANUAL_SMART_HEALTH_KEY) ?? '[]') as unknown;
+    if (!Array.isArray(rows)) return;
+    for (const row of rows) {
+      if (!Array.isArray(row) || row.length !== 3) continue;
+      const [modelDbId, rateLimitHits, penalty] = row.map(Number);
+      if (Number.isInteger(modelDbId) && modelDbId > 0 && Number.isFinite(rateLimitHits) && Number.isFinite(penalty) && penalty > 0) {
+        manualSmartHealth.set(modelDbId, { rateLimitHits, penalty: Math.min(1, penalty), lastFailureTime: 0 });
+      }
+    }
+  } catch {
+    // Ignore malformed legacy state; the next health event rewrites it.
+  }
+}
+
+function persistManualSmartHealth(): void {
+  setSetting(MANUAL_SMART_HEALTH_KEY, JSON.stringify(
+    [...manualSmartHealth].map(([modelDbId, h]) => [modelDbId, h.rateLimitHits, h.penalty]),
+  ));
+}
+
+function currentHealth(modelDbId: number): ManualSmartHealth {
+  loadManualSmartHealth();
+  const current = manualSmartHealth.get(modelDbId) ?? { rateLimitHits: 0, penalty: 0, lastFailureTime: 0 };
+  if (current.penalty > 0 && current.lastFailureTime > 0) {
+    const periods = Math.floor((Date.now() - current.lastFailureTime) / MANUAL_SMART_COOLDOWN_MS);
+    if (periods > 0) {
+      current.penalty = Math.max(0, current.penalty - periods * MANUAL_SMART_RECOVERY_RATE);
+      current.lastFailureTime += periods * MANUAL_SMART_COOLDOWN_MS;
+      manualSmartHealth.set(modelDbId, current);
+      persistManualSmartHealth();
+    }
+  }
+  return current;
+}
+
+export function recordHealthFailure(modelDbId: number, failure: HealthFailure, provider: string = ''): { rateLimitHits: number; healthFactor: number } {
+  const current = currentHealth(modelDbId);
+  const rateLimitHits = failure === 'rate-limit' ? current.rateLimitHits + 1 : current.rateLimitHits;
+
+  let penaltyIncrease: number;
+  switch (failure) {
+    case 'rate-limit':
+      penaltyIncrease = RATE_LIMIT_PENALTIES[Math.min(rateLimitHits, 4)];
+      break;
+    case 'transient':
+      penaltyIncrease = TRANSIENT_FAILURE_PENALTY;
+      break;
+    case 'client-error':
+      penaltyIncrease = CLIENT_ERROR_PENALTY;
+      break;
+    case 'provider-error':
+      penaltyIncrease = PROVIDER_ERROR_PENALTY;
+      break;
+    default:
+      penaltyIncrease = TRANSIENT_FAILURE_PENALTY;
+  }
+
+  const newPenalty = Math.min(1, current.penalty + penaltyIncrease);
+  manualSmartHealth.set(modelDbId, {
+    rateLimitHits,
+    penalty: newPenalty,
+    lastFailureTime: Date.now(),
+    provider: provider || current.provider,
+  });
+  persistManualSmartHealth();
+  return { rateLimitHits, healthFactor: 1 - newPenalty };
+}
+
+export function recordHealthSuccess(modelDbId: number): void {
+  const current = currentHealth(modelDbId);
+  if (current.penalty > 0) {
+    const newPenalty = Math.max(0, current.penalty - HEALTH_RECOVERY_PER_SUCCESS);
+    manualSmartHealth.set(modelDbId, {
+      rateLimitHits: current.rateLimitHits,
+      penalty: newPenalty,
+      lastFailureTime: current.lastFailureTime,
+      provider: current.provider,
+    });
+    persistManualSmartHealth();
+  }
+}
+
+export function getManualSmartHealth(modelDbId: number): { rateLimitHits: number; healthFactor: number } {
+  const health = currentHealth(modelDbId);
+  return { rateLimitHits: health.rateLimitHits, healthFactor: 1 - health.penalty };
+}
+
+export function resetManualSmartHealth(): void {
+  manualSmartHealth.clear();
+  manualSmartHealthLoaded = true;
+  persistManualSmartHealth();
+}
+
+export function markKeyAuthFailure(keyId: number): void {
+  getDb().prepare("UPDATE api_keys SET status = 'error', last_checked_at = datetime('now') WHERE id = ?").run(keyId);
+}
+
+export function getAllManualSmartHealth(): Array<{ modelDbId: number; rateLimitHits: number; penalty: number; healthFactor: number }> {
+  loadManualSmartHealth();
+  return [...manualSmartHealth]
+    .filter(([, health]) => health.penalty > 0)
+    .map(([modelDbId, health]) => ({ modelDbId, ...health, healthFactor: 1 - health.penalty }))
+    .sort((a, b) => b.penalty - a.penalty);
+}
 
 /**
- * Record an upstream failure for a model — increases its penalty so it sinks in
+ * Record an upstream failure for a model 鈥?increases its penalty so it sinks in
  * priority. Default weight is the LIGHT one for ordinary upstream failures
  * (5xx/timeout/empty stream, +1); callers that know they saw a hard limit
- * signal (429/402) pass the heavier weight — a quota limit is the stronger,
+ * signal (429/402) pass the heavier weight 鈥?a quota limit is the stronger,
  * longer-lived health cue.
  */
 export function recordModelFailure(modelDbId: number, weight = PENALTY_PER_FAIL) {
@@ -285,7 +408,7 @@ export function recordModelFailure(modelDbId: number, weight = PENALTY_PER_FAIL)
 }
 
 /**
- * Record a 429 for a model — heavier penalty (priority demotion) than ordinary
+ * Record a 429 for a model 鈥?heavier penalty (priority demotion) than ordinary
  * failures, since a rate-limit signal is the strongest short-term health cue.
  */
 export function recordRateLimitHit(modelDbId: number) {
@@ -293,7 +416,7 @@ export function recordRateLimitHit(modelDbId: number) {
 }
 
 /**
- * Record a success for a model — reduces its penalty so it rises back up.
+ * Record a success for a model 鈥?reduces its penalty so it rises back up.
  */
 export function recordSuccess(modelDbId: number) {
   const existing = rateLimitPenalties.get(modelDbId);
@@ -307,7 +430,7 @@ export function recordSuccess(modelDbId: number) {
 
 /**
  * Get the current penalty for a model (with time-based decay).
- * Pure read — does not mutate the entry; decay is applied lazily only when
+ * Pure read 鈥?does not mutate the entry; decay is applied lazily only when
  * recording a new hit (recordRateLimitHit) so the clock isn't reset on every
  * routing call.
  */
@@ -339,7 +462,7 @@ export function getAllPenalties(): Array<{ modelDbId: number; count: number; pen
   return result.sort((a, b) => b.penalty - a.penalty);
 }
 
-// ── Routing strategy (persisted) ────────────────────────────────────────────
+// 鈹€鈹€ Routing strategy (persisted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 const STRATEGY_KEY = 'routing_strategy';
 const CUSTOM_WEIGHTS_KEY = 'routing_custom_weights';
 const EXPLORE_KEY = 'routing_explore_enabled';
@@ -419,7 +542,7 @@ export const EXPLORE_CHANCE = 0.1;
 /** A model counts as "has data" once its decay-weighted success+failure
  *  pseudo-count reaches this many samples. */
 export const EXPLORE_MIN_SAMPLES = 5;
-const VALID_STRATEGIES: RoutingStrategy[] = ['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom'];
+const VALID_STRATEGIES: RoutingStrategy[] = ['priority', 'balanced', 'smartest', 'fastest', 'reliable', 'custom', 'manual-smart'];
 
 export function getRoutingStrategy(): RoutingStrategy {
   const raw = getSetting(STRATEGY_KEY);
@@ -435,7 +558,7 @@ export function setRoutingStrategy(strategy: RoutingStrategy): void {
   setSetting(STRATEGY_KEY, strategy);
 }
 
-// ── Exploration toggle (persisted) ─────────────────────────────────────────
+// 鈹€鈹€ Exploration toggle (persisted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Off by default: existing routing behavior unchanged. When on, routeRequest
 // gives unmeasured models a guaranteed chance to be tried (EXPLORE_CHANCE) so
 // they acquire reliability/speed samples instead of losing every bandit draw.
@@ -447,7 +570,7 @@ export function setExploreEnabled(enabled: boolean): void {
   setSetting(EXPLORE_KEY, enabled ? '1' : '0');
 }
 
-// ── Peak-hours adjustment (persisted, off by default) ──────────────────────
+// 鈹€鈹€ Peak-hours adjustment (persisted, off by default) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Opt-in time-of-day reweighting (#760). Everything about it is operator-set:
 // whether it runs at all, the window, and the timezone the window is read in.
 // With the flag off, weightsFor returns the presets byte-for-byte, so an
@@ -483,14 +606,14 @@ export function setPeakHoursConfig(patch: Partial<PeakHoursConfig>): void {
   if (patch.timezone !== undefined) setSetting(PEAK_TZ_KEY, patch.timezone);
 }
 
-// ── Key selection strategy (persisted) ─────────────────────────────────────
+// 鈹€鈹€ Key selection strategy (persisted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Which of a platform's several keys to reach for, once a model has been
 // picked. Independent of the routing strategy on purpose (#919): the strategy
 // enum drives the MODEL bandit, so putting a key policy in it would make
 // choosing a key policy also throw away the model ranking.
-//   'auto'            — unchanged: per-key bandit score when there is data,
+//   'auto'            鈥?unchanged: per-key bandit score when there is data,
 //                       round-robin otherwise.
-//   'least-remaining' — additionally rank by observed remaining quota, roomiest
+//   'least-remaining' 鈥?additionally rank by observed remaining quota, roomiest
 //                       key first, so the key closest to its cap is held back
 //                       instead of being the next one to 429.
 const KEY_SELECTION_KEY = 'key_selection_strategy';
@@ -511,7 +634,7 @@ export function setKeySelectionStrategy(strategy: KeySelectionStrategy): void {
   setSetting(KEY_SELECTION_KEY, strategy);
 }
 
-// ── Custom weights (persisted) ──────────────────────────────────────────────
+// 鈹€鈹€ Custom weights (persisted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // User-tuned weight vector for the 'custom' strategy. Stored normalized (sums
 // to 1) so the dashboard percentages read cleanly; combineScore would tolerate
 // any non-negative vector regardless. Falls back to the balanced preset until
@@ -527,7 +650,7 @@ export function getCustomWeights(): RoutingWeights {
       ) {
         return { reliability: w.reliability, speed: w.speed, intelligence: w.intelligence };
       }
-    } catch { /* corrupt setting → fall through to default */ }
+    } catch { /* corrupt setting 鈫?fall through to default */ }
   }
   return { ...BANDIT_PRESETS.balanced };
 }
@@ -548,19 +671,19 @@ export function setCustomWeights(weights: RoutingWeights): void {
   }));
 }
 
-// ── Community reliability prior (persisted) ────────────────────────────────
+// 鈹€鈹€ Community reliability prior (persisted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Aggregated, de-poisoned counts from other self-hosted instances, folded into
 // the Beta posterior as a starting balance so a brand-new model isn't blind
 // (#685 follow-up). Keyed "platform:model_id" (endpoint-scoped keys use the
 // same modelStatsKey form). Local samples dilute it automatically.
 //
 // Opt-in: priors only reach the posterior when routing_community_prior_enabled
-// is on (default off). Server-side only for now — there is deliberately no
+// is on (default off). Server-side only for now 鈥?there is deliberately no
 // ingestion path yet, so the flag pins the opt-in semantics before one lands.
 type CommunityPriorMap = Record<string, { successes: number; failures: number }>;
 
 /** Ceiling on a single prior's effective sample size. Local counts are
- *  decay-weighted (2-day half-life — a busy install still only carries on the
+ *  decay-weighted (2-day half-life 鈥?a busy install still only carries on the
  *  order of a hundred effective samples), so an unbounded, undecayed community
  *  count would drown local evidence forever and collapse the Thompson-sampling
  *  variance to zero. Capping at ~50 pseudo-observations keeps a prior worth
@@ -572,7 +695,7 @@ export const COMMUNITY_PRIOR_MAX_SAMPLES = 50;
  *  Shared by the read path and the write path so a value is bounded no matter
  *  how it entered (fresh set, legacy stored blob, hand-edited settings row).
  *  Invalid entries (negative, all-zero, no ':') are dropped; oversized ones
- *  are rescaled preserving the success/failure ratio (980/20 → 49/1). */
+ *  are rescaled preserving the success/failure ratio (980/20 鈫?49/1). */
 function sanitizeCommunityPriors(priors: unknown): CommunityPriorMap {
   const clean: CommunityPriorMap = {};
   if (!priors || typeof priors !== 'object') return clean;
@@ -609,7 +732,7 @@ function communityPriorState(): { map: CommunityPriorMap; enabled: boolean } {
   if (raw) {
     try {
       map = sanitizeCommunityPriors(JSON.parse(raw));
-    } catch { /* corrupt setting → no priors */ }
+    } catch { /* corrupt setting 鈫?no priors */ }
   }
   communityPriorCache = { map, enabled: getSetting(COMMUNITY_PRIOR_ENABLED_KEY) === '1' };
   communityPriorCacheTime = now;
@@ -631,7 +754,7 @@ export function setCommunityPriorEnabled(enabled: boolean): void {
 }
 
 /** Community prior for one model, or undefined when none is stored.
- *  Raw read — ignores the enabled flag; routing goes through
+ *  Raw read 鈥?ignores the enabled flag; routing goes through
  *  activeCommunityPrior, which honors it. */
 export function getCommunityPrior(platform: string, modelId: string, endpointScope?: string):
   { successes: number; failures: number } | undefined {
@@ -669,18 +792,17 @@ function weightsFor(strategy: RoutingStrategy): RoutingWeights | null {
 }
 
 /** The weight vector routing will use right now for the active strategy, and
- *  whether the peak-hours adjustment moved it. Cheap (settings reads only) —
- *  for the PUT /routing echo, which must not pay for a full score sweep. */
+ *  whether the peak-hours adjustment moved it. Cheap (settings reads only) 鈥? *  for the PUT /routing echo, which must not pay for a full score sweep. */
 export function getActiveRoutingWeights(): { weights: RoutingWeights | null; adjusted: boolean } {
   return weightsWithPeak(getRoutingStrategy());
 }
 
-// ── Analytics stats cache (decay-weighted) ──────────────────────────────────
+// 鈹€鈹€ Analytics stats cache (decay-weighted) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Instead of the fork's flat 7-day window (where a model that degrades today
 // keeps a stale week-long average), each request is weighted by an exponential
 // decay so recent behavior dominates while older data still stabilizes the
-// estimate. We aggregate by (model, integer day age) in SQL — at most ~7 rows
-// per model — then apply the per-bucket decay weight in JS.
+// estimate. We aggregate by (model, integer day age) in SQL 鈥?at most ~7 rows
+// per model 鈥?then apply the per-bucket decay weight in JS.
 const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const HALF_LIFE_DAYS = 2; // a 2-day-old request counts half as much as a fresh one
 const CACHE_TTL_MS = 60 * 1000;
@@ -689,13 +811,13 @@ interface ModelStats {
   successes: number;   // decay-weighted pseudo-count
   failures: number;    // decay-weighted pseudo-count
   // Output tokens from successes over the time spent on successes AND timeouts
-  // (#619 — see the accumulator below); 0 = no data.
+  // (#619 鈥?see the accumulator below); 0 = no data.
   tokPerSec: number;
   avgTtfbMs: number | null; // null = no first-byte timing yet
   monthlyUsedTokens: number; // calendar-month usage, for the headroom guardrail
   // Decay-weighted requests that actually SAY something about speed: successes
   // plus timeouts. A model can have hundreds of 401s and still no speed signal,
-  // so this — not successes + failures — is what gates the observed speed_rank
+  // so this 鈥?not successes + failures 鈥?is what gates the observed speed_rank
   // writeback.
   speedSamples: number;
 }
@@ -703,7 +825,7 @@ interface ModelStats {
 // Per-key slice of the same window (#580): reliability/speed observed through
 // ONE credential of a model. With unified groups, a model's traffic can span
 // several keys whose real quality diverges (expired, quota-drained, region-
-// blocked keys fail while siblings are fine) — the rolled-up model bucket
+// blocked keys fail while siblings are fine) 鈥?the rolled-up model bucket
 // can't see that, so key selection needs its own buckets.
 interface KeyStats {
   successes: number;   // decay-weighted pseudo-count
@@ -726,7 +848,7 @@ function decayWeight(ageDays: number): number {
 // SQL predicate for "this row is a timed-out request" (#619). A timeout is an
 // error row whose text carries one of the shared timeout markers
 // (lib/error-classify.ts), which is also what the failover attempt trail
-// classifies on. 'canceled' rows (#752 — client hung up) never reach this
+// classifies on. 'canceled' rows (#752 鈥?client hung up) never reach this
 // predicate: the stats query below filters them out entirely, because a
 // vanished client says nothing about the model's reliability or speed. The
 // markers are hard-coded lowercase identifiers from our own source, never
@@ -735,7 +857,7 @@ const IS_TIMEOUT_SQL = `(status != 'success' AND (${
   TIMEOUT_ERROR_MARKERS.map(m => `LOWER(COALESCE(error, '')) LIKE '%${m}%'`).join(' OR ')
 }))`;
 
-/** api_keys.id → endpoint scope, for every custom credential on record (#651). */
+/** api_keys.id 鈫?endpoint scope, for every custom credential on record (#651). */
 function customEndpointScopes(db: Db): Map<number, string> {
   const rows = db.prepare("SELECT id, base_url FROM api_keys WHERE platform = 'custom'")
     .all() as { id: number; base_url: string | null }[];
@@ -750,8 +872,8 @@ export function refreshStatsCache(db: Db, force = false): void {
   invalidateCommunityPriorCache();
 
   const since = new Date(Date.now() - WINDOW_MS).toISOString();
-  // Grouped by (model, key, day age): still a handful of rows per model — key
-  // count × ≤7 day buckets — so the finer grain keeps the same one-query,
+  // Grouped by (model, key, day age): still a handful of rows per model 鈥?key
+  // count 脳 鈮? day buckets 鈥?so the finer grain keeps the same one-query,
   // 60s-cached shape. Aggregated two ways below: rolled up per model (ordering)
   // and per key (in-model key selection, #580).
   const buckets = db.prepare(`
@@ -779,7 +901,7 @@ export function refreshStatsCache(db: Db, force = false): void {
   // Timeouts (#619) land in the SAME latency/TTFB accumulators as successes,
   // because that is what they are: time spent, nothing produced. Each one adds
   // its capped wall-clock latency to the throughput denominator with zero
-  // output tokens, and that same figure as a first-byte sample — which is past
+  // output tokens, and that same figure as a first-byte sample 鈥?which is past
   // TTFB_WORST_MS, so it scores no latency credit. Net effect: a model that
   // times out constantly can no longer keep a stellar speed number just because
   // its handful of successes were quick.
@@ -866,7 +988,7 @@ export function refreshStatsCache(db: Db, force = false): void {
   statsCacheTime = Date.now();
 
   // Natural tail of a recompute: fold what we just measured back into
-  // models.speed_rank (#619). Never allowed to break routing — the caches above
+  // models.speed_rank (#619). Never allowed to break routing 鈥?the caches above
   // are already published, and a failed write just means the column keeps its
   // previous value until the next pass.
   if (Date.now() - speedRankWriteTime >= SPEED_RANK_WRITE_INTERVAL_MS) {
@@ -879,10 +1001,10 @@ export function refreshStatsCache(db: Db, force = false): void {
   }
 }
 
-// ── Observed speed_rank writeback (#619) ────────────────────────────────────
+// 鈹€鈹€ Observed speed_rank writeback (#619) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // models.speed_rank is the catalog's hand-assigned speed ordering and drives
 // the dashboard's sort-by-speed preset. It was only ever WRITTEN by the seed
-// migrations, catalog sync, and an explicit user override — never by anything
+// migrations, catalog sync, and an explicit user override 鈥?never by anything
 // that had actually watched the model run, so a relay model that hangs on half
 // its calls kept whatever rank the catalog guessed for it forever.
 //
@@ -890,7 +1012,7 @@ export function refreshStatsCache(db: Db, force = false): void {
 //   - a model needs SPEED_RANK_MIN_SAMPLES decay-weighted speed-bearing
 //     requests (successes + timeouts) before we claim to know anything; below
 //     that it keeps its catalog value;
-//   - a user-set speed_rank override always wins — we skip those models
+//   - a user-set speed_rank override always wins 鈥?we skip those models
 //     entirely rather than fight applyModelOverrides for the column;
 //   - the UPDATE is guarded on the value actually changing, so a steady system
 //     writes nothing at all.
@@ -910,7 +1032,7 @@ export function resetSpeedRankWriteback(): void {
 /**
  * Write an observed speed rank for every model with enough recent samples and
  * no user-set speed_rank override. Returns how many rows actually changed.
- * Reads the stats cache as-is — callers refresh it first (refreshStatsCache
+ * Reads the stats cache as-is 鈥?callers refresh it first (refreshStatsCache
  * calls this from its own tail).
  */
 export function writeObservedSpeedRanks(db: Db): number {
@@ -924,8 +1046,8 @@ export function writeObservedSpeedRanks(db: Db): number {
   let written = 0;
   const tx = db.transaction(() => {
     for (const row of rows) {
-      // Overrides are keyed (platform, model_id) — they only exist for
-      // catalog-managed rows, which are never endpoint-scoped — while the
+      // Overrides are keyed (platform, model_id) 鈥?they only exist for
+      // catalog-managed rows, which are never endpoint-scoped 鈥?while the
       // measured stats are per endpoint, so each relay's copy gets its own
       // observed rank instead of one shared number (#651).
       if (pinned.has(`${row.platform}:${row.model_id}`)) continue;
@@ -943,7 +1065,7 @@ export function writeObservedSpeedRanks(db: Db): number {
 
 // Composite intelligence (tier-first, rank-as-tiebreaker) lives in scoring.ts
 // so the seeding path can reason about the same tier ladder the router scores
-// on — see intelligenceComposite there.
+// on 鈥?see intelligenceComposite there.
 
 // Per-model axis values + the final score. `sampled` chooses Thompson sampling
 // (for routing) vs. the expected value (for a stable dashboard display).
@@ -956,7 +1078,7 @@ interface ScoredEntry {
 
 // Enabled + healthy/unknown key count per platform, for pooled-budget scaling.
 // This is the SAME filter both /api/fallback endpoints use (issue #456): the
-// monthly budget is a PER-KEY free-tier allowance, so N usable keys pool N× the
+// monthly budget is a PER-KEY free-tier allowance, so N usable keys pool N脳 the
 // capacity. `monthlyUsedTokens` is already summed across all keys, so budget
 // must scale to match or the headroom guardrail damps a multi-key model to the
 // floor after just one account's worth of tokens.
@@ -995,12 +1117,12 @@ function scoreChainEntry(
   );
 
   // Scale the per-key monthly budget by the usable key count for this platform,
-  // matching the pooled `monthlyUsedTokens` aggregate (#456). Math.max(1, …) so a
+  // matching the pooled `monthlyUsedTokens` aggregate (#456). Math.max(1, 鈥? so a
   // model whose platform currently has no usable key isn't handed a 0 budget.
   const budget = parseBudget(entry.monthly_token_budget) * Math.max(1, keyCounts.get(entry.platform) ?? 1);
   // Tunable headroom thresholds (#899): persisted overrides for when demotion
   // starts and its floor; absent settings keep the scoring.ts defaults. Read
-  // ONCE per chain by the caller, not per entry — getSetting is an uncached
+  // ONCE per chain by the caller, not per entry 鈥?getSetting is an uncached
   // SELECT, so reading it here cost two extra SQLite round-trips per model per
   // request, the same reason `weights` and `keyCounts` are hoisted.
   const monthlyHeadroom = headroomFactor(stats?.monthlyUsedTokens ?? 0, budget, headroomCfg);
@@ -1020,14 +1142,14 @@ function scoreChainEntry(
 
   // The WORSE of the two, not their product: both express the same "this model
   // is close to burning out" opinion on different meters, and multiplying them
-  // would push a model that is low on both to floor², below the floor the
+  // would push a model that is low on both to floor虏, below the floor the
   // operator configured. Taking the binding constraint keeps the floor meaning
-  // what it says — the same rule getKeyQuotaHeadroom applies across metrics.
+  // what it says 鈥?the same rule getKeyQuotaHeadroom applies across metrics.
   const headroom = Math.min(monthlyHeadroom, windowHeadroom);
   const rl = rateLimitFactor(getPenalty(entry.model_db_id));
 
   // Per-model env overrides (#738) scale the final score so a slow or
-  // poor-quality model is demoted without being disabled outright — a manual
+  // poor-quality model is demoted without being disabled outright 鈥?a manual
   // 'priority' chain can still select it.
   const score = applyModelWeightOverride(
     combineScore({ reliability, speed, intelligence, headroom, rateLimit: rl }, weights),
@@ -1038,18 +1160,24 @@ function scoreChainEntry(
 
 /**
  * Order the enabled fallback chain for routing.
- *  - 'priority' strategy → legacy manual order + 429 penalty (unchanged).
- *  - bandit strategy      → convex score, manual priority as the deterministic
+ *  - 'priority' strategy 鈫?legacy manual order + 429 penalty (unchanged).
+ *  - bandit strategy      鈫?convex score, manual priority as the deterministic
  *                           tiebreaker for (near-)equal scores.
  *
  * `sampled` controls the bandit branch: Thompson sampling (the default) for
  * live routing, where per-call randomness is the exploration the bandit needs;
  * the deterministic expected score (`sampled = false`) for callers that want a
- * STABLE ranking under the chosen strategy — the fusion panel, which should be a
+ * STABLE ranking under the chosen strategy 鈥?the fusion panel, which should be a
  * faithful reflection of the user's picked strategy, not a re-sampled draw each
  * request. Priority mode is deterministic either way.
  */
 function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true, task?: 'code' | 'chat'): ChainRow[] {
+  if (strategy === 'manual-smart') {
+    return chain
+      .map(e => ({ e, score: e.intelligence_rank / Math.max(getManualSmartHealth(e.model_db_id).healthFactor, 0.01) }))
+      .sort((a, b) => a.score - b.score || a.e.priority - b.e.priority)
+      .map(x => x.e);
+}
   // Tier first, always: it is the one ordering input that score must not be able
   // to override (see ChainRow.match_tier). Zero for every chain built anywhere
   // else, so this is a no-op outside slug-fallback resolution.
@@ -1059,16 +1187,16 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
     // Legacy priority mode: manual chain order + the 429/failure penalty,
     // ascending.
     //
-    // The penalty is denominated in PRIORITY POSITIONS — PENALTY_PER_429 = 3
+    // The penalty is denominated in PRIORITY POSITIONS 鈥?PENALTY_PER_429 = 3
     // positions per rate limit, PENALTY_PER_FAIL = 1 per upstream failure,
-    // capped at MAX_PENALTY = 10 — so adding it to the RAW priority only ever
+    // capped at MAX_PENALTY = 10 鈥?so adding it to the RAW priority only ever
     // reorders a chain whose neighbours sit within 10 of each other. Nothing
     // guarantees that, and several ordinary paths guarantee the opposite:
     //   - PUT /api/fallback validates `priority` as a bare z.number(), so any
     //     spacing the caller likes (10 / 20 / 30) is persisted verbatim;
     //   - the seed and sort-preset paths number the WHOLE catalog 1..N, while
     //     this chain is only the ENABLED subset (`JOIN models m ON
-    //     m.enabled = 1`) — switching models off punches arbitrarily large
+    //     m.enabled = 1`) 鈥?switching models off punches arbitrarily large
     //     holes in the surviving sequence;
     //   - resolveModelGroupCandidates hydrates scattered group members with
     //     whatever COALESCE(fc.priority, 0) they happen to carry.
@@ -1082,7 +1210,7 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
     // is monotonic in priority, so an unpenalized chain comes out in exactly
     // the order the user arranged (tier still dominates as the outer sort key,
     // and the raw priority remains the tiebreaker); the difference is that one
-    // penalty position now means what it says — one position.
+    // penalty position now means what it says 鈥?one position.
     return chain
       .map((e, i) => ({ e, i }))
       .sort((a, b) => a.e.priority - b.e.priority || a.i - b.i)
@@ -1120,8 +1248,8 @@ function orderChain(chain: ChainRow[], strategy: RoutingStrategy, sampled = true
  * Route a request to the best available model.
  *
  * Ordering depends on the configured strategy (see orderChain). Everything
- * downstream — key round-robin, cooldowns, token pre-checks, custom base_url
- * resolution, vision filtering, sticky sessions — is strategy-independent.
+ * downstream 鈥?key round-robin, cooldowns, token pre-checks, custom base_url
+ * resolution, vision filtering, sticky sessions 鈥?is strategy-independent.
  *
  * If preferredModelDbId is set, that model gets tried FIRST (sticky sessions).
  * This prevents hallucination from model switching mid-conversation.
@@ -1151,7 +1279,7 @@ const GLOBAL_SORT_ALIASES: Record<string, string> = {
  *
  * When a profile is active it IS the chain, empty or not (#1021). Falling
  * through to `fallback_config` on an empty one meant a chain the operator had
- * deliberately built by hand — or had not filled in yet — silently routed over
+ * deliberately built by hand 鈥?or had not filled in yet 鈥?silently routed over
  * the entire catalog instead, while the same chain addressed by name
  * (`auto:<name>`) correctly refused. `fallback_config` is the chain only for an
  * install with no profile at all.
@@ -1203,7 +1331,7 @@ function getChainByProfileName(db: Db, name: string): ChainRow[] | null {
 
 function getChainByGlobalSort(db: Db, globalAxis: string): ChainRow[] {
   // A global sort ignores the chain's ORDER, not its enable flags: a model the
-  // operator switched off — in the catalog or just for auto routing — stays off
+  // operator switched off 鈥?in the catalog or just for auto routing 鈥?stays off
   // here too (#634). Models with no chain row yet (fresh catalog rows) default
   // to in, so the sort still spans the whole catalog.
   const profileId = getActiveProfileId(db);
@@ -1230,7 +1358,7 @@ function getChainByGlobalSort(db: Db, globalAxis: string): ChainRow[] {
     'balanced': 'balanced'
   };
   const strat = strategyMap[globalAxis] || 'balanced';
-  
+
   return orderChain(allEnabled, strat);
 }
 
@@ -1239,7 +1367,7 @@ function getChainByGlobalSort(db: Db, globalAxis: string): ChainRow[] {
  *
  * Mirrors what `auto:<name>` already does for a named chain: say the chain is
  * empty rather than routing the request over models the operator never put in
- * it. Only when a profile is active — a legacy install with none keeps the
+ * it. Only when a profile is active 鈥?a legacy install with none keeps the
  * ordinary "all models exhausted" exhaustion path.
  */
 function activeChainOrThrow(db: Db): ChainRow[] {
@@ -1312,10 +1440,10 @@ const KEY_SCORE_WEIGHTS = { reliability: 0.75, speed: 0.25 };
 /**
  * Order a model's candidate keys by a Thompson-sampled per-key score, mirroring
  * orderChain's bandit: reliability is a fresh draw from each key's Beta
- * posterior (so exploration is automatic and proportional to uncertainty — a
+ * posterior (so exploration is automatic and proportional to uncertainty 鈥?a
  * key with no data samples from the uniform prior and still gets traffic),
  * speed is deterministic. Returns null when NO key has recorded data, telling
- * the caller to keep the legacy round-robin rotation (no signal → no ranking).
+ * the caller to keep the legacy round-robin rotation (no signal 鈫?no ranking).
  */
 function orderKeysByScore(entry: ChainRow, keys: KeyRow[]): KeyRow[] | null {
   if (keys.length < 2 || !keyStatsCache) return null;
@@ -1348,7 +1476,7 @@ const UNKNOWN_QUOTA_HEADROOM = 0.5;
  * operator asked for it AND the platform meters its keys separately.
  *
  * An account-scoped pool ('<platform>::account') is ONE budget every key of the
- * account draws down, so "which key has more left" has no answer — every key
+ * account draws down, so "which key has more left" has no answer 鈥?every key
  * reports the same number, and reordering on it would only churn the rotation
  * for nothing (#919).
  */
@@ -1359,13 +1487,13 @@ function quotaWeightingApplies(entry: ChainRow): boolean {
 
 /**
  * Re-order an already-ordered candidate list by observed remaining quota,
- * roomiest first (#919 — the issue asks for higher-remaining-first, so the key
+ * roomiest first (#919 鈥?the issue asks for higher-remaining-first, so the key
  * nearest its cap is tried last, not first).
  *
  * Deliberately a SORT over the caller's list rather than a second walk: the
  * incoming order is the round-robin rotation (or the per-key bandit ranking),
- * and Array#sort is stable, so keys with equal headroom — including the common
- * case of no observations at all — keep exactly the order they would have had.
+ * and Array#sort is stable, so keys with equal headroom 鈥?including the common
+ * case of no observations at all 鈥?keep exactly the order they would have had.
  * Every gate, the custom-endpoint filter and the skip tally stay in the one
  * walk that follows.
  */
@@ -1383,7 +1511,7 @@ function orderKeysByRemainingQuota(entry: ChainRow, ordered: KeyRow[]): KeyRow[]
  * the model has no key that can serve the request right now (all cooled down,
  * over quota, undecryptable, or no provider). Factored out of routeRequest so
  * the fusion panel can HARD-PIN a model: walk that model's keys without ever
- * falling through to a different model (issue #326 — soft preference collapses
+ * falling through to a different model (issue #326 鈥?soft preference collapses
  * panel diversity under rate limits). Keys are tried in per-key bandit-score
  * order when any of them has recorded data (#580), else round-robin.
  * Request-level filters (vision/tools/context window) stay in the caller; this
@@ -1408,12 +1536,12 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   }
 
   // Scoped keys (#657) are dropped before the walk: a key whose model scope
-  // excludes this model is not a candidate at all — it neither takes a
+  // excludes this model is not a candidate at all 鈥?it neither takes a
   // round-robin slot nor burns an attempt on a guaranteed 403. Parsed once per
   // key row.
   const keys = allKeys.filter(k => scopeAllows(parseModelScope(k.model_scope_json), entry.model_id));
   if (keys.length === 0) {
-    diag?.push(`${label}: no usable key — ${allKeys.length} key(s) scoped to other models`);
+    diag?.push(`${label}: no usable key 鈥?${allKeys.length} key(s) scoped to other models`);
     return null;
   }
 
@@ -1442,8 +1570,8 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   let ranked = orderKeysByScore(entry, keys);
 
   // Remaining-quota weighting (#919) layers on top: it re-sorts whatever order
-  // we were going to walk anyway — the bandit ranking when there is per-key
-  // data, otherwise the round-robin rotation starting at the live cursor — so
+  // we were going to walk anyway 鈥?the bandit ranking when there is per-key
+  // data, otherwise the round-robin rotation starting at the live cursor 鈥?so
   // ties fall back to that order instead of to rowid.
   if (keys.length > 1 && quotaWeightingApplies(entry)) {
     const base = ranked ?? Array.from({ length: keys.length }, (_, i) => keys[(idx + i) % keys.length]);
@@ -1451,7 +1579,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   }
 
   // A custom model belongs to exactly one endpoint (#212), but an endpoint can
-  // hold several credentials — so the pool is every key on the same base_url,
+  // hold several credentials 鈥?so the pool is every key on the same base_url,
   // rotated like any other platform's keys (#619). Legacy rows (key_id NULL)
   // keep the old any-key match.
   const endpointKeyIds = entry.platform === 'custom' && entry.key_id != null
@@ -1522,7 +1650,7 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
   // don't get stuck re-trying the same exhausted key first next time.
   roundRobinIndex.set(rrKey, idx);
   const summary = Object.entries(skipTally).map(([r, n]) => `${r}:${n}`).join(', ') || 'no usable key';
-  diag?.push(`${label}: ${keys.length} key(s) — ${summary}`);
+  diag?.push(`${label}: ${keys.length} key(s) 鈥?${summary}`);
   return null;
 }
 
@@ -1530,15 +1658,15 @@ function selectKeyForModel(entry: ChainRow, estimatedTokens: number, skipKeys?: 
  * Whether the model still has ANOTHER key that could serve it right now, given
  * the key that just failed (excludingKeyId) and any keys already ruled out this
  * request (skipKeys, in the "platform:modelId:keyId" form). Applies the same
- * gates selectKeyForModel uses — enabled + healthy status, not on cooldown,
- * under the provider daily cap, and under rpm/rpd/tpm/tpd — so the answer means
+ * gates selectKeyForModel uses 鈥?enabled + healthy status, not on cooldown,
+ * under the provider daily cap, and under rpm/rpd/tpm/tpd 鈥?so the answer means
  * "a real, dispatchable alternative exists".
  *
  * Used by the retry loops to decide whether a single key's 429 should demote the
  * WHOLE model (the model-level 429 penalty). It should not: the per-key cooldown
  * already isolates the failing key, so demoting the model while a sibling key can
  * still serve it wrongly sinks a healthy model in the scorer (#454). We only
- * record the model-level hit when this returns false — i.e. the 429 exhausted the
+ * record the model-level hit when this returns false 鈥?i.e. the 429 exhausted the
  * model, not just one of its keys.
  */
 export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, skipKeys?: Set<string>): boolean {
@@ -1567,7 +1695,7 @@ export function hasOtherUsableKey(modelDbId: number, excludingKeyId: number, ski
   for (const k of keys) {
     if (k.id === excludingKeyId) continue;
     if (endpointKeyIds && !endpointKeyIds.has(k.id)) continue;
-    // A sibling scoped away from this model can never serve it (#657) — counting
+    // A sibling scoped away from this model can never serve it (#657) 鈥?counting
     // it would wrongly suppress the model-level penalty this gate exists for.
     if (!scopeAllows(parseModelScope(k.model_scope_json), m.model_id)) continue;
     if (skipKeys?.has(`${m.platform}:${m.model_id}:${k.id}`)) continue;
@@ -1599,7 +1727,7 @@ export function hasUsableKeyForModel(modelDbId: number): boolean {
 
 /**
  * Every key that can be ROUTED to this model: enabled + healthy/unknown, not
- * scoped away from the model (#657), and — for a custom model — belonging to
+ * scoped away from the model (#657), and 鈥?for a custom model 鈥?belonging to
  * the model's own endpoint (#212, #619). Deliberately ignores the transient
  * gates hasOtherUsableKey applies (cooldown, quotas): the caller here is the
  * model-level bench, which needs the full key set to take a sick model out of
@@ -1661,13 +1789,13 @@ export const CONTEXT_WINDOW_SAFETY_FACTOR = 1.25;
 
 // Platforms whose pre-dispatch trim guard already caps the dispatched input
 // below the live context ceiling (lib/content.ts truncateMessagesForGithub):
-// the guard — not the routing estimate — is what guarantees the fit there, so
+// the guard 鈥?not the routing estimate 鈥?is what guarantees the fit there, so
 // applying the factor too would only make that guard unreachable. The margin
 // checks below treat these platforms as strict comparisons.
 const TRIM_GUARDED_PLATFORMS = new Set(['github']);
 
 /** True when `estimatedTokens` fits the RAW advertised window (null window =
- * unknown, never filtered — same convention as the auto-router). This is the
+ * unknown, never filtered 鈥?same convention as the auto-router). This is the
  * comparison /v1/models publishes and the soft-preference fallback tier. */
 export function fitsContextWindowStrict(contextWindow: number | null | undefined, estimatedTokens: number): boolean {
   return contextWindow == null || estimatedTokens <= contextWindow;
@@ -1677,10 +1805,10 @@ export function fitsContextWindowStrict(contextWindow: number | null | undefined
  * margin. The chars/4 heuristic portion is scaled by the factor; an explicit
  * output reserve derived from the client's max_tokens (`routingReserveTokens`)
  * is already an exact count and is added UNSCALED (#956 review). Trim-guarded
- * platforms compare strictly — their guard guarantees the fit. */
+ * platforms compare strictly 鈥?their guard guarantees the fit. */
 export function fitsContextWindow(platform: string, contextWindow: number | null | undefined, estimatedTokens: number, exactOutputReserve = 0): boolean {
   if (contextWindow == null) return true;
-  // Raw advertised comparison first — the margin can only shrink eligibility.
+  // Raw advertised comparison first 鈥?the margin can only shrink eligibility.
   if (estimatedTokens > contextWindow) return false;
   if (TRIM_GUARDED_PLATFORMS.has(platform)) return true;
   const reserve = Math.max(0, exactOutputReserve);
@@ -1691,7 +1819,7 @@ export function fitsContextWindow(platform: string, contextWindow: number | null
 /**
  * Route to ONE specific model, hard-pinned. Rotates across that model's keys
  * (cooldowns, quotas, decryption all honored) but NEVER substitutes a different
- * model — returns null if the pinned model can't serve right now. This is what
+ * model 鈥?returns null if the pinned model can't serve right now. This is what
  * makes a fusion panel genuinely diverse: a rate-limited slot is dropped, not
  * silently collapsed onto whatever else is available. `skipKeys` lets a slot
  * exclude keys it already failed on this request.
@@ -1703,8 +1831,7 @@ export function routePinnedModel(modelDbId: number, estimatedTokens = 1000, skip
   // Strict comparison only (#956 review): a pinned slot has no substitute, so
   // refusing on a margin violation would drop the slot outright where the
   // pre-margin behavior was one dispatch attempt (a mid-chain context_too_large
-  // 400 is classified and retried downstream). Nothing is multiplied here —
-  // estimatedTokens already carries the exact capped output reserve (#470).
+  // 400 is classified and retried downstream). Nothing is multiplied here 鈥?  // estimatedTokens already carries the exact capped output reserve (#470).
   if (!fitsContextWindowStrict(entry.context_window, estimatedTokens)) return null;
   if (entry.tpm_limit != null && estimatedTokens > entry.tpm_limit) return null;
   return selectKeyForModel(entry, estimatedTokens, skipKeys);
@@ -1719,7 +1846,7 @@ export function routePinnedModel(modelDbId: number, estimatedTokens = 1000, skip
  * able to use a direct model that the user removed from auto routing.
  *
  * Pass the result to routeRequest() as `prefetchedChain` and DO NOT pass a
- * `preferredModelDbId` that isn't already one of these rows — otherwise the
+ * `preferredModelDbId` that isn't already one of these rows 鈥?otherwise the
  * preferred-model injection in routeRequest would unshift an off-group model and
  * the pin would no longer be strict (it could answer with a different model).
  */
@@ -1727,8 +1854,8 @@ export function resolveModelGroupCandidates(
   memberDbIds: number[],
   /**
    * Members that were reached only through a group's auto-derived slug, not the
-   * id the client wrote (#651). They stay in the chain — resolution must never
-   * shrink — but as a strictly lower tier, so they can serve only once every
+   * id the client wrote (#651). They stay in the chain 鈥?resolution must never
+   * shrink 鈥?but as a strictly lower tier, so they can serve only once every
    * literal match is exhausted. Omit it and every row is an equal candidate,
    * which is what every other caller wants.
    */
@@ -1798,14 +1925,14 @@ export function getOrderedFusionChain(estimatedTokens: number, exactOutputReserv
   if (strategy !== 'priority') refreshStatsCache(db);
   const chain = getActiveChain(db).filter(e => e.enabled);
 
-  // Only consider models that can ACTUALLY be served RIGHT NOW — applying the
+  // Only consider models that can ACTUALLY be served RIGHT NOW 鈥?applying the
   // same gate selectKeyForModel uses when the router walks the chain: the model
   // must have a key that is enabled + healthy, NOT on cooldown (e.g. a
   // HuggingFace key benched for a day after a 402 "Payment Required"), within
   // the provider's daily request cap, and under its per-minute/day request
   // limits. Without this, a high-strategy-ranked model whose only key is
   // currently cooled down (huggingface/Kimi-K2.6) would claim a panel slot it
-  // can't fill — surfacing as "no available key" and pushing out a usable model,
+  // can't fill 鈥?surfacing as "no available key" and pushing out a usable model,
   // which also makes the panel look like it's ignoring the routing strategy.
   //
   // The SIZE gates matter as much as the key gates: a model whose context window
@@ -1828,7 +1955,7 @@ export function getOrderedFusionChain(estimatedTokens: number, exactOutputReserv
   // Soft preference (#956 review): prefer models whose window holds the estimate
   // WITH the safety margin; /v1/models still advertises the raw window, so if
   // NOTHING survives that pass, re-run allowing raw advertised-window fits
-  // rather than handing back an empty chain — a request packed to the
+  // rather than handing back an empty chain 鈥?a request packed to the
   // advertised window keeps its one attempt (the mid-chain context_too_large
   // 400 is classified and retried downstream).
   const passesContextGate = (e: ChainRow, allowMarginViolators: boolean) => {
@@ -1943,7 +2070,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   // losing every bandit draw to prior-heavy rivals. With EXPLORE_CHANCE
   // probability, pick one unmeasured model uniformly and try it first; if it
   // fails, the loop falls through to the scored order as usual. Only for
-  // bandit strategies — Manual is the operator's explicit order.
+  // bandit strategies 鈥?Manual is the operator's explicit order.
   // Candidates the main loop would immediately reject for THIS request are
   // excluded up front (ruled-out models plus the request-level capability
   // gates: vision/tools/structured output/context window): promoting a model
@@ -1957,7 +2084,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   if (strategy !== 'priority' && getExploreEnabled() && !isDegraded() && Math.random() < EXPLORE_CHANCE) {
     // A model the operator zeroed out via MODEL_ROUTING_OVERRIDES never wins a
     // bandit draw, so it would stay under EXPLORE_MIN_SAMPLES forever and become
-    // a perpetual probe target — the explicit ban outranks exploration.
+    // a perpetual probe target 鈥?the explicit ban outranks exploration.
     const overrides = getModelWeightOverrides();
     const unmeasured = sortedChain.filter(e => {
       if (overrides.get(e.model_id) === 0) return false;
@@ -1985,7 +2112,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   }
 
   // Sticky session / Explicit pinning: move preferred model to front of chain
-  if (preferredModelDbId) {
+  if (preferredModelDbId && (strategy !== 'manual-smart' || getManualSmartHealth(preferredModelDbId).healthFactor === 1)) {
     const idx = sortedChain.findIndex(e => e.model_db_id === preferredModelDbId);
     if (idx >= 0) {
       if (idx > 0) {
@@ -2005,7 +2132,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
         FROM models m
         WHERE m.id = ? AND m.enabled = 1
       `).get(preferredModelDbId) as ChainRow | undefined;
-      
+
       if (pinnedRow) {
         sortedChain.unshift(pinnedRow);
       }
@@ -2013,12 +2140,12 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
   }
 
   // Per-model disposition, attached to the exhaustion error when the loop falls
-  // through with no route — the only record of WHY the pool was empty on the
+  // through with no route 鈥?the only record of WHY the pool was empty on the
   // synchronous "all exhausted" path (nothing downstream logs it). See issue _1.
   const diag: string[] = [];
 
   // Margin as a SOFT preference (#956 review): /v1/models advertises the raw
-  // window, so clients legitimately pack requests right up to it — excluding
+  // window, so clients legitimately pack requests right up to it 鈥?excluding
   // those models outright turned an already-handled upstream 400 into "all
   // models exhausted" with zero attempts. Keep the operator's order intact but
   // sweep margin-fitting models first; ones that only fit the advertised window
@@ -2033,51 +2160,51 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
 
   for (const entry of servingChain) {
     const label = `${entry.platform}/${entry.model_id}`;
-    // Models the caller has ruled out for this request — e.g. a 404
+    // Models the caller has ruled out for this request 鈥?e.g. a 404
     // "model removed upstream" already seen this request: trying the same
     // model again on a different key would just burn another attempt on the
     // same dead route (PR #111, credits @barbotkonv).
     if (skipModels?.has(entry.model_db_id)) { diag.push(`${label}: ruled out earlier this request`); continue; }
 
     // Platforms the caller has ruled out wholesale (#788): a provider-level
-    // failure this request — a 5xx, a timeout, a dead socket — is about the
+    // failure this request 鈥?a 5xx, a timeout, a dead socket 鈥?is about the
     // PROVIDER, so its other keys and its other models would fail the same way.
     // Skipping the platform moves failover to the next provider instead of
     // burning one hop per key. Request-scoped; nothing is benched by this.
     if (skipPlatforms?.has(entry.platform)) { diag.push(`${label}: provider ruled out earlier this request`); continue; }
 
-    // Vision requests skip text-only models — including a sticky/preferred one,
+    // Vision requests skip text-only models 鈥?including a sticky/preferred one,
     // which is correct: don't pin an image turn to a model that can't see it.
     if (requireVision && !entry.supports_vision) { diag.push(`${label}: no vision support`); continue; }
 
     // Tool-bearing requests skip models that can't emit structured tool_calls.
     // A model that "answers" a tool request with the call serialized as text
     // looks successful at the transport level while the client's harness sees
-    // nothing — worse than a failover. Applies to sticky models too, same
+    // nothing 鈥?worse than a failover. Applies to sticky models too, same
     // reasoning as vision above.
     if (requireTools && !entry.supports_tools) { diag.push(`${label}: no tool-calling support`); continue; }
 
     // Structured-output routing (#514 follow-up): when the request carries a
     // response_format, skip platforms whose param policy can't even receive it
     // (the param would be dropped before send, so the model would answer in
-    // prose and burn a failover hop). Platform-level fast path — model-level
+    // prose and burn a failover hop). Platform-level fast path 鈥?model-level
     // capability isn't in the catalog; models that accept the param but ignore
     // it are caught by the non-stream JSON enforcement downstream.
     if (requireStructured && platformDropsResponseFormat(entry.platform)) { diag.push(`${label}: platform drops response_format`); continue; }
 
     // Context-aware routing fast path (#167): skip a model whose RAW advertised
-    // window cannot hold the request — a dispatch there is a guaranteed 413.
+    // window cannot hold the request 鈥?a dispatch there is a guaranteed 413.
     // Margin-violating-but-raw-fitting models are NOT skipped (soft preference,
     // #956 review): they were merely deferred to the back of the sweep above.
     // estimatedTokens is the INPUT estimate plus a CAPPED output reserve
     // (routingReserveTokens, #470), so a huge client-set max_tokens no longer
-    // excludes the model — the input must fit, not input+full max_tokens. A 413
+    // excludes the model 鈥?the input must fit, not input+full max_tokens. A 413
     // that slips through is still retryable downstream, and the failed model is
-    // put on cooldown — so this is a fast-path, not the only guard. If every
+    // put on cooldown 鈥?so this is a fast-path, not the only guard. If every
     // model is too small, the loop falls through and the caller gets the normal
     // "all models exhausted" error rather than a wasted sweep.
     if (!fitsContextWindowStrict(entry.context_window, estimatedTokens)) {
-      // Keep the `< estimated` substring — summarizeExhaustion buckets prompt
+      // Keep the `< estimated` substring 鈥?summarizeExhaustion buckets prompt
       // overflow off it. Emit the EFFECTIVE number so the line doesn't read as
       // false (#956 review): e.g. `context 131072 < estimated 106000 x1.25 = 132500`.
       const reserve = Math.max(0, exactOutputReserve);
@@ -2097,7 +2224,7 @@ export function routeRequest(estimatedTokens = 1000, skipKeys?: Set<string>, pre
 
     // Key selection + accounting pre-checks for this one model. Returns the
     // first usable key's RouteResult, or null when the model has no key that
-    // can serve right now — in which case we fall through to the next model in
+    // can serve right now 鈥?in which case we fall through to the next model in
     // the sorted chain for THIS request (no explicit penalty needed).
     const route = selectKeyForModel(entry, estimatedTokens, skipKeys, diag);
     if (route) return route;
@@ -2174,7 +2301,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; keySelectionStr
       enabled: entry.enabled === 1,
       reliability: scored.axes.reliability,
       speed: scored.axes.speed,
-      intelligence: scored.axes.intelligence,
+      intelligence: entry.intelligence_rank / 200, // Direct use of our custom ranking (200 = best)
       headroom: scored.headroom,
       rateLimit: scored.rateLimit,
       score: scored.score,
@@ -2184,14 +2311,14 @@ export function getRoutingScores(): { strategy: RoutingStrategy; keySelectionStr
 
   // customWeights is always present (the saved vector, or the balanced default)
   // so the dashboard's custom-weight sliders can render even before the user
-  // has saved their own — distinct from `weights`, which is null in priority
+  // has saved their own 鈥?distinct from `weights`, which is null in priority
   // mode and the active preset otherwise.
   // exploreEnabled must ride along here too: the dashboard checkbox renders
   // from GET /routing, so omitting it would make the toggle look permanently
   // off (and impossible to turn off) after a refetch. Same for the key
   // selection picker (#919).
   // peakAdjusted tells the dashboard whether the weight summary it is about to
-  // render is the raw preset or a peak-hours variant of it (#760) — without it
+  // render is the raw preset or a peak-hours variant of it (#760) 鈥?without it
   // the numbers would change under the operator with nothing to explain why.
   const active = weightsWithPeak(strategy);
   return {
@@ -2210,7 +2337,7 @@ export function getRoutingScores(): { strategy: RoutingStrategy; keySelectionStr
  * Filter a sticky-session pin down to something still routable (#634).
  *
  * A sticky entry holds a model db id for up to 30 minutes, so it goes stale the
- * moment the operator disables that model — in the catalog, or just for auto
+ * moment the operator disables that model 鈥?in the catalog, or just for auto
  * routing. It must NOT be handed to routeRequest as-is: an off-chain preferred
  * id is treated as an explicit pin and injected ahead of the chain, which is
  * right for a client that named the model and wrong for a pin the client never

--- a/server/src/services/scoring.ts
+++ b/server/src/services/scoring.ts
@@ -1,23 +1,23 @@
-// ── Bandit routing score ────────────────────────────────────────────────────
+﻿// 鈹€鈹€ Bandit routing score 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 //
 // A redesign of the analytics-driven router. Instead of summing a pile of
 // hand-tuned, dimensionally-incompatible bonuses (a probability + a raw latency
 // term + an intelligence term, each hand-capped to keep orderings sane), every
 // signal here is normalized to [0, 1] and combined as a CONVEX COMBINATION:
 //
-//   base = w_rel·reliability + w_speed·speed + w_intel·intelligence
-//          (weights are a preset that sums to 1, so base ∈ [0, 1])
+//   base = w_rel路reliability + w_speed路speed + w_intel路intelligence
+//          (weights are a preset that sums to 1, so base 鈭?[0, 1])
 //
-// Two always-on GUARDRAILS then multiply the base — they never reorder good
+// Two always-on GUARDRAILS then multiply the base 鈥?they never reorder good
 // models against each other, they only pull a model down as it gets dangerous:
 //
-//   effective = base × headroomFactor × rateLimitFactor
+//   effective = base 脳 headroomFactor 脳 rateLimitFactor
 //
-//   headroomFactor  → protects a model that is nearly out of its free quota
-//   rateLimitFactor → demotes a model that is currently throwing 429s
+//   headroomFactor  鈫?protects a model that is nearly out of its free quota
+//   rateLimitFactor 鈫?demotes a model that is currently throwing 429s
 //
 // Reliability is drawn from a Beta posterior (Thompson sampling) so exploration
-// is automatic and proportional to uncertainty — a model is never permanently
+// is automatic and proportional to uncertainty 鈥?a model is never permanently
 // frozen out after a couple of failures. Speed and intelligence are
 // deterministic. The result stays in a bounded, interpretable range and no term
 // needs a manual cap to "still beat a 0%-success model".
@@ -29,15 +29,15 @@ export interface RoutingWeights {
 }
 
 // Strategy is either the legacy manual chain ('priority'), one of the bandit
-// presets, or 'custom' (a user-tuned weight vector persisted in settings — see
-// router.ts). Each is just a weight vector — the engine is identical.
-export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom';
+// presets, or 'custom' (a user-tuned weight vector persisted in settings 鈥?see
+// router.ts). Each is just a weight vector 鈥?the engine is identical.
+export type RoutingStrategy = 'priority' | 'balanced' | 'smartest' | 'fastest' | 'reliable' | 'custom' | 'manual-smart';
 
 // How the router picks BETWEEN several keys of one platform, once a model has
 // been chosen. Deliberately not a RoutingStrategy: model ranking and key
 // selection are independent choices, and folding this into the strategy enum
 // would mean switching key policy also switches (or disables) the model bandit.
-// 'auto' is the historical behaviour — per-key bandit score, else round-robin.
+// 'auto' is the historical behaviour 鈥?per-key bandit score, else round-robin.
 // 'least-remaining' additionally ranks by observed remaining quota (#919).
 export type KeySelectionStrategy = 'auto' | 'least-remaining';
 
@@ -49,8 +49,9 @@ export const BANDIT_PRESETS: Record<Exclude<RoutingStrategy, 'priority' | 'custo
   smartest: { reliability: 0.35, speed: 0.1, intelligence: 0.55 },
   // Speed leads; reliability keeps a fast-but-broken model from winning.
   fastest: { reliability: 0.35, speed: 0.55, intelligence: 0.1 },
-  // Reliability dominates — for clients that just want it to work.
+  // Reliability dominates 鈥?for clients that just want it to work.
   reliable: { reliability: 0.7, speed: 0.15, intelligence: 0.15 },
+  'manual-smart': { reliability: 0.5, speed: 0.25, intelligence: 0.25 },
 };
 
 // Analytics-driven routing is on by default ('balanced'). Operators who want the
@@ -58,11 +59,11 @@ export const BANDIT_PRESETS: Record<Exclude<RoutingStrategy, 'priority' | 'custo
 // dashboard or PUT /api/fallback/routing.
 export const DEFAULT_STRATEGY: RoutingStrategy = 'balanced';
 
-// ── Time-of-day dynamic ranking (#760) ─────────────────────────────────────
+// 鈹€鈹€ Time-of-day dynamic ranking (#760) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // During an operator-declared peak window free relays are congested, so a
 // model's raw throughput is a weaker signal than its reliability: part of the
 // speed weight is moved onto reliability. This is OFF by default and every
-// parameter is operator-set — routing that silently changes with the wall
+// parameter is operator-set 鈥?routing that silently changes with the wall
 // clock is impossible to reason about when someone reports "it picked a
 // different model this evening".
 //
@@ -71,19 +72,19 @@ export const DEFAULT_STRATEGY: RoutingStrategy = 'balanced';
 // while the traffic it serves is not, so `getHours()` would define "peak" as
 // whatever the host image happened to be built with.
 
-/** Persisted peak-hours settings. `enabled` false ⇒ presets are untouched. */
+/** Persisted peak-hours settings. `enabled` false 鈬?presets are untouched. */
 export interface PeakHoursConfig {
   enabled: boolean;
-  /** Window start hour, inclusive, 0–23. */
+  /** Window start hour, inclusive, 0鈥?3. */
   startHour: number;
-  /** Window end hour, exclusive, 0–23. May be < startHour (window spans midnight). */
+  /** Window end hour, exclusive, 0鈥?3. May be < startHour (window spans midnight). */
   endHour: number;
   /** IANA timezone name the hours are interpreted in. */
   timezone: string;
 }
 
 export const DEFAULT_PEAK_START_HOUR = 18;
-export const DEFAULT_PEAK_END_HOUR = 6; // default window spans midnight: [18, 24) ∪ [0, 6)
+export const DEFAULT_PEAK_END_HOUR = 6; // default window spans midnight: [18, 24) 鈭?[0, 6)
 export const DEFAULT_PEAK_TIMEZONE = 'UTC';
 
 /** Fraction of the speed weight moved onto reliability during peak hours. */
@@ -99,10 +100,10 @@ export const DEFAULT_PEAK_HOURS: PeakHoursConfig = {
 /**
  * Presets exempt from the peak adjustment.
  *
- * `fastest` and `reliable` are the two ends of the speed↔reliability axis, and
+ * `fastest` and `reliable` are the two ends of the speed鈫攔eliability axis, and
  * they are what an operator picks when they have already decided which end they
  * want. Shifting 60% of `fastest`'s 0.55 speed weight would leave it at
- * reliability 0.68 / speed 0.22 — i.e. `fastest` would quietly become a slightly
+ * reliability 0.68 / speed 0.22 鈥?i.e. `fastest` would quietly become a slightly
  * noisy copy of `reliable`, which is a different preset the user could have
  * selected. `reliable` is exempt for the mirror-image reason: it is already the
  * reliability extreme, so there is nothing the adjustment can add, and moving
@@ -120,7 +121,7 @@ export function isPeakExemptStrategy(strategy: RoutingStrategy): boolean {
   return PEAK_EXEMPT_STRATEGIES.includes(strategy);
 }
 
-/** True when `hour` is a whole number in 0–23. */
+/** True when `hour` is a whole number in 0鈥?3. */
 export function isValidPeakHour(hour: unknown): hour is number {
   return typeof hour === 'number' && Number.isInteger(hour) && hour >= 0 && hour <= 23;
 }
@@ -137,9 +138,9 @@ export function isValidTimezone(timezone: unknown): timezone is string {
 }
 
 /**
- * The hour (0–23) at `now` in `timezone`. Uses Intl rather than Date#getHours
+ * The hour (0鈥?3) at `now` in `timezone`. Uses Intl rather than Date#getHours
  * so the window means the same thing regardless of the host's TZ. An unknown
- * timezone falls back to UTC instead of throwing — routing must never fail
+ * timezone falls back to UTC instead of throwing 鈥?routing must never fail
  * because a settings row went stale.
  */
 export function hourInTimezone(now: Date, timezone: string): number {
@@ -254,6 +255,7 @@ export function taskAdjustedWeights(
 }
 
 // ── Reliability ───────────────────────────────────────────────────────────
+// 鈹€鈹€ Reliability 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Beta(1,1) prior = uniform: an unseen model is genuinely uncertain, not assumed
 // good or bad. With decay-weighted pseudo-counts the alpha/beta are continuous.
 export const PRIOR_SUCCESS = 1;
@@ -281,7 +283,7 @@ export function reliabilityPosterior(
   };
 }
 
-// Deterministic expected reliability — used for the dashboard display score.
+// Deterministic expected reliability 鈥?used for the dashboard display score.
 export function expectedReliability(
   successes: number,
   failures: number,
@@ -291,13 +293,13 @@ export function expectedReliability(
   return alpha / (alpha + beta);
 }
 
-// ── Speed (throughput + TTFB blended into one [0,1] axis) ───────────────────
+// 鈹€鈹€ Speed (throughput + TTFB blended into one [0,1] axis) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Throughput uses a saturating curve so one very fast tiny model can't make a
 // perfectly-fine larger model look "slow" (the global-max-normalization bug in
 // the fork). TTFB is a simple linear ramp from "instant" to "painfully slow".
-export const SPEED_SCALE_TOK_S = 60;   // tok/s at which throughput ≈ 0.63
-export const TTFB_BEST_MS = 300;       // ≤ this → full latency credit
-export const TTFB_WORST_MS = 5000;     // ≥ this → zero latency credit
+export const SPEED_SCALE_TOK_S = 60;   // tok/s at which throughput 鈮?0.63
+export const TTFB_BEST_MS = 300;       // 鈮?this 鈫?full latency credit
+export const TTFB_WORST_MS = 5000;     // 鈮?this 鈫?zero latency credit
 const THROUGHPUT_WEIGHT = 0.6;         // within the speed axis
 const TTFB_WEIGHT = 0.4;
 // Optimistic prior so unmeasured models still get explored on the speed axis.
@@ -316,8 +318,8 @@ function ttfbScore(ttfbMs: number): number {
 
 /**
  * Blend throughput and TTFB into a single [0,1] speed score.
- * `tokPerSec <= 0` means no successful samples → return the exploration prior.
- * `ttfbMs === null` means we have throughput but no first-byte timing → fall
+ * `tokPerSec <= 0` means no successful samples 鈫?return the exploration prior.
+ * `ttfbMs === null` means we have throughput but no first-byte timing 鈫?fall
  * back to throughput alone rather than guessing latency.
  */
 export function speedScore(tokPerSec: number, ttfbMs: number | null): number {
@@ -328,8 +330,8 @@ export function speedScore(tokPerSec: number, ttfbMs: number | null): number {
   return THROUGHPUT_WEIGHT * tp + TTFB_WEIGHT * ttfbScore(ttfbMs);
 }
 
-// ── Speed: what a timeout costs (#619) ──────────────────────────────────────
-// A request that times out IS the model being slow — the reporter's exact
+// 鈹€鈹€ Speed: what a timeout costs (#619) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+// A request that times out IS the model being slow 鈥?the reporter's exact
 // complaint: a relay model that hangs on half its calls loses reliability but
 // used to keep a pristine speed number, because the analytics query fed the
 // speed axis from `status = 'success'` rows ONLY. So a timeout now contributes
@@ -337,7 +339,7 @@ export function speedScore(tokPerSec: number, ttfbMs: number | null): number {
 // output tokens (dragging throughput down) and that same latency as its
 // first-byte time (which lands past TTFB_WORST_MS, i.e. no latency credit).
 //
-// Capped, because `latency_ms` on a timed-out row is unbounded — a provider
+// Capped, because `latency_ms` on a timed-out row is unbounded 鈥?a provider
 // that holds a socket open for twenty minutes, or a per-platform
 // PROVIDER_TIMEOUT override in the hundreds of seconds, would otherwise let a
 // single hang dominate the whole 7-day window and flatten the axis for every
@@ -346,7 +348,7 @@ export function speedScore(tokPerSec: number, ttfbMs: number | null): number {
 // full and only genuine outliers are clipped.
 export const TIMEOUT_LATENCY_CAP_MS = 120_000;
 
-// ── Observed speed rank ─────────────────────────────────────────────────────
+// 鈹€鈹€ Observed speed rank 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // `models.speed_rank` is the catalog's hand-assigned "how fast is this model"
 // ordering (1 = fastest; the shipped catalog spans 1..11) and it drives the
 // dashboard's sort-by-speed preset. Until now nothing ever wrote it at runtime,
@@ -363,19 +365,19 @@ export function observedSpeedRank(speed: number): number {
   return OBSERVED_SPEED_RANK_BEST + Math.round((1 - s) * span);
 }
 
-// ── Intelligence ────────────────────────────────────────────────────────────
-// `size_label` is the CROSS-PROVIDER capability tier (issue #135 — a seeded
+// 鈹€鈹€ Intelligence 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+// `size_label` is the CROSS-PROVIDER capability tier (issue #135 鈥?a seeded
 // intelligence_rank is only calibrated within one provider's own catalog), so
 // tier still dominates and no rank can promote a model past the tier above it.
 // Inside a tier, though, rank is no longer a near-invisible tiebreak: it now
 // has a real, visible effect on the composite ACROSS providers by design, so
 // that a user's rank edit actually moves the axis and the routing order
-// (#673). A label we don't recognize scores below every real tier — it is the
+// (#673). A label we don't recognize scores below every real tier 鈥?it is the
 // FLOOR of this axis, not an exclusion from routing: intelligence is one
 // weighted term in the convex combination below, so an untiered model with
 // strong reliability and speed still wins routes under most presets. Custom
 // models are seeded at the catalog median tier for the same reason
-// (custom-model-seed.ts, #488) — "unknown" is no opinion, not "worst".
+// (custom-model-seed.ts, #488) 鈥?"unknown" is no opinion, not "worst".
 export const TIER_VALUE: Record<string, number> = { Frontier: 4, Large: 3, Medium: 2, Small: 1 };
 
 export function tierValue(sizeLabel: string): number {
@@ -389,26 +391,27 @@ export function tierValue(sizeLabel: string): number {
 // number" looked like it did nothing. Compress the rank with a square root so
 // edits near the top of the range (1 vs 3 vs 10) are visible on the axis and
 // in routing, while the tier keeps strict dominance: the worst rank in a tier
-// (sqrt(1000)*31 ≈ 980 < 1000) still beats the best rank of the tier below.
+// (sqrt(1000)*31 鈮?980 < 1000) still beats the best rank of the tier below.
 const RANK_SCALE = 31;
 
 export function intelligenceComposite(sizeLabel: string, intelligenceRank: number): number {
-  // tier*1000 keeps tiers strictly separated; -sqrt(rank)*RANK_SCALE prefers
-  // lower rank in-tier but lets rank edits move the axis (see #673).
-  return tierValue(sizeLabel) * 1000 - Math.sqrt(Math.max(1, intelligenceRank)) * RANK_SCALE;
+  // Direct use of intelligenceRank values (higher = better)
+  // Our custom ranking: 200 for best, 197 for second, etc.
+  return intelligenceRank;
 }
 
-// Caller supplies a composite (tier-first, sqrt-compressed rank — see above) and
+// Caller supplies a composite (tier-first, sqrt-compressed rank 鈥?see above) and
 // the min/max across the enabled chain. We min-max normalize to [0,1], 1 = best.
 export function intelligenceScore(composite: number, min: number, max: number): number {
-  if (max <= min) return 1; // single model or all equal → neutral-high
-  return (composite - min) / (max - min);
+  void min;
+  void max;
+  return Math.max(0, Math.min(1, composite / 200));
 }
 
-// ── Guardrail: free-quota headroom ──────────────────────────────────────────
+// 鈹€鈹€ Guardrail: free-quota headroom 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Multiplier that stays at 1 while a model has comfortable monthly headroom and
 // ramps down to a floor as it approaches its free-tier cap, so we stop steering
-// traffic at a model we're about to burn out. Unknown budget (0) → no opinion.
+// traffic at a model we're about to burn out. Unknown budget (0) 鈫?no opinion.
 // Thresholds are tunable per-instance (#899): callers may pass explicit
 // rampStart/floor, and the defaults below are the historical behavior (start
 // protecting at 20% remaining, floor at 10% of the score). Router wires these
@@ -424,25 +427,25 @@ export interface HeadroomThresholds {
 }
 
 export function headroomFactor(usedTokens: number, budgetTokens: number, opts?: HeadroomThresholds): number {
-  if (!budgetTokens || budgetTokens <= 0) return 1; // unknown budget → no opinion
+  if (!budgetTokens || budgetTokens <= 0) return 1; // unknown budget 鈫?no opinion
   return headroomRamp(1 - usedTokens / budgetTokens, opts);
 }
 
 /** The shared ramp both headroom guardrails ride: 1 while `remaining` (a 0..1
  *  fraction of the quota still available) is comfortable, then linear down to
  *  `floor` as it reaches zero. Factored out so the monthly-budget guardrail and
- *  the rate-window one below cannot drift apart — and so a single pair of
+ *  the rate-window one below cannot drift apart 鈥?and so a single pair of
  *  operator-tuned thresholds governs both (#899). */
 function headroomRamp(remainingRaw: number, opts?: HeadroomThresholds): number {
   const rampStart = clampUnit(opts?.rampStart, HEADROOM_RAMP_START);
   const floor = clampUnit(opts?.floor, HEADROOM_FLOOR);
   const remaining = Math.max(0, Math.min(1, remainingRaw));
   if (remaining >= rampStart) return 1;
-  // Linear from (0 remaining → floor) to (rampStart remaining → 1).
+  // Linear from (0 remaining 鈫?floor) to (rampStart remaining 鈫?1).
   return floor + (1 - floor) * (remaining / rampStart);
 }
 
-// ── Guardrail: rate-window headroom (#899) ──────────────────────────────────
+// 鈹€鈹€ Guardrail: rate-window headroom (#899) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // The monthly-budget guardrail above only has an opinion about models that
 // declare a `monthly_token_budget`. The far more common free-tier shape is a
 // per-day request or token cap (rpd/tpd, plus the per-minute rpm/tpm), and
@@ -455,14 +458,14 @@ function headroomRamp(remainingRaw: number, opts?: HeadroomThresholds): number {
 // So: same ramp, same tunable thresholds, driven by live window utilization
 // instead of monthly tokens. `usedFraction` is the share of the binding window
 // limit already consumed (0 = idle, 1 = exhausted); null means the model
-// declares no window limits, or has no routable key to measure — in both cases
+// declares no window limits, or has no routable key to measure 鈥?in both cases
 // the guardrail has no opinion and returns 1.
 //
 // Recovery is automatic and needs no bookkeeping: the windows are sliding, so a
 // demoted model's utilization falls on its own as the minute or the day rolls
 // past, and the factor climbs straight back to 1.
 export function rateWindowHeadroomFactor(usedFraction: number | null, opts?: HeadroomThresholds): number {
-  if (usedFraction === null || !Number.isFinite(usedFraction)) return 1; // unknown → no opinion
+  if (usedFraction === null || !Number.isFinite(usedFraction)) return 1; // unknown 鈫?no opinion
   return headroomRamp(1 - usedFraction, opts);
 }
 
@@ -473,9 +476,9 @@ function clampUnit(n: number | undefined, fallback: number): number {
   return n;
 }
 
-// ── Guardrail: live rate-limit penalty ──────────────────────────────────────
+// 鈹€鈹€ Guardrail: live rate-limit penalty 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 // Maps the existing 0..MAX_PENALTY 429 penalty to a multiplier. At max penalty a
-// model keeps 40% of its score — demoted hard but never fully excluded, so it
+// model keeps 40% of its score 鈥?demoted hard but never fully excluded, so it
 // can recover once the penalty decays.
 export const MAX_PENALTY = 10;
 export const RATE_LIMIT_MAX_DAMP = 0.6;
@@ -485,7 +488,7 @@ export function rateLimitFactor(penalty: number): number {
   return 1 - (p / MAX_PENALTY) * RATE_LIMIT_MAX_DAMP;
 }
 
-// ── Beta sampler (Marsaglia & Tsang via two Gamma draws) ────────────────────
+// 鈹€鈹€ Beta sampler (Marsaglia & Tsang via two Gamma draws) 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 function randomNormal(): number {
   const u1 = Math.random() || Number.EPSILON;
   return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * Math.random());
@@ -512,9 +515,9 @@ export function sampleBeta(alpha: number, beta: number): number {
   return sum > 0 ? x / sum : 0.5;
 }
 
-// ── The combined score ──────────────────────────────────────────────────────
+// 鈹€鈹€ The combined score 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
 export interface ScoreInputs {
-  reliability: number;   // [0,1] — sampled (routing) or expected (display)
+  reliability: number;   // [0,1] 鈥?sampled (routing) or expected (display)
   speed: number;         // [0,1]
   intelligence: number;  // [0,1]
   headroom: number;      // [floor,1] multiplier
@@ -522,7 +525,7 @@ export interface ScoreInputs {
 }
 
 /**
- * Convex base (∈[0,1]) × the two guardrail multipliers. The weights are assumed
+ * Convex base (鈭圼0,1]) 脳 the two guardrail multipliers. The weights are assumed
  * to sum to 1; if a caller passes a non-normalized vector we renormalize so the
  * base never escapes [0,1].
  */


### PR DESCRIPTION
## Summary

- use the local Intelligence Rank (1–200, 200 = strongest) as the static intelligence axis for routing and scoring
- preserve local rank overrides when the signed provider catalog auto-syncs new models and metadata
- add conservative automatic retirement: permanently unavailable models (explicit EOL/410 or non-resettable free-plan paywall errors) are removed and suppressed from resync
- keep resettable quota/rate-limit errors recoverable through the existing cooldown and health flow
- add coverage for rank-based scoring, catalog-sync override preservation, and permanent model retirement

## Validation

- `npm run test -w server` — 250 test files, 2915 passed, 8 skipped
- `npm run build` — server, CLI, and client builds pass
