### PR TITLE
docs(zh-cn): translate recurring-credit gateway guide

### DIFF
--- a/docs/en/providers/04-recurring-credit-gateways.md
+++ b/docs/en/providers/04-recurring-credit-gateways.md
@@ -1,3 +1,5 @@
+**English** · [简体中文](../../zh-cn/providers/04-recurring-credit-gateways.md)
+
 # ElectronHub and Experiential Labs
 
 Both providers use bearer-authenticated Chat Completions at their `/v1` base

--- a/docs/en/providers/OVERVIEW.md
+++ b/docs/en/providers/OVERVIEW.md
@@ -15,6 +15,7 @@ The authoritative sources are [`shared/types.ts`](../../../shared/types.ts) (the
 | [01-supported-platforms.md](01-supported-platforms.md) | One row per platform declared in `shared/types.ts`: auth model (keyed/keyless), adapter class (native/OpenAI-compatible), and integration notes. Explicit counts for every grouping. |
 | [02-quotas-and-cooldowns.md](02-quotas-and-cooldowns.md) | RPM/RPD and TPM/TPD window accounting, concurrency leases and opt-in caps, the cooldown ladder and its provenance classes, probe-based early recovery, back-off parsed from `Retry-After` headers and error bodies (#798), and why health checks must not burn metered quota (#882). |
 | [03-adding-a-new-provider.md](03-adding-a-new-provider.md) | Contributor walkthrough: extending the `Platform` union, choosing an adapter, registration options (timeouts, keyless, extra headers), key-validation semantics, catalog seeding policy, and the tests a new provider is expected to ship. |
+| [04-recurring-credit-gateways.md](04-recurring-credit-gateways.md) | ElectronHub and Experiential Labs: shared credits, key validation, adapter behavior, and billing limits. |
 
 ## Conventions
 

--- a/docs/zh-cn/providers/04-recurring-credit-gateways.md
+++ b/docs/zh-cn/providers/04-recurring-credit-gateways.md
@@ -1,0 +1,22 @@
+[English](../../en/providers/04-recurring-credit-gateways.md) · **简体中文**
+
+# ElectronHub 和 Experiential Labs
+
+这两家提供方均使用 Bearer 鉴权，通过各自 `/v1` 基础 URL 下的 Chat Completions 接口提供服务。可用模型由经过签名的 Oracle 目录管理，不通过应用迁移预置。现有目录政策保持不变：Premium 用户可立即访问，Free 用户在 30 天后可访问。
+
+| 提供方 ID | 基础 URL | 密钥校验端点 | 免费计划额度 |
+| --- | --- | --- | --- |
+| `electronhub` | `https://api.electronhub.ai/v1` | `GET /v1/user/me` | 每周共享 $0.25 额度，并非每月；仅适用于非 Premium、按额度扣费的路由 |
+| `experiential` | `https://api.experientiallabs.ai/v1` | `GET /v1/models` | 公布的额度为每月共享 500 点，每点 $0.01（共 $5）；账户资格和余额需在其仪表盘确认 |
+
+2026-09-06 的核验结果：23 个 ElectronHub 模型 ID 和 25 个 Experiential 模型 ID 返回了有效文本。ElectronHub 的账户 API 显示订阅为 Free，消费从每周额度中扣除，且没有购买的额度余额。Experiential 的鉴权和推理均正常，但账户余额只能通过网页登录会话查看；仅凭推理成功，无法确定账户消耗的是每月额度、欢迎额度还是购买的额度。两家提供方均有使用限额，也都不是按模型分别发放额度。
+
+ElectronHub 的模型列表公开可访问，因此密钥校验使用需要鉴权的账户端点。其专用兼容子类会识别并拒绝 HTTP 200 响应中观察到的代理错误提示，包括提示跨越多个 SSE 数据块的情况。另外 7 个经过测试的 ElectronHub 候选模型未加入目录。
+
+Experiential 的兼容子类会针对拒绝相应参数的特定 Claude 路由，省略固定 temperature 参数和不受支持的 top-p 参数。这个问题是通过使用仪表盘常规采样设置的适配器实测发现的，而非仅靠最简直接 API 请求。其他模型仍保留各自支持的设置。
+
+密钥导入接受 `ELECTRONHUB_API_KEY`、`ELECTRON_HUB_API_KEY`、`EXPERIENTIAL_API_KEY`、`EXPERIENTIALLABS_API_KEY`、`EXPERIENTIAL_LABS_API_KEY` 和 `EXPLABS_API_KEY`。
+
+适配器不会更改提供方的计费设置。它们依据共享额度池和提供方响应头处理额度，不会自行假定每个模型有独立的积分或词元额度。启用付费充值或自带提供方密钥的路由前，请先在提供方处设置支出控制。
+
+来源：[ElectronHub 额度](https://docs.electronhub.ai/billing/credits)、[模型访问](https://docs.electronhub.ai/billing/model-access)、[账户 API](https://docs.electronhub.ai/api-reference/usage)、[Experiential 定价](https://www.experientiallabs.ai/pricing)、[计费](https://platform.experientiallabs.ai/docs/billing)、[API 参考](https://platform.experientiallabs.ai/docs/reference)。

--- a/docs/zh-cn/providers/OVERVIEW.md
+++ b/docs/zh-cn/providers/OVERVIEW.md
@@ -15,6 +15,7 @@
 | [01-supported-platforms.md](01-supported-platforms.md) | `shared/types.ts` 中声明的每个平台一行：鉴权方式（带密钥/免密钥）、适配器类（原生/OpenAI 兼容）以及集成注意事项。每种分组都有明确的数量。 |
 | [02-quotas-and-cooldowns.md](02-quotas-and-cooldowns.md) | RPM/RPD 与 TPM/TPD 窗口记账、并发租约与可选上限、冷却阶梯及其来源分类、基于探测的提前恢复、从 `Retry-After` 响应头和错误正文解析退避时间（#798），以及为什么健康检查绝不能烧掉计量额度（#882）。 |
 | [03-adding-a-new-provider.md](03-adding-a-new-provider.md) | 贡献者走查：扩展 `Platform` 联合、选择适配器、注册选项（超时、免密钥、额外请求头）、密钥校验语义、目录播种策略，以及新提供方应当随附的测试。 |
+| [04-recurring-credit-gateways.md](04-recurring-credit-gateways.md) | ElectronHub 和 Experiential Labs：共享额度、密钥校验、适配器行为及计费限制。 |
 
 ## 约定
 


### PR DESCRIPTION
Adds the missing Simplified Chinese translation of the ElectronHub and Experiential Labs guide, with language-switch links and entries in both provider indexes.

The translation follows `docs/TRANSLATION.md` and preserves the English page's dated test observations, shared-credit limits, billing caveats, endpoint names, and source links.

Validation:

- `npm run check:i18n` from `client/`: 60 locales and 1041 keys passed.
- `npm test`: completed successfully; Vitest reported 3332 passed and 5 skipped across server, CLI, and client.
- Checked the translation against the English source, including numbers, inline code, source URLs, and local navigation links. `git diff --check` passed.
