### PR TITLE
README: App Store badge in the download row

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Aggregate free tiers from dozens of providers, plus custom OpenAI-compatible cha
 **English** · [简体中文](README.zh-cn.md)
 
 <p align="center">
-  <a href="https://play.google.com/store/apps/details?id=co.freellmapi.app"><img src="repo-assets/badges/play-store.svg" height="60" alt="Get it on Google Play"></a>
-  <a href="https://github.com/tashfeenahmed/freellmapi/releases/latest"><img src="repo-assets/badges/macos.svg" height="60" alt="Download for macOS"></a>
-  <a href="https://github.com/tashfeenahmed/freellmapi/releases/latest"><img src="repo-assets/badges/windows.svg" height="60" alt="Download for Windows"></a>
-  <a href="docs/en/install/01-install.md#docker-compose"><img src="repo-assets/badges/docker.svg" height="60" alt="Self-host with Docker"></a>
+  <a href="https://play.google.com/store/apps/details?id=co.freellmapi.app"><img src="repo-assets/badges/play-store.svg" height="48" alt="Get it on Google Play"></a>
+  <a href="https://apps.apple.com/app/id6804648934"><img src="repo-assets/badges/app-store.svg" height="48" alt="Download on the App Store"></a>
+  <a href="https://github.com/tashfeenahmed/freellmapi/releases/latest"><img src="repo-assets/badges/macos.svg" height="48" alt="Download for macOS"></a>
+  <a href="https://github.com/tashfeenahmed/freellmapi/releases/latest"><img src="repo-assets/badges/windows.svg" height="48" alt="Download for Windows"></a>
+  <a href="docs/en/install/01-install.md#docker-compose"><img src="repo-assets/badges/docker.svg" height="48" alt="Self-host with Docker"></a>
 </p>
 
 ![FreeLLMAPI dashboard — Models page with the monthly token budget](repo-assets/github-hero.png)

--- a/repo-assets/badges/app-store.svg
+++ b/repo-assets/badges/app-store.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="180" viewBox="0 0 600 180" role="img" aria-label="Download On The App Store">
+  <title>Download On The App Store</title>
+  <rect x="3" y="3" width="594" height="174" rx="30" fill="#17171a" stroke="#3a3a42" stroke-width="3"/>
+  <g transform="translate(54,52) scale(3.1667)">
+    <rect x="0" y="0" width="24" height="24" rx="5.4" fill="#1a8cff"/>
+    <g fill="none" stroke="#ffffff" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M7.1 17.9 L12.9 6.6"/>
+      <path d="M11.1 6.6 L16.9 17.9"/>
+      <path d="M4.8 14.9 L19.2 14.9"/>
+    </g>
+  </g>
+  <text x="172" y="74" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="28" font-weight="500" letter-spacing="2.5" fill="#a8a8b3">DOWNLOAD ON THE</text>
+  <text x="172" y="133" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="54" font-weight="700" letter-spacing="-0.5" fill="#ffffff">App Store</text>
+</svg>


### PR DESCRIPTION
Adds an App Store badge after Google Play, linking to the iOS listing, and shrinks the row to height 48 so five badges fit on one line.