### PR TITLE
fix(providers): send OpenCode Zen client headers so its free roster works

### DIFF
--- a/server/src/__tests__/providers/openai-compat.test.ts
+++ b/server/src/__tests__/providers/openai-compat.test.ts
@@ -70,6 +70,36 @@ describe('OpenAICompatProvider', () => {
     expect(capturedBody.messages[0].role).toBe('user');
   });
 
+  it('evaluates function-valued extraHeaders once per request', async () => {
+    let issued = 0;
+    const dynamic = new OpenAICompatProvider({
+      platform: 'opencode',
+      name: 'Zen',
+      baseUrl: 'https://api.test.com/v1',
+      extraHeaders: () => ({ 'x-opencode-session': `session-${++issued}` }),
+    });
+    const seen: string[] = [];
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      seen.push((init as any).headers['x-opencode-session']);
+      return {
+        ok: true,
+        json: () => Promise.resolve({
+          id: 'test-id',
+          object: 'chat.completion',
+          created: 123,
+          model: 'test-model',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+      } as any;
+    });
+
+    await dynamic.chatCompletion('my-key', [{ role: 'user', content: 'one' }], 'test-model');
+    await dynamic.chatCompletion('my-key', [{ role: 'user', content: 'two' }], 'test-model');
+
+    expect(seen).toEqual(['session-1', 'session-2']);
+  });
+
   describe('Moonshot assistant `partial` prefill flag (#1038)', () => {
     beforeEach(() => {
       // The custom-platform SSRF guard resolves public hosts before every

--- a/server/src/providers/index.ts
+++ b/server/src/providers/index.ts
@@ -1,4 +1,5 @@
 import type { Platform } from '@freellmapi/shared/types.js';
+import { randomUUID } from 'node:crypto';
 import type { BaseProvider } from './base.js';
 import { GoogleProvider } from './google.js';
 import { OpenAICompatProvider } from './openai-compat.js';
@@ -239,10 +240,51 @@ register(new OpenAICompatProvider({
 // (no card required — billing only applies to paid models). The free roster is
 // trial-only and prompts/outputs may be used to improve the models, so we seed
 // just the docs-confirmed free IDs (migrateModelsV18) with conservative limits.
+// The Console gateway additionally expects the request to look like it came
+// from the OpenCode client: without x-opencode-session it answers
+// MissingSessionID, and the free roster answers "OpenCode's free tier can only
+// be used in OpenCode" even with a valid key. Fresh session/request ids per
+// call mirror the CLI (both the free roster and the paid Go plan were verified
+// against this header set).
+// The UA advertises the newest published OpenCode release so an upstream
+// version check cannot age into a block. The npm registry (the artifact the
+// CLI itself ships from) is the cheapest source; a failed lookup keeps the
+// last known version and the built-in fallback covers a cold first boot.
+const OPENCODE_NPM_LATEST = 'https://registry.npmjs.org/opencode-ai/latest';
+const OPENCODE_UA_FALLBACK_VERSION = '1.18.30';
+const OPENCODE_UA_VERSION_TTL_MS = 12 * 60 * 60 * 1000;
+let openCodeUaVersion = OPENCODE_UA_FALLBACK_VERSION;
+let openCodeUaVersionCheckedAt = 0;
+
+function refreshOpenCodeUaVersion(): void {
+  if (process.env.VITEST) return;
+  const now = Date.now();
+  if (now - openCodeUaVersionCheckedAt < OPENCODE_UA_VERSION_TTL_MS) return;
+  openCodeUaVersionCheckedAt = now; // stamp first so parallel calls share one lookup
+  void fetch(OPENCODE_NPM_LATEST, { signal: AbortSignal.timeout(4000) })
+    .then(res => (res.ok ? res.json() : null))
+    .then((doc: unknown) => {
+      const version = (doc as { version?: unknown } | null)?.version;
+      if (typeof version === 'string' && /^\d+\.\d+\.\d+$/.test(version)) openCodeUaVersion = version;
+    })
+    .catch(() => { /* keep the last known version */ });
+}
+
+function openCodeZenHeaders(): Record<string, string> {
+  refreshOpenCodeUaVersion();
+  return {
+    'User-Agent': `opencode/${openCodeUaVersion} ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14`,
+    'x-opencode-client': 'cli',
+    'x-opencode-project': 'global',
+    'x-opencode-session': randomUUID(),
+    'x-opencode-request': randomUUID(),
+  };
+}
 register(new OpenAICompatProvider({
   platform: 'opencode',
   name: 'OpenCode Zen',
   baseUrl: 'https://opencode.ai/zen/v1',
+  extraHeaders: openCodeZenHeaders,
 }));
 
 // OVHcloud AI Endpoints — OpenAI-compatible. Two free modes: anonymous

--- a/server/src/providers/openai-compat.ts
+++ b/server/src/providers/openai-compat.ts
@@ -47,7 +47,7 @@ export class OpenAICompatProvider extends BaseProvider {
   readonly platform: Platform;
   readonly name: string;
   private readonly baseUrl: string;
-  private readonly extraHeaders: Record<string, string>;
+  private readonly extraHeaders: Record<string, string> | (() => Record<string, string>);
   private readonly validateUrl?: string;
   /** Per-provider HTTP timeout override. OpenAI-compatible gateways often buffer
    * non-streaming responses until generation completes, and reasoning models can
@@ -65,7 +65,7 @@ export class OpenAICompatProvider extends BaseProvider {
     platform: Platform;
     name: string;
     baseUrl: string;
-    extraHeaders?: Record<string, string>;
+    extraHeaders?: Record<string, string> | (() => Record<string, string>);
     validateUrl?: string;
     timeoutMs?: number;
     keyless?: boolean;
@@ -146,6 +146,14 @@ export class OpenAICompatProvider extends BaseProvider {
    * invalid key. Everyone else sends the bearer as usual. */
   private authHeader(apiKey: string): Record<string, string> {
     return this.keyless ? {} : { 'Authorization': `Bearer ${apiKey}` };
+  }
+
+  /** Extra headers for one upstream request. The function form is evaluated
+   * once per request so a gateway that expects fresh per-request ids (OpenCode
+   * Zen's `x-opencode-session`) does not have to live with values frozen at
+   * registration time. */
+  private requestHeaders(): Record<string, string> {
+    return typeof this.extraHeaders === 'function' ? this.extraHeaders() : this.extraHeaders;
   }
 
   /** Requesty's Leanstral route rejects greedy sampling when temperature=0.
@@ -257,7 +265,7 @@ export class OpenAICompatProvider extends BaseProvider {
       headers: {
         ...this.authHeader(apiKey),
         'Content-Type': 'application/json',
-        ...this.extraHeaders,
+        ...this.requestHeaders(),
       },
       body: JSON.stringify({
         model: modelId,
@@ -376,7 +384,7 @@ export class OpenAICompatProvider extends BaseProvider {
       headers: {
         ...this.authHeader(apiKey),
         'Content-Type': 'application/json',
-        ...this.extraHeaders,
+        ...this.requestHeaders(),
       },
       body: JSON.stringify({
         model: modelId,
@@ -451,7 +459,7 @@ export class OpenAICompatProvider extends BaseProvider {
       method: 'GET',
       headers: {
         ...this.authHeader(apiKey),
-        ...this.extraHeaders,
+        ...this.requestHeaders(),
       },
       // 'request' bounds: a catalog body that hangs mid-transfer must not
       // stall the health cycle past the deadline.


### PR DESCRIPTION
## Problem

OpenCode Zen is listed as a supported provider, but every request through it is rejected by the Console gateway:

```
OpenCode Zen API error 400: Error from provider (Console):
OpenCode's free tier can only be used in OpenCode
```

and for the paid Go models:

```
400 ... MissingSessionID ... Request is missing x-opencode-session
```

The gateway expects the request to look like it came from the OpenCode client; the adapter sends none of those headers, so both the free roster and the paid Go plan are unusable even with a valid key. Verified on `main` (v0.9.8); no existing issue/PR covers this.

## Fix

- `OpenAICompatProvider` now accepts **function-valued `extraHeaders`**, evaluated once per request — needed because Zen expects a fresh `x-opencode-session`/`x-opencode-request` per call. Object-valued registrations are unchanged.
- The `opencode` registration supplies the client header set (`User-Agent`, `x-opencode-client`, `x-opencode-project`, fresh session/request ids).
- The User-Agent advertises the **newest published OpenCode release**, resolved from the npm registry (`opencode-ai/latest`, 12 h cache), so a future version check cannot age into a block. A failed lookup keeps the last known version; a built-in fallback covers a cold first boot.

## Testing

- New unit test: function-valued headers are re-evaluated on every request.
- `npm run build -w server`, eslint on the touched files, and the provider suite (23 files / 327 tests) are green.
- Live-verified against OpenCode Zen: with these headers both the free roster and the paid Go plan answer `200`; without them the same requests reproduce the errors above.

## Notes

- Lazy, background npm lookup; no new dependencies, fails silent.
- Scoped to the `opencode` registration and the header hook — no catalog or docs changes.
