### PR TITLE
feat(observability): put execution_id on every chat body and log the caller on all routes

### DIFF
--- a/docs/en/architecture/06-observability.md
+++ b/docs/en/architecture/06-observability.md
@@ -74,6 +74,22 @@ The desktop app has no terminal attached, so it tees every console line to a **f
 | `client_info` | User agent, IP hash |
 | `served_model` | Upstream-reported model (observability) |
 | `attempt_error_summary` | Aggregated failure classes for this request |
+| `caller` | Which gateway pathway produced the request |
+
+### `execution_id` and the `caller` dimension
+
+Every JSON body the chat completion routes send — success, cache/idempotency
+replay, and error alike — carries a top-level `execution_id` holding the same
+value as the `X-Request-ID` header, so a client that only kept the response body
+can still find the row and its attempt trail. It is stamped on the outbound copy,
+so a replayed cache hit reports the id of *that* request, not the one that filled
+the cache. Streamed frames omit it (the header carries it there).
+
+`requests.caller` records the surface: today every inference path writes `http`
+(the OpenAI-compatible proxy, `/v1/responses`, `/v1/messages`, the Ollama and
+Gemini wires, and fusion sub-calls). `/mcp` is introspection-only and runs no
+inference, and the dashboard playground calls the same HTTP endpoints as any
+other client. The column is free-form, so a new surface needs no migration.
 
 ### Attempt Trail (`request_attempts` table)
 

--- a/docs/zh-cn/architecture/06-observability.md
+++ b/docs/zh-cn/architecture/06-observability.md
@@ -103,6 +103,19 @@ levelCounts(): { debug: number; info: number; warn: number; error: number }
 | `client_info` | User agent、IP 哈希 |
 | `served_model` | 上游报的模型（可观测性） |
 | `attempt_error_summary` | 本请求聚合的失败类别 |
+| `caller` | 产生该请求的网关通路 |
+
+### `execution_id` 与 `caller` 维度
+
+聊天补全路由发出的每个 JSON 响应体——成功、缓存/幂等重放、错误一律——都带一个
+顶层 `execution_id`，其值与 `X-Request-ID` 头相同，于是只留下响应体的客户端也能
+找回对应行及其尝试轨迹。它盖在**出站副本**上，因此重放的缓存命中报的是*本次*请求
+的 id，而不是当初填充缓存那次的。流式帧不带它（那里由头部承载）。
+
+`requests.caller` 记录请求来自哪个面：目前所有推理通路都写 `http`（OpenAI 兼容
+代理、`/v1/responses`、`/v1/messages`、Ollama 与 Gemini 线路，以及 fusion 子调用）。
+`/mcp` 只做内省、不跑推理；仪表盘 playground 调的就是同一批 HTTP 端点，与其他
+客户端无从区分。该列是自由文本，新增一个面无需迁移。
 
 ### 尝试轨迹 (`request_attempts` 表)
 

--- a/server/src/__tests__/routes/proxy-execution-id.test.ts
+++ b/server/src/__tests__/routes/proxy-execution-id.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import { createApp } from '../../app.js';
+import { initDb, getDb, getUnifiedApiKey } from '../../db/index.js';
+import { mintDashboardToken, isGatedApiPath } from '../helpers/auth.js';
+
+// #1102 follow-up: `execution_id` must be on EVERY JSON body the chat
+// completion route sends — success and error alike — or clients cannot rely on
+// it. A field that is present only when the call succeeds is worse than no
+// field: the failing case is exactly the one you need the id for. It always
+// carries the same value as the X-Request-ID header. Streamed frames are
+// deliberately excluded (the id rides the header there).
+
+let dashToken = '';
+
+async function request(app: Express, method: string, path: string, body?: any, headers: Record<string, string> = {}) {
+  const server = app.listen(0, '127.0.0.1');
+  if (!server.listening) await new Promise<void>(resolve => server.once('listening', () => resolve()));
+  const addr = server.address() as any;
+  const res = await fetch(`http://127.0.0.1:${addr.port}${path}`, {
+    method,
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(isGatedApiPath(path) && !('Authorization' in headers) ? { Authorization: `Bearer ${dashToken}` } : {}),
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  server.close();
+  let json: any = null;
+  try { json = JSON.parse(text); } catch { /* SSE body */ }
+  return { status: res.status, headers: res.headers, text, body: json };
+}
+
+function authHeaders() {
+  return { Authorization: `Bearer ${getUnifiedApiKey()}` };
+}
+
+const sse = (...payloads: (object | string)[]) =>
+  payloads.map(p => `data: ${typeof p === 'string' ? p : JSON.stringify(p)}\n\n`).join('');
+
+/** Mock the groq upstream: a clean answer, or a hard non-retryable failure. */
+function mockUpstream(opts: { fail?: boolean; stream?: boolean } = {}) {
+  const origFetch = global.fetch;
+  vi.spyOn(global, 'fetch').mockImplementation(async (url, init) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    if (!urlStr.includes('api.groq.com/openai/v1/chat/completions')) return origFetch(url as any, init as any);
+    if (opts.fail) {
+      return {
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: new Headers(),
+        json: () => Promise.resolve({ error: { message: 'invalid api key' } }),
+      } as any;
+    }
+    if (opts.stream) {
+      const chunk = (delta: object, finish: string | null) => ({
+        id: 'c1', object: 'chat.completion.chunk', created: 1, model: 'groq/compound-mini',
+        choices: [{ index: 0, delta, finish_reason: finish }],
+      });
+      return new Response(
+        sse(chunk({ role: 'assistant' }, null), chunk({ content: 'hi' }, null), chunk({}, 'stop'), '[DONE]'),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    }
+    return new Response(JSON.stringify({
+      id: 'chatcmpl-exec', object: 'chat.completion', created: 1, model: 'groq/compound-mini',
+      choices: [{ index: 0, message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+}
+
+describe('execution_id on chat completion bodies (#1102)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.ENCRYPTION_KEY = '0'.repeat(64);
+    initDb(':memory:');
+    app = createApp();
+    dashToken = mintDashboardToken();
+  });
+
+  beforeEach(async () => {
+    const db = getDb();
+    db.prepare('DELETE FROM api_keys').run();
+    db.prepare('DELETE FROM requests').run();
+    db.prepare('DELETE FROM rate_limit_cooldowns').run();
+    const addKey = await request(app, 'POST', '/api/keys',
+      { platform: 'groq', key: 'gsk_execution_id_test_key', label: 'execution-id' });
+    expect(addKey.status).toBe(201);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('non-streaming success carries execution_id matching the X-Request-ID header', async () => {
+    mockUpstream();
+    const { status, body, headers } = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini', messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(status).toBe(200);
+    expect(typeof body.execution_id).toBe('string');
+    expect(body.execution_id).toBe(headers.get('x-request-id'));
+    // Additive only: the OpenAI-shaped payload is untouched.
+    expect(body.choices[0].message.content).toBe('hello');
+  });
+
+  it('the 400 validation rejection carries execution_id', async () => {
+    const { status, body, headers } = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini', messages: 'not-an-array',
+    }, authHeaders());
+
+    expect(status).toBe(400);
+    expect(body.error.type).toBe('invalid_request_error');
+    expect(body.execution_id).toBe(headers.get('x-request-id'));
+  });
+
+  it('the 502 provider-error body carries execution_id', async () => {
+    mockUpstream({ fail: true });
+    const { status, body, headers } = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini', messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(status).toBe(502);
+    expect(body.error).toBeTruthy();
+    expect(body.execution_id).toBe(headers.get('x-request-id'));
+  });
+
+  it('streamed frames stay clean — the id rides the header, not every chunk', async () => {
+    mockUpstream({ stream: true });
+    const r = await request(app, 'POST', '/v1/chat/completions', {
+      model: 'groq/compound-mini', stream: true, messages: [{ role: 'user', content: 'hello' }],
+    }, authHeaders());
+
+    expect(r.status).toBe(200);
+    expect(r.headers.get('x-request-id')).toBeTruthy();
+    const frames = r.text.split('\n')
+      .filter(l => l.startsWith('data: ') && l.trim() !== 'data: [DONE]')
+      .map(l => JSON.parse(l.slice(6)));
+    expect(frames.length).toBeGreaterThan(0);
+    for (const f of frames) expect(f.execution_id).toBeUndefined();
+  });
+});

--- a/server/src/db/migrations/20260901_000003_request_caller.ts
+++ b/server/src/db/migrations/20260901_000003_request_caller.ts
@@ -4,8 +4,10 @@
 // DOWN: reversible
 //
 // Request log rows (requests table) gain a `caller` column so self-hosters can
-// tell which pathway produced a request: 'http' (OpenAI-compatible endpoints),
-// 'mcp' (/mcp JSON-RPC), or 'web' (dashboard API). Pairs with the top-level
+// tell which pathway produced a request. Every inference surface writes 'http'
+// today (see lib/request-log.ts for the full list and why /mcp and the
+// dashboard write nothing); the column is free-form TEXT so a future surface
+// can add a value without another migration. Pairs with the top-level
 // `execution_id` on response bodies (see routes/proxy.ts) — given an id from a
 // client error you can look up the row and see its caller at a glance.
 

--- a/server/src/lib/inbound-chat.ts
+++ b/server/src/lib/inbound-chat.ts
@@ -338,6 +338,8 @@ export async function runInboundChat(
           null,
           null,
           pin.pinnedLabel,
+          null,
+          'http',
         );
         wire.sendNonStream(res, normalized);
         return 'done';
@@ -512,6 +514,8 @@ export async function runInboundChat(
           null,
           null,
           pin.pinnedLabel,
+          null,
+          'http',
         );
         return 'done';
       } catch (error: any) {
@@ -529,6 +533,8 @@ export async function runInboundChat(
           sanitizeProviderErrorMessage(error.message),
           null,
           pin.pinnedLabel,
+          null,
+          'http',
         );
         return 'committed';
       }
@@ -545,6 +551,8 @@ export async function runInboundChat(
         sanitizeProviderErrorMessage(error.message),
         null,
         pin.pinnedLabel,
+        null,
+        'http',
       );
     },
     onFatal: (route, error, attempt) => {

--- a/server/src/lib/request-log.ts
+++ b/server/src/lib/request-log.ts
@@ -67,9 +67,16 @@ export function logRequest(
   // lib/served-model.ts). NULL when it matches or the provider reported
   // nothing usable, so the column stays empty in the healthy case.
   servedModel: string | null = null,
-  // Which gateway pathway produced this request: 'http' (OpenAI-compatible
-  // endpoints), 'mcp' (/mcp JSON-RPC), or 'web' (dashboard API). Lets
-  // analytics tell paths apart when debugging. NULL for legacy callers.
+  // Which gateway pathway produced this request. Today every inference
+  // surface writes 'http': the OpenAI-compatible proxy (/v1/chat/completions,
+  // /v1/completions), /v1/responses, /v1/messages, the Ollama + Gemini wires
+  // (lib/inbound-chat.ts), and fusion's panel/judge sub-calls. The /mcp
+  // JSON-RPC surface is introspection-only (list models, health, usage) and
+  // runs no inference, so it logs nothing; the dashboard playground calls the
+  // same HTTP endpoints as any other client and is indistinguishable from
+  // them here. The column is free-form so a future surface can add a value
+  // without a migration. NULL for call sites that pass no caller — notably
+  // the shared fallback loop's 'canceled' row, which is surface-agnostic.
   caller: string | null = null,
 ) {
   try {

--- a/server/src/routes/anthropic.ts
+++ b/server/src/routes/anthropic.ts
@@ -720,12 +720,12 @@ anthropicRouter.post('/messages', async (req: Request, res: Response) => {
 
       res.setHeader('X-Routed-Via', routedViaValue(route.platform, route.modelId));
       setFallbackHeaders(res, attempt, attemptLog);
-      logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null, null, pinnedModelId);
+      logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null, null, pinnedModelId, null, 'http');
       res.json(anthropicResponse);
       return 'done';
     },
     logFailure: (route, err) => {
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, sanitizeProviderErrorMessage(err.message), null, pinnedModelId);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, sanitizeProviderErrorMessage(err.message), null, pinnedModelId, null, 'http');
     },
     onFatal: (route, err, attempt) => {
       setFallbackHeaders(res, attempt, attemptLog);
@@ -863,7 +863,7 @@ async function streamCompletion(
         if (!messageStarted) throw new Error(`in-band provider error from ${route.displayName}: ${msg}`);
         writeSse(res, 'error', { type: 'error', error: { type: 'api_error', message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(String(msg))}` } });
         res.end();
-        logRequest(route.platform, route.modelId, route.keyId, 'error', ctx.estimatedInputTokens, outputChars, Date.now() - ctx.start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, null, ctx.pinnedModelId);
+        logRequest(route.platform, route.modelId, route.keyId, 'error', ctx.estimatedInputTokens, outputChars, Date.now() - ctx.start, `in-band error frame: ${sanitizeProviderErrorMessage(String(msg))}`, null, ctx.pinnedModelId, null, 'http');
         throw new StreamAlreadyStarted();
       }
 
@@ -1017,7 +1017,7 @@ async function streamCompletion(
 
     recordUpstreamSuccess(route, ctx.estimatedInputTokens + outputTokens);
     if (!ctx.pinned || ctx.stickyScope) setStickyModel(messages, route.modelDbId, ctx.sessionId, ctx.stickyScope);
-    logRequest(route.platform, route.modelId, route.keyId, 'success', ctx.estimatedInputTokens, outputTokens, Date.now() - ctx.start, null, null, ctx.pinnedModelId);
+    logRequest(route.platform, route.modelId, route.keyId, 'success', ctx.estimatedInputTokens, outputTokens, Date.now() - ctx.start, null, null, ctx.pinnedModelId, null, 'http');
   } catch (err: any) {
     if (err instanceof StreamAlreadyStarted) throw err;
     // Client abort mid-stream: the pump's own `if (ctx.clientGone()) break`
@@ -1031,7 +1031,7 @@ async function streamCompletion(
       // honestly instead of leaving Claude Code hanging, and stop the retry loop.
       writeSse(res, 'error', { type: 'error', error: { type: 'api_error', message: `Provider error (${route.displayName}): stream interrupted` } });
       try { res.end(); } catch { /* socket gone */ }
-      logRequest(route.platform, route.modelId, route.keyId, 'error', ctx.estimatedInputTokens, outputChars, Date.now() - ctx.start, sanitizeProviderErrorMessage(err.message), null, ctx.pinnedModelId);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', ctx.estimatedInputTokens, outputChars, Date.now() - ctx.start, sanitizeProviderErrorMessage(err.message), null, ctx.pinnedModelId, null, 'http');
       throw new StreamAlreadyStarted();
     }
     // Headers never sent — bubble to the outer loop for failover.

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -106,6 +106,20 @@ function shortRequestId(requestId: string): string {
   return requestId.replace(/-/g, '').slice(0, 6);
 }
 
+/**
+ * Stamp the execution id onto a body that was stored by an EARLIER request
+ * (response cache hit, idempotency replay). The id goes on the outbound copy
+ * only — never on the stored entry — so a replay reports the id of THIS
+ * request instead of the one that first filled the store, which is what makes
+ * the field safe to trust on every response. Stored bodies are typed
+ * `unknown`; a non-object entry (corrupt) is passed through untouched rather
+ * than spread into indexed characters.
+ */
+function withExecutionId(body: unknown, executionId: string): unknown {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return body;
+  return { ...(body as Record<string, unknown>), execution_id: executionId };
+}
+
 type TraceEvent = 'start' | 'next' | 'ok' | 'fail';
 
 export function traceRouteEvent(
@@ -1019,6 +1033,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
       .join(', ');
     res.status(400).json({
       error: { message: `Invalid request: ${detail}`, type: 'invalid_request_error' },
+      execution_id: requestGroupId,
     });
     return;
   }
@@ -1045,6 +1060,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
   if (budgetCheck.rejection) {
     res.status(413).json({
       error: { message: tokenBudgetMessage(budgetCheck.rejection), type: 'invalid_request_error', code: 'request_token_budget' },
+      execution_id: requestGroupId,
     });
     return;
   }
@@ -1076,6 +1092,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
               type: 'service_unavailable',
               code: 'no_providers_configured',
             },
+            execution_id: requestGroupId,
           });
         } else {
           res.status(404).json({
@@ -1084,6 +1101,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
               type: 'invalid_request_error',
               code: 'model_not_found',
             },
+            execution_id: requestGroupId,
           });
         }
         return;
@@ -1101,6 +1119,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
             type: 'invalid_request_error',
             code: 'model_not_found',
           },
+          execution_id: requestGroupId,
         });
         return;
       }
@@ -1345,6 +1364,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
           finish_reason: result.choices?.[0]?.finish_reason ?? 'stop',
         }],
         usage: result.usage,
+        execution_id: requestGroupId,
       });
 
       traceRouteEvent('Proxy', {
@@ -1381,6 +1401,7 @@ proxyRouter.post('/completions', async (req: Request, res: Response) => {
           message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`,
           type: 'provider_error',
         },
+        execution_id: requestGroupId,
       });
     },
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {
@@ -1604,6 +1625,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         type: 'invalid_request_error',
         code: 'no_vision_model',
       },
+      execution_id: requestGroupId,
     });
     return;
   }
@@ -1630,6 +1652,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         type: 'invalid_request_error',
         code: 'no_tools_model',
       },
+      execution_id: requestGroupId,
     });
     return;
   }
@@ -1643,6 +1666,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
   if (budgetCheck.rejection) {
     res.status(413).json({
       error: { message: tokenBudgetMessage(budgetCheck.rejection), type: 'invalid_request_error', code: 'request_token_budget' },
+      execution_id: requestGroupId,
     });
     return;
   }
@@ -1747,19 +1771,19 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         if (fusionText) {
           const enforced = enforceJsonContent(fusionText);
           if (!enforced.ok) {
-            res.status(502).json({ error: { message: `fusion produced non-JSON output despite response_format=${samplingParams.response_format.type} — retry, or pin a structured-output-capable model instead of "fusion"`, type: 'server_error' } });
+            res.status(502).json({ error: { message: `fusion produced non-JSON output despite response_format=${samplingParams.response_format.type} — retry, or pin a structured-output-capable model instead of "fusion"`, type: 'server_error' }, execution_id: requestGroupId });
             return;
           }
           if (enforced.healed) fusionMsg.content = enforced.content;
         }
       }
       res.setHeader('X-Routed-Via', safeHeaderValue(routedVia));
-      res.json(response);
+      res.json({ ...response, execution_id: requestGroupId });
     } catch (err: any) {
       if (err instanceof FusionError) {
-        res.status(err.status).json({ error: { message: err.message, type: err.status === 429 ? 'rate_limit_error' : 'invalid_request_error' } });
+        res.status(err.status).json({ error: { message: err.message, type: err.status === 429 ? 'rate_limit_error' : 'invalid_request_error' }, execution_id: requestGroupId });
       } else {
-        res.status(502).json({ error: { message: `fusion error: ${sanitizeProviderErrorMessage(err?.message)}`, type: 'server_error' } });
+        res.status(502).json({ error: { message: `fusion error: ${sanitizeProviderErrorMessage(err?.message)}`, type: 'server_error' }, execution_id: requestGroupId });
       }
     }
     return;
@@ -1827,7 +1851,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
         // The savings are reported separately by GET /api/cache/stats.
         res.setHeader('X-Routed-Via', 'cache');
         res.setHeader('X-FreeLLM-Cache', 'HIT');
-        res.json(hit.body);
+        res.json(withExecutionId(hit.body, requestGroupId));
         return;
       }
     }
@@ -1861,7 +1885,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
       // Replay consumes NO provider quota — same zero-cost rationale as a
       // cache hit, so request/usage bookkeeping is skipped here too.
       res.setHeader('X-Routed-Via', 'idempotency');
-      res.status(claim.status).json(claim.body);
+      res.status(claim.status).json(withExecutionId(claim.body, requestGroupId));
       return;
     }
     if (claim.kind === 'conflict') {
@@ -1870,6 +1894,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           message: 'idempotency_key_conflict',
           type: 'invalid_request_error',
         },
+        execution_id: requestGroupId,
       });
       return;
     }
@@ -1959,6 +1984,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               type: 'service_unavailable',
               code: 'no_providers_configured',
             },
+            execution_id: requestGroupId,
           });
         } else {
           res.status(404).json({
@@ -1967,6 +1993,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
               type: 'invalid_request_error',
               code: 'model_not_found',
             },
+            execution_id: requestGroupId,
           });
         }
         return;
@@ -1991,6 +2018,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
             type: 'invalid_request_error',
             code: 'model_not_found',
           },
+          execution_id: requestGroupId,
         });
         return;
       }
@@ -2802,6 +2830,7 @@ proxyRouter.post('/chat/completions', async (req: Request, res: Response) => {
           message: `Provider error (${route.displayName}): ${sanitizeProviderErrorMessage(err.message)}`,
           type: 'provider_error',
         },
+        execution_id: requestGroupId,
       });
     },
     onRoutingExhausted: (lastError, routeErr, exhaustion, info) => {

--- a/server/src/routes/responses.ts
+++ b/server/src/routes/responses.ts
@@ -1074,7 +1074,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
             inputTokens: estimatedInputTokens,
             outputTokens: totalOutputTokens,
           });
-          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, ttfbMs);
+          logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedInputTokens, totalOutputTokens, Date.now() - start, null, ttfbMs, null, null, 'http');
           return 'done';
         } catch (streamErr: any) {
           // Client abort mid-stream: the pump's own `if (clientGone) break`
@@ -1097,7 +1097,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
               latencyMs: Date.now() - start,
               error: safe,
             });
-            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, safe, ttfbMs);
+            logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, Date.now() - start, safe, ttfbMs, null, null, 'http');
             sse('response.failed', { response: { id: responseId, object: 'response', status: 'failed', error: { message: `Provider error (${route.displayName}): stream interrupted`, type: 'stream_error' } } });
             res.end();
             return 'committed';
@@ -1207,7 +1207,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         inputTokens: promptTokens,
         outputTokens: completionTokens,
       });
-      logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null);
+      logRequest(route.platform, route.modelId, route.keyId, 'success', promptTokens, completionTokens, Date.now() - start, null, null, null, null, 'http');
       return 'done';
     },
     logFailure: (route, err, attempt) => {
@@ -1222,7 +1222,7 @@ responsesRouter.post('/responses', async (req: Request, res: Response) => {
         latencyMs: latency,
         error: safeError,
       });
-      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', estimatedInputTokens, 0, latency, safeError, null, null, null, 'http');
     },
     onFatal: (route, err, attempt) => {
       setFallbackHeaders(res, attempt, attemptLog);

--- a/server/src/services/fusion.ts
+++ b/server/src/services/fusion.ts
@@ -246,7 +246,7 @@ async function runModelCall(
 
       if (!text && !hasToolCalls) {
         // Empty completion — fail over like the main proxy path does.
-        logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, 'empty completion (fusion)', null, FUSION_TAG);
+        logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, 'empty completion (fusion)', null, FUSION_TAG, null, 'http');
         skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
         setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
         recordRateLimitHit(route.modelDbId);
@@ -258,7 +258,7 @@ async function runModelCall(
       recordRequest(route.platform, route.modelId, route.keyId);
       recordTokens(route.platform, route.modelId, route.keyId, usage.total_tokens);
       recordSuccess(route.modelDbId);
-      logRequest(route.platform, route.modelId, route.keyId, 'success', usage.prompt_tokens ?? 0, usage.completion_tokens ?? 0, Date.now() - startedAt, null, null, FUSION_TAG);
+      logRequest(route.platform, route.modelId, route.keyId, 'success', usage.prompt_tokens ?? 0, usage.completion_tokens ?? 0, Date.now() - startedAt, null, null, FUSION_TAG, null, 'http');
       return {
         ok: true,
         route,
@@ -269,7 +269,7 @@ async function runModelCall(
       };
     } catch (err: any) {
       const safe = sanitizeProviderErrorMessage(err?.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, safe, null, FUSION_TAG);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, safe, null, FUSION_TAG, null, 'http');
       lastError = safe;
 
       if (isRetryableError(err)) {
@@ -337,7 +337,7 @@ async function runJudgeStreaming(
         }
       }
       if (!text) {
-        logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, 'empty completion (fusion judge)', null, FUSION_TAG);
+        logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, 'empty completion (fusion judge)', null, FUSION_TAG, null, 'http');
         skipKeys.add(`${route.platform}:${route.modelId}:${route.keyId}`);
         setCooldown(route.platform, route.modelId, route.keyId, getCooldownDurationForLimit(route.platform, route.modelId, route.keyId, { rpd: route.rpdLimit, tpd: route.tpdLimit }));
         recordRateLimitHit(route.modelDbId);
@@ -349,11 +349,11 @@ async function runJudgeStreaming(
       recordRequest(route.platform, route.modelId, route.keyId);
       recordTokens(route.platform, route.modelId, route.keyId, usage.total_tokens);
       recordSuccess(route.modelDbId);
-      logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedTokens, out, Date.now() - startedAt, null, null, FUSION_TAG);
+      logRequest(route.platform, route.modelId, route.keyId, 'success', estimatedTokens, out, Date.now() - startedAt, null, null, FUSION_TAG, null, 'http');
       return { ok: true, route, text, usage };
     } catch (err: any) {
       const safe = sanitizeProviderErrorMessage(err?.message);
-      logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, safe, null, FUSION_TAG);
+      logRequest(route.platform, route.modelId, route.keyId, 'error', 0, 0, Date.now() - startedAt, safe, null, FUSION_TAG, null, 'http');
       lastError = safe;
       // Already streamed bytes — can't fail over without duplicating output.
       // Keep whatever the client already received.


### PR DESCRIPTION
Follow-up to #1103: execution_id is now on every JSON body both completion routes send, including cache hits, idempotency replays and error paths. The Responses, Messages, Ollama/Gemini and fusion paths now log their caller. Adds a route test and docs in en and zh-cn.