### PR TITLE
fix(fallback): bench a route that ate the whole retry budget with no first byte

### DIFF
--- a/server/src/__tests__/lib/fallback-loop-hedge.test.ts
+++ b/server/src/__tests__/lib/fallback-loop-hedge.test.ts
@@ -10,9 +10,10 @@ import type { RouteResult } from '../../services/router.js';
  * the loop calls abortInFlight() so a stalled attempt is abandoned instead of
  * only refusing to start the next retry behind it. The surface aborts its
  * composed fetch signal with newHedgeAbortError(); the loop must render
- * timedOut exhaustion WITHOUT any provider-health bookkeeping — no cooldown,
- * no skip entry, no logFailure row — because the budget is spent, not the
- * provider broken.
+ * timedOut exhaustion, and the provider-health bookkeeping — cooldown, skip
+ * entry, logFailure row — depends on WHOSE silence spent the budget: an attempt
+ * handed only the scraps a ladder left is not benched, one that stayed silent
+ * for most of the whole budget is.
  */
 
 let keySeq = 900;
@@ -158,6 +159,48 @@ describe('fallback loop time-budget hedging', () => {
     // And the request rendered as timedOut exhaustion, not a third failure.
     expect(h.onExhausted).toHaveBeenCalledTimes(1);
     expect(h.onExhausted.mock.calls[0][1].timedOut).toBe(true);
+  });
+
+  it('benches the route when one attempt stayed silent for the whole budget', async () => {
+    // The production shape behind this branch. Same ladder position as the two
+    // tests above — hedging only arms from the third attempt on (#751) — but
+    // here the two failures ahead of it are INSTANT, so the stalled attempt
+    // inherits essentially the whole budget and then sends no first byte for
+    // all of it. That is a stalled upstream, not a scheduling accident:
+    // unbenched it stays at the head of the route order and re-stalls every
+    // subsequent request, burning the full budget each time while the healthy
+    // routes queued behind it never run.
+    const state = newFallbackState();
+    const hedgeAbort = new AbortController();
+    const fast429 = async () => {
+      throw Object.assign(new Error('fake API error 429: rate limit'), { status: 429 });
+    };
+    const dispatch = vi.fn()
+      .mockImplementationOnce(fast429)
+      .mockImplementationOnce(fast429)
+      .mockImplementation(stalledDispatch(hedgeAbort));
+
+    const h = hooks(state, {
+      maxRetries: 5,
+      timeBudgetMs: 100,
+      abortInFlight: () => hedgeAbort.abort(newHedgeAbortError()),
+      route: () => leasedRoute().route,
+      dispatch,
+    });
+
+    await runFallbackLoop(h);
+
+    // Still a timedOut exhaustion — the render is unchanged.
+    expect(h.onExhausted).toHaveBeenCalledTimes(1);
+    expect(h.onExhausted.mock.calls[0][1].timedOut).toBe(true);
+    // But the stalled route now carries a cooldown and a skip entry of its own,
+    // on top of the two fast 429s', so the next request routes past it. This is
+    // the exact assertion that inverts for the shared-budget case above, where
+    // the same three attempts produce only two of each.
+    const cooldowns = getDb().prepare('SELECT COUNT(*) AS n FROM rate_limit_cooldowns').get() as { n: number };
+    expect(cooldowns.n).toBe(3);
+    expect(state.skipKeys.size).toBe(3);
+    expect(h.logFailure).toHaveBeenCalledTimes(3);
   });
 
   it('never cancels an attempt that already committed, however long it then runs', async () => {

--- a/server/src/lib/fallback-loop.ts
+++ b/server/src/lib/fallback-loop.ts
@@ -127,6 +127,14 @@ function clearModelFailure(route: RouteResult): void {
 // TODO(fallback-v2): AbortController hedging so a stalled attempt can be
 // abandoned mid-flight instead of only refusing to start the next one.
 export const DEFAULT_FALLBACK_TIME_BUDGET_MS = 45_000;
+// Share of the wall-clock budget an aborted attempt must have been silent for
+// before the hedge abort counts as provider health rather than bad luck. An
+// attempt late in a ladder inherits only the scraps of the budget its
+// predecessors left, and killing it proves nothing about that route; one that
+// owned most of the window and still sent no first byte is stalled. Kept a
+// fraction rather than a constant because the budget IS the declared patience
+// — raising FALLBACK_TIME_BUDGET_MS should raise the evidence bar with it.
+export const HEDGE_BENCH_MIN_SILENT_FRACTION = 0.75;
 export const FALLBACK_TIME_BUDGET_SETTING = 'fallback_time_budget_ms';
 
 export function getFallbackTimeBudgetMs(): number {
@@ -937,8 +945,8 @@ export interface FallbackHooks {
   // (remaining wall-clock budget) and calls this to ABORT the in-flight
   // upstream instead of just refusing to start the next retry behind a
   // stalled attempt. The surface aborts its composed fetch signal with
-  // newHedgeAbortError() — a non-provider-health signal, so the loop renders
-  // timedOut exhaustion without benching the model+key (see the
+  // newHedgeAbortError(); the loop renders timedOut exhaustion, and benches the
+  // model+key only when that attempt ate the whole budget by itself (see the
   // isHedgeAbortError branch below). Absent = pre-v2 behavior.
   abortInFlight?: () => void;
   // Skip state; recordRetryableFailure / recordAuthFailure (called by the loop)
@@ -1179,12 +1187,33 @@ async function runFallbackLoopAttempts(hooks: FallbackHooks, trace: RequestTrace
       }
       // Time-budget hedge abort: the wall-clock retry budget expired while this
       // attempt was still in flight, and the surface aborted the composed fetch
-      // signal (see newHedgeAbortError). Not a provider-health signal — no
-      // cooldown, no penalty, no failure stats — and the budget is spent, so
+      // signal (see newHedgeAbortError). The budget is spent either way, so we
       // render timedOut exhaustion exactly like the loop-top budget check does.
+      //
+      // Whether it also counts as a provider-health signal depends on how much
+      // of the silence belongs to THIS attempt. Sharing a budget that earlier
+      // attempts already mostly spent says nothing about this route — it was
+      // simply last in line, and cancelling it is a scheduling accident. But an
+      // attempt that stayed silent for most of the operator's whole declared
+      // patience on its own produced no first byte over that entire window,
+      // and that is a stalled upstream. Left unbenched it stays at the head of the route
+      // order and re-stalls every subsequent request, burning the full budget
+      // each time and starving the healthy routes queued behind it — observed
+      // in production as one dead free-tier route 45s-ing every request for
+      // hours. Benching costs a short transient cooldown (a timeout is not a
+      // rate-limit signal, so cooldownDecisionForError keeps it light) plus the
+      // gradual model-level sink, both of which decay on their own if the route
+      // recovers.
       if (isHedgeAbortError(err)) {
         const elapsedMs = Date.now() - startedAt;
-        console.log(`[FallbackLoop] retry time budget expired mid-attempt on ${route.platform}/${route.modelId} after ${(elapsedMs / 1000).toFixed(1)}s — rendering timedOut exhaustion without benching`);
+        const attemptElapsedMs = Date.now() - attemptStartedAt;
+        const ownedWholeBudget = budgetMs > 0
+          && attemptElapsedMs >= budgetMs * HEDGE_BENCH_MIN_SILENT_FRACTION;
+        if (ownedWholeBudget) {
+          hooks.logFailure(route, err, attempt);
+          recordRetryableFailure(route, err, hooks.state);
+        }
+        console.log(`[FallbackLoop] retry time budget expired mid-attempt on ${route.platform}/${route.modelId} after ${(elapsedMs / 1000).toFixed(1)}s — rendering timedOut exhaustion ${ownedWholeBudget ? `and benching the route (silent for the whole ${budgetMs}ms budget)` : 'without benching'}`);
         hooks.onExhausted(
           exhaustedRetryError(lastError, maxRetries, { attempts, timedOut: true, budgetMs }),
           { attempts, timedOut: true },


### PR DESCRIPTION
## Problem

A hedge abort is currently treated as pure scheduling noise: no cooldown, no penalty, no failure row, on the reasoning that "the budget expiring is not a provider-health signal".

That reasoning holds for an attempt handed only the scraps its predecessors left. It does not hold for an attempt that owned the whole window. A route that accepts the connection and then never sends a first byte burns the entire `FALLBACK_TIME_BUDGET_MS`, gets abandoned unbenched, stays at the head of the route order, and does exactly the same thing on the next request. Forever, while the healthy routes queued behind it never get tried.

Observed in production on a gray-tier instance: one dead free-tier route consumed the full 45s budget on every request for hours.

```
[FallbackLoop] retry time budget (45000ms) expired with no first byte on kilo/nvidia/nemotron-3-ultra-550b-a55b:free - aborting stalled upstream
[FallbackLoop] retry time budget expired mid-attempt on kilo/nvidia/nemotron-3-ultra-550b-a55b:free after 45.0s - rendering timedOut exhaustion without benching
```
(repeating, same route, across hours)

The user-visible failure is worse than a slow request. With the budget spent, only the one always-allowed hop remains, and if that hop happens to be a model the provider advertises but does not serve, the whole request renders as a client-facing 400:

```
400 All routed providers rejected the request as invalid (stopped early: retry time budget 45s exceeded ...).
Attempt trail: kilo/nvidia/nemotron-3-ultra-550b-a55b:free key1: error; navy/gpt-5 key2: provider_bad_request.
```

## Change

Split the `isHedgeAbortError` branch on *whose* silence spent the budget, using the attempt's own elapsed time rather than the request's.

- An attempt silent for at least `HEDGE_BENCH_MIN_SILENT_FRACTION` (0.75) of the whole budget now takes the normal retryable path: `logFailure` + `recordRetryableFailure`, giving it a short transient cooldown, the gradual model-level sink via `noteModelFailure`, and a `skipKeys` entry. A timeout is not a rate-limit signal, so `cooldownDecisionForError` keeps the bench light and it decays on its own if the route recovers.
- Anything below that threshold keeps the existing no-bench behaviour unchanged.
- The exhaustion render is identical either way (`timedOut: true`).

The threshold is a fraction rather than a constant because the budget *is* the operator's declared patience: raising `FALLBACK_TIME_BUDGET_MS` should raise the evidence bar with it.

## Tests

Added `benches the route when one attempt stayed silent for the whole budget` to `fallback-loop-hedge.test.ts`. It uses the same three-attempt ladder as the two existing no-bench tests (hedging only arms from the third attempt, #751), but the two failures ahead of it are instant, so the stalled attempt inherits essentially the whole budget. It asserts 3 cooldown rows / 3 `skipKeys` / 3 `logFailure` where the shared-budget case asserts 2 - the same assertion, inverted.

Both existing hedge tests are the shared-budget shape and pass untouched, which is the point: they are the discriminator for the new branch, not collateral.

- `npm test` (server): 2965 passed, 8 skipped, 255 files
- `tsc --noEmit`: clean
- Mutation-checked: forcing the fraction to `100` fails only the new test

Assisted by AI.
