### PR TITLE
Gray out depleted models and fold them to the bottom (#1015)

### DIFF
--- a/client/src/components/model-table.tsx
+++ b/client/src/components/model-table.tsx
@@ -11,6 +11,7 @@ import {
   formatContext,
   groupMaxContext,
   groupQuotaBadge,
+  isGroupDepleted,
   memberEndpointTitle,
   memberProviderLabel,
   providerLabel,
@@ -390,6 +391,9 @@ export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsag
   const { t } = useI18n()
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: `grp:${group.key}` })
   const anyEnabled = group.members.some(m => m.enabled)
+  // A fully exhausted group grays out (#1015) — but an all-members-disabled
+  // row keeps its stronger dim, so the two states never fight over opacity.
+  const depleted = anyEnabled && rateUsage !== undefined && isGroupDepleted(group.members, rateUsage)
   const navigate = useNavigate()
   const detailId = encodeURIComponent(group.members[0].canonicalId ?? group.members[0].modelId)
   const handle = (
@@ -408,7 +412,7 @@ export function SortableGroupRow({ group, rank, onToggleGroup, allRows, rateUsag
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
       onClick={() => navigate(`/models/chat/${detailId}`)}
-      className={`group/row border-b last:border-0 bg-card cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${isDragging ? 'opacity-50' : ''} ${anyEnabled ? '' : 'opacity-50'}`}
+      className={`group/row border-b last:border-0 bg-card cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${isDragging ? 'opacity-50' : ''} ${anyEnabled ? (depleted ? 'opacity-60' : '') : 'opacity-50'}`}
     >
       <GroupHeaderCells group={group} rank={rank} dragHandle={handle} onToggleGroup={onToggleGroup} allRows={allRows} rateUsage={rateUsage} />
     </tr>

--- a/client/src/lib/routing.test.ts
+++ b/client/src/lib/routing.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
+  buildGroups,
   groupMatchesQuery,
+  isGroupDepleted,
+  isMemberDepleted,
   isMemberSplit,
   memberEndpointTitle,
   memberOverrideKey,
@@ -9,6 +12,7 @@ import {
   splitsWithoutMember,
   tightestRateLimit,
   type RateLimitUsageRow,
+  type Row,
 } from './routing'
 
 // Per-endpoint identity must be INVISIBLE until two endpoints actually serve the
@@ -297,5 +301,103 @@ describe('groupMatchesQuery (#1056)', () => {
     expect(groupMatchesQuery(g, 'glm')).toBe(true)
     expect(groupMatchesQuery(g, 'groq')).toBe(true)
     expect(groupMatchesQuery(g, 'mistral')).toBe(false)
+  })
+})
+
+// #1015: models whose time-window quota is used up gray out and sink to the
+// bottom of the table, so operators see healthy capacity first. The fold is
+// score-mode-only: manual mode is the operator's drag-arranged ladder.
+describe('depleted rows (#1015)', () => {
+  function chainRow(modelDbId: number, over: Partial<Row> = {}): Row {
+    return {
+      modelDbId,
+      priority: modelDbId,
+      effectivePriority: modelDbId,
+      penalty: 0,
+      rateLimitHits: 0,
+      enabled: true,
+      platform: 'groq',
+      modelId: 'm' + modelDbId,
+      displayName: 'M' + modelDbId,
+      intelligenceRank: 50,
+      speedRank: 50,
+      sizeLabel: '',
+      monthlyTokenBudget: '',
+      supportsVision: false,
+      supportsTools: false,
+      keyCount: 1,
+      ...over,
+    } as Row
+  }
+
+  const exhaustedUsage = (modelDbId: number) => usageRow(modelDbId, { rpm: { used: 30, limit: 30 } })
+  const healthyUsage = (modelDbId: number) => usageRow(modelDbId, { rpm: { used: 3, limit: 30 } })
+
+  it('isMemberDepleted: used-up tightest window is depleted', () => {
+    expect(isMemberDepleted(exhaustedUsage(1))).toBe(true)
+    expect(isMemberDepleted(healthyUsage(1))).toBe(false)
+  })
+
+  it('isMemberDepleted: no usage data or a fully idle member is not depleted', () => {
+    expect(isMemberDepleted(undefined)).toBe(false)
+    expect(isMemberDepleted(usageRow(1, { rpm: { used: 0, limit: 30 } }))).toBe(false)
+    expect(isMemberDepleted(usageRow(1, { rpm: { used: 5, limit: 0 } }))).toBe(false)
+  })
+
+  it('isGroupDepleted: only when every member is out of headroom', () => {
+    const members = [chainRow(1), chainRow(2)]
+    expect(isGroupDepleted(members, new Map([
+      [1, exhaustedUsage(1)],
+      [2, exhaustedUsage(2)],
+    ]))).toBe(true)
+    // One healthy provider keeps the group routable — same rule as the badge.
+    expect(isGroupDepleted(members, new Map([
+      [1, exhaustedUsage(1)],
+      [2, healthyUsage(2)],
+    ]))).toBe(false)
+    // A member we have never polled is not proven exhausted either.
+    expect(isGroupDepleted(members, new Map([[1, exhaustedUsage(1)]]))).toBe(false)
+  })
+
+  it('buildGroups sinks a depleted group below healthy ones, score order intact', () => {
+    const rows = [
+      chainRow(1, { score: 0.5 }),
+      // Depleted despite the best score: it cannot serve right now.
+      chainRow(2, { score: 0.9 }),
+      chainRow(3, { score: 0.7 }),
+    ]
+    const usage = new Map([[2, exhaustedUsage(2)]])
+    const groups = buildGroups(rows, false, usage)
+    // Healthy groups keep their score order (3 → 1); the depleted 2 sinks.
+    expect(groups.map(g => g.members[0].modelDbId)).toEqual([3, 1, 2])
+  })
+
+  it('buildGroups sinks depleted members within a group in score mode', () => {
+    const rows = [
+      chainRow(1, { score: 0.9, groupKey: 'g1', displayName: 'Shared' }),
+      chainRow(2, { score: 0.5, groupKey: 'g1', displayName: 'Shared' }),
+    ]
+    const usage = new Map([[1, exhaustedUsage(1)]])
+    const [group] = buildGroups(rows, false, usage)
+    expect(group.members.map(m => m.modelDbId)).toEqual([2, 1])
+  })
+
+  it('buildGroups leaves the manual ladder alone even with usage data', () => {
+    const rows = [
+      chainRow(1, { priority: 1, score: 0.1 }),
+      chainRow(2, { priority: 2, score: 0.9 }),
+    ]
+    const usage = new Map([[1, exhaustedUsage(1)]])
+    const groups = buildGroups(rows, true, usage)
+    expect(groups.map(g => g.members[0].modelDbId)).toEqual([1, 2])
+  })
+
+  it('buildGroups without usage data keeps the plain score order', () => {
+    const rows = [
+      chainRow(1, { score: 0.5 }),
+      chainRow(2, { score: 0.9 }),
+    ]
+    const groups = buildGroups(rows, false)
+    expect(groups.map(g => g.members[0].modelDbId)).toEqual([2, 1])
   })
 })

--- a/client/src/lib/routing.ts
+++ b/client/src/lib/routing.ts
@@ -375,6 +375,27 @@ export function tightestRateLimit(
   return best
 }
 
+// ── Depleted rows (#1015) ────────────────────────────────────────────────────
+// A member is depleted when its tightest time-window quota (#876) is used up —
+// exactly the state that turns its RateLimitBadge red. A member with no usage
+// data is never depleted: an idle provider may simply not have been polled
+// yet, and there is no evidence it cannot serve.
+export function isMemberDepleted(usage: RateLimitUsageRow | undefined): boolean {
+  const tightest = usage ? tightestRateLimit([usage]) : null
+  return tightest !== null && tightest.used >= tightest.limit
+}
+
+// A group is depleted only when EVERY member is — the group stays routable
+// while any single provider has headroom, the same rule the group badge reads
+// from the best member. Members without usage data count as healthy here, so
+// the table only folds a row it can prove is exhausted across the board.
+export function isGroupDepleted(
+  members: readonly { modelDbId: number }[],
+  rateUsage: ReadonlyMap<number, RateLimitUsageRow>,
+): boolean {
+  return members.length > 0 && members.every(m => isMemberDepleted(rateUsage.get(m.modelDbId)))
+}
+
 export const platformColors: Record<string, string> = {
   google:      '#4285f4',
   groq:        '#f55036',
@@ -428,7 +449,18 @@ export interface ModelGroupRow {
 // when ungrouped). Members are ordered like the flat chain — by manual priority
 // under the priority strategy, by live score otherwise — and groups inherit the
 // best member's position so the unified order matches the flat order.
-export function buildGroups(rows: Row[], isManual: boolean): ModelGroupRow[] {
+//
+// With rate-limit usage supplied (#1015) and the table ordering itself (score
+// mode), members and groups whose time-window quota is used up sink to the
+// bottom so healthy models stay on top. Both passes are stable sorts, so the
+// score order survives inside each partition. Manual mode deliberately opts
+// out: the visible order there is the operator's explicit drag-arranged ladder
+// and must not reshuffle under them (the graying still applies).
+export function buildGroups(
+  rows: Row[],
+  isManual: boolean,
+  rateUsage?: ReadonlyMap<number, RateLimitUsageRow>,
+): ModelGroupRow[] {
   const map = new Map<string, Row[]>()
   for (const r of rows) {
     const key = r.groupKey ?? `solo:${r.modelDbId}`
@@ -446,6 +478,11 @@ export function buildGroups(rows: Row[], isManual: boolean): ModelGroupRow[] {
       ? Math.min(...a.members.map(m => m.priority)) - Math.min(...b.members.map(m => m.priority))
       : Math.max(...b.members.map(m => m.score ?? 0)) - Math.max(...a.members.map(m => m.score ?? 0)),
   )
+  if (rateUsage && !isManual) {
+    const depleted = (m: Row) => isMemberDepleted(rateUsage.get(m.modelDbId))
+    for (const g of groups) g.members.sort((a, b) => Number(depleted(a)) - Number(depleted(b)))
+    groups.sort((a, b) => Number(isGroupDepleted(a.members, rateUsage)) - Number(isGroupDepleted(b.members, rateUsage)))
+  }
   return groups
 }
 

--- a/client/src/pages/FallbackPage.tsx
+++ b/client/src/pages/FallbackPage.tsx
@@ -21,6 +21,7 @@ import { useI18n } from '@/i18n'
 import { apiFetch } from '@/lib/api'
 import {
   buildGroups,
+  isGroupDepleted,
   groupMatchesQuery,
   groupMaxContext,
   type FallbackEntry,
@@ -229,7 +230,7 @@ export default function FallbackPage() {
 
   // ── Model unification: a model served by several providers is always shown as
   // one logical row that links to its own page (the on/off toggle was removed). ─
-  const orderedGroups = useMemo(() => buildGroups(rows, isManual), [rows, isManual])
+  const orderedGroups = useMemo(() => buildGroups(rows, isManual, rateUsageByModel), [rows, isManual, rateUsageByModel])
 
   // Catalog search + filters (#343). Filtering operates on whole logical-model
   // groups; rank stays the model's position in the full chain so the numbers
@@ -614,7 +615,7 @@ export default function FallbackPage() {
                       <tr
                         key={g.key}
                         onClick={() => navigate(`/models/chat/${encodeURIComponent(g.members[0].canonicalId ?? g.members[0].modelId)}`)}
-                        className={`group/row border-b last:border-0 cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${g.members.some(m => m.enabled) ? '' : 'opacity-50'}`}
+                        className={`group/row border-b last:border-0 cursor-pointer transition-colors hover:[&>td]:bg-muted/50 [&>td:first-child]:rounded-l-lg [&>td:last-child]:rounded-r-lg ${g.members.some(m => m.enabled) ? (isGroupDepleted(g.members, rateUsageByModel) ? 'opacity-60' : '') : 'opacity-50'}`}
                       >
                         <GroupHeaderCells group={g} rank={rankByKey.get(g.key) ?? 0} onToggleGroup={handleGroupToggle} allRows={rows} rateUsage={rateUsageByModel} />
                       </tr>

--- a/client/src/pages/ModelDetailPage.tsx
+++ b/client/src/pages/ModelDetailPage.tsx
@@ -18,6 +18,7 @@ import { ModelsTabs } from '@/components/models-tabs'
 import { ModelTableHead, RateLimitBadge, RowContent } from '@/components/model-table'
 import {
   groupQuotaBadge,
+  isMemberDepleted,
   isMemberSplit,
   memberEndpointTitle,
   memberOverrideKey,
@@ -270,7 +271,7 @@ export default function ModelDetailPage() {
                 <ModelTableHead />
                 <tbody>
                   {members.map((m, i) => (
-                    <tr key={m.modelDbId} className={`border-b last:border-0 ${m.enabled ? '' : 'opacity-50'}`}>
+                    <tr key={m.modelDbId} className={`border-b last:border-0 ${m.enabled ? (isMemberDepleted(rateUsageByModel.get(m.modelDbId)) ? 'opacity-60' : '') : 'opacity-50'}`}>
                       <RowContent row={m} rank={i + 1} draggable={false} onToggle={handleToggle} providerName={memberProviderLabel(m, siblings)} providerTitle={memberEndpointTitle(m, siblings)} rateUsage={rateUsageByModel.get(m.modelDbId)} />
                     </tr>
                   ))}


### PR DESCRIPTION
## Gray out depleted models and fold them to the bottom

Fixes [tashfeenahmed/freellmapi#1015](https://github.com/tashfeenahmed/freellmapi/issues/1015)

### Problem

The unified model table already turns a model's quota badge red when its
time-window quota (`RPM`/`RPD`/`TPM`, #876) is used up — but the row itself
keeps its normal weight and position, so an exhausted model sits wherever its
score put it, mixed in with healthy capacity. Operators have to scan the red
badges to find what can actually serve.

### Changes

- **Depleted definition** (`client/src/lib/routing.ts`, pure helpers):
  - a provider is **depleted** when its tightest rate-limit window is used up
    (`used >= limit`) — exactly the evidence that turns its badge red;
  - a provider with **no usage data is never depleted** — an unpolled provider
    is not proven exhausted;
  - a group is depleted only when **every member** is — the same routability
    rule the group badge applies ("the group stays routable while any one
    provider can serve").
- **Graying:** depleted rows render dimmed (`opacity-60`) on the fallback
  model table (both the draggable and non-draggable render paths) and on the
  per-model detail page's provider list. All-disabled rows keep their
  stronger `opacity-50`, so the two states never fight over opacity.
- **Folding:** in score mode, depleted members sink within their group and
  fully-depleted groups sink below healthy ones. Both passes are **stable
  sorts**, so score order survives inside each partition. Manual (priority)
  mode deliberately opts out of the fold — the visible order there is the
  operator's drag-arranged ladder — though graying still applies.
- No new i18n strings: the existing red badge already communicates the reason.

### Validation

- 7 new unit tests in `routing.test.ts`: member depletion (exhausted / idle /
  no data / zero limit), group depletion (all members, one healthy, one
  unpolled), group fold with score order preserved, within-group member fold,
  manual-mode ladder untouched, and no-usage-data no-op.
- Full client suite green: **265/265 tests**, i18n validation passing across
  60 locales.
- `npm run build -w client` clean; client lint error count unchanged from
  `main` (44 pre-existing, none added).