### PR TITLE
fix(desktop): fix Windows and Linux backdrop contrast and remove macOS traffic-light padding

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -146,12 +146,23 @@ function Brand() {
 const isDesktopApp = typeof window !== 'undefined'
   && (window as Window & { __FREEAPI_DESKTOP__?: boolean }).__FREEAPI_DESKTOP__ === true
 
+const desktopPlatform = typeof window !== 'undefined'
+  ? (window as Window & { __FREEAPI_PLATFORM__?: string }).__FREEAPI_PLATFORM__
+  : undefined
+
+const isMacDesktop = isDesktopApp && (
+  desktopPlatform ? desktopPlatform === 'darwin' : (typeof navigator !== 'undefined' && /Macintosh|Mac OS X/.test(navigator.userAgent))
+)
+
 // The preload's own early classList.add can be lost (it may run before this
 // document exists), so the client claims the class itself at module load —
 // before the first React paint — keeping html.desktop CSS (transparent body,
-// glass backdrop) reliable.
+// glass backdrop on macOS) reliable.
 if (isDesktopApp) {
   document.documentElement.classList.add('desktop')
+  if (isMacDesktop) {
+    document.documentElement.classList.add('desktop-mac')
+  }
 }
 
 function AccountMenuItems({
@@ -224,17 +235,17 @@ function Navbar() {
   return (
     <>
       <header
-        // In the desktop shell the body backdrop is already translucent glass;
-        // a lighter wash keeps the title bar from looking more solid than the page.
-        className={`sticky top-0 z-40 border-b backdrop-blur ${isDesktopApp ? 'bg-background/45' : 'bg-background/80'}`}
+        // In macOS desktop shell the window carries vibrancy blur, so a lighter wash (45%)
+        // lets it read as glass. Everywhere else (Windows/Linux/browser), use solid wash (80%)
+        // so text and contrast stay sharp and readable.
+        className={`sticky top-0 z-40 border-b backdrop-blur ${isMacDesktop ? 'bg-background/45' : 'bg-background/80'}`}
         style={isDesktopApp ? ({ WebkitAppRegion: 'drag' } as React.CSSProperties) : undefined}
       >
         <div
-          // Physical pl (not logical ps): the gutter reserves the macOS
-          // traffic lights, which stay top-left even when an RTL locale
-          // flips the document direction.
-          className={`mx-auto flex max-w-6xl items-center px-4 sm:px-6 ${isDesktopApp ? 'pl-20 sm:pl-20' : ''}`}
-          style={isDesktopApp ? { minHeight: 52 } : undefined}
+          // Physical pl: reserves macOS traffic lights only on macOS. On Windows and Linux,
+          // standard window controls sit on the top-right, so no left padding is needed.
+          className={`mx-auto flex max-w-6xl items-center px-4 sm:px-6 ${isMacDesktop ? 'pl-20 sm:pl-20' : ''}`}
+          style={isMacDesktop ? { minHeight: 52 } : undefined}
         >
           <Brand />
           <nav
@@ -417,7 +428,7 @@ function AppShell({ children }: { children: ReactNode }) {
   const location = useLocation()
   const fullBleed = FULL_BLEED_ROUTES.has(location.pathname)
   return (
-    <div className={`flex flex-col ${fullBleed ? 'h-dvh overflow-hidden' : 'min-h-screen'} ${isDesktopApp ? 'desktop-backdrop' : 'bg-background'}`}>
+    <div className={`flex flex-col ${fullBleed ? 'h-dvh overflow-hidden' : 'min-h-screen'} ${isMacDesktop ? 'desktop-backdrop' : 'bg-background'}`}>
       {children}
     </div>
   )

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -136,15 +136,15 @@
         @apply bg-background text-foreground;
         font-feature-settings: 'ss01', 'cv11', 'tnum';
     }
-    /* Desktop shell (html.desktop set by the app's preload): let the
-       window's vibrancy show through a translucent backdrop so the
+    /* Desktop shell: on macOS where the window has native sidebar vibrancy,
+       let the vibrancy show through a translucent backdrop so the
        dashboard reads as real glass, like the tray popover. Cards and
-       popovers stay opaque on top. No effect in the browser, where
-       .desktop is never set. */
-    html.desktop body {
+       popovers stay opaque on top. On Windows and Linux, keep the solid
+       background so contrast and legibility are preserved. */
+    html.desktop.desktop-mac body {
         background-color: transparent;
     }
-    html.desktop .desktop-backdrop {
+    html.desktop.desktop-mac .desktop-backdrop {
         background-color: color-mix(in oklab, var(--background) 55%, transparent);
     }
     code, pre, kbd, samp {

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -18,6 +18,7 @@ if (arg) {
 // Lets the client adapt its chrome (drag region, traffic-light padding,
 // no Sign out) when running inside the desktop shell.
 contextBridge.exposeInMainWorld('__FREEAPI_DESKTOP__', true);
+contextBridge.exposeInMainWorld('__FREEAPI_PLATFORM__', process.platform);
 
 // The dashboard window signs in as the hidden machine account, whose password
 // is random and never shown, so it must never land on the login form. When the
@@ -39,15 +40,15 @@ contextBridge.exposeInMainWorld(
   versionArg ? versionArg.slice('--freeapi-version='.length) : null,
 );
 
-// `desktop` class on <html> activates the client's translucent backdrop
-// (html.desktop in index.css). CAREFUL: for an http:// load the preload
-// runs before the page's document is parsed — documentElement is null or
-// a placeholder that the parser replaces — so the early add is best-effort
-// (no-flash when it sticks) and MUST NOT throw, or the theme observer
-// below would never register. The client re-adds the class itself at
-// module load (App.tsx), so the effect never depends on the early add.
+// `desktop` class on <html> identifies the desktop shell. On macOS, `desktop-mac`
+// activates the translucent glass backdrop that pairs with native vibrancy;
+// on Windows and Linux, the solid theme background is preserved so contrast and
+// readability remain intact.
 function applyDesktopClass() {
   document.documentElement?.classList.add('desktop');
+  if (process.platform === 'darwin') {
+    document.documentElement?.classList.add('desktop-mac');
+  }
 }
 try {
   applyDesktopClass();


### PR DESCRIPTION
Restrict translucent desktop styling and traffic-light spacing to macOS. Windows and Linux keep a solid backdrop and use the standard header spacing. The preload exposes the platform explicitly, with a macOS user-agent fallback for older desktop shells.

Validation: 274 client tests, 30 desktop tests and client build passed locally. Fresh GitHub CI passed on Node 20/22, both Docker architectures, and Windows, macOS and Linux desktop installer builds.
