### PR TITLE
Add Claude Code GitHub Action (@claude on issues/PRs)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,58 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Configure Claude's behavior with CLI arguments
+          # claude_args: |
+          #   --model claude-opus-4-1-20250805
+          #   --max-turns 10
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
+
+          # Optional: Advanced settings configuration
+          # settings: |
+          #   {
+          #     "env": {
+          #       "NODE_ENV": "test"
+          #     }
+          #   }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml` (Anthropic [`claude-code-action`](https://github.com/anthropics/claude-code-action)) so `@claude` on issues/PR comments can run Claude Code in Actions.

This workflow alone is not enough — **only the `tashfeenahmed` account owner can finish setup** (collaborators cannot install GitHub Apps on a personal account).

## What you need to do after merge (2 minutes)
1. **Install the Claude GitHub App** on your account (select this repo, or all repos):  
   https://github.com/apps/claude/installations/new
2. **Create a 1-year OAuth token** locally: `claude setup-token`
3. **Add repo secret** `CLAUDE_CODE_OAUTH_TOKEN` with that token  
   (Settings → Secrets and variables → Actions)
4. Comment `@claude what does this repo do?` on any issue/PR to verify

## Test plan
- [ ] Install Claude GitHub App on `tashfeenahmed`
- [ ] Set `CLAUDE_CODE_OAUTH_TOKEN`
- [ ] Merge this PR
- [ ] `@claude` smoke test on an issue

Happy to adjust the workflow (model, tools, trigger phrase) if you prefer different defaults.

Made with [Cursor](https://cursor.com)