### PR TITLE
Stamp request history with the concrete model row

### DIFF
--- a/server/src/__tests__/db/migrate/roundtrip.test.ts
+++ b/server/src/__tests__/db/migrate/roundtrip.test.ts
@@ -37,6 +37,7 @@ const QUOTA_OBSERVATION_LOOKUP_FILENAME = '20260901_000002_quota_observation_loo
 const ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME = '20260902_000001_analytics_latency_percentile_index.ts';
 const MCP_ENABLED_DEFAULT_FILENAME = '20260903_000001_mcp_enabled_default.ts';
 const RESPONSE_CACHE_FILENAME = '20260903_000002_response_cache.ts';
+const REQUEST_MODEL_ATTRIBUTION_FILENAME = '20260910_000001_request_model_attribution.ts';
 
 interface SchemaRow {
   type: string;
@@ -120,6 +121,7 @@ describe('migration round trip', () => {
         ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME,
         MCP_ENABLED_DEFAULT_FILENAME,
         RESPONSE_CACHE_FILENAME,
+        REQUEST_MODEL_ATTRIBUTION_FILENAME,
       ]);
     } finally {
       db.close();

--- a/server/src/__tests__/routes/custom-endpoint-identity.test.ts
+++ b/server/src/__tests__/routes/custom-endpoint-identity.test.ts
@@ -7,6 +7,7 @@ import { setCooldown, isOnCooldown, clearCooldownsForKey } from '../../services/
 import { getModelGroups, resolveRequestedIdToMembers, setUnifyOverrides } from '../../services/model-groups.js';
 import { noteModelRetirementSignal, resetModelRetirementObservations } from '../../services/model-retirement.js';
 import { endpointHandle, qualifiedModelMemberId } from '../../lib/endpoint-scope.js';
+import { logRequest } from '../../lib/request-log.js';
 import { buildModelListing } from '../../services/model-listing.js';
 import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
 
@@ -233,6 +234,20 @@ describe('per-endpoint identity for custom relay models (#651)', () => {
       );
 
       expect(rowsFor(SHARED_MODEL).map(r => r.enabled)).toEqual([1, 1]);
+    });
+
+    it('records the concrete model row selected for each relay', async () => {
+      await registerBothRelays(app);
+      const b = rowOn(RELAY_B);
+
+      logRequest('custom', SHARED_MODEL, b.key_id!, 'success', 10, 20, 30, null);
+
+      const logged = getDb().prepare(`
+        SELECT model_db_id FROM requests
+         WHERE platform = 'custom' AND model_id = ?
+         ORDER BY id DESC LIMIT 1
+      `).get(SHARED_MODEL) as { model_db_id: number };
+      expect(logged.model_db_id).toBe(b.id);
     });
   });
 

--- a/server/src/db/migrate/defaults.ts
+++ b/server/src/db/migrate/defaults.ts
@@ -32,6 +32,7 @@ import * as quotaObservationLookup from '../migrations/20260901_000002_quota_obs
 import * as analyticsLatencyPercentileIndex from '../migrations/20260902_000001_analytics_latency_percentile_index.js';
 import * as mcpEnabledDefault from '../migrations/20260903_000001_mcp_enabled_default.js';
 import * as responseCache from '../migrations/20260903_000002_response_cache.js';
+import * as requestModelAttribution from '../migrations/20260910_000001_request_model_attribution.js';
 
 export interface MigrationModule {
   up(db: Db): void;
@@ -76,6 +77,7 @@ export const QUOTA_OBSERVATION_LOOKUP_FILENAME = '20260901_000002_quota_observat
 export const ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME = '20260902_000001_analytics_latency_percentile_index.ts';
 export const MCP_ENABLED_DEFAULT_FILENAME = '20260903_000001_mcp_enabled_default.ts';
 export const RESPONSE_CACHE_FILENAME = '20260903_000002_response_cache.ts';
+export const REQUEST_MODEL_ATTRIBUTION_FILENAME = '20260910_000001_request_model_attribution.ts';
 
 export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: LEGACY_BASELINE_FILENAME, module: legacyBaseline },
@@ -111,4 +113,5 @@ export const DEFAULT_MIGRATIONS: readonly DefaultMigration[] = [
   { filename: ANALYTICS_LATENCY_PERCENTILE_INDEX_FILENAME, module: analyticsLatencyPercentileIndex },
   { filename: MCP_ENABLED_DEFAULT_FILENAME, module: mcpEnabledDefault },
   { filename: RESPONSE_CACHE_FILENAME, module: responseCache },
+  { filename: REQUEST_MODEL_ATTRIBUTION_FILENAME, module: requestModelAttribution },
 ];

--- a/server/src/db/migrations/20260910_000001_request_model_attribution.ts
+++ b/server/src/db/migrations/20260910_000001_request_model_attribution.ts
@@ -1,0 +1,57 @@
+// Migration: attach request history to the concrete model row that served it.
+// Created: 2026-09-10
+//
+// DOWN: reversible.
+//
+// Custom relays may share an upstream model id, so (platform, model_id) is no
+// longer enough to identify the row whose price, reliability, and speed apply.
+//
+// Deliberately no foreign key: request history must survive a user deleting
+// the model row it once served. This also keeps cleanup paths from requiring
+// a raw-history delete first.
+
+import type { Db } from '../types.js';
+
+function hasColumn(db: Db, table: string, column: string): boolean {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[])
+    .some(candidate => candidate.name === column);
+}
+
+export function up(db: Db): void {
+  if (!hasColumn(db, 'requests', 'model_db_id')) {
+    db.exec('ALTER TABLE requests ADD COLUMN model_db_id INTEGER;');
+  }
+  db.exec('CREATE INDEX IF NOT EXISTS idx_requests_model_db_id ON requests(model_db_id);');
+
+  // Historical catalog requests remain unambiguous. A custom request can be
+  // attributed only while its key survives: the key's normalized base URL is
+  // the endpoint_scope of the concrete model row. Leave orphaned custom rows
+  // NULL rather than assigning their traffic to the wrong relay.
+  db.exec(`
+    UPDATE requests
+       SET model_db_id = (
+         SELECT m.id
+           FROM models m
+          WHERE m.platform = requests.platform
+            AND m.model_id = requests.model_id
+            AND (
+              m.platform != 'custom'
+              OR m.endpoint_scope = (
+                SELECT rtrim(trim(k.base_url), '/')
+                  FROM api_keys k
+                 WHERE k.id = requests.key_id
+                   AND k.platform = 'custom'
+              )
+            )
+          LIMIT 1
+       )
+     WHERE model_db_id IS NULL;
+  `);
+}
+
+export function down(db: Db): void {
+  db.exec('DROP INDEX IF EXISTS idx_requests_model_db_id;');
+  if (hasColumn(db, 'requests', 'model_db_id')) {
+    db.exec('ALTER TABLE requests DROP COLUMN model_db_id;');
+  }
+}

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -29,6 +29,31 @@ function setSettingIfMissing(db: LogTx, key: string, value: string): void {
   `).run(key, value);
 }
 
+// A custom model id can exist on more than one relay. Resolve through the key
+// selected for this request, whose normalized base URL is the row's endpoint
+// scope; catalog models remain uniquely identified by platform + model id.
+// NULL for custom requests whose key never reached routing (keyId null) — an
+// unattributable request must not land on the wrong relay's row.
+function resolveModelDbId(db: LogTx, platform: string, modelId: string, keyId: number | null): number | null {
+  const row = db.prepare(`
+    SELECT m.id
+      FROM models m
+     WHERE m.platform = ?
+       AND m.model_id = ?
+       AND (
+         m.platform != 'custom'
+         OR m.endpoint_scope = (
+           SELECT rtrim(trim(k.base_url), '/')
+             FROM api_keys k
+            WHERE k.id = ?
+              AND k.platform = 'custom'
+         )
+       )
+     LIMIT 1
+  `).get(platform, modelId, keyId) as { id: number } | undefined;
+  return row?.id ?? null;
+}
+
 // Append a row to the request analytics table. Shared by the chat proxy, the
 // responses path, and the fusion panel so every served (or failed) sub-request
 // is logged identically. Lives in a neutral lib module to avoid an import cycle
@@ -74,10 +99,11 @@ export function logRequest(
     // middleware); null when logging happens outside an HTTP request.
     const client = getClientContext();
     const tx = db.transaction(() => {
+      const modelDbId = resolveModelDbId(db, platform, modelId, keyId);
       const insert = db.prepare(`
-        INSERT INTO requests (platform, model_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(platform, modelId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
+        INSERT INTO requests (platform, model_id, model_db_id, key_id, status, input_tokens, output_tokens, latency_ms, error, ttfb_ms, requested_model, served_model, client_ip, client_user_agent, client_agent)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(platform, modelId, modelDbId, keyId, status, inputTokens, outputTokens, latencyMs, error, ttfbMs, requestedModel, servedModel, client.ip, client.userAgent, client.agent);
 
       // Report the row id back to the fallback loop's attempt trace (if one is
       // active): the LAST id noted during a loop run is the terminal row the


### PR DESCRIPTION
## Stamp request history with the concrete model row

### Context

This is a direct follow-up to [PR #668 on the upstream repo](https://github.com/tashfeenahmed/freellmapi/pull/668)
("Proposal: Attribute request history to concrete model rows"), which was
closed as superseded. Per [the maintainer's closing comment](https://github.com/tashfeenahmed/freellmapi/pull/668#issuecomment-2320107000):

- the **analytics half** of #668 is already fixed on upstream main by
  [#958](https://github.com/tashfeenahmed/freellmapi/pull/958) (endpoint-scoped
  `/by-model` grouping), and the **routing half** by per-endpoint
  `modelStatsKey` keys — so this PR deliberately contains **no router and no
  analytics read-side changes**;
- one real gap remained: *"request identity is derived at read time from
  api_keys.base_url, so deleting a key or editing its base_url retroactively
  reattributes old history"* — and the maintainer explicitly invited
  *"a much smaller PR with just the migration and backfill (no FK, like you
  had it) plus logRequest stamping the column, and no router changes."*

This is that PR, rebased onto current main (the old 188-line version is
reduced to ~100 lines; the router and analytics hunks of #668 are dropped).
His note that main widened `logRequest` to `keyId: number | null` is
incorporated: custom requests whose key never reached routing stay `NULL`.

### Problem

Custom relays can expose the same upstream model id, so `(platform, model_id)`
no longer uniquely identifies the `models` row whose pricing, reliability, and
speed apply. Today, request identity is derived at *read time* from
`api_keys.base_url`: deleting a key, or editing its base URL, retroactively
reattributes (or orphans) all of that key's historical requests. The history
was never frozen to the row that actually served it.

### Changes

- **Migration** (`20260910_000001_request_model_attribution.ts`): adds the
  nullable column with a non-unique index and backfills existing rows.
  - Catalog requests backfill unambiguously by `(platform, model_id)`.
  - Custom requests backfill only while the saved key still resolves to the
    matching normalized endpoint scope (`rtrim(trim(base_url), '/')`, matching
    `endpoint-scope.ts`).
  - Orphaned custom history stays `NULL` rather than being attributed to the
    wrong relay.
  - Deliberately **no foreign key**, as in #668: request history must survive
    the user deleting the model row that once served it.
- **`logRequest`** resolves and persists the concrete `models.id` inside the
  same transaction as the insert:
  - catalog rows resolve by platform + model id;
  - custom rows resolve through the request's key (its normalized base URL is
    the row's `endpoint_scope`);
  - custom requests whose key never reached routing (`keyId: null`) stay
    `NULL` — an unattributable request must not land on the wrong relay.

### Out of scope

No router and no analytics read-side changes — this only freezes the record.
Read paths can adopt the column incrementally later, as discussed on #668.

### Validation

- New regression test (carried over from #668): two relays sharing one model
  id — a request logged against relay B's key stamps relay B's row id.
- `npm run build -w server`
- `npm run lint -w server`
- Focused suites, all green (105 tests):
  `roundtrip`, `custom-endpoint-identity`, `routed-via-header`,
  `analytics`, `proxy-model-groups`, `custom-provider`